### PR TITLE
workflows: robotupload task improvement

### DIFF
--- a/inspire/modules/workflows/tasks/submission.py
+++ b/inspire/modules/workflows/tasks/submission.py
@@ -22,6 +22,8 @@
 
 """Contains INSPIRE specific submission tasks"""
 
+import os
+
 
 def approve_record(obj, eng):
     """Halt the workflow for approval."""
@@ -30,7 +32,7 @@ def approve_record(obj, eng):
 
 
 def finalize_and_post_process(workflow_name, **kwargs):
-    """Finalizes the submission and starts post-processing."""
+    """Finalize the submission and starts post-processing."""
     def _finalize_and_post_process(obj, eng):
         from invenio.modules.workflows.api import start_delayed
         from invenio.modules.workflows.models import ObjectVersion
@@ -45,21 +47,32 @@ def finalize_and_post_process(workflow_name, **kwargs):
 
 
 def send_robotupload(url):
-    """Gets the MARCXML from the deposit object and ships it."""
-
+    """Get the MARCXML from the deposit object and ships it."""
     def _send_robotupload(obj, eng):
         from invenio.modules.deposit.models import Deposition
+        from invenio.modules.workflows.errors import WorkflowError
         from inspire.utils.robotupload import make_robotupload_marcxml
+        from invenio.base.globals import cfg
 
         d = Deposition(obj)
-        sip = d.get_latest_sip(sealed=False)
-        sip.seal()
+
+        sip = d.get_latest_sip(d.submitted)
+        if not sip:
+            raise WorkflowError("No sip found", eng.uuid, obj.id)
+        if not d.submitted:
+            sip.seal()
+            d.update()
+
+        callback_url = os.path.join(cfg["CFG_SITE_URL"],
+                                    "callback/workflows/continue")
 
         result = make_robotupload_marcxml(
             url=url,
-            marcxml=sip.package
+            marcxml=sip.package,
+            callback_url=callback_url,
+            nonce=obj.id
         )
-        if not "[INFO]" in result.text:
+        if "[INFO]" not in result.text:
             if "cannot use the service" in result.text:
                 # IP not in the list
                 obj.log.error("Your IP is not in CFG_BATCHUPLOADER_WEB_ROBOT_RIGHTS on host")
@@ -70,5 +83,5 @@ def send_robotupload(url):
         else:
             obj.log.info("Robotupload sent!")
             obj.log.info(result.text)
+            eng.halt("Waiting for robotupload: {0}".format(result.text))
     return _send_robotupload
-

--- a/inspire/testsuite/test_robotupload.py
+++ b/inspire/testsuite/test_robotupload.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+#
+## This file is part of INSPIRE.
+## Copyright (C) 2014 CERN.
+##
+## INSPIRE is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## INSPIRE is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+from __future__ import print_function, absolute_import
+from invenio.testsuite import make_test_suite, run_test_suite, InvenioTestCase
+
+import httpretty
+
+
+class RobotUploadTests(InvenioTestCase):
+
+    @httpretty.activate
+    def test_robotupload_bad_xml(self):
+        from inspire.utils.robotupload import make_robotupload_marcxml
+        httpretty.register_uri(
+            httpretty.POST,
+            "http://localhost:4000/batchuploader/robotupload/insert",
+            body="[ERROR] MARCXML is not valid.\n",
+            status=400
+        )
+        invalid_marcxml = "record></record>"
+        response = make_robotupload_marcxml(
+            "http://localhost:4000",
+            invalid_marcxml,
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertTrue("not valid" in response.text)
+
+    @httpretty.activate
+    def test_robotupload_success(self):
+        from inspire.utils.robotupload import make_robotupload_marcxml
+        httpretty.register_uri(
+            httpretty.POST,
+            "http://localhost:4000/batchuploader/robotupload/insert",
+            body="[INFO] bibupload batchupload --insert /dummy/file/path\n",
+            status=200
+        )
+        valid_marcxml = "<record></record>"
+        response = make_robotupload_marcxml(
+            "http://localhost:4000",
+            valid_marcxml,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue("[INFO] bibupload batchupload" in response.text)
+
+    @httpretty.activate
+    def test_robotupload_callback_url(self):
+        from inspire.utils.robotupload import make_robotupload_marcxml
+        body = (
+            "[INFO] bibupload batchupload --insert /some/path"
+            "--callback-url http://localhost"
+        )
+        httpretty.register_uri(
+            httpretty.POST,
+            "http://localhost:4000/batchuploader/robotupload/insert",
+            body=body,
+            status=200
+        )
+        valid_marcxml = "<record></record>"
+        response = make_robotupload_marcxml(
+            "http://localhost:4000",
+            valid_marcxml,
+            callback_url="http://localhost",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue("--callback-url http://localhost" in response.text)
+
+
+TEST_SUITE = make_test_suite(RobotUploadTests)
+
+if __name__ == "__main__":
+    run_test_suite(TEST_SUITE)

--- a/inspire/utils/robotupload.py
+++ b/inspire/utils/robotupload.py
@@ -24,7 +24,7 @@ import os
 import requests
 
 
-def make_robotupload_marcxml(url, marcxml):
+def make_robotupload_marcxml(url, marcxml, **kwargs):
     """Make a robotupload request and return it."""
     from invenio.utils.url import make_user_agent_string
     headers = {
@@ -33,5 +33,9 @@ def make_robotupload_marcxml(url, marcxml):
         "Content-Length": len(marcxml),
     }
     url = os.path.join(url, "batchuploader/robotupload/insert")
-    return requests.post(url, data=marcxml, headers=headers)
-
+    return requests.post(
+        url,
+        data=marcxml,
+        headers=headers,
+        params=kwargs,
+    )


### PR DESCRIPTION
- Improves the new robotupload task to accept additional
  parameters such as callback_url, nonce for use with BibUpload.
- Adds a new URL route /callback/workflow/continue to receive a callback
  structure to continue a workflow.
- Adds tests for robotupload utils.

Signed-off-by: Jan Aage Lavik jan.age.lavik@cern.ch
