### PR TITLE
deposit: fixes to MarcXML mapping

### DIFF
--- a/inspire/modules/deposit/workflows/literature.py
+++ b/inspire/modules/deposit/workflows/literature.py
@@ -200,6 +200,14 @@ class literature(SimpleRecordDeposition):
             metadata['license']['url'] = metadata['license_url']
             delete_keys.append('license_url')
 
+        # ===========
+        # Files (FFT)
+        # ===========
+        if 'fft' in metadata and metadata['fft']:
+            fft = metadata['fft']
+            metadata['fft'] = {}
+            metadata['fft']['url'] = fft[0]['path']
+
         # ================
         # Publication Info
         # ================


### PR DESCRIPTION
- Only other languages are added in 041, and they were abbreviated (before 041__a:ger, now 041__a:German)
- Journal title was missing in 773__p.
- No space between author initials (if abreviated).
- We try to add the source to abstracts. For arxiv import 520__9:arXiv
- arXiv id in 037 was missing.
- adds "$$9arXiv$$aoai:arXiv.org:" to the arXiv ID.
- fixes file upload.
