### PR TITLE
deposit: change of hiding method of hidden fields

### DIFF
--- a/inspire/modules/deposit/forms.py
+++ b/inspire/modules/deposit/forms.py
@@ -21,7 +21,7 @@
 """Contains forms related to INSPIRE submission."""
 
 from wtforms import validators
-from wtforms.widgets import html_params, HTMLString
+from wtforms.widgets import html_params, HTMLString, HiddenInput
 
 from invenio.base.i18n import _
 from invenio.base.globals import cfg
@@ -186,6 +186,7 @@ class LiteratureForm(WebDepositForm):
 
     title_arXiv = fields.TitleField(
         export_key='title_arXiv',
+        widget=HiddenInput(),
     )
 
     title_translation = fields.TitleField(
@@ -274,8 +275,8 @@ class LiteratureForm(WebDepositForm):
 
     license_url = fields.TextField(
         label=_('License URL'),
-        widget_classes="form-control",
         export_key='license_url',
+        widget=HiddenInput(),
     )
 
     # ==============
@@ -357,7 +358,7 @@ class LiteratureForm(WebDepositForm):
 
     note = fields.TextAreaField(
         export_key='note',
-        widget_classes="form-control"
+        widget=HiddenInput(),
     )
 
     # ====================

--- a/inspire/modules/deposit/static/js/deposit/fillform.js
+++ b/inspire/modules/deposit/static/js/deposit/fillform.js
@@ -113,12 +113,8 @@ LiteratureSubmissionForm.prototype = {
       enableCaseInsensitiveFiltering: true
     });
 
+    this.hideHiddenFields();
     this.handleTranslatedTitle();
-
-    $("#state-group-title_arXiv").addClass("hidden");
-    $("#state-group-note").addClass("hidden");
-    $("#state-group-license_url").addClass("hidden");
-
     this.taskmanager = new TaskManager(this.$deposition_type);
     this.messageBox = $('#flash-import').messageBox({
       hoganTemplate: tpl_flash_message,
@@ -145,6 +141,20 @@ LiteratureSubmissionForm.prototype = {
       that.importData();
     });
 
+  },
+
+  /**
+   * Hide form-group container of hidden fields
+   *
+   */
+  hideHiddenFields: function hideHiddenFields() {
+    // "not" part excludes field list elements e.g. authors
+    // FIXME: move hidden html template element of DynamiFieldList 
+    //   to a Hogan template to get rid of 'not' part
+    $('input[type="hidden"]')
+      .not('[id$="__last_index__"]')
+      .parents('.form-group')
+      .hide();
   },
 
   onDepositionTypeChanged: function onDepositionTypeChanged() {
@@ -229,7 +239,7 @@ LiteratureSubmissionForm.prototype = {
     }
   },
 
-    /**
+  /**
    * Strips the prefix off the identifier.
    * @param identifier DOI/arXiv/ISBN id
    * @returns stripped identifier


### PR DESCRIPTION
- Uses HiddenInput widget in forms.py, and hides
  all leftovers generic using class based jQuery
  selector in fillform.js.

Signed-off-by: Kamil Neczaj kamil.neczaj@cern.ch
