### PR TITLE
recordext: external_key to value change

### DIFF
--- a/inspire/base/recordext/fields/inspire.cfg
+++ b/inspire/base/recordext/fields/inspire.cfg
@@ -417,12 +417,12 @@ spires_sysno:
 system_number_external, system_control_number:
   creator:
         @legacy((("035", "035__", "035__%"), ""),
-                ("035__a", "external_key"),
+                ("035__a", "value"),
                 ("035__z", "obsolete"),
                 ("035__9", "institute"))
-        marc, "035__", {'external_key': value['a'], 'obsolete':value['z'], 'institute':value['9']}
+        marc, "035__", {'value': value['a'], 'obsolete':value['z'], 'institute':value['9']}
     producer:
-        json_for_marc(), {"035__a": "external_key", "035__z": "obsolete", "035__9": "institute"}
+        json_for_marc(), {"035__a": "value", "035__z": "obsolete", "035__9": "institute"}
 
 thesaurus_terms:
     creator:

--- a/inspire/modules/deposit/workflows/literature.py
+++ b/inspire/modules/deposit/workflows/literature.py
@@ -295,7 +295,7 @@ class literature(SimpleRecordDeposition, WorkflowBase):
                         metadata['subject_term'].extend(subject_list)
                     else:
                         metadata['subject_term'] = subject_list
-                metadata['system_number_external'] = {'external_key': 'oai:arXiv.org:' + metadata['arxiv_id'],
+                metadata['system_number_external'] = {'value': 'oai:arXiv.org:' + metadata['arxiv_id'],
                                                       'institute': 'arXiv'}
                 metadata['collections'].extend([{'primary': "arXiv"}, {'primary': "Citeable"}])
 


### PR DESCRIPTION
- Changes the system_control_number 035__a value back to "value"
  in order to be compatible with lookups in Invenio.

Signed-off-by: Jan Aage Lavik jan.age.lavik@cern.ch

@pedrogaudencio  @jmartinm  This is better for the short term, as things in Invenio expect "value" instead of "external_key". 

Remember when changing the config, to check if other modules expects the old value. For example, a "report_number" subfield now is called "primary" which is not expected by some workflow tasks in our overlay. I will fix the latter on my side as part of #132 as I could not find any use of "report_number" in Invenio core. 

Anyway, this goes towards fully syncing Atlantis.cfg and inspire.cfg where we only have additions and not corrections that causes code lookups to break. See https://github.com/inveniosoftware/invenio/issues/2075
