### PR TITLE
dojson: new jobs-0.0.1.json schema

### DIFF
--- a/inspire/dojson/conferences/schemas/conferences-0.0.1.json
+++ b/inspire/dojson/conferences/schemas/conferences-0.0.1.json
@@ -1,118 +1,118 @@
 {
     "$schema": "http://json-schema.org/schema#",
-    "type": "object",
     "id": "http://labs.inspirehep.net/schemas/conferences-0.0.1.json",
     "properties": {
-        "alternative_titles": {
-            "uniqueItems": true,
-            "items": {
-                "type": "string",
-                "title": "Alternative title"
-            },
-            "type": "array",
-            "title": "Alternative titles"
-        },
-        "subtitle": {
-            "type": "string",
-            "title": "Conference subtitle"
-        },
-        "contact person": {
-            "type": "string",
-            "title": "Contact person"
-        },
-        "title": {
-            "type": "string",
-            "title": "Conference title"
-        },
         "acronym": {
-            "type": "string",
-            "title": "Conference acronym"
+            "title": "Conference acronym",
+            "type": "string"
+        },
+        "alternative_titles": {
+            "items": {
+                "title": "Alternative title",
+                "type": "string"
+            },
+            "title": "Alternative titles",
+            "type": "array",
+            "uniqueItems": true
+        },
+        "closing_date": {
+            "format": "date",
+            "title": "Conference closing date",
+            "type": "string"
         },
         "cnum": {
             "pattern": "C\\d\\d-\\d\\d(-\\d\\d)?(\\.\\d+)",
-            "type": "string",
-            "title": "Conference ID (CNUM)"
+            "title": "Conference ID (CNUM)",
+            "type": "string"
+        },
+        "contact person": {
+            "title": "Contact person",
+            "type": "string"
+        },
+        "contact_email": {
+            "format": "email",
+            "title": "Contact email",
+            "type": "string"
         },
         "field_code": {
-            "uniqueItems": true,
             "items": {
+                "description": "FIXME: shall we normalize this to the usual arXiv?",
                 "enum": [
                     "Astrophysics",
                     "Phenomenology-HEP",
                     "..."
                 ],
-                "type": "string",
-                "description": "FIXME: shall we normalize this to the usual arXiv?",
-                "title": "Field code"
+                "title": "Field code",
+                "type": "string"
             },
+            "title": "Field codes",
             "type": "array",
-            "title": "Field codes"
+            "uniqueItems": true
         },
-        "transparencies": {
-            "format": "url",
-            "type": "string",
-            "title": "Conference transparencies URL"
+        "keywords": {
+            "items": {
+                "title": "Free keyword",
+                "type": "string"
+            },
+            "title": "Free keywords",
+            "type": "array",
+            "uniqueItems": true
+        },
+        "nonpublic_note": {
+            "title": "Non public note",
+            "type": "string"
         },
         "note": {
-            "type": "string",
-            "title": "Note"
+            "title": "Note",
+            "type": "string"
         },
-        "closing_date": {
-            "title": "Conference closing date",
-            "type": "string",
-            "format": "date"
-        },
-        "proceedings": {
-            "format": "url",
-            "type": "string",
-            "description": "FIXME: Shall we rather have a nice link towards the proceedings record? Can we simply derive it?",
-            "title": "Conference proceedings URL"
-        },
-        "short_description": {
-            "type": "string",
-            "title": "Short description"
+        "opening_date": {
+            "format": "date",
+            "title": "Conference opening date",
+            "type": "string"
         },
         "place": {
             "pattern": "\\.+, \\.+",
-            "type": "string",
-            "title": "Conference place"
+            "title": "Conference place",
+            "type": "string"
+        },
+        "proceedings": {
+            "description": "FIXME: Shall we rather have a nice link towards the proceedings record? Can we simply derive it?",
+            "format": "url",
+            "title": "Conference proceedings URL",
+            "type": "string"
         },
         "series": {
-            "type": "string",
-            "title": "Conference series"
+            "title": "Conference series",
+            "type": "string"
         },
-        "keywords": {
-            "uniqueItems": true,
-            "items": {
-                "type": "string",
-                "title": "Free keyword"
-            },
-            "type": "array",
-            "title": "Free keywords"
+        "series_number": {
+            "title": "Conference series number",
+            "type": "integer"
         },
-        "opening_date": {
-            "title": "Conference opening date",
-            "type": "string",
-            "format": "date"
+        "short_description": {
+            "title": "Short description",
+            "type": "string"
+        },
+        "subtitle": {
+            "title": "Conference subtitle",
+            "type": "string"
+        },
+        "title": {
+            "title": "Conference title",
+            "type": "string"
+        },
+        "transparencies": {
+            "format": "url",
+            "title": "Conference transparencies URL",
+            "type": "string"
         },
         "url": {
             "format": "url",
-            "type": "string",
-            "title": "Conference URL"
-        },
-        "contact_email": {
-            "title": "Contact email",
-            "type": "string",
-            "format": "email"
-        },
-        "series_number": {
-            "type": "integer",
-            "title": "Conference series number"
-        },
-        "nonpublic_note": {
-            "type": "string",
-            "title": "Non public note"
+            "title": "Conference URL",
+            "type": "string"
         }
     },
-    "title": "Conference"
+    "title": "Conference",
+    "type": "object"
 }

--- a/inspire/dojson/current_marcxml_usage/closed-jobs.txt
+++ b/inspire/dojson/current_marcxml_usage/closed-jobs.txt
@@ -1,0 +1,574 @@
+
+005__ (), (5548 Jobs Hidden records with values) (478635 distinct values in general)
+intbitset([938406, 938927, 938941, 957573, 957750, ..., 1376803, 1376804, 1377896, 1380530, 1382238])
+-----------------------------------------------------------------------------------------------------
+---- Example of values ----
+20130528212324.0
+20130528204418.0
+20130528204033.0
+20130528203903.0
+20121023232241.0
+20150331093641.0
+20141031110838.0
+20121023232240.0
+20140211115013.0
+20121023235612.0
+
+037__a (report number), (3139 Jobs Hidden records with values) (995013 distinct values in general)
+intbitset([1080824, 1080957, 1080959, 1080960, 1080961, ..., 1376803, 1376804, 1377896, 1380530, 1382238])
+----------------------------------------------------------------------------------------------------------
+---- Example of values ----
+arXiv:1405.4865
+arXiv:1405.4863
+arXiv:1405.4861
+arXiv:1405.4858
+arXiv:1405.4856
+SLAC-TN-62-026
+SLAC-0023
+SLAC-023
+SLAC-23
+SLAC-R-023
+
+040__a (), (6983 Jobs Hidden records with values) (73 distinct values in general)
+intbitset([934443, 938406, 938941, 955456, 955584, ..., 1346889, 1346892, 1346895, 1375421, 1375426])
+-----------------------------------------------------------------------------------------------------
+---- Good values ----
+      4102 webform 
+       883 web 
+       430 ajo 
+       408 doe 
+       403 us 
+       172 verified 
+       121 australia 
+        76 japan 
+        60 oz 
+        51 Web 
+        36 nz 
+        33 na 
+        17 ca 
+        14 au 
+        14 uk 
+        11 email 
+        12 NA 
+        12 jp 
+        10 AJO 
+        10 canada 
+         6 eu 
+         6 as 
+         6 gov 
+         6 usa 
+         6 aip 
+         5 AU 
+         5 af 
+         4 india 
+         4 Australia 
+         4 fr 
+         3 US 
+         3 europe 
+         3 mj 
+         3 submission 
+         2 sa 
+         2 africa 
+         2 source 
+         2 wen 
+         2 listserv email 
+         2 email submission 
+         1 AS 
+         1 EU 
+         1 Canada 
+         1 os 
+         1 CERN-LHC-ATLAS 
+         1 SANDY HEINZ <heinz@oddjob.uchicago.edu> 
+         1 ksikorski@li.hodes.com 
+         1 dod 
+         1 nsf 
+         1 DOE 
+         1 interactions 
+         1 North America 
+         1 ch 
+         1 kek 
+         1 cern 
+         1 aus 
+         1 Cancelled 
+         1 triumf 
+         1 Continued as 52701 
+         1 america 
+         1 slac 
+         1 cancelled 
+         1 JP 
+         1 at 
+         1 JOBSUBMIT-JOB-2012-033 
+         1 de 
+         1 shelly 
+         1 Shelley 
+         1 Twitter 
+         1 se 
+         1 academic.se 
+         1 oldwebform 
+         1 noreply@academicpositions.eu 
+---- Outliers ----
+AS (1 Jobs Hidden records): intbitset([963127])
+EU (1 Jobs Hidden records): intbitset([962935])
+Canada (1 Jobs Hidden records): intbitset([962674])
+os (1 Jobs Hidden records): intbitset([962368])
+CERN-LHC-ATLAS (1 Jobs Hidden records): intbitset([962075])
+SANDY HEINZ <heinz@oddjob.uchicago.edu> (1 Jobs Hidden records): intbitset([961568])
+ksikorski@li.hodes.com (1 Jobs Hidden records): intbitset([961389])
+dod (1 Jobs Hidden records): intbitset([961357])
+nsf (1 Jobs Hidden records): intbitset([961068])
+DOE (1 Jobs Hidden records): intbitset([960684])
+
+043__a (continent), (12386 Jobs Hidden records with values) (29 distinct values in general)
+intbitset([934304, 934443, 938406, 938927, 938941, ..., 1376803, 1376804, 1377896, 1380530, 1382238])
+-----------------------------------------------------------------------------------------------------
+---- Good values ----
+      5371 North America 
+      5317 Europe 
+       751 Asia 
+       436 Australia 
+       151 South America 
+       131 Australasia 
+        74 Middle East 
+        65 Africa 
+        43 AF 
+        22 na 
+        14 Choose one 
+         6 eu 
+         2 United States 
+         2 Asia, North America 
+         1 Europe, North America 
+         1 Noth America 
+---- Outliers ----
+Europe, North America (1 Jobs Hidden records): intbitset([1191946])
+Noth America (1 Jobs Hidden records): intbitset([1267269])
+United States (2 Jobs Hidden records): intbitset([962764, 962765])
+Asia, North America (2 Jobs Hidden records): intbitset([1184265, 1186064])
+eu (6 Jobs Hidden records): intbitset([958533, 960282, 960285, 960289, 960290, 960792])
+Choose one (14 Jobs Hidden records): intbitset([962268, 962294, 962328, 962329, 962439, ..., 962516, 962870, 963222, 963292, 963311])
+na (22 Jobs Hidden records): intbitset([957380, 957851, 957852, 957853, 957859, ..., 960288, 960291, 960565, 960567, 960572])
+AF (43 Jobs Hidden records): intbitset([955676, 955946, 956120, 956295, 956434, ..., 961397, 961487, 962016, 962627, 962642])
+Africa (65 Jobs Hidden records): intbitset([961468, 961983, 962407, 962818, 962929, ..., 1328827, 1329893, 1332047, 1340776, 1376803])
+Middle East (74 Jobs Hidden records): intbitset([955447, 955527, 955622, 956257, 956712, ..., 1319801, 1328717, 1329689, 1344828, 1375359])
+Australasia (131 Jobs Hidden records): intbitset([960718, 961567, 961894, 962185, 962254, ..., 1345323, 1351715, 1351869, 1365596, 1365626])
+South America (151 Jobs Hidden records): intbitset([955566, 955992, 956126, 956153, 956241, ..., 1346594, 1348393, 1352755, 1353298, 1366115])
+Australia (436 Jobs Hidden records): intbitset([955505, 955526, 955579, 955637, 955640, ..., 962495, 962507, 962700, 962711, 962813])
+Asia (751 Jobs Hidden records): intbitset([955427, 955434, 955435, 955440, 955442, ..., 1357142, 1365937, 1367263, 1370070, 1373568])
+Europe (5317 Jobs Hidden records): intbitset([934304, 955428, 955431, 955438, 955448, ..., 1376216, 1376405, 1376802, 1376804, 1380530])
+North America (5371 Jobs Hidden records): intbitset([934443, 938406, 938927, 938941, 955429, ..., 1369934, 1372025, 1375426, 1377896, 1382238])
+
+046__i (application deadline), (12311 Jobs Hidden records with values) (1160 distinct values in general)
+intbitset([934304, 934443, 938406, 938927, 938941, ..., 1376803, 1376804, 1377896, 1380530, 1382238])
+--------------------------------------------------------------------------------------------------------
+---- Example of values ----
+2014-01-25
+8888
+0000
+2014-03-14
+9999
+2012-03-15
+2011
+2012-01-13
+2011-12-11
+2011-12-15
+
+046__l (application closing date), (4622 Jobs Hidden records with values) (1380 distinct values in general)
+intbitset([934304, 934443, 955732, 955747, 956372, ..., 1079996, 1080005, 1081089, 1089493, 1089529])
+-----------------------------------------------------------------------------------------------------------
+---- Example of values ----
+chengwei@ncu.edu.tw
+theory-job@imperial.ac.uk
+https://academicjobsonline.org/ajo/jobs/1116
+cinzia.davia@manchester.ac.uk
+http://academicjobsonline.org/ajo/jobs/1250
+http://physics.princeton.edu/jobs
+https://academicjobsonline.org/ajo/jobs/1137
+odurfjobs@odu.edu
+khewitt@mit.edu
+katerina.lipka@desy.de
+
+100__a (first author name), (4 Jobs Hidden records with values) (304249 distinct values in general)
+intbitset([962934, 1082883, 1090647, 1115391])
+---------------------------------------------------------------------------------------------------
+---- Example of values ----
+Wong, Yung-Chow
+Brodsky, Stanley J.
+Lisin, A.V.
+Panofsky, W.K.H.
+Cole, J.L.
+Bondi, H.
+Woods, Hugh A.
+Jurow, Joe
+Breymayer, K.E.
+Muray, J.J.
+
+100__u (first author affiliation), (1 Jobs Hidden records with values) (11779 distinct values in general)
+intbitset([962934])
+---------------------------------------------------------------------------------------------------------
+---- Example of values ----
+Hong Kong U.
+SLAC
+Sussex U.
+NIIEFA, St. Petersburg
+LBL, Berkeley
+Lockheed Martin, Palo Alto
+Stanford U., ITP
+Cornell U., LNS
+Harvard U.
+Dubna, JINR
+
+110__a (institution), (12359 Jobs Hidden records with values) (3807 distinct values in general)
+intbitset([934304, 934443, 938406, 938927, 938941, ..., 1376803, 1376804, 1377896, 1380530, 1382238])
+-----------------------------------------------------------------------------------------------------
+---- Example of values ----
+Several European Institutions
+Université de Lausanne
+Universidad Tecnologica Nacional (UTN)
+Gyumri State Pedagogical Institute (GSPI)
+Universität Bielefeld
+Universität Bern
+Center for Astroparticle Physics (CAP)
+Swiss Institute of Bioinformatics (SIB)
+École polytechnique fédérale de Lausanne (EPFL)
+Université de Genève
+
+245__a (title), (12389 Jobs Hidden records with values) (1130107 distinct values in general)
+intbitset([934304, 934443, 938406, 938927, 938941, ..., 1376803, 1376804, 1377896, 1380530, 1382238])
+-----------------------------------------------------------------------------------------------------
+---- Example of values ----
+Isoclinic N planes in Euclidean 2N space, Clifford parallels in elliptic (2N-1) space, and the Hurwitz matrix equations
+Aspects of wimp dark matter
+Oblique parameters in gauged baryon and lepton numbers with a 125 GeV Higgs
+An Electroweak-like Theory from Four Fermion Interactions
+WAVEGUIDE TEMPERATURE CONTROL
+2-MILE ACCELERATOR PROJECT: QUARTERLY STATUS REPORT, 1 JUL - 30 SEP 1963
+SYSTEM INTERCONNECTION AND PROTECTION OF THE MODULATOR
+IRRADIATION OF A CERIUM - CONTAINING SILICATE GLASS
+PROPOSAL FOR A LARGE SOLID ANGLE PHOTON AND ELECTRON INTERACTION DETECTOR
+Study of electron Induced Desorption from the Surface of Metals
+
+270__m (contact email), (9390 Jobs Hidden records with values) (14706 distinct values in general)
+intbitset([938941, 955448, 955449, 955458, 955459, ..., 1376803, 1376804, 1377896, 1380530, 1382238])
+-----------------------------------------------------------------------------------------------------
+---- Example of values ----
+Recruitment.Service@CERN.CH
+employ@fnal.gov
+pasquin@fnal.gov
+rush@math.ucr.edu
+didupree@indiana.edu
+sobrito@bnl.gov
+khewitt@mit.edu
+mkowalczyk@anl.gov
+Doug.Wright@llnl.gov
+jobs@slac.stanford.edu
+
+270__o (reference email), (2485 Jobs Hidden records with values) (1802 distinct values in general)
+intbitset([1079380, 1080218, 1080219, 1080220, 1080221, ..., 1376216, 1376802, 1376803, 1377896, 1382238])
+----------------------------------------------------------------------------------------------------------
+---- Example of values ----
+abhijit.majumder@wayne.edu
+igk2012@math.uni-bielefeld.de
+hep@totoro.phyast.pitt.edu
+enectali@mit.edu
+walton@uleth.ca
+fabian.schussler@cea.fr
+phys-recruit@qmul.ac.uk
+phd@fisica.unina.it
+HoDSec@damtp.cam.ac.uk
+menzemer@physi.uni-heidelberg.de
+
+270__p (contact person), (9941 Jobs Hidden records with values) (6570 distinct values in general)
+intbitset([938927, 938941, 955427, 955431, 955433, ..., 1376803, 1376804, 1377896, 1380530, 1382238])
+-----------------------------------------------------------------------------------------------------
+---- Example of values ----
+Hou, George W.S.
+Bertrand, Daniel
+Bianchi, Luciana
+Kim, Yoon Hee
+Huchra, John
+van der Bij, J.J.
+Dooley, John W.
+Choi, Young
+Padamsee, Hasan
+Kipperman, M.
+
+520__a (abstract), (12331 Jobs Hidden records with values) (593846 distinct values in general)
+intbitset([934304, 934443, 938406, 938927, 938941, ..., 1376803, 1376804, 1377896, 1380530, 1382238])
+-----------------------------------------------------------------------------------------------------
+---- Example of values ----
+The original Schrodinger's paper is translated and annotated in honour of the 70-th anniversary of his Uncertainty Relation [published also in: Bulg. Journal of Physics,vol.26,no.5/6 (1999) pp.193-203]. In the annotation it is shown that the Uncertainty Relation can be written in a complete compact canonical form.
+(Foreword by translator.) The aim of present translation is to clarify the historically important question who was the pioneer in obtaining of exact static solutions of Einstein equations minimally coupled with scalar field. Usually, people cite the works by Janis, Newman, Winicour (Phys. Rev. Lett. 20 (1968) 878) and others authors whereas it is clear that JNW rediscovered (in other coordinates) the Fisher's solution which was obtained 20 years before, in 1947. Regrettably, up to now I continue to meet many papers (even very fresh ones) whose authors evidently do not know about the Fisher's work, so I try to remove this gap by virtue of present translation and putting it into the LANL e-print archive. (Original Abstract.) It is considered the scalar mesostatic field of a point source with the regard for spacetime curvature caused by this field. For the field with $\mass = 0$ the exact solution of Einstein equations was obtained. It was demonstrated that at small distance from a source the gravitational effects are so large that they cause the significant changes in behavior of meson field. In particular, the total energy of static field diverges logarithmically.
+According to Dirac's theory of the positron, an electromagnetic field tends to create pairs of particles which leads to a change of Maxwell's equations in the vacuum. These changes are calculated in the special case that no real electrons or positrons are present and the field varies little over a Compton wavelength.
+We discuss an exotic class of Kaluza-Klein models in which the internal space is neither compact nor even of finite volume. Rather than using the usual compact internal space we consider the case where particles are gravitationally trapped near a four-dimensional submanifold of the higher dimensional spacetime. A specific model exhibiting this phenomenon is constructed in five dimensions. Physics Letters B159, 22-25 (1985). Note: This rather old paper has recently been subject of renewed interest due to the explosion of activity in the ``non-compact extra dimensions'' variant of the Kaluza-Klein model. It is not available elsewhere on the Internet, and in the interests of easy access I am placing it on hep-th. The body of the paper is identical to the published version. A small separate note has been added at the end of the paper.
+We prove that in the Hartle-Hawking approach to quantum cosmology the existence of an inflationary phase is a general property of minisuperspace models given by a closed Friedmann-Robertson-Walker universe containing a massless scalar field with a $\lambda\phi~{n}$ self-interaction. The evolution in time of the cosmic scale factor and of the scalar field in the very early universe is derived, together with the conditions to be satisfied in order to solve the horizon and flatness problems.
+The decay rate for a black hole to decay nonperturbatively via tunneling is shown to be related to the Bekenstein-Hawking black hole entropy $S_{bh}$. This new physical interpretation of the black hole entropy was presented first in 1988 in this paper. I quote here the relevant statement: ``It should be noticed that the decay rate of a black hole due to nonperturbative instability is proportional to $\exp(-S_{bh}$, where $S_{bh}$ is the Bekenstein-Hawking entropy. This seems to indicate that the Bekenstein-Hawking entropy is the measure of the ability of a black hole to disappear from our Universe in the one quantum jump, with the simultaneous production of particles carrying away its total energy.''
+We summarize the standard factorization theorems for hard processes in QCD, and describe their proofs.
+The simple physics of a free particle reveals important features of the path-integral formulation of relativistic quantum theories. The exact quantum-mechanical propagator is calculated here for a particle described by the simple relativistic action proportional to its proper time. This propagator is nonvanishing outside the light cone, implying that spacelike trajectories must be included in the path integral. The propagator matches the WKB approximation to the corresponding configuration-space path integral far from the light cone; outside the light cone that approximation consists of the contribution from a single spacelike geodesic. This propagator also has the unusual property that its short-time limit does not coincide with the WKB approximation, making the construction of a concrete skeletonized version of the path integral more complicated than in nonrelativistic theory.
+We show that the quantum-algebra-invariant open spin chains associated with the affine Lie algebras $A~{(1)}_n$ for $n>1$ are integrable. The argument, which applies to a large class of other quantum-algebra-invariant chains, does not require that the corresponding $R$ matrix have crossing symmetry.
+The gravitational measure on an arbitrary topological three-manifold is constructed. The nontrivial dependence of the measure on the conformal factor is discussed. We show that only in the case of a compact manifold with boundary the measure acquires a nontrivial dependence on the conformal factor which is given by the Liouville action. A nontrivial Jacobian (the divergent part of it) generates the Einstein-Hilbert action. The Hartle-Hawking wave function of Universe is given in terms of the Liouville action. In the gaussian approximation to the Wheeler-DeWitt equation this result was earlier derived by Banks et al. Possible connection with the Chern-Simons gravity is also discussed.
+
+65017a (subject), (12328 Jobs Hidden records with values) (575 distinct values in general)
+intbitset([934304, 934443, 938406, 938927, 938941, ..., 1376803, 1376804, 1377896, 1380530, 1382238])
+-----------------------------------------------------------------------------------------------------
+---- Good values ----
+         1 Experiment-HEP 
+         3 Instrumentation 
+         1 Math and Math Physics 
+      3216 hep-ph 
+         1 HEP-EX 
+      2743 hep-th 
+      1403 gr-qc 
+      4079 hep-ex 
+       983 nucl-th 
+       434 math-ph 
+         1 NUCL-EX 
+      1404 nucl-ex 
+      3513 astro-ph 
+       550 physics.ins-det 
+       835 hep-lat 
+       219 quant-ph 
+        41 physics.acc-ph 
+      1311 physics 
+         1 HEP-LAT 
+       843 physics.acc-phys 
+       683 math 
+       661 cs 
+       454 cond-mat 
+       296 physics-other 
+---- Outliers ----
+
+65017e (), (1 Jobs Hidden records with values) (5 distinct values in general)
+intbitset([1337707])
+-----------------------------------------------------------------------------
+---- Good values ----
+         1 hep-ex 
+---- Outliers ----
+hep-ex (1 Jobs Hidden records): intbitset([1337707])
+
+65017q (), (1 Jobs Hidden records with values) (1 distinct values in general)
+intbitset([1249774])
+-----------------------------------------------------------------------------
+---- Good values ----
+         1 physics.ins-det 
+---- Outliers ----
+physics.ins-det (1 Jobs Hidden records): intbitset([1249774])
+
+656__a (rank), (12355 Jobs Hidden records with values) (37 distinct values in general)
+intbitset([934304, 934443, 938406, 938927, 938941, ..., 1376803, 1376804, 1377896, 1380530, 1382238])
+-----------------------------------------------------------------------------------------------------
+---- Good values ----
+      7055 Postdoc 
+      1307 Junior 
+      1151 Student 
+      1017 Tenure-track 
+       941 Senior 
+       818 Staff 
+       774 Tenured 
+        76 Visitor 
+        36 postdoc 
+        23 Visiting Scientist 
+        14 senior 
+        13 junior 
+         9 tenure-track 
+         5 Tenure-Track 
+         5 staff 
+         4 phd 
+         3 tenured 
+         2 Postdocs 
+         2 visiting scientist 
+         2 8888 
+         2 Research Associate 
+         2 JUNIOR 
+         1 Senior Mgmt 
+         1 Research Staff 
+         1 Popstdoc 
+         1 Tenure 
+         1 Tenure-track FIELD = physics.acc-phys 
+         1 Staff (non-research) 
+         1 physics 
+         1 Senior Postdoc 
+         1 on 
+         1 astro-ph 
+         1 student 
+         1 PhD 
+         1 Psotdoc 
+---- Outliers ----
+Senior Mgmt (1 Jobs Hidden records): intbitset([957341])
+Research Staff (1 Jobs Hidden records): intbitset([958070])
+Popstdoc (1 Jobs Hidden records): intbitset([958246])
+Tenure (1 Jobs Hidden records): intbitset([960007])
+Tenure-track FIELD = physics.acc-phys (1 Jobs Hidden records): intbitset([960027])
+Staff (non-research) (1 Jobs Hidden records): intbitset([960229])
+physics (1 Jobs Hidden records): intbitset([961456])
+Senior Postdoc (1 Jobs Hidden records): intbitset([962156])
+on (1 Jobs Hidden records): intbitset([962952])
+astro-ph (1 Jobs Hidden records): intbitset([1185335])
+
+693__3 (accelerator), (1 Jobs Hidden records with values) (2 distinct values in general)
+intbitset([1186496])
+----------------------------------------------------------------------------------------
+---- Good values ----
+         1 GlueX 
+---- Outliers ----
+GlueX (1 Jobs Hidden records): intbitset([1186496])
+
+693__a (accelerator), (4 Jobs Hidden records with values) (114 distinct values in general)
+intbitset([1242211, 1247338, 1253786, 1264717])
+------------------------------------------------------------------------------------------
+---- Good values ----
+         1 BNL-RHIC-STAR 
+         1 CERN-LHC-LHCB 
+         1 FNAL-T-0962 
+         1 FNAL-E-0929 
+         1 FNAL-TEV-CDF 
+---- Outliers ----
+
+693__e (experiment), (1955 Jobs Hidden records with values) (4262 distinct values in general)
+intbitset([934304, 934443, 955439, 955443, 955451, ..., 1376216, 1376802, 1376803, 1376804, 1377896])
+-----------------------------------------------------------------------------------------------------
+---- Example of values ----
+SLAC-E-007
+BNL-E-0530
+Superseded by 67202
+FNAL-E-0141
+BNL-E-0500
+Robert Snihur
+Michael B. Green
+SLAC-BC-008
+SLAC-BC-020
+SLAC-BC-028
+
+8564_u (url), (10500 Jobs Hidden records with values) (2702084 distinct values in general)
+intbitset([934304, 934443, 938406, 938927, 938941, ..., 1376405, 1376802, 1376803, 1376804, 1377896])
+-----------------------------------------------------------------------------------------------------
+---- Example of values ----
+http://inspirehep.net/record/1297195/files/Future3.png
+http://www.slac.stanford.edu/cgi-wrap/pubpage?slac-tn-62-026
+http://www.slac.stanford.edu/cgi-wrap/pubpage?slac-r-023
+http://www-public.slac.stanford.edu/sciDoc/docMeta.aspx?slacPubNumber=SLAC-PUB-0416
+http://www-public.slac.stanford.edu/sciDoc/docMeta.aspx?slacPubNumber=SLAC-PUB-0483
+http://www-public.slac.stanford.edu/sciDoc/docMeta.aspx?slacPubNumber=SLAC-PUB-0551
+http://www-public.slac.stanford.edu/sciDoc/docMeta.aspx?slacPubNumber=SLAC-PUB-0484
+http://www.slac.stanford.edu/cgi-wrap/pubpage?slac-tn-63-023
+http://www-public.slac.stanford.edu/sciDoc/docMeta.aspx?slacPubNumber=SLAC-PUB-0341
+http://www-public.slac.stanford.edu/sciDoc/docMeta.aspx?slacPubNumber=SLAC-PUB-0553
+
+8564_y (url label), (44 Jobs Hidden records with values) (1356236 distinct values in general)
+intbitset([963104, 1080231, 1085162, 1094225, 1094692, ..., 1279205, 1279442, 1297449, 1305231, 1333338])
+---------------------------------------------------------------------------------------------------------
+---- Example of values ----
+SLACPUB
+SLACTN
+ADSABS
+SLACREPT
+SLAC
+DOI
+RSINA
+RMPHA
+PHRVA
+AJPIA
+
+8654_u (), (1 Jobs Hidden records with values) (1 distinct values in general)
+intbitset([1089529])
+-----------------------------------------------------------------------------
+---- Good values ----
+         1 http://atlas.web.cern.ch/Atlas/GROUPS/GENERAL/JOBS/Dallas_13.02.2012.pdf 
+---- Outliers ----
+http://atlas.web.cern.ch/Atlas/GROUPS/GENERAL/JOBS/Dallas_13.02.2012.pdf (1 Jobs Hidden records): intbitset([1089529])
+
+909COo (), (2052 Jobs Hidden records with values) (1264281 distinct values in general)
+intbitset([957771, 961721, 961823, 962188, 962367, ..., 1376802, 1376803, 1376804, 1377896, 1380530])
+-----------------------------------------------------------------------------------------------------
+---- Example of values ----
+oai:inspirehep.net:1333355
+oai:inspirehep.net:1276252
+oai:inspirehep.net:1265189
+oai:inspirehep.net:1347216
+oai:inspirehep.net:1274799
+oai:inspirehep.net:1278431
+oai:inspirehep.net:1278449
+oai:atlantis.cern.ch:1077
+oai:atlantis.cern.ch:10849
+oai:atlantis.cern.ch:21550
+
+909COq (), (2052 Jobs Hidden records with values) (12 distinct values in general)
+intbitset([957771, 961721, 961823, 962188, 962367, ..., 1376802, 1376803, 1376804, 1377896, 1380530])
+-----------------------------------------------------------------------------------------------------
+---- Good values ----
+      2052 INSPIRE:Jobs 
+---- Outliers ----
+INSPIRE:Jobs (2052 Jobs Hidden records): intbitset([957771, 961721, 961823, 962188, 962367, ..., 1376802, 1376803, 1376804, 1377896, 1380530])
+
+961__c (cataloging date update), (8242 Jobs Hidden records with values) (7535 distinct values in general)
+intbitset([934304, 934443, 938406, 938927, 938941, ..., 1114793, 1115003, 1115232, 1219665, 1319813])
+---------------------------------------------------------------------------------------------------------
+---- Example of values ----
+2001-02-23
+2001-07-30
+2009-09-10
+2005-02-23
+2002-02-05
+1999-08-30
+2009-07-07
+2002-01-24
+1999-08-19
+1999-08-26
+
+961__x (cataloging date creation), (8242 Jobs Hidden records with values) (9491 distinct values in general)
+intbitset([934304, 934443, 938406, 938927, 938941, ..., 1114793, 1115003, 1115232, 1219665, 1319813])
+-----------------------------------------------------------------------------------------------------------
+---- Example of values ----
+2001-02-23
+1977
+1972-01
+1962-04
+1963-06
+1963-01
+2002-07-23
+1963-08
+1962-05
+1963-10
+
+963__e (), (1 Jobs Hidden records with values) (1 distinct values in general)
+intbitset([1079380])
+-----------------------------------------------------------------------------
+---- Good values ----
+         1 CERN-LHC-ATLAS 
+---- Outliers ----
+CERN-LHC-ATLAS (1 Jobs Hidden records): intbitset([1079380])
+
+970__a (SPIRES IRN), (7952 Jobs Hidden records with values) (1122867 distinct values in general)
+intbitset([934304, 934443, 938406, 938927, 938941, ..., 1080004, 1080005, 1080006, 1219665, 1319813])
+-----------------------------------------------------------------------------------------------------
+---- Example of values ----
+SPIRES-60
+SPIRES-10325093
+SPIRES-10325107
+SPIRES-10325115
+SPIRES-10325123
+SPIRES-248
+SPIRES-256
+SPIRES-264
+SPIRES-299
+SPIRES-302
+
+980__a (collection), (12391 Jobs Hidden records with values) (81 distinct values in general)
+intbitset([934304, 934443, 938406, 938927, 938941, ..., 1376803, 1376804, 1377896, 1380530, 1382238])
+-----------------------------------------------------------------------------------------------------
+---- Good values ----
+     12391 JOBHIDDEN 
+---- Outliers ----
+
+981__a (), (13 Jobs Hidden records with values) (3352 distinct values in general)
+intbitset([962894, 1184084, 1222410, 1232553, 1235473, ..., 1309524, 1310216, 1313554, 1319371, 1346881])
+---------------------------------------------------------------------------------------------------------
+---- Example of values ----
+674175
+640540
+487440
+487442
+459597
+196523
+167913
+776487
+895309
+159338

--- a/inspire/dojson/current_marcxml_usage/jobs.txt
+++ b/inspire/dojson/current_marcxml_usage/jobs.txt
@@ -1,0 +1,377 @@
+
+005__ (), (414 Jobs records with values) (478361 distinct values in general)
+intbitset([958099, 961064, 961145, 962775, 1083758, ..., 1382421, 1382511, 1382536, 1382658, 1382723])
+------------------------------------------------------------------------------------------------------
+---- Example of values ----
+20130528212324.0
+20130528204418.0
+20130528204033.0
+20130528203903.0
+20121023232241.0
+20150331093641.0
+20141031110838.0
+20121023232240.0
+20140211115013.0
+20121023235612.0
+
+037__a (report number), (330 Jobs records with values) (994989 distinct values in general)
+intbitset([1083758, 1116344, 1126044, 1126045, 1189703, ..., 1382421, 1382511, 1382536, 1382658, 1382723])
+----------------------------------------------------------------------------------------------------------
+---- Example of values ----
+arXiv:1405.4865
+arXiv:1405.4863
+arXiv:1405.4861
+arXiv:1405.4858
+arXiv:1405.4856
+SLAC-TN-62-026
+SLAC-0023
+SLAC-023
+SLAC-23
+SLAC-R-023
+
+040__a (), (79 Jobs records with values) (73 distinct values in general)
+intbitset([958099, 961064, 961145, 962775, 1219663, ..., 1375435, 1375895, 1375897, 1375898, 1375899])
+------------------------------------------------------------------------------------------------------
+---- Good values ----
+         2 webform 
+        51 web 
+        22 ajo 
+         1 doe 
+         1 verified 
+         1 Web 
+         1 email 
+---- Outliers ----
+
+043__a (continent), (414 Jobs records with values) (29 distinct values in general)
+intbitset([958099, 961064, 961145, 962775, 1083758, ..., 1382421, 1382511, 1382536, 1382658, 1382723])
+------------------------------------------------------------------------------------------------------
+---- Good values ----
+       162 North America 
+       170 Europe 
+        52 Asia 
+        13 South America 
+         6 Australasia 
+         6 Middle East 
+         6 Africa 
+         1 Europe / South America 
+---- Outliers ----
+Europe / South America (1 Jobs records): intbitset([1375854])
+Africa (6 Jobs records): intbitset([1219663, 1333331, 1342310, 1346564, 1356684, 1373564])
+Middle East (6 Jobs records): intbitset([961064, 1278529, 1368799, 1368800, 1368801, 1375358])
+Australasia (6 Jobs records): intbitset([1346887, 1362423, 1375408, 1375423, 1375424, 1375425])
+South America (13 Jobs records): intbitset([1295619, 1332384, 1337711, 1346581, 1351851, ..., 1370065, 1371053, 1374542, 1375854, 1382088])
+Asia (52 Jobs records): intbitset([1189703, 1206133, 1210538, 1239755, 1242549, ..., 1376527, 1377843, 1380505, 1380509, 1382257])
+Europe (170 Jobs records): intbitset([962775, 1126044, 1126045, 1226059, 1240420, ..., 1381876, 1381891, 1382298, 1382421, 1382536])
+North America (162 Jobs records): intbitset([958099, 961145, 1083758, 1116344, 1222166, ..., 1382237, 1382241, 1382511, 1382658, 1382723])
+
+046__a (), (17 Jobs records with values) (12 distinct values in general)
+intbitset([1375407, 1375408, 1375409, 1375410, 1375411, ..., 1375419, 1375422, 1375423, 1375424, 1375425])
+----------------------------------------------------------------------------------------------------------
+---- Good values ----
+         5 2015-07-31 
+         4 2015-09-07 
+         1 2015-06-30 
+         1 2015-07-04 
+         1 2015-10-30 
+         1 2015-08-16 
+         1 2015-07-12 
+         1 2015-07-16 
+         1 2015-07-05 
+         1 2015-07-10 
+---- Outliers ----
+2015-06-30 (1 Jobs records): intbitset([1375412])
+2015-07-04 (1 Jobs records): intbitset([1375411])
+2015-10-30 (1 Jobs records): intbitset([1375410])
+2015-08-16 (1 Jobs records): intbitset([1375408])
+2015-07-12 (1 Jobs records): intbitset([1375407])
+2015-07-16 (1 Jobs records): intbitset([1375424])
+2015-07-05 (1 Jobs records): intbitset([1375423])
+2015-07-10 (1 Jobs records): intbitset([1375422])
+2015-09-07 (4 Jobs records): intbitset([1375409, 1375413, 1375414, 1375415])
+2015-07-31 (5 Jobs records): intbitset([1375416, 1375417, 1375418, 1375419, 1375425])
+
+046__i (application deadline), (393 Jobs records with values) (1158 distinct values in general)
+intbitset([958099, 961064, 961145, 962775, 1083758, ..., 1382298, 1382421, 1382511, 1382536, 1382658])
+------------------------------------------------------------------------------------------------------
+---- Example of values ----
+2014-01-25
+8888
+0000
+2014-03-14
+9999
+2012-03-15
+2011
+2012-01-13
+2011-12-11
+2011-12-15
+
+110__a (institution), (414 Jobs records with values) (3805 distinct values in general)
+intbitset([958099, 961064, 961145, 962775, 1083758, ..., 1382421, 1382511, 1382536, 1382658, 1382723])
+------------------------------------------------------------------------------------------------------
+---- Example of values ----
+Several European Institutions
+Université de Lausanne
+Universidad Tecnologica Nacional (UTN)
+Gyumri State Pedagogical Institute (GSPI)
+Universität Bielefeld
+Universität Bern
+Center for Astroparticle Physics (CAP)
+Swiss Institute of Bioinformatics (SIB)
+École polytechnique fédérale de Lausanne (EPFL)
+Université de Genève
+
+110__e (institution), (1 Jobs records with values) (2 distinct values in general)
+intbitset([1345193])
+---------------------------------------------------------------------------------
+---- Good values ----
+         1 ESS, Lund 
+---- Outliers ----
+ESS, Lund (1 Jobs records): intbitset([1345193])
+
+245__a (title), (414 Jobs records with values) (1130038 distinct values in general)
+intbitset([958099, 961064, 961145, 962775, 1083758, ..., 1382421, 1382511, 1382536, 1382658, 1382723])
+------------------------------------------------------------------------------------------------------
+---- Example of values ----
+Isoclinic N planes in Euclidean 2N space, Clifford parallels in elliptic (2N-1) space, and the Hurwitz matrix equations
+Aspects of wimp dark matter
+Oblique parameters in gauged baryon and lepton numbers with a 125 GeV Higgs
+An Electroweak-like Theory from Four Fermion Interactions
+WAVEGUIDE TEMPERATURE CONTROL
+2-MILE ACCELERATOR PROJECT: QUARTERLY STATUS REPORT, 1 JUL - 30 SEP 1963
+SYSTEM INTERCONNECTION AND PROTECTION OF THE MODULATOR
+IRRADIATION OF A CERIUM - CONTAINING SILICATE GLASS
+PROPOSAL FOR A LARGE SOLID ANGLE PHOTON AND ELECTRON INTERACTION DETECTOR
+Study of electron Induced Desorption from the Surface of Metals
+
+270__m (contact email), (384 Jobs records with values) (14702 distinct values in general)
+intbitset([958099, 961064, 961145, 962775, 1083758, ..., 1382421, 1382511, 1382536, 1382658, 1382723])
+------------------------------------------------------------------------------------------------------
+---- Example of values ----
+Recruitment.Service@CERN.CH
+employ@fnal.gov
+pasquin@fnal.gov
+rush@math.ucr.edu
+didupree@indiana.edu
+sobrito@bnl.gov
+khewitt@mit.edu
+mkowalczyk@anl.gov
+Doug.Wright@llnl.gov
+jobs@slac.stanford.edu
+
+270__o (reference email), (246 Jobs records with values) (1799 distinct values in general)
+intbitset([1083758, 1116344, 1126044, 1189703, 1206133, ..., 1382237, 1382241, 1382257, 1382298, 1382658])
+----------------------------------------------------------------------------------------------------------
+---- Example of values ----
+abhijit.majumder@wayne.edu
+igk2012@math.uni-bielefeld.de
+hep@totoro.phyast.pitt.edu
+enectali@mit.edu
+walton@uleth.ca
+fabian.schussler@cea.fr
+phys-recruit@qmul.ac.uk
+phd@fisica.unina.it
+HoDSec@damtp.cam.ac.uk
+menzemer@physi.uni-heidelberg.de
+
+270__p (contact person), (373 Jobs records with values) (6568 distinct values in general)
+intbitset([958099, 961064, 961145, 962775, 1083758, ..., 1382421, 1382511, 1382536, 1382658, 1382723])
+------------------------------------------------------------------------------------------------------
+---- Example of values ----
+Hou, George W.S.
+Bertrand, Daniel
+Bianchi, Luciana
+Kim, Yoon Hee
+Huchra, John
+van der Bij, J.J.
+Dooley, John W.
+Choi, Young
+Padamsee, Hasan
+Kipperman, M.
+
+520__a (abstract), (414 Jobs records with values) (593745 distinct values in general)
+intbitset([958099, 961064, 961145, 962775, 1083758, ..., 1382421, 1382511, 1382536, 1382658, 1382723])
+------------------------------------------------------------------------------------------------------
+---- Example of values ----
+The original Schrodinger's paper is translated and annotated in honour of the 70-th anniversary of his Uncertainty Relation [published also in: Bulg. Journal of Physics,vol.26,no.5/6 (1999) pp.193-203]. In the annotation it is shown that the Uncertainty Relation can be written in a complete compact canonical form.
+(Foreword by translator.) The aim of present translation is to clarify the historically important question who was the pioneer in obtaining of exact static solutions of Einstein equations minimally coupled with scalar field. Usually, people cite the works by Janis, Newman, Winicour (Phys. Rev. Lett. 20 (1968) 878) and others authors whereas it is clear that JNW rediscovered (in other coordinates) the Fisher's solution which was obtained 20 years before, in 1947. Regrettably, up to now I continue to meet many papers (even very fresh ones) whose authors evidently do not know about the Fisher's work, so I try to remove this gap by virtue of present translation and putting it into the LANL e-print archive. (Original Abstract.) It is considered the scalar mesostatic field of a point source with the regard for spacetime curvature caused by this field. For the field with $\mass = 0$ the exact solution of Einstein equations was obtained. It was demonstrated that at small distance from a source the gravitational effects are so large that they cause the significant changes in behavior of meson field. In particular, the total energy of static field diverges logarithmically.
+According to Dirac's theory of the positron, an electromagnetic field tends to create pairs of particles which leads to a change of Maxwell's equations in the vacuum. These changes are calculated in the special case that no real electrons or positrons are present and the field varies little over a Compton wavelength.
+We discuss an exotic class of Kaluza-Klein models in which the internal space is neither compact nor even of finite volume. Rather than using the usual compact internal space we consider the case where particles are gravitationally trapped near a four-dimensional submanifold of the higher dimensional spacetime. A specific model exhibiting this phenomenon is constructed in five dimensions. Physics Letters B159, 22-25 (1985). Note: This rather old paper has recently been subject of renewed interest due to the explosion of activity in the ``non-compact extra dimensions'' variant of the Kaluza-Klein model. It is not available elsewhere on the Internet, and in the interests of easy access I am placing it on hep-th. The body of the paper is identical to the published version. A small separate note has been added at the end of the paper.
+We prove that in the Hartle-Hawking approach to quantum cosmology the existence of an inflationary phase is a general property of minisuperspace models given by a closed Friedmann-Robertson-Walker universe containing a massless scalar field with a $\lambda\phi~{n}$ self-interaction. The evolution in time of the cosmic scale factor and of the scalar field in the very early universe is derived, together with the conditions to be satisfied in order to solve the horizon and flatness problems.
+The decay rate for a black hole to decay nonperturbatively via tunneling is shown to be related to the Bekenstein-Hawking black hole entropy $S_{bh}$. This new physical interpretation of the black hole entropy was presented first in 1988 in this paper. I quote here the relevant statement: ``It should be noticed that the decay rate of a black hole due to nonperturbative instability is proportional to $\exp(-S_{bh}$, where $S_{bh}$ is the Bekenstein-Hawking entropy. This seems to indicate that the Bekenstein-Hawking entropy is the measure of the ability of a black hole to disappear from our Universe in the one quantum jump, with the simultaneous production of particles carrying away its total energy.''
+We summarize the standard factorization theorems for hard processes in QCD, and describe their proofs.
+The simple physics of a free particle reveals important features of the path-integral formulation of relativistic quantum theories. The exact quantum-mechanical propagator is calculated here for a particle described by the simple relativistic action proportional to its proper time. This propagator is nonvanishing outside the light cone, implying that spacelike trajectories must be included in the path integral. The propagator matches the WKB approximation to the corresponding configuration-space path integral far from the light cone; outside the light cone that approximation consists of the contribution from a single spacelike geodesic. This propagator also has the unusual property that its short-time limit does not coincide with the WKB approximation, making the construction of a concrete skeletonized version of the path integral more complicated than in nonrelativistic theory.
+We show that the quantum-algebra-invariant open spin chains associated with the affine Lie algebras $A~{(1)}_n$ for $n>1$ are integrable. The argument, which applies to a large class of other quantum-algebra-invariant chains, does not require that the corresponding $R$ matrix have crossing symmetry.
+The gravitational measure on an arbitrary topological three-manifold is constructed. The nontrivial dependence of the measure on the conformal factor is discussed. We show that only in the case of a compact manifold with boundary the measure acquires a nontrivial dependence on the conformal factor which is given by the Liouville action. A nontrivial Jacobian (the divergent part of it) generates the Einstein-Hilbert action. The Hartle-Hawking wave function of Universe is given in terms of the Liouville action. In the gaussian approximation to the Wheeler-DeWitt equation this result was earlier derived by Banks et al. Possible connection with the Chern-Simons gravity is also discussed.
+
+65017a (subject), (414 Jobs records with values) (575 distinct values in general)
+intbitset([958099, 961064, 961145, 962775, 1083758, ..., 1382421, 1382511, 1382536, 1382658, 1382723])
+------------------------------------------------------------------------------------------------------
+---- Good values ----
+        93 hep-ph 
+        89 hep-th 
+        52 gr-qc 
+       184 hep-ex 
+        30 nucl-th 
+        19 math-ph 
+        65 nucl-ex 
+        92 astro-ph 
+        45 physics.ins-det 
+        29 hep-lat 
+         3 quant-ph 
+        23 physics 
+        34 physics.acc-phys 
+        17 math 
+        28 cs 
+        19 cond-mat 
+        45 physics-other 
+---- Outliers ----
+
+656__a (rank), (413 Jobs records with values) (37 distinct values in general)
+intbitset([958099, 961064, 961145, 962775, 1083758, ..., 1382421, 1382511, 1382536, 1382658, 1382723])
+------------------------------------------------------------------------------------------------------
+---- Good values ----
+       241 Postdoc 
+        61 Junior 
+        66 Student 
+        42 Senior 
+        39 Staff 
+         6 Visitor 
+        11 Visiting Scientist 
+         1 POSITIONLEVEL 
+         1 SENIOR 
+---- Outliers ----
+
+693__e (experiment), (178 Jobs records with values) (4260 distinct values in general)
+intbitset([961064, 962775, 1210538, 1226059, 1249814, ..., 1382257, 1382511, 1382536, 1382658, 1382723])
+--------------------------------------------------------------------------------------------------------
+---- Example of values ----
+SLAC-E-007
+BNL-E-0530
+Superseded by 67202
+FNAL-E-0141
+BNL-E-0500
+Robert Snihur
+Michael B. Green
+SLAC-BC-008
+SLAC-BC-020
+SLAC-BC-028
+
+8564_u (url), (328 Jobs records with values) (2702034 distinct values in general)
+intbitset([958099, 961064, 961145, 1083758, 1116344, ..., 1382298, 1382421, 1382536, 1382658, 1382723])
+-------------------------------------------------------------------------------------------------------
+---- Example of values ----
+http://inspirehep.net/record/1297195/files/Future3.png
+http://www.slac.stanford.edu/cgi-wrap/pubpage?slac-tn-62-026
+http://www.slac.stanford.edu/cgi-wrap/pubpage?slac-r-023
+http://www-public.slac.stanford.edu/sciDoc/docMeta.aspx?slacPubNumber=SLAC-PUB-0416
+http://www-public.slac.stanford.edu/sciDoc/docMeta.aspx?slacPubNumber=SLAC-PUB-0483
+http://www-public.slac.stanford.edu/sciDoc/docMeta.aspx?slacPubNumber=SLAC-PUB-0551
+http://www-public.slac.stanford.edu/sciDoc/docMeta.aspx?slacPubNumber=SLAC-PUB-0484
+http://www.slac.stanford.edu/cgi-wrap/pubpage?slac-tn-63-023
+http://www-public.slac.stanford.edu/sciDoc/docMeta.aspx?slacPubNumber=SLAC-PUB-0341
+http://www-public.slac.stanford.edu/sciDoc/docMeta.aspx?slacPubNumber=SLAC-PUB-0553
+
+8564_y (url label), (3 Jobs records with values) (1356221 distinct values in general)
+intbitset([1335203, 1343050, 1344966])
+-------------------------------------------------------------------------------------
+---- Example of values ----
+SLACPUB
+SLACTN
+ADSABS
+SLACREPT
+SLAC
+DOI
+RSINA
+RMPHA
+PHRVA
+AJPIA
+
+909COo (), (414 Jobs records with values) (1264281 distinct values in general)
+intbitset([958099, 961064, 961145, 962775, 1083758, ..., 1382421, 1382511, 1382536, 1382658, 1382723])
+------------------------------------------------------------------------------------------------------
+---- Example of values ----
+oai:inspirehep.net:1333355
+oai:inspirehep.net:1276252
+oai:inspirehep.net:1265189
+oai:inspirehep.net:1347216
+oai:inspirehep.net:1274799
+oai:inspirehep.net:1278431
+oai:inspirehep.net:1278449
+oai:atlantis.cern.ch:1077
+oai:atlantis.cern.ch:10849
+oai:atlantis.cern.ch:21550
+
+909COp (), (414 Jobs records with values) (12 distinct values in general)
+intbitset([958099, 961064, 961145, 962775, 1083758, ..., 1382421, 1382511, 1382536, 1382658, 1382723])
+------------------------------------------------------------------------------------------------------
+---- Good values ----
+       414 INSPIRE:Jobs 
+---- Outliers ----
+INSPIRE:Jobs (414 Jobs records): intbitset([958099, 961064, 961145, 962775, 1083758, ..., 1382421, 1382511, 1382536, 1382658, 1382723])
+
+961__c (cataloging date update), (5 Jobs records with values) (7535 distinct values in general)
+intbitset([958099, 961064, 961145, 962775, 1083758])
+-----------------------------------------------------------------------------------------------
+---- Example of values ----
+2001-02-23
+2001-07-30
+2009-09-10
+2005-02-23
+2002-02-05
+1999-08-30
+2009-07-07
+2002-01-24
+1999-08-19
+1999-08-26
+
+961__x (cataloging date creation), (5 Jobs records with values) (9491 distinct values in general)
+intbitset([958099, 961064, 961145, 962775, 1083758])
+-------------------------------------------------------------------------------------------------
+---- Example of values ----
+2001-02-23
+1977
+1972-01
+1962-04
+1963-06
+1963-01
+2002-07-23
+1963-08
+1962-05
+1963-10
+
+970__a (SPIRES IRN), (4 Jobs records with values) (1122867 distinct values in general)
+intbitset([958099, 961064, 961145, 962775])
+--------------------------------------------------------------------------------------
+---- Example of values ----
+SPIRES-60
+SPIRES-10325093
+SPIRES-10325107
+SPIRES-10325115
+SPIRES-10325123
+SPIRES-248
+SPIRES-256
+SPIRES-264
+SPIRES-299
+SPIRES-302
+
+980__a (collection), (414 Jobs records with values) (81 distinct values in general)
+intbitset([958099, 961064, 961145, 962775, 1083758, ..., 1382421, 1382511, 1382536, 1382658, 1382723])
+------------------------------------------------------------------------------------------------------
+---- Good values ----
+       414 JOB 
+---- Outliers ----
+
+981__a (), (3 Jobs records with values) (3340 distinct values in general)
+intbitset([1319424, 1332454, 1351967])
+-------------------------------------------------------------------------
+---- Example of values ----
+674175
+640540
+487440
+487442
+459597
+196523
+167913
+776487
+895309
+159338

--- a/inspire/dojson/jobs/schemas/jobs-0.0.1.json
+++ b/inspire/dojson/jobs/schemas/jobs-0.0.1.json
@@ -1,0 +1,123 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "id": "http://labs.inspirehep.net/schemas/jobs-0.0.1.json",
+    "properties": {
+        "closed": {
+            "format": "date",
+            "title": "Date when the job was closed",
+            "type": "string"
+        },
+        "contact_email": {
+            "format": "email",
+            "title": "Contact email",
+            "type": "string"
+        },
+        "contact_person": {
+            "title": "Contact person",
+            "type": "string"
+        },
+        "continent": {
+            "items": {
+                "enum": [
+                    "North America",
+                    "Europe",
+                    "Asia",
+                    "South America",
+                    "Africa",
+                    "Oceania"
+                ],
+                "title": "Continent",
+                "type": "string"
+            },
+            "title": "Continent",
+            "type": "array",
+            "uniqueItems": true
+        },
+        "deadline": {
+            "format": "date",
+            "title": "Application deadline",
+            "type": "string"
+        },
+        "experiment": {
+            "description": "FIXME: we can simply store here the ID of the experiment.",
+            "title": "Experiment recid",
+            "type": "integer"
+        },
+        "institution": {
+            "properties": {
+                "curated_relation": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "title": "Institution name",
+                    "type": "string"
+                },
+                "recid": {
+                    "title": "Institution Record ID",
+                    "type": "integer"
+                }
+            },
+            "title": "Institution",
+            "type": "object"
+        },
+        "job_description": {
+            "title": "Job description",
+            "type": "string"
+        },
+        "position": {
+            "title": "Job position",
+            "type": "string"
+        },
+        "rank": {
+            "description": "FIXME: should this be identical to hepnames rank? I would say so",
+            "enum": [
+                "Postdc",
+                "Junior",
+                "Student",
+                "Senior",
+                "Staff",
+                "Visitor",
+                "Visiting Scientist"
+            ],
+            "title": "Rank",
+            "type": "string"
+        },
+        "reference_email": {
+            "description": "FIXME: what is the difference from contact_email!?",
+            "format": "email",
+            "title": "Reference email",
+            "type": "string"
+        },
+        "research_area": {
+            "items": {
+                "enum": [
+                    "usual",
+                    "arXiv",
+                    "list"
+                ],
+                "type": "string"
+            },
+            "title": "Research area",
+            "type": "array",
+            "uniqueItems": true
+        },
+        "url": {
+            "format": "url",
+            "title": "Link to job description",
+            "type": "string"
+        }
+    },
+    "required": [
+        "continent",
+        "position",
+        "institution",
+        "contact_email",
+        "contact_person",
+        "job_description",
+        "url",
+        "rank",
+        "research_area"
+    ],
+    "title": "HEP Job",
+    "type": "object"
+}


### PR DESCRIPTION
* Introduces new jobs-0.0.1.json schema.

* Resorts inspire/dojson/conferences/schemas/conferences-0.0.1.json
  schema.

* Provide closed-jobs.txt and jobs.txt statistics.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>