### PR TITLE
deposit: hide-element class only if DEBUG

### DIFF
--- a/inspire/modules/deposit/templates/deposit/run_group_start.html
+++ b/inspire/modules/deposit/templates/deposit/run_group_start.html
@@ -20,7 +20,7 @@
 {# Adss mandatory indicator for required fields and wraps the rest of the form to hide it #}
 {% if idx == 2 %}
   <div class="hide-element" id="mandatory-indicator" style="color: red;">&#42; Mandatory</div><br>
-  <div class="form-wrapper hide-element">
+  <div class="form-wrapper {% if config["DEBUG"] != True %}hide-element{% endif %}">
 {% endif %}
 
 <div class="panel panel-default">


### PR DESCRIPTION
- It hides the rest of the form if it's not in DEBUG mode.

@jmartinm do we want this or should we take a closer look to the hiding the form only if it's a new one?
