### PR TITLE
recordext: fill the empty values

### DIFF
--- a/inspire/base/recordext/fields/inspire.cfg
+++ b/inspire/base/recordext/fields/inspire.cfg
@@ -22,19 +22,19 @@ accelerator_experiment:
 affiliation_old:
     creator:
         @legacy((("902", "902__", "902__%"), ""),
-                ("902__a", ""))
+                ("902__a", "value"))
         marc, "902__", value['a']
     producer:
-        json_for_marc(), {"902__a": ""}
+        json_for_marc(), {"902__a": "value"}
     description:
         """affiliations not associated with authors - old spires legacy"""
 
 agency_code:
     creator:
-        @legacy(("003", ""), )
+        @legacy(("003", "value"), )
         marc, "003", value
     producer:
-        json_for_marc(), {"003": ""}
+        json_for_marc(), {"003": "value"}
     description:
         """code for the agency whose system control number is present in field recid"""
 
@@ -84,22 +84,22 @@ authors:
 book_series:
     creator:
         @legacy((("490", "490__", "490__%"), ""),
-                ("490__a", ""),
+                ("490__a", "value"),
                 ("490__v", "volume"))
         marc, "490__", {'value': value['a'], 'volume':value['v']}
     producer:
-        json_for_marc(), {"490__a": "", "490__v": "volume"}
+        json_for_marc(), {"490__a": "value", "490__v": "volume"}
 
 
 classification_number:
     creator:
         @legacy((("084", "084__", "084__%"), ""),
-                ("084__a", ""),
+                ("084__a", "value"),
                 ("084__2", "standard"),
                 ("084__9", "source"))
         marc, "084__", {'value': value['a'], 'standard':value['2'], 'source':value['9']}
     producer:
-        json_for_marc(), {"084__a": "", "084__2": "standard", "084__9": "source"}
+        json_for_marc(), {"084__a": "value", "084__2": "standard", "084__9": "source"}
 
 creation_modification_date:
     creator:
@@ -136,10 +136,10 @@ collaboration:
 corporate_author:
     creator:
         @legacy((("110", "110__", "110__%"), ""),
-                ("110__a", ""))
+                ("110__a", "value"))
          marc, "110__", value['a']
     producer:
-        json_for_marc(), {"110__a":""}
+        json_for_marc(), {"110__a":"value"}
 
 
 coyright:
@@ -156,28 +156,28 @@ coyright:
 deleted_recid:
     creator:
         @legacy((("981", "981__", "981__%"), ""),
-                ("981__a", ""))
+                ("981__a", "value"))
         marc, "981__", {'value':value['a']}
     producer:
-        json_for_marc(), {"981__a": ""}
+        json_for_marc(), {"981__a": "value"}
  
 
 @persistent_identifier(3)
 doi:
     creator:
         @legacy((("024", "0247_", "0247_%"), ""),
-                ("0247_a", ""))
+                ("0247_a", "value"))
         marc, "0247_", get_doi(value)
     producer:
-        json_for_marc(), {'0247_2': 'str("DOI")', '0247_a': ''}
+        json_for_marc(), {'0247_2': 'str("DOI")', '0247_a': 'value'}
 
 edition:
     creator:
         @legacy((("250", "250__", "250__%"), ""),
-                ("250__a", ""))
+                ("250__a", "value"))
         marc, "250__", value['a']
     producer:
-        json_for_marc(), {"250__a": ""}
+        json_for_marc(), {"250__a": "value"}
 
 
 fft:
@@ -201,11 +201,11 @@ fft:
 free_keyword:
     creator:
         @legacy((("653", "6531_", "6531_%"), ""),
-                ("6531_a", ""),
+                ("6531_a", "value"),
                 ("6531_9", "source"))
         marc, "6531_", {'value': value['a'], 'source': value['9'] }
     producer:
-        json_for_marc(), {"6531_a": "", "6531_9": "source"}
+        json_for_marc(), {"6531_a": "value", "6531_9": "source"}
 
 funding_info:
     creator:
@@ -225,7 +225,7 @@ funding_info:
                 ("595__b", "cern_reference"))
         marc, "595__", {'value': value['a'], 'cern_reference':value['b']}
     producer:
-        json_for_marc(), {"595__a": "", "595__b": "cern_reference"}
+        json_for_marc(), {"595__a": "value", "595__b": "cern_reference"}
 
 imprint:
   creator:
@@ -241,21 +241,21 @@ imprint:
 isbn:
     creator:
         @legacy((("020", "020__", "020__%"), ""),
-                ("020__a", ""),
+                ("020__a", "value"),
                 ("020__b", "medium"))
         marc, "020__", {'value': value['a'], 'medium':value['b']}
     producer:
-        json_for_marc(), {"020__a": "", "020__b": "medium"}
+        json_for_marc(), {"020__a": "value", "020__b": "medium"}
 
 
 
 language:
     creator:
         @legacy((("041", "041__", "041__%"), ""),
-                ("041__a", ""))
+                ("041__a", "value"))
         marc, "041__", value['a']
     producer:
-        json_for_marc(), {"041__a": ""}
+        json_for_marc(), {"041__a": "value"}
 
 
 license:
@@ -273,7 +273,7 @@ license:
 nonpublic_note:
     creator:
         @legacy((("590", "590__", "590__%"), ""),
-                ("500__a", ""))
+                ("500__a", "value"))
         marc, "500__", { 'value': value['a']}
     producer:
         json_for_marc(), {"500__a": "value"}
@@ -281,7 +281,7 @@ nonpublic_note:
 note:
     creator:
         @legacy((("500", "500__", "500__%"), ""),
-                ("500__a", ""),
+                ("500__a", "value"),
                 ("500__9", "source"))
         marc, "500__", {'value': value['a'], 'source':value['9'] }
     producer:
@@ -331,10 +331,10 @@ publication_info:
 page_nr:
     creator:
         @legacy((("300", "300__", "300__%", "")),
-                ("300__a", ""))
+                ("300__a", "value"))
         marc, "300__", value['a']
     producer:
-        json_for_marc(), {"300__a": ""}
+        json_for_marc(), {"300__a": "value"}
 
 
 reference:
@@ -374,18 +374,18 @@ refextract:
 report_number:
     creator:
         @legacy((("037", "037__", "037__%"), ""),
-                ("037__a", ""),
+                ("037__a", "value"),
                 ("037__c", "arxiv_category"),
                 ("037__9", "source"))
         marc, "037__", {'value': value['a'], 'arxiv_category': value['c'], 'source': value['9']}
     producer:
-        json_for_marc(), {"037__a": "", "037__c": "arxiv_category", "037__9": "source"}
+        json_for_marc(), {"037__a": "value", "037__c": "arxiv_category", "037__9": "source"}
 
 
 subject_term:
     creator:
         @legacy((("650", "65017", "65017%"), ""),
-                ("65017a", ""),
+                ("65017a", "value"),
                 ("650172", "scheme"),
                 ("650179", "source"))
         marc, "65017", {'term':value['a'], 'scheme':value['2'], 'source':value['9']}
@@ -406,21 +406,21 @@ succeeding_entry:
 spires_sysno:
     creator:
         @legacy((("970", "970__", "970__%"), ""),
-                ("970__a", ""))
+                ("970__a", "value"))
         marc, "970__", {'value':value['a']}
     producer:
-        json_for_marc(), {"970__a": ""}
+        json_for_marc(), {"970__a": "value"}
  
 @persistent_identifier(2)
 system_number_external:
   creator:
         @legacy((("035", "035__", "035__%"), ""),
-                ("035__a", ""),
+                ("035__a", "value"),
                 ("035__z", "obsolete"),
                 ("035__9", "institute"))
         marc, "035__", {'value': value['a'], 'obsolete':value['z'], 'institute':value['9']}
     producer:
-        json_for_marc(), {"035__a": "", "035__z": "obsolete", "035__9": "institute"}
+        json_for_marc(), {"035__a": "value", "035__z": "obsolete", "035__9": "institute"}
 
 thesaurus_terms:
     creator:
@@ -456,10 +456,10 @@ thesis_supervisor:
 title_variation:
     creator:
         @legacy((("210", "210__", "210__%"), ""),
-                ("210__a", ""))
+                ("210__a", "value"))
         marc, "210__", value['a']
     producer:
-        json_for_marc(), {"210__a": ""}
+        json_for_marc(), {"210__a": "value"}
 
 title:
     creator:
@@ -474,11 +474,11 @@ title_arXiv:
     creator:
         @legacy((("246", "246__", "246__%"), ""),
                 ("246__%", ""),
-                ("246__a", ""),
+                ("246__a", "value"),
                 ("246__b", "subtitle"))
         marc, "246__", { 'value': value['a'], 'subtitle':value['b']}
     producer:
-        json_for_marc(), {"246__a": "", "246__b": "subtitle"}
+        json_for_marc(), {"246__a": "value", "246__b": "subtitle"}
 
 title_old:
     creator:
@@ -493,26 +493,26 @@ title_old:
 title_translation:
     creator:
         @legacy((("242", "242__", "242__%"), ""),
-                ("242__a", ""),
+                ("242__a", "value"),
                 ("242__b", "subtitle"))
         marc, "242__", {'value': value['a'], 'subtitle':value['b']}
     producer:
-        json_for_marc(), {"242__a": "", "242__b": "subtitle"}
+        json_for_marc(), {"242__a": "value", "242__b": "subtitle"}
 
 
 url:
     creator:
         @legacy((("856", "8564_", "8564_%"), ""),
-                ("8564_u", ""),
+                ("8564_u", "value"),
                 ("8564_w", "doc_string"),
                 ("8564_y", "description"),
                 ("8564_3", "material_type"))
-        marc, "8564_", {'': value['u'],
+        marc, "8564_", {'value': value['u'],
                         'doc_string':value['w'],
                         'description':value['y'],
                         'material_type':value['3']}
     producer:
-        json_for_marc(), {"8564_u": "", "8564_w": "doc_string", "8564_y": "description", "8564_3": "material_type"}
+        json_for_marc(), {"8564_u": "value", "8564_w": "doc_string", "8564_y": "description", "8564_3": "material_type"}
 
 ###############################################################################
 ##########                                                           ##########


### PR DESCRIPTION
- Fixes a bug with the stylesheet where some tag wasn't
  attached to a key value. Creating a problem when
  bibfield try to transform a dict to a marcxml.

Signed-off-by: guillaume lastecoueres guillaume.lastecoueres@cern.ch
