### PR TITLE
converter: add encoding task

### DIFF
--- a/inspire/modules/converter/tasks.py
+++ b/inspire/modules/converter/tasks.py
@@ -1,3 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2015 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
 import traceback
 
 from functools import wraps
@@ -23,7 +45,6 @@ def convert_record(stylesheet="oaidc2marcxml.xsl"):
             raise WorkflowError("Error: conversion data missing",
                                 id_workflow=eng.uuid,
                                 id_object=obj.id)
-
         try:
             obj.data = convert(obj.data, stylesheet)
         except Exception as e:
@@ -35,3 +56,13 @@ def convert_record(stylesheet="oaidc2marcxml.xsl"):
 
     _convert_record.description = 'Convert record'
     return _convert_record
+
+
+def convert_encoding(from_encoding="ISO-8859-1", to_encoding="UTF-8"):
+    """Convert obj.data string from one encoding to another."""
+    @wraps(convert_encoding)
+    def _convert_encoding(obj, dummy):
+        try:
+            obj.data = obj.data.encode(from_encoding).decode(to_encoding)
+        except (UnicodeEncodeError, UnicodeDecodeError) as err:
+            obj.log.error(err)

--- a/inspire/modules/workflows/workflows/oaiharvest_production_sync.py
+++ b/inspire/modules/workflows/workflows/oaiharvest_production_sync.py
@@ -22,7 +22,10 @@
 from invenio_oaiharvester.tasks.records import convert_record_to_json
 from invenio_workflows.definitions import RecordWorkflow
 
-from inspire.modules.converter.tasks import convert_record
+from inspire.modules.converter.tasks import (
+    convert_record,
+    convert_encoding,
+)
 from inspire.modules.workflows.tasks.upload import store_record
 
 
@@ -33,7 +36,13 @@ class oaiharvest_production_sync(RecordWorkflow):
     object_type = "production sync"
 
     workflow = [
-        convert_record("oaiinspiremarc2marcxml.xsl"),
+        convert_encoding(
+            from_encoding="ISO-8859-1",
+            to_encoding="UTF-8"
+        ),
+        convert_record(
+            stylesheet="oaiinspiremarc2marcxml.xsl",
+        ),
         convert_record_to_json,
         store_record,
     ]


### PR DESCRIPTION
* Adds an encoding task for use in the INSPIRE production
  synchronization workflow as the data coming from INSPIRE
  is given as ISO-8859-1.

Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>