### PR TITLE
recordext: more definition updates

### DIFF
--- a/inspire/base/recordext/fields/inspire.cfg
+++ b/inspire/base/recordext/fields/inspire.cfg
@@ -1,12 +1,12 @@
 abstract:
     creator:
         @legacy((("520", "520__", "520__%"), "abstract", ""),
-                ("520__a", "abstract"),
+                ("520__a", "summary"),
                 ("520__h", "hepdata_summary"),
                 ("520__9", "source"))
-        marc, "520__", {'abstract':value['a'], 'hepdata_summary':value['h'], 'source':value['9']}
+        marc, "520__", {'summary':value['a'], 'hepdata_summary':value['h'], 'source':value['9']}
     producer:
-        json_for_marc(), {"520__a": "abstract", "520__h": "hepdata_summary", "520__9": "source"}
+        json_for_marc(), {"520__a": "summary", "520__h": "hepdata_summary", "520__9": "source"}
 
 
 accelerator_experiment:
@@ -464,11 +464,11 @@ title_variation:
 title:
     creator:
         @legacy((("245", "245__", "245__%"), ""),
-                ("245__a", "main"),
+                ("245__a", "title"),
                 ("245__b", "subtitle"),)
-        marc, "245__", {'main':value['a'], 'subtitle':value['b']}
+        marc, "245__", {'title':value['a'], 'subtitle':value['b']}
     producer:
-        json_for_marc(), {"245__a": "main", "245__b": "subtitle"}
+        json_for_marc(), {"245__a": "title", "245__b": "subtitle"}
 
 title_arXiv:
     creator:

--- a/inspire/base/templates/format/record/Inspire_Default_HTML_brief.tpl
+++ b/inspire/base/templates/format/record/Inspire_Default_HTML_brief.tpl
@@ -24,12 +24,12 @@
 
 {% block record_header %}
   <a href="{{ url_for('record.metadata', recid=record['recid']) }}">
-    {{ record.get('title.main', '') }}
+    {{ record.get('title.title', '') }}
     {{- record.get('book_series.volume', '')|prefix(', ') }}
     {{- record.get('title.subtitle', '')|prefix(': ') }}
   </a>
 {% endblock %}
 
 {% block record_content %}
-  {{ record.get('abstract.abstract', '')|sentences(3) }}
+  {{ record.get('abstract.summary', '')|sentences(3) }}
 {% endblock %}


### PR DESCRIPTION
- Changes "title:main" to "title:title" to follow atlantis.cfg and
  MARC standard closer.
- NOTE reload your record configuration by truncating your records_json
  table. Unfortunately existing submissions/workflow objects may have
  problems that it is not up to date.

Signed-off-by: Jan Aage Lavik jan.age.lavik@cern.ch
