### PR TITLE
deposit: datetime picker library modification

### DIFF
--- a/inspire/base/static/js/settings.js
+++ b/inspire/base/static/js/settings.js
@@ -36,10 +36,12 @@ require.config({
         flight: 'vendors/flight/lib',
         bootstrap: 'vendors/bootstrap/dist/js/bootstrap',
         'typeahead': 'vendors/typeahead.js/dist/typeahead.bundle',
+        'moment': 'vendors/moment/moment',
+        'bootstrap-datetimepicker': 'vendors/bootstrap-datetimepicker/src/js/bootstrap-datetimepicker',
         // INSPIRE
         'bootstrap-multiselect': 'vendors/bootstrap-multiselect/js/bootstrap-multiselect',
         'readmore': 'vendors/readmore/readmore',
-        'buckets': 'vendors/buckets/buckets'
+        'buckets': 'vendors/buckets/buckets',
     },
     shim: {
         // Invenio
@@ -49,10 +51,12 @@ require.config({
         "bootstrap" : { deps :['jquery'] },
         'typeahead': { deps :['jquery'],
                        exports: "Bloodhound" },
+        "bootstrap-datetimepicker": { deps: ['jquery', 'bootstrap', 'moment'],
+                                    exports: '$.fn.datetimepicker' },
         // INSPIRE
         "bootstrap-multiselect" : { deps :['jquery'],
                                     exports: '$.fn.multiselect' },
         "readmore" : { deps :['jquery'],
-                                    exports: '$.fn.readmore' }
+                                    exports: '$.fn.readmore' },
     }
 })

--- a/inspire/modules/deposit/templates/deposit/run.html
+++ b/inspire/modules/deposit/templates/deposit/run.html
@@ -57,7 +57,11 @@ require(["jquery", "js/deposit/form", "js/deposit/literature_submission_form", "
       complete_url: complete_url,
       autocomplete_url: autocomplete_url,
       datepicker_element: '.datepicker',
-      datepicker_format: 'yy-mm-dd'
+      datepicker_options: {
+        format: 'YYYY-MM-DD',
+        pickTime: false,
+        maxDate: new Date(),
+      }
     });
 
     $('.pluploader').pluploadWidget({


### PR DESCRIPTION
- Changes the datetime picker library from the jQuery UI to
  bootstrap-datetimepicker.
- Increases the consistency with the Bootstrap design.
- Goes with https://github.com/inspirehep/invenio/pull/116.

Signed-off-by: Pedro Gaudêncio pedro.gaudencio@cern.ch
Co-authored-by: Georgios Kokosioulis georgios.kokosioulis@cern.ch
