### PR TITLE
grunt: remove unused code

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -39,26 +39,6 @@ module.exports = function(grunt) {
     pkg: grunt.file.readJSON('package.json'),
     globalConfig: globalConfig,
 
-    copy: {
-      js: {
-        expand: true,
-        flatten: true,
-        cwd: '<%= globalConfig.bower_path %>/',
-        src: ['buckets/buckets.js',
-          'jquery-feeds/dist/jquery.feeds.min.js',
-          'moment/min/moment.min.js',
-          'bootstrap-multiselect/js/bootstrap-multiselect.js'
-        ],
-        dest: '<%= globalConfig.installation_path %>/js/'
-      },
-      css: {
-        expand: true,
-        flatten: true,
-        cwd: '<%= globalConfig.bower_path %>/',
-        src: ['bootstrap-multiselect/css/bootstrap-multiselect.css'],
-        dest: '<%= globalConfig.installation_path %>/css/'
-      }
-    },
     jshint: {
       options: {
         curly: true,
@@ -99,6 +79,6 @@ module.exports = function(grunt) {
     }
   });
 
-  grunt.registerTask('default', ['copy']);
+  grunt.registerTask('default', ['jshint']);
 
 };

--- a/package.json
+++ b/package.json
@@ -3,8 +3,6 @@
   "version": "0.0.1",
   "devDependencies": {
     "grunt": "~0.4.2",
-    "grunt-contrib-watch": "*",
-    "grunt-contrib-copy": "*",
     "load-grunt-tasks": "~0.2.0",
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-jsbeautifier": "~0.2.7"


### PR DESCRIPTION
 * Removes the copy task from the Gruntfile, since it's no longer
   used, and makes `jshint` the default task.  (fixes #201)

Documentation was already fixed in #210, I think.