### PR TITLE
deposit: updates to arXiv fulltext task

### DIFF
--- a/inspire/modules/deposit/workflows/literature.py
+++ b/inspire/modules/deposit/workflows/literature.py
@@ -79,12 +79,12 @@ class literature(SimpleRecordDeposition, WorkflowBase):
         # Process metadata to match your JSONAlchemy record model. This will
         # call process_sip_metadata() on your subclass.
         process_sip_metadata(),
-        # Get FFT from arXiv, if arXiv ID is provided
-        arxiv_fft_get,
-        add_files_to_task_results,
         # Generate MARC based on metadata dictionary.
         finalize_record_sip(is_dump=False),
         halt_to_render,
+        # Get FFT from arXiv, if arXiv ID is provided
+        arxiv_fft_get,
+        add_files_to_task_results,
         classify_paper_with_deposit(
             taxonomy="HEPont.rdf",
             output_mode="dict",


### PR DESCRIPTION
- Updates the arXiv automatic fulltext downloader with various
  fixes and enhancements:
- Moves the download task in the workflow to after user confirmation
  to avoid users to wait for the download in the background.
- Fixes an exception if there was one file attached already
  (then metadata["fft"] is not a list but a dict).
- Hardcodes the filename to be equal to "1234.1234.pdf" to be
  consistent with user file upload names.
- Removes the call to secure_filename as this is anyway called
  in DepositionFile.

Signed-off-by: Jan Aage Lavik jan.age.lavik@cern.ch

@pedrogaudencio 
