### PR TITLE
Language field workaround and empty author's field hotfix

### DIFF
--- a/inspire/modules/deposit/workflows/literature.py
+++ b/inspire/modules/deposit/workflows/literature.py
@@ -104,6 +104,7 @@ class literature(SimpleRecordDeposition):
         # =======
         # Authors
         # =======
+        metadata['authors'] = filter(None, metadata['authors'])
         if 'authors' in metadata and metadata['authors']:
             first_author = metadata['authors'][0].get('full_name').split(',')
             if len(first_author) > 1 and \


### PR DESCRIPTION
- language field workaround: if https://github.com/inveniosoftware/invenio/pull/2154 doesn't get accepted, we should be careful with the `_()` values. They should be converted to `unicode()` in the post processing before the MarcXML is generated.
- empty author's field hotfix: by default, even if the author's field is empty its value is [{}], which does not appear empty. The empty values should be cleared before processing the author's field. It doesn't matter if we make the author's field required, but just in case we should clean the empty fields if a user inputs something like:
  1. name: "", aff: ""
  2. name: "Bunny, Bugs", aff: "Looney Tunes"
  3. name: "", aff: ""
  4. name: "Bunny, Lola", aff: "Looney Tunes"
  
  to:
  1. name: "Bunny, Bugs", aff: "Looney Tunes"
  2. name: "Bunny, Lola", aff: "Looney Tunes"
