### PR TITLE
brief: implements brief results for every collection

### DIFF
--- a/inspire/base/templates/format/record/Journal_HTML_brief.tpl
+++ b/inspire/base/templates/format/record/Journal_HTML_brief.tpl
@@ -25,14 +25,16 @@
     <div class="panel panel-default custom-panel" >
     <div class="panel-body" >
       <div class="row">
-      <div class="col-md-12">
+        <div class="col-md-12">
         <h4 class="custom-h">
           <b>
             <a href="{{ url_for('record.metadata', recid=record['control_number']) }}">
               {{ record['title'] }}
             </a>
           </b> 
-      </h4>
+        </h4>
+        </div>
+      </div>
       <div class="row">
         <div class="col-md-12 record-brief-details">
          {{ record['short_title'] }}
@@ -42,7 +44,7 @@
       <div class="row">
         <div class="col-md-12 record-brief-details">
          {% for url in record['urls'] %}
-            {{ url|urlize }} 
+            {{ url['urls']|urlize }} 
             {% if url['doc_string'] %}
               ({{ url['doc_string']}})
             {% endif %}
@@ -51,10 +53,15 @@
         </div>
       </div>
       {% endif %}
+      {% if record['publisher'] %}
+      <div class="row">
+        <div class="col-md-12 record-brief-details">
+         {{ record['publisher'] }}
+        </div>
       </div>
+      {% endif %}
     </div>
-  </div>
-  </div>
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/inspire/dojson/journals/fields/bd1xx.py
+++ b/inspire/dojson/journals/fields/bd1xx.py
@@ -51,6 +51,12 @@ def breadcrum_title(self, key, value):
     return value.get('a')
 
 
+@journals.over('publisher', '^643..')
+def publisher(self, key, value):
+    """Title used in breadcrum and html title."""
+    return value.get('b')
+
+
 @journals.over('short_title', '^711..')
 def short_title(self, key, value):
     """Title Statement."""


### PR DESCRIPTION
* journals: Missing doc_string from url and Publisher.

* jobs: Creation date, Link to institution, Experiment name missing.

* experiments: Missing HEP articles and collaboration link.

* institutions: Missing affiliation line (e.g 860 Papers from KIPAC, Menlo Park)

* conferences: Contributions link missing.

* authors: Affiliation, Author profile link missing.

Signed-off-by: Ioannis Tsanaktsidis <ioannis.tsanaktsidis@cern.ch>