### PR TITLE
forms: initial commit

### DIFF
--- a/inspire/config.py
+++ b/inspire/config.py
@@ -78,6 +78,7 @@ PACKAGES = [
     'inspire.modules.deposit',
     'inspire.modules.access',
     'inspire.modules.harvester',
+    'inspire.modules.forms',
     'invenio.modules.access',
     'invenio.modules.accounts',
     'invenio.modules.alerts',

--- a/inspire/modules/forms/__init__.py
+++ b/inspire/modules/forms/__init__.py
@@ -1,0 +1,18 @@
+#
+## This file is part of INSPIRE.
+## Copyright (C) 2015 CERN.
+##
+## INSPIRE is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## INSPIRE is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#

--- a/inspire/modules/forms/bundles.py
+++ b/inspire/modules/forms/bundles.py
@@ -1,0 +1,27 @@
+#
+## This file is part of INSPIRE.
+## Copyright (C) 2015 CERN.
+##
+## INSPIRE is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## INSPIRE is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#
+
+from invenio.ext.assets import Bundle
+
+styles = Bundle(
+    "less/forms/form.less",
+    output="form.css",
+    filters="less,cleancss",
+    weight=51
+)

--- a/inspire/modules/forms/field_base.py
+++ b/inspire/modules/forms/field_base.py
@@ -1,0 +1,44 @@
+#
+## This file is part of INSPIRE.
+## Copyright (C) 2015 CERN.
+##
+## INSPIRE is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## INSPIRE is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#
+
+from wtforms import Field
+
+__all__ = ('InspireField', )
+
+
+class InspireField(Field):
+
+    """Base field that all fields in INSPIRE should inherit from."""
+
+    def __init__(self, *args, **kwargs):
+        self.placeholder = kwargs.pop('placeholder', None)
+        self.icon = kwargs.pop('icon', None)
+        self.export_key = kwargs.pop('export_key', None)
+        self.widget_classes = kwargs.pop('widget_classes', None)
+
+        super(InspireField, self).__init__(*args, **kwargs)
+
+    def __call__(self, *args, **kwargs):
+        if 'placeholder' not in kwargs and self.placeholder:
+            kwargs['placeholder'] = self.placeholder
+        if 'class_' in kwargs and self.widget_classes:
+            kwargs['class_'] = kwargs['class_'] + self.widget_classes
+        elif self.widget_classes:
+            kwargs['class_'] = self.widget_classes
+        return super(InspireField, self).__call__(*args, **kwargs)

--- a/inspire/modules/forms/fields/__init__.py
+++ b/inspire/modules/forms/fields/__init__.py
@@ -1,0 +1,20 @@
+#
+## This file is part of INSPIRE.
+## Copyright (C) 2015 CERN.
+##
+## INSPIRE is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## INSPIRE is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#
+
+from .wtformsext import *

--- a/inspire/modules/forms/fields/wtformsext.py
+++ b/inspire/modules/forms/fields/wtformsext.py
@@ -1,0 +1,44 @@
+#
+## This file is part of INSPIRE.
+## Copyright (C) 2015 CERN.
+##
+## INSPIRE is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## INSPIRE is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#
+
+import wtforms
+
+from ..field_base import InspireField
+
+__all__ = []
+
+for attr_name in dir(wtforms):
+    attr = getattr(wtforms, attr_name)
+    try:
+        if issubclass(attr, wtforms.Field):
+            # From a WTForm field, dynamically create a new class the same name
+            # as the WTForm field (inheriting from InspireField() and the
+            # WTForm field itself). Store the new class in the current module
+            # with the same name as the WTForms.
+            #
+            # For further information please see Python reference documentation
+            # for globals() and type() functions.
+            globals()[attr_name] = type(
+                str(attr_name),
+                (InspireField, attr),
+                {}
+            )
+            __all__.append(attr_name)
+    except TypeError:
+        pass

--- a/inspire/modules/forms/form.py
+++ b/inspire/modules/forms/form.py
@@ -1,0 +1,76 @@
+#
+## This file is part of INSPIRE.
+## Copyright (C) 2015 CERN.
+##
+## INSPIRE is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## INSPIRE is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#
+
+from flask.ext.wtf import Form
+
+CFG_GROUPS_META = {
+    'classes': None,
+    'indication': None,
+    'description': None
+}
+
+
+class InspireForm(Form):
+
+    """Generic Form class to be used in INSPIRE forms. """
+
+    def __init__(self, *args, **kwargs):
+        super(InspireForm, self).__init__(*args, **kwargs)
+
+    def get_groups(self):
+        """Get a list of the (group metadata, list of fields)-tuples.
+
+        The last element of the list has no group metadata (i.e. None),
+        and contains the list of fields not assigned to any group.
+        """
+        fields_included = set()
+        field_groups = []
+
+        if hasattr(self, 'groups'):
+            for group in self.groups:
+                group_obj = {
+                    'name': group[0],
+                    'meta': CFG_GROUPS_META.copy(),
+                }
+
+                fields = []
+                for field_name in group[1]:
+                    if field_name in ['-', ]:
+                        fields.append(field_name)
+                    else:
+                        try:
+                            fields.append(self[field_name])
+                            fields_included.add(field_name)
+                        except KeyError:
+                            pass
+
+                if len(group) == 3:
+                    group_obj['meta'].update(group[2])
+
+                field_groups.append((group_obj, fields))
+
+        # Append missing fields not defined in groups
+        rest_fields = []
+        for field in self:
+            if field.name not in fields_included:
+                rest_fields.append(field)
+        if rest_fields:
+            field_groups.append((None, rest_fields))
+
+        return field_groups

--- a/inspire/modules/forms/static/less/forms/form.less
+++ b/inspire/modules/forms/static/less/forms/form.less
@@ -1,5 +1,4 @@
 /**
- * -*- mode: text; coding: utf-8; -*-
  *
  * This file is part of INSPIRE.
  * Copyright (C) 2015 CERN.

--- a/inspire/modules/forms/static/less/forms/form.less
+++ b/inspire/modules/forms/static/less/forms/form.less
@@ -1,0 +1,28 @@
+/**
+ * -*- mode: text; coding: utf-8; -*-
+ *
+ * This file is part of INSPIRE.
+ * Copyright (C) 2015 CERN.
+
+ * INSPIRE is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * Invenio is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Invenio; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+@media (min-width: 1200px) {
+    #form_container {
+        width: 970px;
+        float: none;
+        margin: 0 auto;
+    }
+}

--- a/inspire/modules/forms/templates/forms/action_bar.html
+++ b/inspire/modules/forms/templates/forms/action_bar.html
@@ -1,0 +1,28 @@
+{#
+## This file is part of INSPIRE.
+## Copyright (C) 2015 CERN.
+##
+## INSPIRE is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## INSPIRE is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#}
+
+<div class="well action-bar hide-element"{% if margin %}style="margin-top: {{margin}}"{% endif %}>
+    <a class="btn btn-danger pull-left" href="#"><i class="fa fa-trash-o fa-lg"></i> {{ _('Delete') }}</a>
+    <span class="pull-right">
+        <span class="loader hide"><img src="{{ url_for('static', filename='img/loading.gif' ) }}" /></span>
+        <span class="status-indicator text-muted"></span>&nbsp;
+        <button title="{{_('Press Submit to finalize your upload.')}}" class="btn btn-success form-submit"><i class="fa fa-check-circle fa-lg"></i> {{ _('Submit') }}</button>
+    </span>
+    <span class="clearfix"></span>
+</div>

--- a/inspire/modules/forms/templates/forms/field.html
+++ b/inspire/modules/forms/templates/forms/field.html
@@ -1,0 +1,43 @@
+{#
+## This file is part of INSPIRE.
+## Copyright (C) 2015 CERN.
+##
+## INSPIRE is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## INSPIRE is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#}
+
+{%- if thisfield == '-' %}
+  <hr />
+{%- else %}
+  {%- if thisfield.widget_classes -%}
+    {% set field_class = thisfield.widget_classes %}
+  {% else %}
+    {% set field_class = field_class %}
+  {%- endif -%}
+  {%- set field_size = ("col-md-9 col-md-offset-3" if not thisfield.label.text else "col-md-9") if field_size is none else field_size -%}
+  <div class="{{container_class}} {{ "error" if thisfield.errors }}" id="state-group-{{ thisfield.name }}"{% if thisfield.flags.hidden %} style="display:none;"{% endif %}>
+      {{ field_label(thisfield) }}
+      <div id="field-{{ thisfield.name }}" class="{{field_size}}">
+          {{ thisfield(class_= field_class + " " + thisfield.short_name, **field_kwargs) }}
+          {%- if thisfield.description %}
+              <p class="text-muted field-desc"><small>{{thisfield.description|urlize}}</small></p>
+          {%- endif %}
+          <div class="alert help-block alert-danger" id="state-{{ thisfield.name }}" style="margin-top: 5px;{% if thisfield.errors %} display:block;{% else%} display: none;{% endif %}">
+              {%- for error in thisfield.errors %}
+                  <div>{{ error }}</div>
+              {%- endfor %}
+          </div>
+      </div>
+  </div>
+{%- endif %}

--- a/inspire/modules/forms/templates/forms/field_label.html
+++ b/inspire/modules/forms/templates/forms/field_label.html
@@ -1,0 +1,28 @@
+{#
+## This file is part of INSPIRE.
+## Copyright (C) 2015 CERN.
+##
+## INSPIRE is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## INSPIRE is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#}
+
+{% if thisfield.label.text %}
+    <label class="control-label col-md-3 {{' required' if thisfield.flags.required}}{{ ' error' if thisfield.errors }}" for="{{thisfield.label.field_id}}">
+        {%- if thisfield.icon %}
+            <span class=""><i class="{{ thisfield.icon }}"></i></span>
+        {%- endif %}
+        {{ thisfield.label.text }}
+    </label>
+{% endif %}
+

--- a/inspire/modules/forms/templates/forms/form.html
+++ b/inspire/modules/forms/templates/forms/form.html
@@ -1,0 +1,119 @@
+{#
+## This file is part of INSPIRE.
+## Copyright (C) 2015 CERN.
+##
+## INSPIRE is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## INSPIRE is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#}
+{%- extends "page.html" -%}
+
+{% block global_bundles %}
+  {{ super() }}
+  {% bundles "form.css" %}
+{% endblock %}
+
+{% macro form_action_bar(margin="") -%}
+  {% block form_action_bar scoped %}
+    {% include "forms/action_bar.html" %}
+  {% endblock %}
+{%- endmacro %}
+
+{%- macro form_group_accordion_start(group, idx) -%}
+    {% include "forms/group_start.html" %}
+{%- endmacro -%}
+
+{%- macro field_label(thisfield) -%}
+    {% include "forms/field_label.html" %}
+{%- endmacro -%}
+
+{%- macro field_display(thisfield, field_size=None, field_class="form-control", container_class="form-group") -%}
+  {%- set field_size = field_size if field_size else (form.field_sizes.get(thisfield.name) if form.field_sizes else none) -%}
+  {%- set field_kwargs = kwargs -%}
+  {% include "forms/field.html" %}
+{%- endmacro -%}
+
+{% block form_submit_dialog %}
+<div id="form-submit-dialog" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="{{id}}Label" aria-hidden="true">
+    <div class="modal-dialog">
+    <div class="modal-content">
+        <div class="modal-body">
+            <div align="center" id="{{id}}Label">{{ _('Submitting') }} <img src="/img/loading.gif" /></div>
+        </div>
+    </div>
+    </div>
+</div>
+{% endblock form_submit_dialog %}
+
+{% block body %}
+<div class="row">
+  <div id="form_container" class="col-md-12 form-feedback-warning">
+    <div id="flash-message"></div>
+    <form enctype="multipart/form-data" name="{{ name }}" id="{{ id }}" role="form" class="form-horizontal" method="post" action="{{ action }}">
+        {% block form_title scoped %}
+          <h1>{{ form._title }}</h1>
+          {% if form._subtitle %}
+              <p class="text-muted">
+                <small>{{ form._subtitle|safe }}</small>
+              </p>
+          {% endif %}
+        {% endblock form_title %}
+
+        {% block form_body scoped %}
+          {{ form.hidden_tag() }}
+          {% for group, fields in form.get_groups() %}
+            {% set grouploop = loop %}
+            {% block form_group scoped %}
+              {% if grouploop.first %}
+                <div id="webdeposit_form_accordion">
+              {% endif %}
+              {% block form_group_header scoped %}
+                {% if group %}
+                  {{ form_group_accordion_start(group, grouploop.index) }}
+                {% endif %}
+              {% endblock %}
+
+              {% block form_group_body scoped %}
+                {% if group and group.meta.description %}
+                  <p>{{ group.meta.description|urlize }}</p>
+                {% endif %}
+
+                {% block fieldset scoped %}
+                {% for field in fields if field.widget.input_type != 'hidden' %}
+                  {% block field_body scoped %}
+                      {{ field_display(field) }}
+                  {% endblock field_body %}
+                {% endfor %}
+                {% endblock fieldset %}
+              {% endblock form_group_body%}
+
+              {% block form_group_footer scoped %}
+                {% if group %}
+                  </div></div></div>
+                {% endif %}
+
+              {% endblock form_group_footer %}
+
+              {% if grouploop.last %}
+                </div>
+              {% endif %}
+            {% endblock form_group %}
+          {% endfor %}
+        {% endblock form_body %}
+        {% block form_footer scoped %}
+          {{ form_action_bar() }}
+        {% endblock form_footer %}
+    </form>
+  </div>
+</div>
+{% endblock body %}

--- a/inspire/modules/forms/templates/forms/form_demo.html
+++ b/inspire/modules/forms/templates/forms/form_demo.html
@@ -1,0 +1,19 @@
+{#
+## This file is part of INSPIRE.
+## Copyright (C) 2015 CERN.
+##
+## INSPIRE is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## INSPIRE is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#}
+{%- extends "forms/form.html" -%}

--- a/inspire/modules/forms/templates/forms/form_demo_success.html
+++ b/inspire/modules/forms/templates/forms/form_demo_success.html
@@ -1,0 +1,23 @@
+{#
+## This file is part of INSPIRE.
+## Copyright (C) 2015 CERN.
+##
+## INSPIRE is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## INSPIRE is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#}
+{%- extends "page.html" -%}
+
+{% block body %}
+<div class="alert alert-success" role="alert">Form was submitted with success!</div>
+{% endblock body %}

--- a/inspire/modules/forms/templates/forms/group_start.html
+++ b/inspire/modules/forms/templates/forms/group_start.html
@@ -1,0 +1,37 @@
+{#
+## This file is part of INSPIRE.
+## Copyright (C) 2015 CERN.
+##
+## INSPIRE is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## INSPIRE is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#}
+
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <a data-toggle="collapse" class="panel-toggle{{ ' collapsed' if group.meta.classes is not none else '' }}" href="#collapse-{{ idx }}"> {{ group.name }}
+      <span class="pull-right show-on-collapsed">
+        <i class="glyphicon glyphicon-chevron-right">
+        </i>
+      </span>
+      <span class="pull-right hide-on-collapsed">
+        <i class="glyphicon glyphicon-chevron-down">
+        </i>
+      </span>
+    </a>
+    {% if group.meta.indication %}
+      <span class="text-muted pull-right" style="padding-right: 10px;">{{ group.meta.indication }}</span>
+    {% endif %}
+  </div>
+  <div id="collapse-{{ idx }}" class="panel-collapse collapse {{ 'in' if group.meta.classes is none else group.meta.classes }}">
+  <div class="panel-body">

--- a/inspire/modules/forms/templates/holdingpen/demoform.html
+++ b/inspire/modules/forms/templates/holdingpen/demoform.html
@@ -1,0 +1,25 @@
+{#
+## This file is part of INSPIRE.
+## Copyright (C) 2015 CERN.
+##
+## INSPIRE is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## INSPIRE is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#}
+
+<dl>
+{% for key, value in data.iteritems() %}
+    <dt>{{ key|e }}</dt>
+    <dd>{{ value|e }}</dd>
+{% endfor %}
+</dl>

--- a/inspire/modules/forms/utils.py
+++ b/inspire/modules/forms/utils.py
@@ -1,0 +1,128 @@
+#
+## This file is part of INSPIRE.
+## Copyright (C) 2015 CERN.
+##
+## INSPIRE is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## INSPIRE is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#
+
+from wtforms import Field, FieldList, Form, FormField
+
+
+class FormVisitor(object):
+    """
+    Generic form visitor to iterate over all fields in a form. See DataExporter
+    for example how to export all data.
+    """
+    def visit(self, form_or_field):
+        if isinstance(form_or_field, FormField):
+            self.visit_formfield(form_or_field)
+        elif isinstance(form_or_field, FieldList):
+            self.visit_fieldlist(form_or_field)
+        elif isinstance(form_or_field, Form):
+            self.visit_form(form_or_field)
+        elif isinstance(form_or_field, Field):
+            self.visit_field(form_or_field)
+
+    def visit_form(self, form):
+        for field in form:
+            self.visit(field)
+
+    def visit_field(self, field):
+        pass
+
+    def visit_fieldlist(self, fieldlist):
+        for field in fieldlist.get_entries():
+            self.visit(field)
+
+    def visit_formfield(self, formfield):
+        self.visit(formfield.form)
+
+
+class DataExporter(FormVisitor):
+    """
+    Visitor to export form data into dictionary supporting filtering and key
+    renaming.
+
+    Usage::
+        form = ...
+        visitor = DataExporter(filter_func=lambda f: not f.flags.disabled)
+        visitor.visit(form)
+
+    Given e.g. the following form::
+
+        class MyForm(WebDepositForm):
+            title = TextField(export_key='my_title')
+            notes = TextAreaField()
+            authors = FieldList(FormField(AuthorForm))
+
+    the visitor will export a dictionary similar to::
+
+        {'my_title': ..., 'notes': ..., authors: [{...}, ...], }
+    """
+    def __init__(self, filter_func=None):
+        self.data = {}
+        self.data_stack = [self.data]
+
+        if filter_func is not None:
+            self.filter_func = filter_func
+        else:
+            self.filter_func = lambda f: True
+
+    def _export_name(self, field):
+        """ Get dictionary key - defaults to field name """
+        return field.export_key if getattr(field, 'export_key', None) \
+            else field.short_name
+
+    #
+    # Stack helper methods
+    #
+    def _top_stack_element(self):
+        return self.data_stack[-1]
+
+    def _pop_stack(self):
+        self.data_stack.pop()
+
+    def _push_stack(self, field, prototype):
+        data = self._top_stack_element()
+
+        if isinstance(data, list):
+            data.append(prototype)
+            self.data_stack.append(data[-1])
+        else:
+            data[self._export_name(field)] = prototype
+            self.data_stack.append(data[self._export_name(field)])
+
+    #
+    # Visit methods
+    #
+    def visit_field(self, field):
+        if (self.filter_func)(field):
+            data = self._top_stack_element()
+            if isinstance(data, list):
+                data.append(field.data)
+            else:
+                data[self._export_name(field)] = field.data
+
+    def visit_formfield(self, formfield):
+        if (self.filter_func)(formfield):
+            self._push_stack(formfield, {})
+            super(DataExporter, self).visit_formfield(formfield)
+            self._pop_stack()
+
+    def visit_fieldlist(self, fieldlist):
+        if (self.filter_func)(fieldlist):
+            self._push_stack(fieldlist, [])
+            super(DataExporter, self).visit_fieldlist(fieldlist)
+            self._pop_stack()

--- a/inspire/modules/forms/views.py
+++ b/inspire/modules/forms/views.py
@@ -1,0 +1,82 @@
+#
+## This file is part of INSPIRE.
+## Copyright (C) 2015 CERN.
+##
+## INSPIRE is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## INSPIRE is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#
+
+from flask import Blueprint, render_template, url_for
+
+from inspire.modules.forms import fields
+
+from invenio.base.i18n import _
+
+from wtforms.validators import DataRequired
+
+from .form import InspireForm
+
+
+blueprint = Blueprint(
+    'inspire_forms',
+    __name__,
+    url_prefix='/forms',
+    template_folder='templates',
+    static_folder="static",
+)
+
+
+class DemoForm(InspireForm):
+
+    """Demo sample Form."""
+
+    nickname = fields.StringField(
+        _("Nickname"),
+        validators=[DataRequired(message=_("Nickname not provided"))],
+        placeholder="My placeholder",
+        description="My description",
+        export_key="custom_nickname_key"
+        )
+    password = fields.PasswordField(_("Password"))
+    referer = fields.HiddenField()
+    login_method = fields.HiddenField()
+
+    _title = _("Demo INSPIRE form")
+
+    groups = [
+        ('Personal information',
+            ['nickname', 'password']),
+    ]
+
+
+@blueprint.route('/demoform', methods=['GET', 'POST'])
+def demoform():
+    """View for INSPIRE demo form."""
+    # from inspire.modules.forms.utils import DataExporter
+
+    form = DemoForm(data={"nickname": "John Doe"})
+    ctx = {
+        "action": url_for('.demoform'),
+        "name": "inspireForm",
+        "id": "inspireForm",
+    }
+    if form.validate_on_submit():
+        # If it is needed to post process the form keys, for example to match
+        # the names in the JSONAlchemy, one can use the DataExporter.
+        # The keys will then be renamed using `export_key` parameter.
+        # visitor = DataExporter()
+        # visitor.visit(form)
+        # visitor.data
+        return render_template('forms/form_demo_success.html', form=form)
+    return render_template('forms/form_demo.html', form=form, **ctx)

--- a/inspire/modules/forms/views.py
+++ b/inspire/modules/forms/views.py
@@ -78,5 +78,12 @@ def demoform():
         # visitor = DataExporter()
         # visitor.visit(form)
         # visitor.data
+        from invenio.modules.workflows.models import BibWorkflowObject
+        from flask.ext.login import current_user
+        myobj = BibWorkflowObject.create_object(id_user=current_user.get_id())
+        myobj.set_data(form.data)
+        # Start workflow. delayed=True will execute the workflow in the
+        # background using, for example, Celery.
+        myobj.start_workflow("demoworkflow", delayed=True)
         return render_template('forms/form_demo_success.html', form=form)
     return render_template('forms/form_demo.html', form=form, **ctx)

--- a/inspire/modules/forms/workflows/__init__.py
+++ b/inspire/modules/forms/workflows/__init__.py
@@ -1,0 +1,18 @@
+#
+## This file is part of INSPIRE.
+## Copyright (C) 2015 CERN.
+##
+## INSPIRE is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## INSPIRE is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#

--- a/inspire/modules/forms/workflows/demoworkflow.py
+++ b/inspire/modules/forms/workflows/demoworkflow.py
@@ -1,0 +1,70 @@
+#
+## This file is part of INSPIRE.
+## Copyright (C) 2015 CERN.
+##
+## INSPIRE is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## INSPIRE is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#
+
+from flask import render_template
+
+from invenio.modules.workflows.definitions import WorkflowBase
+from invenio.modules.workflows.tasks.logic_tasks import (
+    workflow_else,
+    workflow_if,
+)
+from invenio.modules.workflows.tasks.marcxml_tasks import (
+    approve_record,
+    was_approved
+)
+from invenio.modules.workflows.tasks.workflows_tasks import log_info
+
+
+class demoworkflow(WorkflowBase):
+
+    """Demo workflow for forms module."""
+
+    object_type = "demo"
+
+    workflow = [
+        approve_record,
+        workflow_if(was_approved),
+        [
+            log_info("Record has been approved"),
+        ],
+        workflow_else,
+        [
+            log_info("Record has been rejected")
+        ]
+    ]
+
+    @staticmethod
+    def get_title(bwo):
+        """Return title of object."""
+        from invenio.modules.access.control import acc_get_user_email
+        id_user = bwo.id_user
+        user_email = acc_get_user_email(id_user)
+
+        return u"Demo form by: {0}".format(user_email)
+
+    @staticmethod
+    def get_description(bwo):
+        """Return description of object."""
+        return bwo.workflow.name
+
+    @staticmethod
+    def formatter(bwo, **kwargs):
+        """Return formatted data of object."""
+        return render_template("holdingpen/demoform.html",
+                               data=bwo.get_data())


### PR DESCRIPTION
* Introduces new forms module that contains base wtforms fields
  for INSPIRE.

* Contains base form template that can be used in all INSPIRE forms.

* Demo can be found in forms/views.py.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>