### PR TITLE
workflows: arxiv approval ajax call

### DIFF
--- a/inspire/modules/workflows/static/js/workflows/actions/arxiv_approval.js
+++ b/inspire/modules/workflows/static/js/workflows/actions/arxiv_approval.js
@@ -102,20 +102,22 @@ define(
         var $this = this;
         var objectids = payload.objectids;
 
-        jQuery.ajax({
-          type: "POST",
-          url: $this.attr.action_url,
-          data: payload,
-          success: function(data) {
-            $this.post_request(data);
-            $this.trigger(document, "removeSentElements", {"ids":objectids});
-          },
-          error: function(request, status, error) {
-            console.log(error);
-          }
-        });
+        if (objectids) {
+          jQuery.ajax({
+            type: "POST",
+            url: $this.attr.action_url,
+            data: payload,
+            success: function (data) {
+              $this.post_request(data);
+              $this.trigger(document, "removeSentElements", {"ids": objectids});
+            },
+            error: function (request, status, error) {
+              console.log(error);
+            }
+          });
 
-        this.pdf_submission_readonly();
+          this.pdf_submission_readonly();
+        }
       };
 
       this.post_request = function(data) {

--- a/inspire/modules/workflows/static/js/workflows/actions/arxiv_approval.js
+++ b/inspire/modules/workflows/static/js/workflows/actions/arxiv_approval.js
@@ -102,7 +102,7 @@ define(
         var $this = this;
         var objectids = payload.objectids;
 
-        if (objectids) {
+        if (objectids.length > 0) {
           jQuery.ajax({
             type: "POST",
             url: $this.attr.action_url,


### PR DESCRIPTION
* Checks whether the selected ids list is empty
  and if so it does not allow for calls to the server.

Signed-off-by: Ilias Koutsakis <ilias.koutsakis@cern.ch>