### PR TITLE
deposit: fix for import

### DIFF
--- a/inspire/modules/deposit/forms.py
+++ b/inspire/modules/deposit/forms.py
@@ -535,7 +535,7 @@ class LiteratureForm(WebDepositForm):
         default=False,
         widget=CheckboxButton(msg=_('I confirm I have read the License Agreement')),
         validators=[required_if('file_field',
-                                [lambda x: bool(len(x)), ],  # non-empty
+                                [lambda x: x and len(x), ],  # non-empty
                                 message=_("Please, check this box to upload material.")
                                 ),
                     ]


### PR DESCRIPTION
- Allows to validate None as the state of ok_to_upload checkbox.
  This is the case when the form is validated partially i.e. during
  the import.

Signed-off-by: Kamil Neczaj kamil.neczaj@cern.ch
