### PR TITLE
deposit: removal of inspire_init.js

### DIFF
--- a/inspire/modules/deposit/bundles.py
+++ b/inspire/modules/deposit/bundles.py
@@ -27,7 +27,6 @@ from invenio.modules.deposit.bundles import js as _deposit_js, \
 _deposit_js.contents += (
     'vendors/buckets/buckets.js',
     'vendors/bootstrap-multiselect/js/bootstrap-multiselect.js',
-    'js/deposit/inspire_init.js'
 )
 
 _deposit_js.bower.update({

--- a/inspire/modules/deposit/static/js/deposit/inspire_init.js
+++ b/inspire/modules/deposit/static/js/deposit/inspire_init.js
@@ -1,4 +1,0 @@
-require(['/js/deposit/literature_submission_form.js'], function() {
-  // Loads the required module into a bundle that can be used in the html
-  // pages.
-})


### PR DESCRIPTION
- Removes inspire_init.js as the file is only to keep legacy js
  working, and all our js is already adapted to requirejs.

Signed-off-by: Kamil Neczaj kamil.neczaj@cern.ch
