### PR TITLE
deposit: rename /deposit to /submit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ bower.json
 *~
 dump.rdb
 .idea/
+*.mo

--- a/babel.cfg
+++ b/babel.cfg
@@ -1,0 +1,10 @@
+[python: **.py]
+encoding = utf-8
+
+[jinja2: **/templates/**]
+encoding = utf-8
+extensions = jinja2.ext.autoescape.jinja2.ext.with_
+
+;[javascript: **.js]
+;encoding = utf-8
+;extract_messages = $._, jQuery._

--- a/inspire/base/templates/header.html
+++ b/inspire/base/templates/header.html
@@ -53,7 +53,7 @@
           </a>
         </li>
         <li>
-          <a href="/deposit/"> <i class="fa fa-upload"></i>
+          <a href="{{ url_for('webdeposit.index') }}"> <i class="fa fa-upload"></i>
             Submit
           </a>
         </li>

--- a/inspire/base/translations/en/LC_MESSAGES/messages.po
+++ b/inspire/base/translations/en/LC_MESSAGES/messages.po
@@ -1,0 +1,267 @@
+# English translations for Inspire.
+# Copyright (C) 2014 ORGANIZATION
+# This file is distributed under the same license as the Inspire project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2014.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Inspire dev\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2014-09-09 14:22+0200\n"
+"PO-Revision-Date: 2014-09-09 14:25+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: en <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 1.3\n"
+
+#: inspire/base/views.py:39
+msgid "About"
+msgstr ""
+
+#: inspire/base/views.py:46
+msgid "Privacy"
+msgstr ""
+
+#: inspire/base/views.py:53
+msgid "FAQ"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:59
+msgid "Importing data..."
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:60
+msgid "Import data"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:147
+msgid "DOI"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:155
+msgid "ArXiv ID"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:159
+msgid "ISBN"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:164 inspire/modules/deposit/forms.py:365
+msgid " "
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:168
+msgid "Article/Conference paper"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:169
+msgid "Thesis"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:170
+msgid "Book Chapter"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:171
+msgid "Book"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:172
+msgid "Proceedings"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:184
+msgid "Title"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:196
+msgid "Translated Title"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:219
+msgid "Collaboration"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:224 inspire/modules/deposit/forms.py:275
+#: inspire/modules/deposit/forms.py:331
+msgid "Start typing for suggestions"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:225
+msgid "Experiment"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:233
+msgid "Subject"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:239
+msgid "Abstract"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:246
+msgid "Number of Pages"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:251
+msgid "English"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:252
+msgid "French"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:253
+msgid "German"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:254
+msgid "Dutch"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:255
+msgid "Italian"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:256
+msgid "Spanish"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:257
+msgid "Portuguese"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:258
+msgid "Greek"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:259
+msgid "Slovak"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:260
+msgid "Czech"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:261
+msgid "Hungarian"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:262
+msgid "Polish"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:263
+msgid "Norwegian"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:264
+msgid "Swedish"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:265
+msgid "Finnish"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:266
+msgid "Russian"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:267
+msgid "Other"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:270
+msgid "Language"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:276
+msgid "Conference Information"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:277
+msgid "Conference name, acronym, place, date"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:288
+msgid "License URL"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:304
+msgid "Supervisors"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:305
+msgid "Add another supervisor"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:312
+msgid "Date of Defense"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:318
+msgid "Degree type"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:323
+msgid "University"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:332
+msgid "Journal Title"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:339
+msgid "Page Range"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:340
+msgid "e.g. 1-100"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:345
+msgid "Article ID"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:350
+msgid "Volume"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:355
+msgid "Year"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:360
+msgid "Issue"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:385
+msgid "External URL"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:387
+msgid "http://www.example.com"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:409
+msgid "Literature suggestion"
+msgstr ""
+
+#: inspire/modules/deposit/validators/dynamic_fields.py:40
+msgid "Affiliations should have an author name associated."
+msgstr ""
+
+#: inspire/modules/deposit/validators/dynamic_fields.py:43
+msgid "At least one author is required."
+msgstr ""
+
+#: inspire/modules/workflows/actions/inspire_approval.py:32
+msgid "Approve (INSPIRE)"
+msgstr ""
+
+msgid "Deposit"
+msgstr "Submit"
+

--- a/inspire/base/translations/inspire.pot
+++ b/inspire/base/translations/inspire.pot
@@ -1,0 +1,268 @@
+# Translations template for Inspire.
+# Copyright (C) 2014 ORGANIZATION
+# This file is distributed under the same license as the Inspire project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2014.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Inspire dev\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2014-09-09 14:22+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 1.3\n"
+
+#: inspire/base/views.py:39
+msgid "About"
+msgstr ""
+
+#: inspire/base/views.py:46
+msgid "Privacy"
+msgstr ""
+
+#: inspire/base/views.py:53
+msgid "FAQ"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:59
+msgid "Importing data..."
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:60
+msgid "Import data"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:147
+msgid "DOI"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:155
+msgid "ArXiv ID"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:159
+msgid "ISBN"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:164 inspire/modules/deposit/forms.py:365
+msgid " "
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:168
+msgid "Article/Conference paper"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:169
+msgid "Thesis"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:170
+msgid "Book Chapter"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:171
+msgid "Book"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:172
+msgid "Proceedings"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:184
+msgid "Title"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:196
+msgid "Translated Title"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:219
+msgid "Collaboration"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:224 inspire/modules/deposit/forms.py:275
+#: inspire/modules/deposit/forms.py:331
+msgid "Start typing for suggestions"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:225
+msgid "Experiment"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:233
+msgid "Subject"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:239
+msgid "Abstract"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:246
+msgid "Number of Pages"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:251
+msgid "English"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:252
+msgid "French"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:253
+msgid "German"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:254
+msgid "Dutch"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:255
+msgid "Italian"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:256
+msgid "Spanish"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:257
+msgid "Portuguese"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:258
+msgid "Greek"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:259
+msgid "Slovak"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:260
+msgid "Czech"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:261
+msgid "Hungarian"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:262
+msgid "Polish"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:263
+msgid "Norwegian"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:264
+msgid "Swedish"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:265
+msgid "Finnish"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:266
+msgid "Russian"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:267
+msgid "Other"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:270
+msgid "Language"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:276
+msgid "Conference Information"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:277
+msgid "Conference name, acronym, place, date"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:288
+msgid "License URL"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:304
+msgid "Supervisors"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:305
+msgid "Add another supervisor"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:312
+msgid "Date of Defense"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:318
+msgid "Degree type"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:323
+msgid "University"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:332
+msgid "Journal Title"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:339
+msgid "Page Range"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:340
+msgid "e.g. 1-100"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:345
+msgid "Article ID"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:350
+msgid "Volume"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:355
+msgid "Year"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:360
+msgid "Issue"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:385
+msgid "External URL"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:387
+msgid "http://www.example.com"
+msgstr ""
+
+#: inspire/modules/deposit/forms.py:409
+msgid "Literature suggestion"
+msgstr ""
+
+#: inspire/modules/deposit/validators/dynamic_fields.py:40
+msgid "Affiliations should have an author name associated."
+msgstr ""
+
+#: inspire/modules/deposit/validators/dynamic_fields.py:43
+msgid "At least one author is required."
+msgstr ""
+
+#: inspire/modules/workflows/actions/inspire_approval.py:32
+msgid "Approve (INSPIRE)"
+msgstr ""
+
+#: Allows to rename Deposit to Submit
+msgid "Deposit"
+msgstr ""
+

--- a/inspire/config.py
+++ b/inspire/config.py
@@ -131,19 +131,23 @@ PACKAGES = [
     'invenio.base',
 ]
 
+# Configuration related to Deposit module
+
 DEPOSIT_TYPES = [
     'inspire.modules.deposit.workflows.literature.literature',
     'inspire.modules.deposit.workflows.literature_simple.literature_simple',
 ]
 DEPOSIT_DEFAULT_TYPE = "inspire.modules.deposit.workflows.literature:literature"
 
+# Task queue configuration
+
 CELERY_RESULT_BACKEND = "amqp://guest:guest@localhost:5672//"
 BROKER_URL = "amqp://guest:guest@localhost:5672//"
 
+# Site name configuration
+
 CFG_SITE_LANG = u"en"
 CFG_SITE_LANGS = ['en', ]
-
-CFG_SITE_ADMIN_EMAIL = "admin@inspirehep.net"
 
 # CFG_SITE_NAME and main collection name should be the same for empty search
 # to work
@@ -154,6 +158,16 @@ for lang in CFG_SITE_LANGS:
     langs[lang] = u"INSPIRE - High-Energy Physics Literature Database"
 CFG_SITE_NAME_INTL = langs
 
+# Site emails
+
+CFG_SITE_ADMIN_EMAIL = "admin@inspirehep.net"
+
+# Rename blueprint prefixes
+
+BLUEPRINTS_URL_PREFIXES = {'webdeposit': '/submit'}
+
+# For production only, instance_config contains configuration of
+# database credentials and other instance specific configuration
 try:
     from inspire.instance_config import *
 except ImportError:

--- a/inspire/modules/deposit/forms.py
+++ b/inspire/modules/deposit/forms.py
@@ -406,7 +406,7 @@ class LiteratureForm(WebDepositForm):
     #
     # Form Configuration
     #
-    _title = _("Literature suggestion")
+    _title = _("Literature submission")
     # _subtitle = 'Instructions: (i) Press "Save" to save your upload for '\
     #             'editing later, as many times you like. (ii) Upload or remove'\
     #             ' extra files in the bottom of the form. (iii) When ready, '\

--- a/inspire/modules/deposit/static/css/deposit-inspire.css
+++ b/inspire/modules/deposit/static/css/deposit-inspire.css
@@ -50,3 +50,9 @@
 .panel-heading .panel-toggle.collapsed:after {
     content: "\e080"; /* extracted from bootstrap.css */
 }
+
+.vcenter {
+    display: inline-block;
+    vertical-align: middle;
+    float: none;
+}

--- a/inspire/modules/deposit/templates/deposit/deposition_type.html
+++ b/inspire/modules/deposit/templates/deposit/deposition_type.html
@@ -1,0 +1,89 @@
+{#
+## This file is part of Invenio.
+## Copyright (C) 2013, 2014 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#}
+
+{% extends "deposit/deposition_type_base.html" %}
+
+{% block global_bundles %}
+  {{ super() }}
+  {% bundles "deposit.css" %}
+{% endblock %}
+
+{% block body %}
+
+  <div class="page-header">
+    <div class="row">
+      <div class="col-md-6 vcenter">
+        <h3>
+          {{ _(deposition_type.name_plural) }}
+        </h3>
+      </div><!--
+      --><div class="col-md-6 vcenter">
+          <a class="btn btn-primary pull-right"
+             href="{{ url_for('webdeposit.create', deposition_type=deposition_type.get_identifier()) }}">
+            <i class="glyphicon glyphicon-plus"></i> {{ _('New Submission') }}
+          </a>
+      </div>
+    </div>
+  </div>
+
+
+<div class="row">
+  {% if my_depositions %}
+  <h4 class="col-md-offset-1"style="margin-top: 25px;">{{ _('Ongoing submissions') }}</h4>
+  <ul class="nav nav-tabs nav-stacked col-md-offset-3 col-md-6">
+  {% for dep in my_depositions if not dep.has_sip() %}
+    <li> <a href="{{ url_for('webdeposit.run', deposition_type=dep.type.get_identifier(), uuid=dep.id) }}">
+       <i class="glyphicon glyphicon-chevron-right pull-right"></i>
+        <strong>{{ dep.type.name }}: {{ dep.title or _('Untitled') }}</strong>
+    <span style="font-size: 80%;" class="text-muted">{{ dep.modified|invenio_pretty_date }}</span>
+     </a>
+    </li>
+  {% endfor %}
+  </ul>
+  {% else %}
+  <div class="col-md-12">
+    <strong>{{ _('There is no ongoing submission.') }}</strong>
+  </div>
+  {% endif %}
+</div>
+
+{% for dep in my_depositions if dep.has_sip() %}
+{% if loop.first %}
+<div class="row" style="margin-top: 22px;">
+  <ul class="nav nav-list">
+    <li class="divider" style="overflow: visible;"></li>
+  </ul>
+
+  <h4 class="col-md-offset-1"style="margin-top: 25px;">{{ _('Past submissions') }}</h4>
+
+   <ul class="nav nav-tabs nav-stacked col-md-offset-3 col-md-6">
+{% endif %}
+  <li>
+    <a href="{{ url_for('webdeposit.run', deposition_type=dep.type.get_identifier(), uuid=dep.id) }}">
+    <i class="glyphicon glyphicon-chevron-right pull-right"></i>
+    {{ dep.type.name }}: {{ dep.title or _('Untitled') }}
+    </a>
+  </li>
+{% if loop.last %}
+</ul>
+</div>
+{% endif %}
+{% endfor %}
+
+{% endblock %}

--- a/inspire/modules/deposit/workflows/literature.py
+++ b/inspire/modules/deposit/workflows/literature.py
@@ -82,7 +82,7 @@ class literature(SimpleRecordDeposition, WorkflowBase):
     ]
 
     name = "Literature"
-    name_plural = "Literature depositions"
+    name_plural = "Literature submissions"
     group = "Articles & Preprints"
     draft_definitions = {
         'default': LiteratureForm,

--- a/inspire/modules/deposit/workflows/literature_simple.py
+++ b/inspire/modules/deposit/workflows/literature_simple.py
@@ -53,4 +53,4 @@ class literature_simple(literature):
     ]
 
     name = "Literature (No approval)"
-    name_plural = "Literature (No approval) depositions"
+    name_plural = "Literature (No approval) submissions"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,13 @@
+[compile_catalog]
+directory = inspire/base/translations/
+
+[extract_messages]
+output-file = inspire/base/translations/inspire.pot
+
+[init_catalog]
+input-file = inspire/base/translations/inspire.pot
+output-dir = inspire/base/translations/
+
+[update_catalog]
+input-file = inspire/base/translations/inspire.pot
+output-dir = inspire/base/translations/


### PR DESCRIPTION
- Renames all appearances of deposit for submit.
- Adds BLUEPRINTS_URL_PREFIXES to modify deposit url prefix.
- NOTE In order to modify the breadcrum of deposit module and useful
  for the future, introduces Babel configuration to allow translation
  of strings in the overlay. In development mode, to see the translated
  strings, run $ python setup.py compile_catalog
  Translation catalog is compiled automatically if you install
  using $ python setup.py install

Signed-off-by: Javier Martin Montull javier.martin.montull@cern.ch
