### PR TITLE
setup: mixer downgrade

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     install_requires=[
         "rt",
         "HarvestingKit>=0.3",
-        "mixer",
+        "mixer==4.9.5",
         "ipython",
         "Babel>=1.3",
         "Invenio",


### PR DESCRIPTION
* Downgrades mixer to 4.9.5 which doesn't cause problems with
  knwKB table.

Signed-off-by: Mateusz Susik <mateusz.susik@cern.ch>