### PR TITLE
deposit: deposit-inspire.css improvements

### DIFF
--- a/inspire/modules/deposit/static/css/deposit-inspire.css
+++ b/inspire/modules/deposit/static/css/deposit-inspire.css
@@ -28,10 +28,14 @@
     }
 }
 
-.add-element {
+.add-element, .remove-element {
     cursor: pointer;
 }
 
 #abstract {
     height: 120px;
+}
+
+#webdeposit_form_accordion textarea {
+    resize: vertical;
 }


### PR DESCRIPTION
- Resize of textareas is set to vertical only.
- Add pointer:cursor for remove icons.

Signed-off-by: Georgios Kokosioulis georgios.kokosioulis@cern.ch
