### PR TITLE
demosite: brand new demo records

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -261,7 +261,7 @@ You can now load the INSPIRE demo records:
 .. code-block:: console
 
     (inspire)$ cdvirtualenv src/inspire-next
-    (inspire)$ inveniomanage records create inspire/demosite/data/demo-records.xml -t marcxml
+    (inspire)$ inveniomanage migrator populate -t marcxml -f inspire/demosite/data/demo-records.xml --force
 
 
 Now you should have a running INSPIRE demo site running at `http://localhost:4000 <http://localhost:4000>`_!

--- a/inspire/dojson/experiments/fields/bd1xx.py
+++ b/inspire/dojson/experiments/fields/bd1xx.py
@@ -90,7 +90,14 @@ def spokesperson(self, key, value):
 @experiments.over('collaboration', '^710..')
 def collaboration(self, key, value):
     """Collaboration of experiment."""
-    return value.get("g")
+    if isinstance(value, list):
+        collaborations = sorted((elem["g"] for elem in value if 'g' in elem), key=lambda x: len(x))
+        if len(collaborations) > 1:
+            self['collaboration_alternative_names'] = collaborations[1:]
+        if collaborations:
+            return collaborations[0]
+    else:
+        return value.get("g")
 
 
 @experiments.over('urls', '^856.[10_28]')

--- a/inspire/dojson/experiments/schemas/experiments-0.0.1.json
+++ b/inspire/dojson/experiments/schemas/experiments-0.0.1.json
@@ -22,6 +22,15 @@
             "title": "Collaboration",
             "type": "string"
         },
+        "collaboration_alternative_names": {
+            "title": "Collaboration alternative names",
+            "type": "array",
+            "items": {
+                "title": "Collaboration alternative name",
+                "type": "string"
+            },
+            "uniqueItems": true
+        },
         "contact_email": {
             "title": "Contact email",
             "type": "string"

--- a/inspire/dojson/hep/fields/bd01x09x.py
+++ b/inspire/dojson/hep/fields/bd01x09x.py
@@ -55,7 +55,7 @@ def dois(self, key, value):
     value = utils.force_list(value)
     out = []
     for val in value:
-        if val and val.get("2").lower() == "doi":
+        if val and val.get("2", '').lower() == "doi":
             out.append({
                 'value': val.get('a'),
                 'source': val.get('9')
@@ -69,7 +69,7 @@ def persistent_identifiers(self, key, value):
     value = utils.force_list(value)
     out = []
     for val in value:
-        if val and val.get("2").lower() != "doi":
+        if val and val.get("2", '').lower() != "doi":
             out.append({
                 'value': val.get('a'),
                 'source': val.get('9'),

--- a/inspire/dojson/hep/fields/bd25x28x.py
+++ b/inspire/dojson/hep/fields/bd25x28x.py
@@ -74,6 +74,8 @@ def imprints2marc(self, key, value):
 @hep.over('preprint_date', '^269..')
 def preprint_date(self, key, value):
     """Preprint info."""
+    if isinstance(value, list):
+        return min(elem['c'] for elem in value if 'c' in elem)
     return value.get('c')
 
 

--- a/inspire/modules/citations/models.py
+++ b/inspire/modules/citations/models.py
@@ -37,7 +37,6 @@ class Citation(db.Model):
         self.citer = citer
         self.last_updated = last_updated
 
-    @session_manager
     def save(self):
         db.session.merge(self)
 
@@ -67,7 +66,6 @@ class Citation_Log(db.Model):
         self.action_date = action_date
         self.citation_type = citation_type
 
-    @session_manager
     def save(self):
         """ Saves the new log entry to the database.
 

--- a/inspire/modules/citations/testsuite/test_citations.py
+++ b/inspire/modules/citations/testsuite/test_citations.py
@@ -23,22 +23,29 @@ import httpretty
 
 from inspire.modules.citations.models import Citation, Citation_Log
 
+from invenio.testsuite import InvenioTestCase
+
 from invenio_base.globals import cfg
 
-from invenio.testsuite import InvenioTestCase
+from invenio_ext.sqlalchemy import db
 
 
 class CitationsTests(InvenioTestCase):
 
     """Test citations connection."""
 
-    setup_flag = True
-    citations_dump = None
-    citations_log_dump = None
-
     @httpretty.activate
     def setUp(self):
         """ Initialises test by adding dummy log entries """
+        from invenio_records.api import create_record
+        from invenio_records.models import Record
+
+        self.__transaction = db.session.begin_nested()
+        for i in range(10):
+            rec = Record(id=i + 1)
+            db.session.add(rec)
+            create_record({'recid': i + 1})
+
         from inspire.modules.citations.tasks import update_citations_log
         data = u'[[1, 2, 1, "added", "2013-04-25 04:20:30"],[2, 3, 1, "added", "2013-04-25 04:20:30"],[3, 5, 1, "added", "2013-04-25 04:20:30"],[4, 4, 2, "added", "2013-04-25 04:20:30"],[5, 5, 2, "added", "2013-04-25 04:20:30"],[6, 6, 2, "added", "2013-04-25 04:20:30"],[7, 10, 4, "added", "2013-04-25 04:20:30"],[8, 5, 1, "removed", "2013-04-25 04:20:30"],[9, 5, 4, "added", "2013-04-25 04:20:30"],[10, 6, 4, "added", "2013-04-25 04:20:30"],[11, 3, 4, "added", "2013-04-25 04:20:31"],[12, 8, 5, "added", "2013-04-25 04:20:31"],[13, 10, 4, "removed", "2013-04-25 04:20:31"],[14, 7, 6, "added", "2013-04-25 04:20:31"],[15, 9, 6, "added", "2013-04-25 04:20:31"],[16, 10, 6, "added", "2013-04-25 04:20:31"],[17, 1, 7, "added", "2013-04-25 04:20:31"],[18, 8, 7, "added", "2013-04-25 04:20:31"],[19, 10, 7, "added", "2013-04-25 04:20:31"],[20, 3, 8, "added", "2013-04-25 04:20:31"],[21, 10, 9, "added", "2013-04-25 04:20:31"],[22, 3, 9, "added", "2013-04-25 04:20:31"],[23, 3, 8, "removed", "2013-04-25 04:20:31"],[24, 1, 10, "added", "2013-04-25 04:20:31"],[25, 2, 10, "added", "2013-04-25 04:20:31"],[26, 3, 10, "added", "2013-04-25 04:20:31"]]'
         # Mocks two responses. The first one contains the dummy data and the second an empty list
@@ -51,22 +58,13 @@ class CitationsTests(InvenioTestCase):
                 httpretty.Response(body='[]', status=200),
             ]
         )
-        if self.setup_flag:
-            self.citations_dump = Citation.query.all()
-            self.citations_log_dump = Citation_Log.query.all()
-            self.setup_flag = False
         Citation.query.delete()
         Citation_Log.query.delete()
         update_citations_log()
 
     def tearDown(self):
         """Deletes all data used for testing"""
-        Citation.query.delete()
-        Citation_Log.query.delete()
-        for cit in self.citations_log_dump:
-            cit.save
-        for cit in self.citations_dump:
-            cit.save()
+        self.__transaction.rollback()
 
     def test_citations_rnkCITATIONDICT(self):
         """Test if rnkCITATIONDICT(Citations) is populated corectly"""

--- a/inspire/modules/migrator/manage.py
+++ b/inspire/modules/migrator/manage.py
@@ -94,6 +94,7 @@ def populate(records, collections, file_input=None, input_type=None, force_impor
             Record.create(data)
         else:
             [Record.create(item) for item in data]
+        db.session.commit()
         if force_import:
             # Disable signal handler
             from inspire.modules.records.receivers import remove_handler

--- a/inspire/modules/migrator/manage.py
+++ b/inspire/modules/migrator/manage.py
@@ -61,7 +61,9 @@ manager = Manager(description=__doc__)
                 help='Specific collections to migrate.')
 @manager.option('-t', '--input-type', dest='input_type', default='marcxml',
                 help="Format of input file.")
-def populate(records, collections, file_input=None, input_type=None):
+@manager.option('--force', action='store_true', dest='force_import', default=None,
+                help="Force records that are not registered to import on the system")
+def populate(records, collections, file_input=None, input_type=None, force_import=None):
     """Train a set of records from the command line.
 
     Usage: inveniomanage predicter train -r /path/to/json -o model.pickle
@@ -80,7 +82,9 @@ def populate(records, collections, file_input=None, input_type=None):
 
     if file_input:
         print("Migrating records from file: {0}".format(file_input))
-        # FIXME: Add hook to allow for pre-allocation of IDs (--force)
+        if force_import:
+            # Load signal handler
+            from inspire.modules.records.receivers import insert_record
         processor = current_app.config['RECORD_PROCESSORS'][input_type]
         if isinstance(processor, six.string_types):
             processor = import_string(processor)
@@ -90,6 +94,10 @@ def populate(records, collections, file_input=None, input_type=None):
             Record.create(data)
         else:
             [Record.create(item) for item in data]
+        if force_import:
+            # Disable signal handler
+            from inspire.modules.records.receivers import remove_handler
+            remove_handler()
     else:
         legacy_base_url = current_app.config.get("CFG_INSPIRE_LEGACY_BASEURL")
         print(

--- a/inspire/modules/records/__init__.py
+++ b/inspire/modules/records/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2015 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.

--- a/inspire/modules/records/receivers.py
+++ b/inspire/modules/records/receivers.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2015 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from invenio.ext.sqlalchemy import db
+
+from invenio_records.models import Record
+
+from invenio_records.signals import before_record_insert
+
+
+@before_record_insert.connect
+def insert_record(sender, *args, **kwargs):
+    """Hack record insertion to add unregistered records.
+
+    This handler is imported when --force flag is used.
+    Example: inveniomanage migrator populate -f inspire/demosite/data/demo-records.xml --force
+    """
+    if 'control_number' in sender:
+        control_number = sender['control_number']
+        control_number = int(control_number)
+        # Searches if record already exists.
+        record = Record.query.filter_by(id=control_number).first()
+        if record is None:
+            # Adds the record to the db.
+            rec = Record(id=control_number)
+            db.session.add(rec)
+            db.session.commit()
+
+
+def remove_handler():
+    """Disconnects the signal handler."""
+    before_record_insert.disconnect(insert_record)

--- a/inspire/modules/records/receivers.py
+++ b/inspire/modules/records/receivers.py
@@ -43,7 +43,6 @@ def insert_record(sender, *args, **kwargs):
             # Adds the record to the db.
             rec = Record(id=control_number)
             db.session.add(rec)
-            db.session.commit()
 
 
 def remove_handler():

--- a/install.sh
+++ b/install.sh
@@ -44,4 +44,4 @@ inveniomanage database create --quiet || echo ':('
 celery worker -E -A invenio_celery.celery --workdir=$VIRTUAL_ENV 1> /dev/null &
 
 # Load demo records
-inveniomanage records create -t marcxml `pwd`/inspire/demosite/data/demo-records.xml
+inveniomanage migrator populate -t marcxml -f `pwd`/inspire/demosite/data/demo-records.xml --force


### PR DESCRIPTION
* Introduces new demo records by using the new script:
  inspirehep/inspire-scripts/utility/generate_demo_records.py.

* Contains the 10 most cited hep papers, 10 core books, theses,
  proceedings, notes, corresponding cited papers, 10 citing papers
  for each paper, 10 collaboration papers.

* Contains all the HepNames record referred across the papers.

* Expands the MARCXML of the publications, by adding 2 new subfields
  in the 100 and 700 tags:
  $x: containing the record ID of the author HepName
  $y: containing 1 if the given ID is claimed/checked, 0 otherwise

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>