### PR TITLE
deposit: duplicate validator with prod inspirehep

### DIFF
--- a/inspire/config.py
+++ b/inspire/config.py
@@ -161,6 +161,9 @@ CFG_SITE_LANGS = ['en', ]
 # to work
 CFG_SITE_NAME = u"HEP"
 
+# a working mode when the server cooperates with inspirehep.net database
+PRODUCTION_MODE = False
+
 langs = {}
 for lang in CFG_SITE_LANGS:
     langs[lang] = u"INSPIRE - High-Energy Physics Literature Database"

--- a/inspire/modules/deposit/fields/arxiv_id.py
+++ b/inspire/modules/deposit/fields/arxiv_id.py
@@ -18,7 +18,6 @@
 #
 
 from wtforms import TextField
-from wtforms.validators import ValidationError
 
 from invenio.modules.deposit.field_base import WebDepositField
 from invenio.modules.deposit.filter_utils import strip_prefixes, strip_string
@@ -33,6 +32,8 @@ class ArXivField(WebDepositField, TextField):
         defaults = dict(
             icon='barcode',
             validators=[arxiv_syntax_validation],
+            # Should have the same logic as stripSourceTags()
+            # in literature_submission_form.js
             filters=[
                 strip_string,
                 strip_prefixes("arxiv:", "arXiv:"),

--- a/inspire/modules/deposit/forms.py
+++ b/inspire/modules/deposit/forms.py
@@ -32,10 +32,14 @@ from invenio.modules.deposit.field_widgets import plupload_widget, \
     ExtendedListWidget, \
     ItemWidget
 from invenio.modules.deposit.autocomplete_utils import kb_dynamic_autocomplete
+from invenio.modules.deposit.validation_utils import DOISyntaxValidator
+
 from .fields import ArXivField
 # from .fields import ISBNField
 from .validators.dynamic_fields import AuthorsValidation
 from .filters import clean_empty_list
+from .validators.simple_fields import duplicated_doi_validator, \
+    duplicated_arxiv_id_validator, arxiv_syntax_validation
 
 #
 # Field class names
@@ -197,11 +201,13 @@ class LiteratureForm(WebDepositForm):
         processors=[],
         export_key='doi',
         description='e.g. 10.1234/foo.bar or doi:10.1234/foo.bar',
-        placeholder=''
+        placeholder='',
+        validators=[DOISyntaxValidator(), duplicated_doi_validator],
     )
 
     arxiv_id = ArXivField(
         label=_('arXiv ID'),
+        validators=[arxiv_syntax_validation, duplicated_arxiv_id_validator],
     )
 
     # isbn = ISBNField(

--- a/inspire/modules/deposit/validators/simple_fields.py
+++ b/inspire/modules/deposit/validators/simple_fields.py
@@ -17,9 +17,12 @@
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 #
 
-from wtforms.validators import ValidationError
+from wtforms.validators import ValidationError, StopValidation
 
+from invenio.base.globals import cfg
 from invenio.utils.persistentid import is_arxiv, is_isbn
+
+from urllib import urlencode
 
 
 def arxiv_syntax_validation(form, field):
@@ -28,7 +31,7 @@ def arxiv_syntax_validation(form, field):
                 similar to 'hep-th/1234567' or '1234.5678'."
 
     if field.data and not is_arxiv(field.data):
-        raise ValidationError(message)
+        raise StopValidation(message)
 
 
 def isbn_syntax_validation(form, field):
@@ -38,4 +41,72 @@ def isbn_syntax_validation(form, field):
                 '978-1-4133-0454-1'."
 
     if field.data and not is_isbn(field.data):
-        raise ValidationError(message)
+        raise StopValidation(message)
+
+
+def does_exist_in_inspirehep(query, collection=None):
+    """Check if there exist an item in the db which satisfies query.
+
+    :param query: http query to check
+    :param collection: collection to search in; by default searches in
+        the default collection
+    """
+    import requests
+    from json import loads
+
+    params = {
+        'p': query,
+        'of': 'id'
+    }
+
+    if collection:
+        params['cc'] = collection
+
+    json_reply = requests.get(
+        "http://inspirehep.net/search?", params=params).text
+
+    reply = loads(json_reply)
+    # not an array -> invalid answer
+    if not isinstance(reply, list):
+        raise ValueError('Invalid server answer.')
+
+    # non-empty answer -> duplicate
+    if len(reply):
+        return True
+
+    return False
+
+
+def inspirehep_duplicated_validator(inspire_query, property_name):
+    """Check if a record with the same doi already exists.
+
+    Needs to be wrapped in a function with proper validator signature.
+    """
+    if does_exist_in_inspirehep(inspire_query):
+        url = "http://inspirehep.net/search?" + urlencode({'p': inspire_query})
+        raise ValidationError(
+            'There exists already an item with the same %s. '
+            '<a target="_blank" href="%s">See the record.</a>'
+            % (property_name, url)
+        )
+
+
+def duplicated_doi_validator(form, field):
+    """Check if a record with the same doi already exists."""
+    doi = field.data
+    # TODO: local check for duplicates
+    if not doi:
+        return
+    if cfg.get('PRODUCTION_MODE'):
+        inspirehep_duplicated_validator('doi:' + doi, 'DOI')
+
+
+def duplicated_arxiv_id_validator(form, field):
+    """Check if a record with the same arXiv ID already exists."""
+    arxiv_id = field.data
+    # TODO: local check for duplicates
+    if not arxiv_id:
+        return
+    if cfg.get('PRODUCTION_MODE'):
+        inspirehep_duplicated_validator(
+            '035__a:oai:arXiv.org:' + arxiv_id, 'arXiv ID')


### PR DESCRIPTION
One issue, but it's not a problem of the validator itself, rather our import logic: on import, even if there are some validation errors, the id is imported.
