### PR TITLE
deposit: save form fields after import

### DIFF
--- a/inspire/modules/deposit/static/js/deposit/data_sources/arxiv.js
+++ b/inspire/modules/deposit/static/js/deposit/data_sources/arxiv.js
@@ -34,7 +34,6 @@ var arxivSource = new DataSource({
           doi: data.doi,
           title: data.title,
           title_arXiv: data.title,
-          year: data.published,
           abstract: data.abstract,
           contributors: data.authors,
           journal_title: data["journal-ref"],

--- a/inspire/modules/deposit/static/js/deposit/fillform.js
+++ b/inspire/modules/deposit/static/js/deposit/fillform.js
@@ -61,7 +61,9 @@ var literatureFormPriorityMapper = new DataMapper({
   }
 });
 
-function LiteratureSubmissionForm() {
+function LiteratureSubmissionForm(save_url) {
+
+  this.save_url = save_url;
 
   // here just global form variables initialization
   this.$field_list = {
@@ -249,8 +251,12 @@ LiteratureSubmissionForm.prototype = {
    *
    * @param dataMapping {} dictionary with schema 'field_id: field_value', and
    *  special 'contributors' key to extract them to authors field.
+   * @param save_url url containing the path to save the form fields content,
+   *  see DEPOSIT_FORM.save_field().
    */
   fillForm: function fillForm(dataMapping) {
+
+    var that = this;
 
     if ($.isEmptyObject(dataMapping)) {
       return;
@@ -262,6 +268,7 @@ LiteratureSubmissionForm.prototype = {
       var $field = $('#' + field_id);
       if ($field) {
         $field.val(value);
+        DEPOSIT_FORM.save_field(that.save_url, field_id, value);
       }
     });
 
@@ -278,4 +285,4 @@ LiteratureSubmissionForm.prototype = {
       }
     }
   }
-}
+};

--- a/inspire/modules/deposit/templates/deposit/run.html
+++ b/inspire/modules/deposit/templates/deposit/run.html
@@ -100,7 +100,7 @@ $(document).ready(function() {
     // Date picker
     $(".datepicker").datepicker(date_options);
 
-    var form = new LiteratureSubmissionForm();
+    var form = new LiteratureSubmissionForm(save_url);
 });
 </script>
 {% endblock javascript %}


### PR DESCRIPTION
- Saves field content after importing data from an external source,
  this way the fields keep the content after a page close or refresh.

Signed-off-by: Pedro Gaudêncio pedro.gaudencio@cern.ch
