### PR TITLE
deposit: replace placeholders with description

### DIFF
--- a/inspire/modules/deposit/fields/arxiv_id.py
+++ b/inspire/modules/deposit/fields/arxiv_id.py
@@ -44,7 +44,7 @@ class ArXivField(WebDepositField, TextField):
                 strip_string,
                 strip_prefixes("arxiv:", "arXiv:"),
             ],
-            placeholder="e.g. hep-th/1234567 or 1234.5678...",
+            description="e.g. hep-th/1234567 or 1234.5678...",
             widget_classes="form-control"
         )
         defaults.update(kwargs)

--- a/inspire/modules/deposit/fields/isbn.py
+++ b/inspire/modules/deposit/fields/isbn.py
@@ -45,7 +45,7 @@ class ISBNField(WebDepositField, TextField):
                 strip_string,
                 strip_prefixes("isbn:", "ISBN:"),
             ],
-            placeholder="e.g. 1413304540, 1-4133-0454-0, 978-1413304541 or 978-1-4133-0454-1...",
+            description="e.g. 1413304540, 1-4133-0454-0, 978-1413304541 or 978-1-4133-0454-1...",
             widget_classes="form-control"
         )
         defaults.update(kwargs)

--- a/inspire/modules/deposit/forms.py
+++ b/inspire/modules/deposit/forms.py
@@ -145,7 +145,9 @@ class LiteratureForm(WebDepositForm):
     doi = fields.DOIField(
         label=_('DOI'),
         processors=[],
-        export_key='doi'
+        export_key='doi',
+        description='e.g. 10.1234/foo.bar...',
+        placeholder=''
     )
 
     arxiv_id = ArXivField(
@@ -270,7 +272,7 @@ class LiteratureForm(WebDepositForm):
 
     conf_name = fields.TextField(
         label=_('Conference Information'),
-        placeholder=_('Conference name, acronym, place, date'),
+        description=_('Conference name, acronym, place, date'),
         widget_classes="form-control"
     )
 
@@ -327,7 +329,7 @@ class LiteratureForm(WebDepositForm):
 
     page_range = fields.TextField(
         label=_('Page Range'),
-        placeholder=_('1-100'),
+        description=_('1-100'),
         widget_classes="form-control"
     )
 
@@ -353,7 +355,7 @@ class LiteratureForm(WebDepositForm):
 
     nonpublic_note = fields.TextAreaField(
         label=_(' '),
-        placeholder='Editors, title of proceedings, publisher, year of publication, page range',
+        description='Editors, title of proceedings, publisher, year of publication, page range',
         widget_classes="form-control"
     )
 


### PR DESCRIPTION
- Removes hint messages from placeholders and adds them under
  the fields.

Signed-off-by: Georgios Kokosioulis georgios.kokosioulis@cern.ch
