### PR TITLE
workflows: core_approval rejection fix

### DIFF
--- a/inspire/modules/workflows/actions/core_approval.py
+++ b/inspire/modules/workflows/actions/core_approval.py
@@ -37,18 +37,26 @@ class core_approval(object):
 
     def render_mini(self, obj):
         """Method to render the minified action."""
+        email = acc_get_user_email(obj.id_user)
+        rejection_text = "\n".join([line.strip() for line in render_template(
+            'deposit/tickets/user_rejected.html',
+            email=email
+        ).split("\n")])
         return render_template(
             'workflows/actions/core_approval_mini.html',
             message=obj.get_action_message(),
             object=obj,
             resolve_url=self.url,
+            rejection_text=rejection_text
         )
 
     def render(self, obj):
         """Method to render the action."""
         email = acc_get_user_email(obj.id_user)
-        rejection_text = render_template('deposit/tickets/user_rejected.html',
-                                         email=email)
+        rejection_text = "\n".join([line.strip() for line in render_template(
+            'deposit/tickets/user_rejected.html',
+            email=email
+        ).split("\n")])
         return {
             "side": render_template('workflows/actions/core_approval_side.html',
                                     message=obj.get_action_message(),

--- a/inspire/modules/workflows/tasks/submission.py
+++ b/inspire/modules/workflows/tasks/submission.py
@@ -144,7 +144,7 @@ def reply_ticket(template=None):
             )
         else:
             # Body already rendered in reason.
-            body = obj.extra_data.get("reason")
+            body = obj.extra_data.get("reason").strip()
         if not body:
             raise WorkflowError("No body for ticket reply")
         # Trick to prepare ticket body

--- a/inspire/modules/workflows/templates/workflows/actions/core_approval_mini.html
+++ b/inspire/modules/workflows/templates/workflows/actions/core_approval_mini.html
@@ -48,7 +48,9 @@
         <form role="form">
           <div class="form-group">
             <label for="message-text" class="control-label">Explain why this was rejected (is sent directly to user):</label>
-            <textarea class="form-control" id="message-text-{{object.id}}">
+            <textarea class="form-control"
+                      id="message-text-{{object.id}}"
+                      cols="50" rows="15">
               {{ rejection_text }}
             </textarea>
           </div>

--- a/inspire/modules/workflows/templates/workflows/actions/core_approval_side.html
+++ b/inspire/modules/workflows/templates/workflows/actions/core_approval_side.html
@@ -50,7 +50,9 @@
         <form role="form">
           <div class="form-group">
             <label for="message-text" class="control-label">Explain why this was rejected (is sent directly to user):</label>
-            <textarea class="form-control" id="message-text-{{object.id}}">
+            <textarea class="form-control"
+                      id="message-text-{{object.id}}"
+                      cols="50" rows="15">
               {{ rejection_text }}
             </textarea>
           </div>


### PR DESCRIPTION
* Improves the default layout of the rejection modal for the
  core_approval action. Also pre-fills rejection text in the mini
  action.

* Strips the content to the reply_ticket body when taken from the
  rejection text.

Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>