### PR TITLE
workflows: delay user email confirmation

### DIFF
--- a/inspire/modules/deposit/workflows/literature.py
+++ b/inspire/modules/deposit/workflows/literature.py
@@ -42,8 +42,7 @@ from inspire.modules.workflows.tasks.submission import (
 
 from inspire.modules.workflows.tasks.actions import was_approved
 from invenio.modules.workflows.tasks.logic_tasks import (
-    workflow_if,
-    workflow_else
+    workflow_if
 )
 from invenio.modules.workflows.definitions import WorkflowBase
 from ...workflows.config import CFG_ROBOTUPLOAD_SUBMISSION_BASEURL
@@ -72,13 +71,7 @@ class literature(SimpleRecordDeposition, WorkflowBase):
         [
             send_robotupload(CFG_ROBOTUPLOAD_SUBMISSION_BASEURL)
         ],
-        workflow_else,
-        [
-            approve_record  # second chance :P
-        ],
         inform_submitter
-        # Upload the marcxml locally (good for debugging)
-        # upload_record_sip(),
     ]
 
     name = "Literature"

--- a/inspire/modules/workflows/tasks/submission.py
+++ b/inspire/modules/workflows/tasks/submission.py
@@ -63,7 +63,9 @@ def inform_submitter(obj, eng):
     id_user = d.workflow_object.id_user
     email = acc_get_user_email(id_user)
     if was_approved(obj, eng):
-        body = 'Accepted'
+        body = 'Accepted: '
+        extra_data = d.workflow_object.get_extra_data()
+        body += extra_data.get('url', '')
     else:
         body = 'Rejected'
     send_email(CFG_SITE_SUPPORT_EMAIL, email, 'Subject', body, header='header')
@@ -110,7 +112,7 @@ def send_robotupload(url):
             d.update()
 
         callback_url = os.path.join(cfg["CFG_SITE_URL"],
-                                    "callback/workflows/continue")
+                                    "callback/workflows/robotupload")
 
         result = make_robotupload_marcxml(
             url=url,

--- a/inspire/modules/workflows/views.py
+++ b/inspire/modules/workflows/views.py
@@ -17,8 +17,12 @@
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 #
 
+import msgpack
+from invenio.ext.cache import cache
 from flask import Blueprint, jsonify, request
+from os.path import join
 from invenio.modules.workflows.models import BibWorkflowObject
+from invenio.config import CFG_SITE_URL
 
 blueprint = Blueprint(
     'inspire_workflows',
@@ -31,7 +35,7 @@ blueprint = Blueprint(
 
 @blueprint.route('/workflows/continue', methods=['POST'])
 def continue_workflow_callback():
-    """Handle callback from robotuploads to continue a workflow.
+    """Handle callback to continue a workflow.
 
     Expects the request data to contain a object ID in the
     nonce field.
@@ -49,3 +53,74 @@ def continue_workflow_callback():
             )
             return jsonify({"result": "success"})
     return jsonify({"result": "failed"})
+
+
+@blueprint.route('/workflows/webcoll', methods=['POST'])
+def webcoll_callback():
+    """Handle a callback from webcoll with the record ids processed.
+
+    Expects the request data to contain a list of record ids in the
+    recids field.
+    """
+    recids = dict(request.form).get('recids', [])
+    try:
+        pending_records = msgpack.loads(cache.get("pending_records"))
+    except TypeError:
+        pending_records = {}
+    if pending_records:
+        pending_records = msgpack.loads(pending_records)
+        for rid in recids:
+            if rid in pending_records:
+                objectid = pending_records[rid]
+                workflow_object = BibWorkflowObject.query.get(objectid)
+                extra_data = workflow_object.get_extra_data()
+                extra_data['url'] = join(CFG_SITE_URL, 'record', str(rid))
+                workflow_object.set_extra_data(extra_data)
+                workflow_object.continue_workflow(delayed=True)
+                del pending_records[rid]
+                cache.set("pending_records", msgpack.dumps(pending_records))
+    return jsonify({"result": "success"})
+
+
+@blueprint.route('/workflows/robotupload', methods=['POST'])
+def robotupload_callback():
+    """Handle callback from robotupload.
+
+    If robotupload was successful caches the workflow
+    object id that corresponds to the uploaded record,
+    so the workflow can be resumed when webcoll finish
+    processing that record.
+    If robotupload encountered an error sends an email
+    to site administrator informing him about the error."""
+    request_data = request.get_json()
+    id_object = request_data.get("nonce", "")
+    results = request_data.get("results", [])
+    for result in results:
+        status = result.get('success', False)
+        if status:
+            recid = result.get('recid')
+            pending_records = cache.get("pending_records")
+            if pending_records:
+                pending_records = msgpack.loads(pending_records)
+                pending_records[str(recid)] = id_object
+                cache.set("pending_records", msgpack.dumps(pending_records))
+            else:
+                cache.set("pending_records", msgpack.dumps({
+                    str(recid): id_object
+                }))
+        else:
+            from invenio.config import CFG_SITE_ADMIN_EMAIL
+            from invenio.ext.email import send_email
+            from invenio.config import CFG_SITE_SUPPORT_EMAIL
+
+            body = ("There was an error when uploading the "
+                    "submission with id: %s.\n" % id_object)
+            body += "Error message:\n"
+            body += result.get('error_message', '')
+            send_email(
+                CFG_SITE_SUPPORT_EMAIL,
+                CFG_SITE_ADMIN_EMAIL,
+                'BATCHUPLOAD ERROR',
+                body
+            )
+    return jsonify({"result": status})


### PR DESCRIPTION
- Adds route callback/workflows/webcoll to wake up
  the workflows that correspond to the record ids
  updated from the webcoll process.
- Caches on the Redis server the record ids that are
  waiting for the webcoll to run, deletes them when
  their workflow is resumed.
- Renames route callback/workflows/continue to
  callback/workflows/robotupload because now the
  workflow only continues in case of rejection of
  the submission.
