### PR TITLE
dojson: source and curated fields

### DIFF
--- a/inspire/dojson/hep/schemas/hep-0.0.1.json
+++ b/inspire/dojson/hep/schemas/hep-0.0.1.json
@@ -1,764 +1,350 @@
 {
-    "description": "An article or thesis or book or...",
-    "title": "Publication",
-    "required": [
-        "title"
-    ],
-    "id": "http://labs.inspirehep.net/schemas/hep-0.0.1.json",
     "$schema": "http://json-schema.org/schema#",
-    "type": "object",
+    "description": "An article or thesis or book or...",
+    "id": "http://labs.inspirehep.net/schemas/hep-0.0.1.json",
     "properties": {
-        "funding_info": {
-            "uniqueItems": true,
+        "abstract": {
             "items": {
-                "type": "object",
                 "properties": {
-                    "grant_number": {
-                        "type": "string",
-                        "title": "Grant number"
-                    },
-                    "agency": {
-                        "type": "string",
-                        "title": "Agency"
-                    },
-                    "project_number": {
-                        "type": "string",
-                        "title": "Project number"
-                    }
-                },
-                "title": "Grant information"
-            },
-            "type": "array",
-            "description": "Information related to funding. FIXME: Do we care about this? So far only 349 records were tagged and all for a single EU project.",
-            "title": "Funding information"
-        },
-        "isbn": {
-            "uniqueItems": true,
-            "items": {
-                "required": [
-                    "value"
-                ],
-                "type": "object",
-                "properties": {
-                    "medium": {
-                        "enum": [
-                            "Print",
-                            "Online",
-                            "ebook",
-                            "hardcover",
-                            "paperback"
-                        ],
-                        "type": "string",
-                        "description": "FIXME: this really need to be an enum and cleaned up. What is Print?!",
-                        "title": "Medium"
-                    },
-                    "value": {
-                        "title": "code",
-                        "type": "string",
-                        "format": "isbn"
-                    }
-                },
-                "title": "ISBN code"
-            },
-            "type": "array",
-            "description": "ISBN codes identifying the given book",
-            "title": "ISBN codes"
-        },
-        "superseding": {
-            "uniqueItems": true,
-            "items": {
-                "type": "integer"
-            },
-            "type": "array"
-        },
-        "report_number": {
-            "uniqueItems": true,
-            "items": {
-                "type": "object",
-                "properties": {
-                    "source": {
-                        "type": "string"
-                    },
-                    "primary": {
+                    "curated": {
+                        "default": false,
                         "type": "boolean"
                     },
-                    "value": {
-                        "type": "string"
-                    }
-                }
-            },
-            "type": "array"
-        },
-        "public_notes": {
-            "uniqueItems": true,
-            "items": {
-                "required": [
-                    "value"
-                ],
-                "type": "object",
-                "properties": {
                     "source": {
+                        "enum": [
+                            "arXiv",
+                            "publisher",
+                            "user"
+                        ],
                         "type": "string"
                     },
                     "value": {
                         "type": "string"
                     }
-                }
-            },
-            "type": "array"
-        },
-        "abstract": {
-            "uniqueItems": true,
-            "items": {
+                },
                 "required": [
                     "source",
                     "value"
                 ],
-                "type": "object",
-                "properties": {
-                    "source": {
-                        "enum": [
-                            "AIP",
-                            "APS",
-                            "Annual Reviews",
-                            "Astronomical Society of the Pacific",
-                            "Author",
-                            "Bulgarian Academy of Sciences",
-                            "CERN",
-                            "CERN/SLAC",
-                            "Cambridge University Press",
-                            "Canadian Center of Science and Education",
-                            "DESY",
-                            "DESY/SLAC",
-                            "EDP Sciences",
-                            "ELSEVIER",
-                            "Education and Upbringing",
-                            "Elsevier",
-                            "European Astronomical Society",
-                            "HEPDATA",
-                            "HINDAWI",
-                            "IEEE",
-                            "INDICO",
-                            "INSPIRE",
-                            "IOP",
-                            "IOS Press",
-                            "IPAP",
-                            "Indian National Science Academy",
-                            "International Press",
-                            "International Society for Optics and Photonics",
-                            "Internet Academy",
-                            "JACoW",
-                            "Kharkov Institute of Physics and Technology",
-                            "MDPI",
-                            "MPI Grav. Phys., Potsdam",
-                            "NRC Research Press",
-                            "National Academy of Sciences of Armenia",
-                            "Niscair",
-                            "Oxford Journals",
-                            "Oxford University Press",
-                            "Physical Society of Japan",
-                            "Polish Physical Society",
-                            "Publisher",
-                            "Royal Society",
-                            "SIGMA",
-                            "Springer",
-                            "Tomsk State Pedagogical University",
-                            "T\u00dcB\u0130TAK",
-                            "WILEY",
-                            "WS",
-                            "WSP",
-                            "World Scientific"
-                        ],
-                        "type": "string",
-                        "description": "FIXME: is there an enumerable list of sources?"
-                    },
-                    "value": {
-                        "type": "string"
-                    }
-                }
-            },
-            "type": "array"
-        },
-        "spires_sysnos": {
-            "uniqueItems": true,
-            "items": {
-                "type": "string"
-            },
-            "type": "array"
-        },
-        "preprint_date": {
-            "type": "string",
-            "format": "date"
-        },
-        "imprint": {
-            "uniqueItems": true,
-            "items": {
-                "type": "object",
-                "properties": {
-                    "date": {
-                        "type": "string",
-                        "format": "date"
-                    },
-                    "publisher": {
-                        "type": "string",
-                        "description": "FIXME: an enum?"
-                    },
-                    "place": {
-                        "type": "string"
-                    }
-                }
-            },
-            "type": "array"
-        },
-        "titles": {
-            "uniqueItems": true,
-            "items": {
-                "type": "object",
-                "properties": {
-                    "source": {
-                        "type": "string"
-                    },
-                    "subtitle": {
-                        "type": "string"
-                    },
-                    "title": {
-                        "type": "string"
-                    }
-                }
-            },
-            "type": "array"
-        },
-        "thesis_supervisor": {
-            "uniqueItems": true,
-            "items": {
-                "required": [
-                    "full_name"
-                ],
-                "type": "object",
-                "properties": {
-                    "affiliation": {
-                        "type": "object",
-                        "properties": {
-                            "curated_relation": {
-                                "type": "boolean"
-                            },
-                            "recid": {
-                                "type": "integer"
-                            },
-                            "value": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "recid": {
-                        "type": "integer"
-                    },
-                    "full_name": {
-                        "type": "string"
-                    },
-                    "curated_relation": {
-                        "type": "boolean"
-                    }
-                }
-            },
-            "type": "array"
-        },
-        "thesis": {
-            "uniqueItems": true,
-            "items": {
-                "type": "object",
-                "properties": {
-                    "date": {
-                        "type": "string",
-                        "format": "date"
-                    },
-                    "curated_relation": {
-                        "type": "boolean"
-                    },
-                    "university": {
-                        "type": "string",
-                        "description": "FIXME: shall we match these with the insitution database? I guess so."
-                    },
-                    "recid": {
-                        "type": "integer",
-                        "description": "Record ID of the matched insitution."
-                    },
-                    "degree_type": {
-                        "enum": [
-                            "PhD",
-                            "Master",
-                            "Bachelor",
-                            "Diploma",
-                            "Habilitation",
-                            "Laurea",
-                            "Thesis"
-                        ],
-                        "type": "string",
-                        "description": "FIXME: this enum must be reviewed"
-                    }
-                }
-            },
-            "type": "array"
-        },
-        "hidden_note": {
-            "uniqueItems": true,
-            "items": {
-                "type": "object",
-                "properties": {
-                    "source": {
-                        "enum": [
-                            "SPIRES-HIDDEN",
-                            "CERN",
-                            "submitter"
-                        ],
-                        "type": "string",
-                        "description": "FIXME: What's the semantic of this source?"
-                    },
-                    "cern_reference": {
-                        "type": "string",
-                        "description": "FIXME: Do we know what this is? do we care?"
-                    },
-                    "value": {
-                        "type": "string"
-                    }
-                }
+                "type": "object"
             },
             "type": "array",
-            "description": "FIXME: what about 595__d??"
-        },
-        "publication_info": {
-            "uniqueItems": true,
-            "items": {
-                "type": "object",
-                "properties": {
-                    "journal_title": {
-                        "type": "string"
-                    },
-                    "pubinfo_freetext": {
-                        "type": "string"
-                    },
-                    "journal_volume": {
-                        "type": "string"
-                    },
-                    "conference_paper_info": {
-                        "type": "string",
-                        "description": "FIXME: This is currently the CNUM"
-                    },
-                    "recid": {
-                        "type": "integer",
-                        "description": "Record ID of the conference"
-                    },
-                    "year": {
-                        "minimum": 1000,
-                        "type": "integer",
-                        "maximum": 2050
-                    },
-                    "curated_relation": {
-                        "type": "boolean"
-                    },
-                    "journal_issue": {
-                        "type": "string"
-                    },
-                    "page_range": {
-                        "type": "string",
-                        "description": "FIXME: for ejournals this could be the page index, but there is no realiable way to know whether something is a page index or a first page, does it?"
-                    }
-                }
-            },
-            "type": "array",
-            "description": "FIXME: Shall we split conference information away? FIXME: shall we move the DOI and ISBN next to where it belongs? So that we can also align erratum and friends?"
-        },
-        "reference": {
-            "uniqueItems": true,
-            "items": {
-                "type": "object",
-                "properties": {
-                    "publisher": {
-                        "type": "string"
-                    },
-                    "doi": {
-                        "pattern": "10\\.\\d+(\\.\\d+)?/.+",
-                        "type": "string"
-                    },
-                    "isbn": {
-                        "type": "string",
-                        "format": "isbn"
-                    },
-                    "texkey": {
-                        "type": "string"
-                    },
-                    "report_number": {
-                        "type": "string"
-                    },
-                    "url": {
-                        "type": "string",
-                        "format": "url"
-                    },
-                    "collaboration": {
-                        "type": "string"
-                    },
-                    "title": {
-                        "type": "string"
-                    },
-                    "misc": {
-                        "type": "string"
-                    },
-                    "editors": {
-                        "type": "string"
-                    },
-                    "number": {
-                        "type": "integer"
-                    },
-                    "curated_relation": {
-                        "type": "boolean"
-                    },
-                    "maintitle": {
-                        "type": "string"
-                    },
-                    "recid": {
-                        "type": "integer"
-                    },
-                    "raw_reference": {
-                        "type": "string"
-                    },
-                    "year": {
-                        "type": "integer"
-                    },
-                    "authors": {
-                        "type": "string"
-                    },
-                    "journal_pubnote": {
-                        "pattern": ".*,.*,.*",
-                        "type": "string"
-                    }
-                }
-            },
-            "type": "array"
-        },
-        "copyright": {
-            "type": "object",
-            "properties": {
-                "url": {
-                    "type": "string",
-                    "format": "url"
-                },
-                "material": {
-                    "enum": [
-                        "Article"
-                    ],
-                    "type": "string"
-                },
-                "holder": {
-                    "enum": [
-                        "American Physical Society",
-                        "World Scientific Publishing Company",
-                        "authors",
-                        "CERN"
-                    ],
-                    "type": "string",
-                    "description": "Copyright holder. FIXME: should we restrict this to an enum, or not?"
-                },
-                "statement": {
-                    "type": "string",
-                    "description": "FIXME: What's that? there are all sorts of usages on production!"
-                },
-                "year": {
-                    "type": "integer"
-                }
-            }
-        },
-        "subject_terms": {
-            "uniqueItems": true,
-            "items": {
-                "required": [
-                    "term"
-                ],
-                "type": "object",
-                "properties": {
-                    "source": {
-                        "enum": [
-                            "automatically added based on DCC, PPF, DK",
-                            "submitter",
-                            "INSPIRE"
-                        ],
-                        "type": "string"
-                    },
-                    "term": {
-                        "type": "string"
-                    },
-                    "scheme": {
-                        "enum": [
-                            "INSPIRE",
-                            "arXiv",
-                            "APS",
-                            "PoS",
-                            "Elsevier"
-                        ],
-                        "type": "string"
-                    }
-                }
-            },
-            "type": "array"
-        },
-        "thesaurus_terms": {
-            "uniqueItems": true,
-            "items": {
-                "type": "object",
-                "properties": {
-                    "scheme": {
-                        "enum": [
-                            "INSPIRE",
-                            "JACoW"
-                        ],
-                        "type": "string"
-                    },
-                    "keyword": {
-                        "type": "string"
-                    },
-                    "energy_range": {
-                        "minimum": 0,
-                        "type": "integer",
-                        "description": "FIXME: What... is... that!?",
-                        "maximum": 9
-                    }
-                }
-            },
-            "type": "array"
-        },
-        "experiment": {
-            "required": [
-                "value"
-            ],
-            "type": "object",
-            "properties": {
-                "curated_relation": {
-                    "default": false,
-                    "type": "boolean",
-                    "description": "Was the experiment actually proofchecked by a cataloguer?"
-                },
-                "recid": {
-                    "type": "integer",
-                    "description": "Record ID of the corresponding experiment."
-                },
-                "value": {
-                    "type": "string",
-                    "description": "Raw string. Do we actually need it at all? Can it be taken from the record ID? NOTE: I am not adding accelerator field. Do we have papers on accelerators but not on experiments? Can we always derive the accelerator from the experiment?"
-                }
-            }
+            "uniqueItems": true
         },
         "arxiv_eprints": {
-            "uniqueItems": true,
             "items": {
                 "properties": {
-                    "value": {
-                        "type": "string",
-                        "pattern": "\\d{4}.\\d{4}{5}|\\w+-\\+/\\d+"
-                    },
                     "categories": {
                         "items": {
                             "type": "string"
                         },
                         "type": "array"
+                    },
+                    "value": {
+                        "pattern": "\\d{4}.\\d{4}{5}|\\w+-\\+/\\d+",
+                        "type": "string"
                     }
                 }
             },
-            "type": "array"
-        },
-        "title_variation": {
-            "uniqueItems": true,
-            "items": {
-                "type": "string"
-            },
-            "type": "array"
-        },
-        "core": {
-            "type": "boolean",
-            "description": "Whether this document is CORE and hence need special curation. NOTE: set this explicitly to false, in order to have real noncore."
-        },
-        "book_series": {
-            "type": "object",
-            "properties": {
-                "volume": {
-                    "type": "string",
-                    "description": "Specific volume number"
-                },
-                "title": {
-                    "type": "string",
-                    "description": "Title of the book series"
-                }
-            }
-        },
-        "collaboration": {
-            "uniqueItems": true,
-            "items": {
-                "type": "string"
-            },
-            "type": "array"
+            "type": "array",
+            "uniqueItems": true
         },
         "authors": {
-            "uniqueItems": true,
+            "description": "List with all the authors",
             "items": {
-                "type": "object",
                 "properties": {
-                    "other_ids": {
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "source": {
-                                    "type": "string",
-                                    "title": "Source of ID"
-                                },
-                                "value": {
-                                    "type": "string",
-                                    "title": "ID"
-                                }
-                            },
-                            "title": "ID"
-                        },
-                        "type": "array",
-                        "description": "Just in case...",
-                        "title": "Other IDs"
-                    },
-                    "name": {
-                        "title": "Author name",
-                        "type": "string",
-                        "description": "author name as it appears in the paper",
-                        "format": ".+, .+"
-                    },
                     "affiliations": {
-                        "uniqueItems": true,
                         "items": {
-                            "type": "object",
                             "properties": {
+                                "curated": {
+                                    "default": false,
+                                    "type": "boolean"
+                                },
                                 "curated_relation": {
-                                    "type": "boolean",
                                     "description": "Did a cataloguer proof-checked the recid?",
-                                    "title": "The affiliation is curated?"
+                                    "title": "The affiliation is curated?",
+                                    "type": "boolean"
                                 },
                                 "recid": {
-                                    "type": "integer",
                                     "description": "Record ID in the Institution collection",
-                                    "title": "Record ID of institution"
+                                    "title": "Record ID of institution",
+                                    "type": "integer"
                                 },
                                 "value": {
-                                    "type": "string",
                                     "description": "The affiliation as it appears on the paper",
-                                    "title": "Name of institution"
+                                    "title": "Name of institution",
+                                    "type": "string"
                                 }
                             },
-                            "title": "Affiliation"
+                            "title": "Affiliation",
+                            "type": "object"
                         },
+                        "title": "Affiliations",
                         "type": "array",
-                        "title": "Affiliations"
+                        "uniqueItems": true
                     },
-                    "inspire_id": {
-                        "pattern": "INSPIRE-\\d+",
-                        "type": "string",
-                        "description": "Legacy INSPIRE ID when available",
-                        "title": "INSPIRE ID"
-                    },
-                    "inspire_bai": {
-                        "pattern": "(\\w+\\.)+\\d+",
-                        "type": "string",
-                        "description": "INSPIRE BAI when available",
-                        "title": "INSPIRE BibAuthorID"
+                    "curated": {
+                        "default": false,
+                        "type": "boolean"
                     },
                     "curated_relation": {
                         "default": false,
-                        "type": "boolean",
                         "description": "Was this signature actually claimed or proof-checked by cataloguer?",
-                        "title": "The relation is curated?"
+                        "title": "The relation is curated?",
+                        "type": "boolean"
                     },
-                    "recid": {
-                        "type": "integer",
-                        "description": "Record ID of the person in HepNames",
-                        "title": "Record ID of the person"
+                    "email": {
+                        "format": "email",
+                        "title": "Email",
+                        "type": "string"
+                    },
+                    "inspire_bai": {
+                        "description": "INSPIRE BAI when available",
+                        "pattern": "(\\w+\\.)+\\d+",
+                        "title": "INSPIRE BibAuthorID",
+                        "type": "string"
+                    },
+                    "inspire_id": {
+                        "description": "Legacy INSPIRE ID when available",
+                        "pattern": "INSPIRE-\\d+",
+                        "title": "INSPIRE ID",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "author name as it appears in the paper",
+                        "format": ".+, .+",
+                        "title": "Author name",
+                        "type": "string"
                     },
                     "orcid": {
+                        "description": "ORCID Id when available",
+                        "format": "orcid",
                         "pattern": "\\d{4}-\\d{4}-\\d{4}-\\d{4}",
                         "title": "ORCID ID",
-                        "type": "string",
-                        "description": "ORCID Id when available",
-                        "format": "orcid"
+                        "type": "string"
+                    },
+                    "other_ids": {
+                        "description": "Just in case...",
+                        "items": {
+                            "properties": {
+                                "source": {
+                                    "title": "Source of ID",
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "title": "ID",
+                                    "type": "string"
+                                }
+                            },
+                            "title": "ID",
+                            "type": "object"
+                        },
+                        "title": "Other IDs",
+                        "type": "array"
+                    },
+                    "recid": {
+                        "description": "Record ID of the person in HepNames",
+                        "title": "Record ID of the person",
+                        "type": "integer"
                     },
                     "role": {
+                        "description": "Role of the author within the paper. So far only Editor was captured.",
                         "enum": [
                             "",
                             "ed."
                         ],
-                        "type": "string",
-                        "description": "Role of the author within the paper. So far only Editor was captured.",
-                        "title": "Role of the person"
+                        "title": "Role of the person",
+                        "type": "string"
                     },
-                    "email": {
-                        "title": "Email",
-                        "type": "string",
-                        "format": "email"
+                    "source": {
+                        "enum": [
+                            "arXiv",
+                            "publisher",
+                            "user"
+                        ],
+                        "type": "string"
                     }
                 },
-                "title": "Author"
+                "title": "Author",
+                "type": "object"
+            },
+            "title": "Authors",
+            "type": "array",
+            "uniqueItems": true
+        },
+        "book_series": {
+            "items": {
+                "properties": {
+                    "curated": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "source": {
+                        "enum": [
+                            "arXiv",
+                            "publisher",
+                            "user"
+                        ],
+                        "type": "string"
+                    },
+                    "title": {
+                        "description": "Title of the book series",
+                        "type": "string"
+                    },
+                    "volume": {
+                        "description": "Specific volume number",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
             },
             "type": "array",
-            "description": "List with all the authors",
-            "title": "Authors"
+            "uniqueItems": true
+        },
+        "citeable": {
+            "description": "Whether this document can be cited. FIXME: can this be derived from other properties?",
+            "title": "Citeable?",
+            "type": "boolean"
         },
         "classification_number": {
-            "uniqueItems": true,
             "items": {
-                "type": "object",
                 "properties": {
-                    "value": {
-                        "type": "string",
-                        "description": "PACS or PDG codes. FIXME: What about better separating these into a PACS field and a PDG field?",
-                        "title": "Number"
+                    "curated": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "source": {
+                        "enum": [
+                            "arXiv",
+                            "publisher",
+                            "user"
+                        ],
+                        "type": "string"
                     },
                     "standard": {
                         "enum": [
                             "PACS",
                             "PDG"
                         ],
-                        "type": "string",
-                        "title": "Standard"
-                    }
-                },
-                "title": "Classification number"
-            },
-            "type": "array",
-            "title": "Classification numbers"
-        },
-        "dois": {
-            "uniqueItems": true,
-            "items": {
-                "type": "object",
-                "properties": {
-                    "source": {
-                        "type": "string",
-                        "description": "Issuing of DOI. FIXME: should we have an enum",
-                        "title": "DOI registrant"
-                    },
-                    "qualifying_information": {
-                        "enum": [
-                            "Erratum",
-                            "Addendum",
-                            "ebook",
-                            "Corrigendum"
-                        ],
-                        "type": "string",
-                        "title": "Qualifying information"
+                        "title": "Standard",
+                        "type": "string"
                     },
                     "value": {
-                        "pattern": "10\\.\\d+(\\.\\d+)?/.+",
-                        "type": "string",
-                        "title": "DOI"
+                        "description": "PACS or PDG codes. FIXME: What about better separating these into a PACS field and a PDG field?",
+                        "title": "Number",
+                        "type": "string"
                     }
                 },
-                "title": "DOI"
+                "title": "Classification number",
+                "type": "object"
+            },
+            "title": "Classification numbers",
+            "type": "array",
+            "uniqueItems": true
+        },
+        "collaboration": {
+            "items": {
+                "properties": {
+                    "curated": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "source": {
+                        "enum": [
+                            "arXiv",
+                            "publisher",
+                            "user"
+                        ],
+                        "type": "string"
+                    },
+                    "value": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
             },
             "type": "array",
-            "title": "DOIs"
+            "uniqueItems": true
+        },
+        "copyright": {
+            "items": {
+                "properties": {
+                    "curated": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "holder": {
+                        "description": "Copyright holder. FIXME: should we restrict this to an enum, or not?",
+                        "enum": [
+                            "American Physical Society",
+                            "World Scientific Publishing Company",
+                            "authors",
+                            "CERN"
+                        ],
+                        "type": "string"
+                    },
+                    "material": {
+                        "enum": [
+                            "Article"
+                        ],
+                        "type": "string"
+                    },
+                    "source": {
+                        "enum": [
+                            "arXiv",
+                            "publisher",
+                            "user"
+                        ],
+                        "type": "string"
+                    },
+                    "statement": {
+                        "description": "FIXME: What's that? there are all sorts of usages on production!",
+                        "type": "string"
+                    },
+                    "url": {
+                        "format": "url",
+                        "type": "string"
+                    },
+                    "year": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "type": "array",
+            "uniqueItems": true
+        },
+        "core": {
+            "description": "Whether this document is CORE and hence need special curation. NOTE: set this explicitly to false, in order to have real noncore.",
+            "type": "boolean"
+        },
+        "corporate_author": {
+            "items": {
+                "properties": {
+                    "curated": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "source": {
+                        "enum": [
+                            "arXiv",
+                            "publisher",
+                            "user"
+                        ],
+                        "type": "string"
+                    },
+                    "value": {
+                        "title": "Corporate author",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "title": "Corporate authors",
+            "type": "array",
+            "uniqueItems": true
         },
         "document_type": {
-            "minItems": 1,
             "items": {
                 "enum": [
                     "Published",
@@ -776,136 +362,791 @@
                 ],
                 "type": "string"
             },
-            "uniqueItems": true,
+            "minItems": 1,
+            "title": "Document type",
             "type": "array",
-            "title": "Document type"
+            "uniqueItems": true
         },
-        "citeable": {
-            "type": "boolean",
-            "description": "Whether this document can be cited. FIXME: can this be derived from other properties?",
-            "title": "Citeable?"
-        },
-        "license": {
-            "uniqueItems": true,
+        "dois": {
             "items": {
-                "type": "object",
                 "properties": {
-                    "imposing": {
-                        "type": "string",
-                        "description": "FIXME: what is this!?",
-                        "title": "Imposing"
+                    "curated": {
+                        "default": false,
+                        "type": "boolean"
                     },
-                    "url": {
-                        "title": "URL of the license",
-                        "type": "string",
-                        "format": "url"
+                    "qualifying_information": {
+                        "enum": [
+                            "Erratum",
+                            "Addendum",
+                            "ebook",
+                            "Corrigendum"
+                        ],
+                        "title": "Qualifying information",
+                        "type": "string"
                     },
-                    "material": {
-                        "type": "string",
-                        "title": "Material referred by the license"
-                    },
-                    "license": {
-                        "type": "string",
-                        "title": "License name"
-                    }
-                },
-                "title": "License"
-            },
-            "type": "array",
-            "title": "License information"
-        },
-        "language": {
-            "type": "string",
-            "description": "FIXME: we shall provide the ISO enum",
-            "title": "Language"
-        },
-        "url": {
-            "uniqueItems": true,
-            "items": {
-                "type": "object",
-                "properties": {
-                    "doc_string": {
-                        "type": "string",
-                        "description": "FIXME: What is this!?",
-                        "title": "Doc String"
-                    },
-                    "url": {
-                        "title": "URL",
-                        "type": "string",
-                        "format": "url"
-                    },
-                    "material_type": {
-                        "type": "string",
-                        "title": "Type of material"
-                    },
-                    "description": {
-                        "type": "string",
-                        "title": "Description"
-                    },
-                    "size": {
-                        "type": "integer",
-                        "title": "Size"
-                    }
-                },
-                "title": "URL"
-            },
-            "type": "array",
-            "title": "URLs"
-        },
-        "number_of_pages": {
-            "type": "integer",
-            "title": "Number of pages"
-        },
-        "title_translation": {
-            "uniqueItems": true,
-            "items": {
-                "type": "object",
-                "properties": {
-                    "subtitle": {
-                        "type": "string",
-                        "title": "Subtitle"
+                    "source": {
+                        "enum": [
+                            "arXiv",
+                            "publisher",
+                            "user"
+                        ],
+                        "type": "string"
                     },
                     "value": {
-                        "type": "string",
-                        "title": "Title"
+                        "pattern": "10\\.\\d+(\\.\\d+)?/.+",
+                        "title": "DOI",
+                        "type": "string"
                     }
                 },
-                "title": "Title translation"
+                "title": "DOI",
+                "type": "object"
             },
+            "title": "DOIs",
             "type": "array",
-            "title": "Title translations"
+            "uniqueItems": true
         },
-        "corporate_author": {
-            "uniqueItems": true,
-            "items": {
-                "type": "string",
-                "title": "Corporate author"
+        "experiment": {
+            "properties": {
+                "curated": {
+                    "default": false,
+                    "type": "boolean"
+                },
+                "curated_relation": {
+                    "default": false,
+                    "description": "Was the experiment actually proofchecked by a cataloguer?",
+                    "type": "boolean"
+                },
+                "recid": {
+                    "description": "Record ID of the corresponding experiment.",
+                    "type": "integer"
+                },
+                "source": {
+                    "enum": [
+                        "arXiv",
+                        "publisher",
+                        "user"
+                    ],
+                    "type": "string"
+                },
+                "value": {
+                    "description": "Raw string. Do we actually need it at all? Can it be taken from the record ID? NOTE: I am not adding accelerator field. Do we have papers on accelerators but not on experiments? Can we always derive the accelerator from the experiment?",
+                    "type": "string"
+                }
             },
-            "type": "array",
-            "title": "Corporate authors"
+            "required": [
+                "value"
+            ],
+            "type": "object"
         },
         "external_system_number": {
-            "uniqueItems": true,
             "items": {
-                "type": "object",
                 "properties": {
                     "institute": {
-                        "type": "string",
-                        "title": "Institute"
+                        "title": "Institute",
+                        "type": "string"
                     },
                     "obsolete": {
-                        "type": "boolean",
-                        "title": "Obsolete?"
+                        "title": "Obsolete?",
+                        "type": "boolean"
                     },
                     "value": {
-                        "type": "string",
-                        "title": "Number"
+                        "title": "Number",
+                        "type": "string"
                     }
                 },
-                "title": "External system number"
+                "title": "External system number",
+                "type": "object"
+            },
+            "title": "External system numbers",
+            "type": "array",
+            "uniqueItems": true
+        },
+        "funding_info": {
+            "description": "Information related to funding. FIXME: Do we care about this? So far only 349 records were tagged and all for a single EU project.",
+            "items": {
+                "properties": {
+                    "agency": {
+                        "title": "Agency",
+                        "type": "string"
+                    },
+                    "curated": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "grant_number": {
+                        "title": "Grant number",
+                        "type": "string"
+                    },
+                    "project_number": {
+                        "title": "Project number",
+                        "type": "string"
+                    },
+                    "source": {
+                        "enum": [
+                            "arXiv",
+                            "publisher",
+                            "user"
+                        ],
+                        "type": "string"
+                    }
+                },
+                "title": "Grant information",
+                "type": "object"
+            },
+            "title": "Funding information",
+            "type": "array",
+            "uniqueItems": true
+        },
+        "hidden_note": {
+            "description": "FIXME: what about 595__d??",
+            "items": {
+                "properties": {
+                    "cern_reference": {
+                        "description": "FIXME: Do we know what this is? do we care?",
+                        "type": "string"
+                    },
+                    "source": {
+                        "description": "FIXME: What's the semantic of this source?",
+                        "enum": [
+                            "SPIRES-HIDDEN",
+                            "CERN",
+                            "submitter"
+                        ],
+                        "type": "string"
+                    },
+                    "value": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
             },
             "type": "array",
-            "title": "External system numbers"
+            "uniqueItems": true
+        },
+        "imprint": {
+            "items": {
+                "properties": {
+                    "curated": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "date": {
+                        "format": "date",
+                        "type": "string"
+                    },
+                    "place": {
+                        "type": "string"
+                    },
+                    "publisher": {
+                        "description": "FIXME: an enum?",
+                        "type": "string"
+                    },
+                    "source": {
+                        "enum": [
+                            "arXiv",
+                            "publisher",
+                            "user"
+                        ],
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "type": "array",
+            "uniqueItems": true
+        },
+        "isbn": {
+            "description": "ISBN codes identifying the given book",
+            "items": {
+                "properties": {
+                    "curated": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "medium": {
+                        "description": "FIXME: this really need to be an enum and cleaned up. What is Print?!",
+                        "enum": [
+                            "Print",
+                            "Online",
+                            "ebook",
+                            "hardcover",
+                            "paperback"
+                        ],
+                        "title": "Medium",
+                        "type": "string"
+                    },
+                    "source": {
+                        "enum": [
+                            "arXiv",
+                            "publisher",
+                            "user"
+                        ],
+                        "type": "string"
+                    },
+                    "value": {
+                        "format": "isbn",
+                        "title": "code",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "value"
+                ],
+                "title": "ISBN code",
+                "type": "object"
+            },
+            "title": "ISBN codes",
+            "type": "array",
+            "uniqueItems": true
+        },
+        "language": {
+            "description": "FIXME: we shall provide the ISO enum",
+            "title": "Language",
+            "type": "string"
+        },
+        "license": {
+            "items": {
+                "properties": {
+                    "curated": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "imposing": {
+                        "description": "FIXME: what is this!?",
+                        "title": "Imposing",
+                        "type": "string"
+                    },
+                    "license": {
+                        "title": "License name",
+                        "type": "string"
+                    },
+                    "material": {
+                        "title": "Material referred by the license",
+                        "type": "string"
+                    },
+                    "source": {
+                        "enum": [
+                            "arXiv",
+                            "publisher",
+                            "user"
+                        ],
+                        "type": "string"
+                    },
+                    "url": {
+                        "format": "url",
+                        "title": "URL of the license",
+                        "type": "string"
+                    }
+                },
+                "title": "License",
+                "type": "object"
+            },
+            "title": "License information",
+            "type": "array",
+            "uniqueItems": true
+        },
+        "number_of_pages": {
+            "items": {
+                "properties": {
+                    "curated": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "source": {
+                        "enum": [
+                            "arXiv",
+                            "publisher",
+                            "user"
+                        ],
+                        "type": "string"
+                    },
+                    "value": {
+                        "title": "Number of pages",
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "type": "array",
+            "uniqueItems": true
+        },
+        "preprint_date": {
+            "format": "date",
+            "type": "string"
+        },
+        "public_notes": {
+            "items": {
+                "properties": {
+                    "curated": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "source": {
+                        "enum": [
+                            "arXiv",
+                            "publisher",
+                            "user"
+                        ],
+                        "type": "string"
+                    },
+                    "value": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "value"
+                ],
+                "type": "object"
+            },
+            "type": "array",
+            "uniqueItems": true
+        },
+        "publication_info": {
+            "description": "FIXME: Shall we split conference information away? FIXME: shall we move the DOI and ISBN next to where it belongs? So that we can also align erratum and friends?",
+            "items": {
+                "properties": {
+                    "conference_paper_info": {
+                        "description": "FIXME: This is currently the CNUM",
+                        "type": "string"
+                    },
+                    "curated": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "curated_relation": {
+                        "type": "boolean"
+                    },
+                    "journal_issue": {
+                        "type": "string"
+                    },
+                    "journal_title": {
+                        "type": "string"
+                    },
+                    "journal_volume": {
+                        "type": "string"
+                    },
+                    "page_range": {
+                        "description": "FIXME: for ejournals this could be the page index, but there is no realiable way to know whether something is a page index or a first page, does it?",
+                        "type": "string"
+                    },
+                    "pubinfo_freetext": {
+                        "type": "string"
+                    },
+                    "recid": {
+                        "description": "Record ID of the conference",
+                        "type": "integer"
+                    },
+                    "source": {
+                        "enum": [
+                            "arXiv",
+                            "publisher",
+                            "user"
+                        ],
+                        "type": "string"
+                    },
+                    "year": {
+                        "maximum": 2050,
+                        "minimum": 1000,
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "type": "array",
+            "uniqueItems": true
+        },
+        "reference": {
+            "items": {
+                "properties": {
+                    "authors": {
+                        "type": "string"
+                    },
+                    "collaboration": {
+                        "type": "string"
+                    },
+                    "curated": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "curated_relation": {
+                        "type": "boolean"
+                    },
+                    "doi": {
+                        "pattern": "10\\.\\d+(\\.\\d+)?/.+",
+                        "type": "string"
+                    },
+                    "editors": {
+                        "type": "string"
+                    },
+                    "isbn": {
+                        "format": "isbn",
+                        "type": "string"
+                    },
+                    "journal_pubnote": {
+                        "pattern": ".*,.*,.*",
+                        "type": "string"
+                    },
+                    "maintitle": {
+                        "type": "string"
+                    },
+                    "misc": {
+                        "type": "string"
+                    },
+                    "number": {
+                        "type": "integer"
+                    },
+                    "publisher": {
+                        "type": "string"
+                    },
+                    "raw_reference": {
+                        "type": "string"
+                    },
+                    "recid": {
+                        "type": "integer"
+                    },
+                    "report_number": {
+                        "type": "string"
+                    },
+                    "source": {
+                        "enum": [
+                            "arXiv",
+                            "publisher",
+                            "user"
+                        ],
+                        "type": "string"
+                    },
+                    "texkey": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "format": "url",
+                        "type": "string"
+                    },
+                    "year": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "type": "array",
+            "uniqueItems": true
+        },
+        "report_number": {
+            "items": {
+                "properties": {
+                    "curated": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "primary": {
+                        "type": "boolean"
+                    },
+                    "source": {
+                        "enum": [
+                            "arXiv",
+                            "publisher",
+                            "user"
+                        ],
+                        "type": "string"
+                    },
+                    "value": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "type": "array",
+            "uniqueItems": true
+        },
+        "spires_sysnos": {
+            "items": {
+                "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+        },
+        "subject_terms": {
+            "items": {
+                "properties": {
+                    "curated": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "scheme": {
+                        "enum": [
+                            "INSPIRE",
+                            "arXiv",
+                            "APS",
+                            "PoS",
+                            "Elsevier"
+                        ],
+                        "type": "string"
+                    },
+                    "source": {
+                        "enum": [
+                            "arXiv",
+                            "publisher",
+                            "user"
+                        ],
+                        "type": "string"
+                    },
+                    "term": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "term"
+                ],
+                "type": "object"
+            },
+            "type": "array",
+            "uniqueItems": true
+        },
+        "superseding": {
+            "items": {
+                "type": "integer"
+            },
+            "type": "array",
+            "uniqueItems": true
+        },
+        "thesaurus_terms": {
+            "items": {
+                "properties": {
+                    "curated": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "energy_range": {
+                        "description": "FIXME: What... is... that!?",
+                        "maximum": 9,
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "keyword": {
+                        "type": "string"
+                    },
+                    "scheme": {
+                        "enum": [
+                            "INSPIRE",
+                            "JACoW"
+                        ],
+                        "type": "string"
+                    },
+                    "source": {
+                        "enum": [
+                            "arXiv",
+                            "publisher",
+                            "user"
+                        ],
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "type": "array",
+            "uniqueItems": true
+        },
+        "thesis": {
+            "items": {
+                "properties": {
+                    "curated_relation": {
+                        "type": "boolean"
+                    },
+                    "date": {
+                        "format": "date",
+                        "type": "string"
+                    },
+                    "degree_type": {
+                        "description": "FIXME: this enum must be reviewed",
+                        "enum": [
+                            "PhD",
+                            "Master",
+                            "Bachelor",
+                            "Diploma",
+                            "Habilitation",
+                            "Laurea",
+                            "Thesis"
+                        ],
+                        "type": "string"
+                    },
+                    "recid": {
+                        "description": "Record ID of the matched insitution.",
+                        "type": "integer"
+                    },
+                    "university": {
+                        "description": "FIXME: shall we match these with the insitution database? I guess so.",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "type": "array",
+            "uniqueItems": true
+        },
+        "thesis_supervisor": {
+            "items": {
+                "properties": {
+                    "affiliation": {
+                        "properties": {
+                            "curated": {
+                                "default": false,
+                                "type": "boolean"
+                            },
+                            "curated_relation": {
+                                "type": "boolean"
+                            },
+                            "recid": {
+                                "type": "integer"
+                            },
+                            "source": {
+                                "enum": [
+                                    "arXiv",
+                                    "publisher",
+                                    "user"
+                                ],
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "curated": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "curated_relation": {
+                        "type": "boolean"
+                    },
+                    "full_name": {
+                        "type": "string"
+                    },
+                    "recid": {
+                        "type": "integer"
+                    },
+                    "source": {
+                        "enum": [
+                            "arXiv",
+                            "publisher",
+                            "user"
+                        ],
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "full_name"
+                ],
+                "type": "object"
+            },
+            "type": "array",
+            "uniqueItems": true
+        },
+        "title_translation": {
+            "items": {
+                "properties": {
+                    "subtitle": {
+                        "title": "Subtitle",
+                        "type": "string"
+                    },
+                    "value": {
+                        "title": "Title",
+                        "type": "string"
+                    }
+                },
+                "title": "Title translation",
+                "type": "object"
+            },
+            "title": "Title translations",
+            "type": "array",
+            "uniqueItems": true
+        },
+        "title_variation": {
+            "items": {
+                "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+        },
+        "titles": {
+            "items": {
+                "properties": {
+                    "curated": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "source": {
+                        "enum": [
+                            "arXiv",
+                            "publisher",
+                            "user"
+                        ],
+                        "type": "string"
+                    },
+                    "subtitle": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "type": "array",
+            "uniqueItems": true
+        },
+        "url": {
+            "items": {
+                "properties": {
+                    "curated": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "description": {
+                        "title": "Description",
+                        "type": "string"
+                    },
+                    "doc_string": {
+                        "description": "FIXME: What is this!?",
+                        "title": "Doc String",
+                        "type": "string"
+                    },
+                    "material_type": {
+                        "title": "Type of material",
+                        "type": "string"
+                    },
+                    "size": {
+                        "title": "Size",
+                        "type": "integer"
+                    },
+                    "source": {
+                        "enum": [
+                            "arXiv",
+                            "publisher",
+                            "user"
+                        ],
+                        "type": "string"
+                    },
+                    "url": {
+                        "format": "url",
+                        "title": "URL",
+                        "type": "string"
+                    }
+                },
+                "title": "URL",
+                "type": "object"
+            },
+            "title": "URLs",
+            "type": "array",
+            "uniqueItems": true
         }
-    }
+    },
+    "required": [
+        "title"
+    ],
+    "title": "Publication",
+    "type": "object"
 }


### PR DESCRIPTION
* Introduces source and curated fields everywhere, so that it is
  possible to cleanly distinguish between arXiv and publisher
  information. Converte to list of objects when necessary.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>