### PR TITLE
workflows: holdingpen updates

### DIFF
--- a/inspire/modules/deposit/workflows/literature.py
+++ b/inspire/modules/deposit/workflows/literature.py
@@ -53,6 +53,8 @@ class literature(SimpleRecordDeposition, WorkflowBase):
 
     """Literature deposit submission."""
 
+    object_type = "Submitted record"
+
     workflow = [
         # Pre-fill draft with values passed in from request
         prefill_draft(draft_id='default'),

--- a/inspire/modules/deposit/workflows/literature_simple.py
+++ b/inspire/modules/deposit/workflows/literature_simple.py
@@ -27,6 +27,10 @@ from invenio.modules.deposit.tasks import (
     upload_record_sip
 )
 
+from inspire.modules.workflows.tasks.submission import (
+    halt_to_render
+)
+
 
 from .literature import literature
 
@@ -50,6 +54,9 @@ class literature_simple(literature):
         finalize_record_sip(is_dump=False),
         # Upload the marcxml locally (good for debugging)
         upload_record_sip(),
+        # Needed to update the title and description
+        # columns in holdingpen
+        halt_to_render
     ]
 
     name = "Literature (No approval)"

--- a/inspire/modules/workflows/templates/workflows/styles/harvesting_record.html
+++ b/inspire/modules/workflows/templates/workflows/styles/harvesting_record.html
@@ -22,16 +22,21 @@
 
 {% if identifiers %}
 <p><b>identifiers</b>:
-{% for i in identifiers %}
-    {{i}}
+{% for identifier in identifiers %}
+        {% if 'arxiv' in identifier.lower() %}
+            {% set identifier = identifier.split(':')[-1] %}
+            <br/><a href="http://arxiv.org/abs/{{identifier}}">{{identifier}}</a>
+        {% else %}
+            <br/>{{ identifier }}
+        {% endif %}
 {% endfor %}
 </p>
 {% endif %}
 
 {% if categories %}
 <p><b>categories</b>:
-{% for i in categories %}
-    {{i}}
+{% for category in categories %}
+    <br/>{{category}}
 {% endfor %}
 {% for result in results %}
 	{{result|safe}}

--- a/inspire/modules/workflows/templates/workflows/styles/submission_record.html
+++ b/inspire/modules/workflows/templates/workflows/styles/submission_record.html
@@ -22,16 +22,16 @@
 
 {% if identifiers %}
 <p><b>identifiers</b>:
-{% for i in identifiers %}
-    {{i}}
+{% for identifier in identifiers %}
+    <br/><a href="http://arxiv.org/abs/{{identifier}}">{{identifier}}</a>
 {% endfor %}
 </p>
 {% endif %}
 
 {% if categories %}
 <p><b>categories</b>:
-{% for i in categories %}
-    {{i}}
+{% for category in categories %}
+    <br/>{{category}}
 {% endfor %}
 </p>
 {% endif %}

--- a/inspire/modules/workflows/workflows/ingestion_arxiv_math.py
+++ b/inspire/modules/workflows/workflows/ingestion_arxiv_math.py
@@ -59,7 +59,7 @@ from invenio.modules.workflows.definitions import WorkflowBase
 
 class ingestion_arxiv_math(WorkflowBase):
 
-    object_type = "workflow"
+    object_type = "Workflow"
 
     @staticmethod
     def get_description(bwo):

--- a/inspire/modules/workflows/workflows/process_record_arxiv.py
+++ b/inspire/modules/workflows/workflows/process_record_arxiv.py
@@ -48,7 +48,7 @@ from ..tasks.filtering import inspire_filter_custom
 
 class process_record_arxiv(WorkflowBase):
 
-    object_type = "record"
+    object_type = "Harvested record"
     workflow = [
         convert_record_with_repository("oaiarXiv2inspire_nofilter.xsl"),
         convert_record_to_bibfield,
@@ -119,7 +119,6 @@ class process_record_arxiv(WorkflowBase):
             else:
                 final_identifiers = [' No ids']
 
-        categories = [" No categories"]
         task_results = bwo.get_tasks_results()
         results = []
         if 'bibclassify' in task_results:
@@ -165,7 +164,8 @@ class process_record_arxiv(WorkflowBase):
                             source_list = subject['source']
                         except KeyError:
                             source_list = ""
-                    categories.append(category + "(" + source_list + ")")
+                    if source_list.lower() == 'inspire':
+                        categories.append(category)
 
         from flask import render_template
         return render_template('workflows/styles/harvesting_record.html',
@@ -181,7 +181,6 @@ class process_record_arxiv(WorkflowBase):
         data = bwo.get_data()
         if not data:
             return ''
-        print kwargs
         formatter = kwargs.get("formatter", None)
         format = kwargs.get("format", None)
         if formatter:


### PR DESCRIPTION
- Adds link to arXiv for arXiv identifiers.
- Shows only INSPIRE categories.
- Change the type of process_record_arxiv workflow
  from 'record' to 'Harvested record' to be distinguished
  from submitted records.
- Adds the type 'Submitted record' to literature and
  literature_simple workflows.
- Adds task halt_to_render to literature_simple workflow
  in order to update the title and description columns in holdingpen
  maintable.
