### PR TITLE
travis: add beard to dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,9 @@ before_install:
   - "travis_retry pip install mock"
 
 install:
+  - "source travis-install.sh"
   - "travis_retry pip install unittest2"
+  - "travis_retry pip install cython"
   - "travis_retry pip install -r requirements.txt --allow-all-external"
   - "travis_retry pip install -e .[$REXTRAS] --process-dependency-links"
   - "python setup.py compile_catalog"
@@ -86,4 +88,5 @@ script:
   - "python setup.py test"
 
 after_success:
-  - coveralls
+  # ERR: Couldn't find a repository matching this job.
+  # - coveralls

--- a/requirements-harvesting.txt
+++ b/requirements-harvesting.txt
@@ -1,1 +1,0 @@
-git+https://github.com/inveniosoftware/beard@master#egg=beard

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ git+https://github.com/inspirehep/invenio@labs#egg=Invenio
 git+https://github.com/inspirehep/invenio-search@master-es-indices#egg=invenio-search==0.1.4.dev20150904
 git+https://github.com/inspirehep/invenio-oaiharvester@master#egg=invenio-oaiharvester==0.1.2.dev20150825
 git+https://github.com/inspirehep/invenio-workflows@master#egg=invenio-workflows==0.1.2.dev20150825
+git+https://github.com/inveniosoftware/beard@master#egg=beard
 git+https://github.com/mloesch/sickle@master#egg=Sickle
 
 -e .[development]

--- a/setup.py
+++ b/setup.py
@@ -3,22 +3,19 @@
 # This file is part of INSPIRE.
 # Copyright (C) 2014, 2015 CERN.
 #
-# INSPIRE is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
 #
-# INSPIRE is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
-#
-# In applying this licence, CERN does not waive the privileges and immunities
-# granted to it by virtue of its status as an Intergovernmental Organization
-# or submit itself to any jurisdiction.
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 """INSPIRE overlay repository for Invenio."""
 
@@ -36,6 +33,7 @@ requirements = [
     "raven==5.0.0",  # FIXME: To be compatible with our sentry version
     "orcid",
     "retrying",
+    "beard",
     "invenio_classifier==0.1.0",
     "invenio-access==0.1.0",
     "invenio-accounts==0.1.2",

--- a/travis-install.sh
+++ b/travis-install.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# This file is part of INSPIRE.
+# Copyright (C) 2015 CERN.
+#
+# Beard is a free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+# This script is freely inspired from the Scikit-Learn integration scripts.
+# https://github.com/scikit-learn/scikit-learn/blob/master/continuous_integration/install.sh
+# License: 3-clause BSD
+
+set -e
+
+# Fix the compilers to workaround avoid having the Python 3.4 build
+# lookup for g++44 unexpectedly.
+export CC=gcc
+export CXX=g++
+
+# Deactivate the travis-provided virtual environment and setup a
+# conda-based environment instead
+deactivate
+
+# Use the miniconda installer for faster download / install of conda
+# itself
+wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh  \
+    -O miniconda.sh
+
+chmod +x miniconda.sh && ./miniconda.sh -b
+export PATH=/home/travis/miniconda/bin:$PATH
+conda update --yes conda
+
+# Configure the conda environment and put it in the path using the
+# provided versions
+conda create -n testenv --yes python=2.7 pip \
+    numpy=1.9 scipy=0.15 scikit-learn=0.16.1 \
+    pytest pytest-pep8 pytest-cache sphinx
+source activate testenv
+
+pip install coveralls pep257 pytest-cov


### PR DESCRIPTION
* Add beard to requirements of setup.py file.

* Add travis-install.sh file, taken from beard git repository.

* Move beard git repository from harvesting to requirements.txt

Signed-off-by: Grzegorz Jacenków <grzegorz.jacenkow@cern.ch>