### PR TITLE
deposit: adaptation to checkbox handling change

### DIFF
--- a/inspire/modules/deposit/forms.py
+++ b/inspire/modules/deposit/forms.py
@@ -534,12 +534,16 @@ class LiteratureForm(WebDepositForm):
         label="",
         default=False,
         widget=CheckboxButton(msg=_('I confirm I have read the License Agreement')),
-        validators=[required_if('file_field',
-                                [lambda x: bool(len(x)), ],  # non-empty
-                                message=_("Please, check this box to upload material.")
-                                ),
-                    ]
-        )
+        validators=[
+            required_if(
+                'file_field',
+                lambda x: bool(len(x)),  # non-empty
+                # FIXME speaklater._LazyString is not serializable
+                # solution http://stackoverflow.com/questions/26124581/flask-json-serializable-error-because-of-flask-babel
+                # message=_("Please, check this box to upload material.")
+            ),
+        ]
+    )
 
     #
     # Form Configuration


### PR DESCRIPTION
adaptation to https://github.com/inspirehep/invenio/pull/151 as `test` parameter format changed.

There is a problem with setting a custom message. I wonder how it was working before. Probably there will be a need to add a json serializer for LazyString sooner or later as described in the FIXME line above.