### PR TITLE
deposit: fix for duplicated import error messages

### DIFF
--- a/inspire/modules/deposit/static/js/deposit/literature_submission_form.js
+++ b/inspire/modules/deposit/static/js/deposit/literature_submission_form.js
@@ -164,12 +164,8 @@ define(function(require, exports, module) {
       this.hideHiddenFields();
       this.handleTranslatedTitle();
       this.taskmanager = new TaskManager(this.$deposition_type);
-      // flash messages on the Modal
-      this.messageBoxModal = $('#flash-import').messageBox({
-        hoganTemplate: tpl_flash_message,
-      })[0];
       // flash messages on the Form
-      this.messageBoxForm = $('#flash-message').messageBox({
+      this.messageBox = $('#flash-message').messageBox({
         hoganTemplate: tpl_flash_message,
       })[0];
 
@@ -392,39 +388,21 @@ define(function(require, exports, module) {
         // priority mapper for merging the results
         literatureFormPriorityMapper
       ).done(function(result) {
-        that.messageBoxModal.clean();
-        that.messageBoxForm.clean();
-
-        // flash messages on the Form or Modal depending on the state of the message
-        for (var i in result.statusMessage) {
-          if (result.statusMessage[i].state === 'warning') {
-            that.messageBoxForm.append(result.statusMessage);
-          }
-          if (result.statusMessage[i].state === 'success') {
-            that.messageBoxModal.clean();
-            that.messageBoxForm.clean();
-            that.messageBoxModal.append(result.statusMessage);
-          }
-        }
-
-        // clear the messages when user cancel to import data
-        that.$previewModal.one("rejected", function(event) {
-          that.messageBoxModal.clean();
-          that.messageBoxForm.clean();
-        });
-
-        // only fill the form if the user accepts the data
-        that.$previewModal.one("accepted", function(event) {
-          that.$inputs.resetColor();
-          that.$inputs.clearForm();
-          that.fillForm(result.mapping);
-          that.fieldsGroup.resetState();
-          that.showForm();
-        });
-
+        that.messageBox.clean();
         // check if there are any data
         if (result.mapping) {
-          that.previewModal.show(result.mapping);
+          // only fill the form if the user accepts the data
+          that.$previewModal.one("accepted", function(event) {
+            that.$inputs.resetColor();
+            that.$inputs.clearForm();
+            that.fillForm(result.mapping);
+            that.fieldsGroup.resetState();
+            that.showForm();
+          });
+          // show the modal with result
+          that.previewModal.show(result);
+        } else { // show the error messages
+          that.messageBox.append(result.statusMessages);
         }
       });
     },

--- a/inspire/modules/deposit/static/js/deposit/modal_preview.js
+++ b/inspire/modules/deposit/static/js/deposit/modal_preview.js
@@ -25,12 +25,15 @@ define(function(require, exports, module) {
   "use strict";
 
   var $ = require('jquery');
+  var tpl_flash_message = require('hgn!js/deposit/templates/flash_message');
+  require("js/deposit/message_box");
   require("readmore");
 
   function PreviewModal($element, options) {
     this.$element = $element;
     this.$acceptButton = this.$element.find('#acceptData');
     this.$rejectButton = this.$element.find('#rejectData');
+    this.$table = this.$element.find('#data-table')
     this.data = {};
     this.labels = options.labels;
     this.ignoredFields = options.ignoredFields;
@@ -40,12 +43,19 @@ define(function(require, exports, module) {
   PreviewModal.prototype = {
 
     init: function() {
+      this.messageBox = this.$element.find('#flash-import').messageBox({
+        hoganTemplate: tpl_flash_message,
+      })[0];
       this.connectEvents();
     },
 
     show: function(data) {
-      this.data = data;
-      var cloneData = jQuery.extend(true, {}, data);
+      this.data = data.mapping;
+      this.messageBox.clean();
+      if (data.statusMessages) {
+        this.messageBox.append(data.statusMessages);
+      }
+      var cloneData = jQuery.extend(true, {}, this.data);
       this.renderModal(cloneData);
     },
 
@@ -105,7 +115,7 @@ define(function(require, exports, module) {
       });
 
       // populate the body of the modal
-      $('#modalData #data-table').html(table);
+      this.$table.html(table);
 
       // show the modal
       this.$element.modal({

--- a/inspire/modules/deposit/static/js/deposit/task_manager.js
+++ b/inspire/modules/deposit/static/js/deposit/task_manager.js
@@ -119,10 +119,14 @@ define(function(require, exports, module) {
         );
       }
 
-      return {
-        mapping: mergedMapping,
-        statusMessage: messages
-      };
+      var result = {
+        statusMessages: messages
+      }
+      if (Object.keys(mergedMapping).length) {
+        result.mapping = mergedMapping
+      }
+
+      return result;
     },
   };
   module.exports = TaskManager;


### PR DESCRIPTION
fixes a following bug:
After import, when it fails, the failure warnings are duplicated.
