### PR TITLE
base: adaptation to new search form from invenio

### DIFF
--- a/inspire/base/templates/page.html
+++ b/inspire/base/templates/page.html
@@ -50,7 +50,7 @@
 {% block body %}
   {{ super() }}
   {% if searchbar_enable %}
-    {{ search_form(collection, easy_search_form) }}
+    {% include "search/form/index.html" %}
   {% endif %}
   {% block inner_content %}
     <!-- Here goes the content visible below the search bar -->


### PR DESCRIPTION
This is needed to adapt code to this commit at invenio side:

search: search form as files
- Splitting the `search_form` macro into files. All the blocks have been
  preserved.
- Deleting the `search_form` macro.
- NOTE if you were using the `search_form` macro you should replace it
  by `{% include "search/form/index.html %}`

Signed-off-by: Yoan Blanc yoan.blanc@cern.ch

https://github.com/jirikuncar/invenio/commit/2312dee28cdcfc7de709071dd31f71e658b3eac8
