### PR TITLE
authors: phonetic name notation

### DIFF
--- a/inspire/dojson/hep/schemas/hep-0.0.1.json
+++ b/inspire/dojson/hep/schemas/hep-0.0.1.json
@@ -626,7 +626,8 @@
                     "uuid": {
                         "title": "UUID",
                         "description": "Universally unique identifier of the author.",
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
                     },
                     "name": {
                         "title": "Author name",
@@ -720,9 +721,9 @@
                         "description": "Status whether the paper was claimed by the author.",
                         "type": "boolean"
                     },
-                    "ml_block": {
+                    "signature_block": {
                         "title": "Phonetic name",
-                        "description": "Phonetic notation of the author's name.",
+                        "description": "Phonetic notation of the author's full name.",
                         "type": "string"
                     }
                 },

--- a/inspire/modules/authors/receivers.py
+++ b/inspire/modules/authors/receivers.py
@@ -3,34 +3,53 @@
 # This file is part of INSPIRE.
 # Copyright (C) 2014, 2015 CERN.
 #
-# INSPIRE is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
 #
-# INSPIRE is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
-#
-# In applying this licence, CERN does not waive the privileges and immunities
-# granted to it by virtue of its status as an Intergovernmental Organization
-# or submit itself to any jurisdiction.
-
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 import uuid
+
+from beard.clustering import block_phonetic
 
 from invenio_records.signals import (
     before_record_insert,
     before_record_update,
 )
 
+import numpy as np
+
 
 @before_record_insert.connect
 @before_record_update.connect
+def assign_phonetic_name(sender, *args, **kwargs):
+    """Assign phonetic notation of each author's name."""
+    if 'authors' in sender:
+        authors = sender['authors']
+
+        for author in authors:
+            if 'full_name' in author:
+                name = {'author_name': author['full_name']}
+
+                signature_block = block_phonetic(
+                    np.array([name], dtype=np.object).reshape(-1, 1),
+                    threshold=0,
+                    phonetic_algorithm='nysiis'
+                )
+
+                author['signature_block'] = signature_block[0]
+
+
+@before_record_insert.connect
 def assign_uuid(sender, *args, **kwargs):
     """Assign uuid to each author of a HEP paper."""
     if 'authors' in sender:
@@ -39,5 +58,3 @@ def assign_uuid(sender, *args, **kwargs):
         for author in authors:
             if 'uuid' not in author:
                 author['uuid'] = str(uuid.uuid4())
-
-        sender['authors'] = authors


### PR DESCRIPTION
* Add new method for assigning phonetic notation of HEP authors'
  names on before_record_insert and before_record_update signals.

* Remove before_record_update signal for assign_uuid method.

Signed-off-by: Grzegorz Jacenków <grzegorz.jacenkow@cern.ch>