### PR TITLE
detailed: implements detailed results for every collection

### DIFF
--- a/inspire/base/searchext/mappings/experiments.json
+++ b/inspire/base/searchext/mappings/experiments.json
@@ -99,13 +99,7 @@
                     }
                 },
                 "collaboration": {
-                    "type": "object",
-                    "properties": {
-                        "collaboration": {
-                            "type": "string",
-                            "index": "not_analyzed"
-                        }
-                    }
+                    "type": "string"
                 },
                 "collections": {
                     "properties": {

--- a/inspire/base/static/less/format/detailed-record.less
+++ b/inspire/base/static/less/format/detailed-record.less
@@ -1,0 +1,38 @@
+/**
+ * This file is part of INSPIRE.
+ * Copyright (C) 2015 CERN.
+
+ * INSPIRE is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * Invenio is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Invenio; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+ */ 
+
+
+#record_content .record-detailed .record-header {
+    padding: 10px;
+    font-size: 15px;
+}
+
+#record_content .record-detailed {
+    background-color: #415161;
+    color: white;
+    border-radius: 3px;
+}
+
+#record_content .record-detailed .record-title {
+    font-size: x-large;
+}
+
+.collection-primary {
+    margin-left: 5px;
+}

--- a/inspire/base/templates/format/record/Conference_HTML_detailed.tpl
+++ b/inspire/base/templates/format/record/Conference_HTML_detailed.tpl
@@ -1,0 +1,170 @@
+{#
+## This file is part of INSPIRE.
+## Copyright (C) 2015 CERN.
+##
+## INSPIRE is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## INSPIRE is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#}
+
+{% extends "format/record/Default_HTML_detailed.tpl" %}
+
+{% block header %}
+{{ record  }}
+  <div class="row">
+    <div class="col-md-12">
+      <h3>
+      {% for collection in record['collections'] %}
+        {% if 'primary' in collection %}
+          <span class="label label-default pull-left {% if not loop.first %} collection-primary {% endif %}">
+          {{ collection['primary'] }}</span>
+        {% endif %}
+      {% endfor %}
+      </h3>
+    </div>
+  </div>
+  <div class="row"><div class="col-md-12"><p></p></div></div>
+  <div class="row"><div class="col-md-12"><p></p></div></div>
+  <div class="row">
+    <div class="col-md-12">
+     <div class="record-title pull-left">
+      {% if record['title']|is_list %}
+        {% for title in record['title'] %}          
+          {{ title|capitalize }}
+        {% endfor %}
+      {% else %}
+        {{ record['title']|capitalize }}
+      {% endif %}
+      {% if record['acronym'] %}
+        ({{ record['acronym'] }}) 
+      {% endif %}
+      </div>
+    </div>
+  </div>
+  {% if record['subtitle'] %}
+  <div class="row">
+    <div class="col-md-12">
+      <div class="pull-left">
+        {{ record['subtitle'] }}
+      </div>
+    </div>
+  </div>
+  {% endif %}
+  <div class="row">
+    <div class="col-md-12">
+      <div class="pull-left">
+      {{ record|conference_date }}.
+      {{ record['place'] }}
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="pull-left">
+        <label >CNUM:</label> {{ record['cnum'] }}
+      </div>
+    </div>
+  </div>
+  {% if record|proceedings_link %}
+  <div class="row">
+    <div class="col-md-12">
+      {{ record|proceedings_link }}<br/>
+    </div>
+  </div>
+  {% endif %}
+  <div class="row">
+    <div class="col-md-12">
+      <a class="pull-left" href="#">Contributions</a>
+    </div>
+  </div>
+  {% if record['url'] %}
+    <div class="row">
+      <div class="col-md-12">
+        <div class="pull-left">
+          <label>URL:</label><a href="{{ record['url'][0] }}"> {{ record['url'][0] }}</a>
+        </div>
+      </div>
+    </div>
+  {% endif %}
+  {% if record['contact_email'] %}
+    <div class="row">
+      <div class="col-md-12">
+        <div class="pull-left">
+          <label>Email:</label>{{ record['contact_email']|email_links|join_array(", ")|new_line_after }} 
+        </div>
+      </div>
+    </div>
+  {% endif %}
+  <div class="row"><div class="col-md-12"><p></p></div></div>
+  {% if record['short_description'] %}
+    <div class="row">
+      <div class="col-md-12">
+        <div style="text-align:left;">
+          {{ record['short_description'][0]['value'] }}
+        </div>
+      </div>
+    </div>
+  {% endif %}
+  <div class="row"><div class="col-md-12"><p></p></div></div>
+  {% if record['note'] %}
+    <div class="row">
+      <div class="col-md-12">
+        <div style="text-align:left;">
+          {{ record['note'][0] }}
+        </div>
+      </div>
+    </div>
+  {% endif %}
+  <div class="row"><div class="col-md-12"><p></p></div></div>
+  {% if record['keywords'] %}
+    <div class="row">
+      <div class="col-md-12">
+        <div style="text-align:left;">
+          {{ record['keywords'][0]['value'] }}
+        </div>
+      </div>
+    </div>
+  {% endif %}
+  <div class="row"><div class="col-md-12"><p></p></div></div>
+  {% if record['alternative_titles'] %}
+    <div class="row">
+      <div class="col-md-12">
+        <div style="text-align:left;">
+          {{ record['alternative_titles']|join(', ') }}
+        </div>
+      </div>
+    </div>
+  {% endif %}
+  <div class="row"><div class="col-md-12"><p></p></div></div>
+  {% if record['sessions'] %}
+    <div class="row">
+      <div class="col-md-12">
+        <div style="text-align:left;">
+          {{ record['sessions']|join(', ') }}
+        </div>
+      </div>
+    </div>
+  {% endif %}
+  <div class="row"><div class="col-md-12"><p></p></div></div>
+  {% if record['extra_place_info'] %}
+    <div class="row">
+      <div class="col-md-12">
+        <div style="text-align:left;">
+          <label>Extra place info: </label>{{ record['extra_place_info'][0] }}
+        </div>
+      </div>
+    </div>
+  {% endif %}
+{% endblock %}
+{% block details %}
+{% endblock %}

--- a/inspire/base/templates/format/record/Experiment_HTML_detailed.tpl
+++ b/inspire/base/templates/format/record/Experiment_HTML_detailed.tpl
@@ -1,0 +1,146 @@
+{#
+## This file is part of INSPIRE.
+## Copyright (C) 2015 CERN.
+##
+## INSPIRE is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## INSPIRE is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#}
+
+{% extends "format/record/Default_HTML_detailed.tpl" %}
+
+{% block header %}
+{{ record }}
+  <div class="row">
+    <div class="col-md-12">
+      <h3>
+      {% for collection in record['collections'] %}
+        {% if 'primary' in collection %}
+          <span class="label label-default pull-left {% if not loop.first %} collection-primary {% endif %}">
+          {{ collection['primary'] }}</span>
+        {% endif %}
+      {% endfor %}
+      </h3>
+    </div>
+  </div>
+  <div class="row"><div class="col-md-12"><p></p></div></div>
+  <div class="row"><div class="col-md-12"><p></p></div></div>
+  <div class="row">
+    <div class="col-md-12">
+     <div class="record-title pull-left">
+        {{ record['experiment_name'][0] }}
+        {% if record['affiliation'] %}
+          ({{ record['affiliation'][0] }})
+        {% endif %}
+      </div>
+    </div>
+  </div>
+  {% if record['breadcrum_title'] %}
+    <div class="row">
+      <div class="col-md-12">
+        <div class="pull-left">
+          {{ record['breadcrum_title'] }}
+        </div>
+      </div>
+    </div>
+  {% endif %}
+  <div class="row"><div class="col-md-12"><p></p></div></div>
+  <div class="row"><div class="col-md-12"><p></p></div></div>
+  {% if record['date_started'] %}
+  <div class="row">
+    <div class="col-md-12">
+      <div class="pull-left">
+        ({{ record|experiment_date }})
+      </div>
+    </div>
+  </div>
+  {% endif %}
+  <div class="row"><div class="col-md-12"><p></p></div></div>
+  <div class="row"><div class="col-md-12"><p></p></div></div>
+  {% if record['spokesperson'] %}
+  <div class="row">
+    <div class="col-md-12">
+      <div class="pull-left">
+        <label>Spokesperson:</label><span> {{ record['spokesperson']|join(', ') }}</span>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+  {% if record['contact_email'] %}
+  <div class="row">
+    <div class="col-md-12">
+      <div class="pull-left">
+        <label>Contact email:</label><span> {{ record['contact_email']|email_links|join_array(", ")|new_line_after }} </span>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+  {% if record['urls'] %}
+  <div class="row">
+    <div class="col-md-12">
+      <div class="pull-left">
+        <label>URL:</label><a> {{ record['urls']|join(', ') }}</a>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+  <div class="row"><div class="col-md-12"><p></p></div></div>
+  <div class="row"><div class="col-md-12"><p></p></div></div>
+  {% if record['description'] %}
+  <div class="row">
+    <div class="col-md-12">
+      <div style="text-align:left;">
+        {{ record['description'][0] }}
+      </div>
+    </div>
+  </div>
+  {% endif %}
+  <div class="row"><div class="col-md-12"><p></p></div></div>
+  <div class="row"><div class="col-md-12"><p></p></div></div>
+  <div class="row">
+    <div class="col-md-12">
+      <a class="pull-left" href="/search?p=experiment:{{ record['experiment_name'][0] }}&cc=HEP">HEP articles associated with {{ record['experiment_name'][0] }}</a>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+    <a class="pull-left" href="/search?p=experiment:{{ record['experiment_name'][0] }}&cc=HepNames">Collaboration members in HepNames</a>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <a class="pull-left" href="#">Citesummary</a>
+    </div>
+  </div>
+  {% if record['related_experiments'] %}
+  <div class="row">
+    <div class="col-md-12">
+      <div  class="pull-left">
+        <label>Related Experiments:</label>
+        {{ record|experiment_link|join(', ') }}
+      </div>
+    </div>
+  </div>
+  {% endif %}
+  {% if record['collaboration'] %}
+  <div class="row">
+    <div class="col-md-12">
+      <div  class="pull-left">
+        <a href="/search?p=collaboration:{{ record['collaboration'] }}&cc=Hep">{{ record['collaboration'] }}</a>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+{% endblock %}
+{% block details %}
+{% endblock %}

--- a/inspire/base/templates/format/record/Institution_HTML_detailed.tpl
+++ b/inspire/base/templates/format/record/Institution_HTML_detailed.tpl
@@ -1,0 +1,152 @@
+{#
+## This file is part of INSPIRE.
+## Copyright (C) 2015 CERN.
+##
+## INSPIRE is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## INSPIRE is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#}
+
+{% extends "format/record/Default_HTML_detailed.tpl" %}
+
+{% block header %}
+  <div class="row">
+    <div class="col-md-12">
+      <h3>
+      {% for collection in record['collections'] %}
+        {% if 'primary' in collection %}
+          <span class="label label-default pull-left {% if not loop.first %} collection-primary {% endif %}">
+          {{ collection['primary'] }}</span>
+        {% endif %}
+      {% endfor %}
+      </h3>
+    </div>
+  </div>
+  <div class="row"><div class="col-md-12"><p></p></div></div>
+  <div class="row">
+    <div class="col-md-12">
+      <h4 class="custom-h pull-left">
+        <b>
+         {{record['department_acronym']}} 
+         {% if record['ICN'] %}
+         [Future INSPIRE ID:{{record['ICN']}}]
+         {%endif%}
+        </b> 
+      </h4>
+    </div>
+  </div>
+  {% if record['institution'] %}
+  <div class="row">
+    <div class="col-md-12">
+     <span class="pull-left">{{ record['institution']}}</span>
+    </div>
+  </div>
+  {% endif %}
+  {% if record['department'] %}
+  <div class="row">
+    <div class="col-md-12">
+     <span class="pull-left">{{ record['department']}}</span>
+    </div>
+  </div>
+  {% endif %}
+  <div class="row">
+    <div class="col-md-12">
+      <span class="pull-left">
+      {% if record['address'][0]['address']|is_list %}
+        {{ record['address'][0]['address']|join(', ') }},
+      {% else %}
+        {{ record['address'][0]['address'] }},
+      {% endif %}
+      {% for country in record['address'] %}
+        {% if 'country' in country %}
+         {{ country['country']}}
+        {% endif %}
+      {% endfor %}
+      </span>
+    </div>
+  </div>
+  <div class="row"><div class="col-md-12"><p></p></div></div>
+  {% if record['urls'] %}
+    <div class="row">
+      <div class="col-md-12">
+        <a class="pull-left" href="{{ record['urls'][0] }}">{{ record['urls'][0] }}</a>
+      </div>
+    </div>
+  {% endif %}
+  {% if record['name_variants'] %}
+    <div class="row">
+      <div class="col-md-12">
+      {% set name_var = [] %}
+      {% for element in record['name_variants'] %}
+        {% if 'source' not in element and 'value' in element %}
+          {% do name_var.append(element) %}
+        {% endif %} 
+      {% endfor %}   
+      {% if name_var %}
+        <label>Name variants: </label>{{ name_var|join(', ') }}
+      {% endif %}
+      </div>
+    </div>
+  {% endif %}
+  {% if record['historical_data'] %}
+    <div class="row">
+      <div class="col-md-12">
+        <label>Historical Data: </label>{{ record['historical_data']|join(', ') }}
+      </div>
+    </div>
+  {% endif %}
+  {% if record['public_notes'] %}
+    <div class="row">
+      <div class="col-md-12">
+        <label>Notes: </label>{{ record['public_notes']|join(', ') }}
+      </div>
+    </div>
+  {% endif %}
+  <div class="row">
+    <div class="col-md-12">
+      <div class="pull-left">
+        <label>Related Institution:</label><span><a href="#"> Related institution</a></span>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="pull-left">
+        <label >Parent Institution:</label><span><a href="#"> Parent institution</a></span>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="pull-left">
+        <span>HEP list of<a href="#"> Ph.D. theses </a> at {{ record['department_acronym'] }}</span>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="pull-left">
+        <span>HEPNAMES list of<a href="#"> people</a> at {{ record['department_acronym'] }}</span>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="pull-left">
+        <span>EXPERIMENTS list of<a href="/search?p=affiliation:{{ record['name'][0] }}&cc=Experiments"> experiments</a> performed <b>at</b> {{ record['department_acronym'] }}</span>
+      </div>
+    </div>
+  </div>
+{% endblock %}
+{% block details %}
+{% endblock %}

--- a/inspire/base/templates/format/record/Job_HTML_detailed.tpl
+++ b/inspire/base/templates/format/record/Job_HTML_detailed.tpl
@@ -1,0 +1,161 @@
+{#
+## This file is part of INSPIRE.
+## Copyright (C) 2015 CERN.
+##
+## INSPIRE is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## INSPIRE is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#}
+
+{% extends "format/record/Default_HTML_detailed.tpl" %}
+
+{% block header %}
+  <div class="row">
+    <div class="col-md-12">
+      <h3>
+      {% for collection in record['collections'] %}
+        {% if 'primary' in collection %}
+          <span class="label label-default pull-left {% if not loop.first %} collection-primary {% endif %}">
+          {{ collection['primary'] }}</span>
+        {% endif %}
+      {% endfor %}
+      </h3>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <h4 class="pull-left">
+        <b>
+          {{ record['position'] }}
+        </b>
+        {% if record['institution'][0]['name']%}
+          {% if record['continent'] %}
+            (<a href="/search?p=department_acronym:{{ record['institution'][0]['name'] }}&cc=Institutions">{{ record['institution'][0]['name'] }}</a> - {{ record['continent'] }})
+          {% else %}
+            (<a href="/search?p=department_acronym:{{ record['institution'][0]['name'] }}&cc=Institutions">{{ record['institution'][0]['name'] }}</a>)
+        {% endif %}
+        {% endif%}
+      </h4>
+    </div>
+  </div>
+  <div class="row"><div class="col-md-12"><p></p></div></div>
+  {% if record['rank'][0] %}
+  <div class="row">
+    <div class="col-md-12">
+     <div class="pull-left">
+        {{ record['rank'][0] }}
+      </div>
+    </div>
+  </div>
+  {% endif %}
+  <div class="row"><div class="col-md-12"><p></p></div></div>
+  {% if record['research_area'] %}
+  <div class="row">
+    <div class="col-md-12">
+     <div class="pull-left">
+      <label>Field of interest: </label><span>{% if record['research_area']|is_list %}
+            {{ record['research_area']|join(', ') }}
+          {% endif %}</span>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+  <div class="row"><div class="col-md-12"><p></p></div></div>
+  {% if record['experiments'] %}
+  <div class="row">
+    <div class="col-md-12">
+     <div class="pull-left">
+      <label>Experiment: </label>{{ record['experiments']|join(', ') }}
+      </div>
+    </div>
+  </div>
+  {% endif %}
+  {% if record['deadline_date'] %}
+  <div class="row">
+    <div class="col-md-12">
+     <div class="pull-left">
+      <label>Deadline: </label><span> {{record['deadline_date']}}</span>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+  {% if record['continent'] %}
+  <div class="row">
+    <div class="col-md-12">
+     <div class="pull-left">
+      <label>Region: </label><span> {{record['continent']}}</span>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+  {% if record['description'] %}
+  <div class="row">
+    <div class="col-md-12">
+      <label class="pull-left">Job description: </label>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <div style="text-align:left;"> {{record['description']}}</div>
+    </div>
+  </div>
+  {% endif %}
+  <div class="row"><div class="col-md-12"><p></p></div></div>
+  {% if record['contact_person'] and record['contact_person'][0] != None  %}
+  <div class="row">
+    <div class="col-md-12">
+     <div class="pull-left">
+      <label>Contact: </label><span> {{ record['contact_person']|join(', ') }}</span>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+  {% if record['contact_email'] %}
+  <div class="row">
+    <div class="col-md-12">
+     <div class="pull-left">
+      <label>Email: </label><span> {{ record['contact_email']|email_links|join_array(", ")|new_line_after}}</span>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+  {% if record['urls'] %}
+  <div class="row">
+    <div class="col-md-12">
+     <div class="pull-left">
+      <label>More information: </label><a href="{{ record['urls'][0] }}"> {{ record['urls'][0] }}</a>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+  {% if record['reference_email']  and record['reference_email'][0] != None %}
+  <div class="row">
+    <div class="col-md-12">
+     <div class="pull-left">
+      <label>Letters of Reference should be sent to: </label><a href=""> {{ record['reference_email']|email_links|join_array(", ")|new_line_after }}</a>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+  <div class="row"><div class="col-md-12"><p></p></div></div>
+  <div class="row"><div class="col-md-12"><p></p></div></div>
+  <div class="row">
+    <div class="col-md-12">
+     <div class="pull-left">
+      <label>To remove this listing: </label><a href="mailto:jobs@inspirehep.net?subject=Remove-listing-{% if record['acquisition_source'] %}{{ record['acquisition_source'][0]['submission_number']}} {% endif %}&body=Please remove listing {% if record['acquisition_source'] %}{{ record['acquisition_source'][0]['submission_number']}} {% endif %} https://inspirehep.net/record/{{ record['control_number'] }}/edit"> Click here</a>
+      </div>
+    </div>
+  </div>
+{% endblock %}
+{% block details %}
+{% endblock %}

--- a/inspire/base/templates/format/record/Journal_HTML_detailed.tpl
+++ b/inspire/base/templates/format/record/Journal_HTML_detailed.tpl
@@ -1,0 +1,111 @@
+{#
+## This file is part of INSPIRE.
+## Copyright (C) 2015 CERN.
+##
+## INSPIRE is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## INSPIRE is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#}
+
+{% extends "format/record/Default_HTML_detailed.tpl" %}
+
+{% block header %}
+<div class="row">
+  <div class="col-md-12">
+    <h3>
+    {% for collection in record['collections'] %}
+      {% if 'primary' in collection %}
+        <span class="label label-default pull-left {% if not loop.first %} collection-primary {% endif %}">
+        {{ collection['primary'] }}</span>
+      {% endif %}
+    {% endfor %}
+    </h3>
+  </div>
+</div>
+<div class="row"><div class="col-md-12"><p></p></div></div>
+<div class="row">
+  <div class="col-md-12">
+    <div class="pull-left">
+      <b>
+      {{ record['title'] }}
+      </b>
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="col-md-12">
+    <div class="pull-left">
+      {{ record['short_title'] }}
+    </div>
+  </div>
+</div>
+{% if record['urls'] %}
+{% for url in record['urls'] %}
+<div class="row">
+  <div class="col-md-12">
+    <div class="pull-left">
+      {{ url['urls']|urlize }} 
+      {% if url['doc_string'] %}
+        ({{ url['doc_string']}})
+      {% endif %}
+   </div>
+  </div>
+</div>
+{% endfor %}
+{% endif %}
+<div class="row"><div class="col-md-12"><p></p></div></div>
+<div class="row"><div class="col-md-12"><p></p></div></div>
+<div class="row">
+  <div class="col-md-12">
+    <div class="pull-left">
+      <a href="/search?p=journal_title:{{ record['short_title'] }}&cc=Hep">Articles in HEP</a>
+   </div>
+  </div>
+</div>
+<div class="row"><div class="col-md-12"><p></p></div></div>
+<div class="row"><div class="col-md-12"><p></p></div></div>
+{% if record['coden'] %}
+<div class="row">
+  <div class="col-md-12">
+    <div class="pull-left">
+      {{ record['coden'] }}
+   </div>
+  </div>
+</div>
+{% endif %}
+{% if record['name_variants'] %}
+<button type="button" class="btn btn-default pull-left" data-toggle="modal" data-target="#showNameVariants">
+  Show name variants
+</button>
+{% endif %}
+<!-- Modal -->
+<div class="modal fade" id="showNameVariants" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title" id="myModalLabel">Name variants</h4>
+      </div>
+      <div class="modal-body">
+        <div style="text-align:left;">
+        {{ record['name_variants']|join(', ')}}
+        </div>
+      </div>
+      <div class="modal-footer">
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+{% block details %}
+{% endblock %}

--- a/inspire/base/templates/records/base_base.html
+++ b/inspire/base/templates/records/base_base.html
@@ -1,0 +1,69 @@
+{#
+# This file is part of INSPIRE.
+# Copyright (C) 2015 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#}
+
+{% extends "page.html" %}
+
+{#
+{% set title = title %}
+#}
+{% block title %}
+{% endblock title %}
+
+{% block metaheader %}
+  {% if recid != -1 and config.CFG_WEBSEARCH_DETAILED_META_FORMAT %}
+  {# format_record(record, of=config.CFG_WEBSEARCH_DETAILED_META_FORMAT, ln = g.ln)|safe #}
+  {% endif %}
+{% endblock metaheader %}
+
+{%- block header %}
+  {%- include "base/scripts.html" %}
+  {{- super() }}
+{%- endblock header %}
+{%- block _bottom_assets %}
+  {# The legacy page requires that the scripts are loaded from the <head>
+   # rather than at the bottom of the page.
+   #}
+{%- endblock %}
+
+{% block global_bundles %}
+  {{ super() }}
+  {% bundles "records.js", "formatter.css", "record.css" %}
+{% endblock %}
+
+{% block body %}
+  {{ super() }}
+
+  {% block record_restriction_flag %}
+  {% if g.bibrec.is_restricted %}
+  <div class="alert alert-danger"><b>{{ _('Restricted') }}</b>
+    {%- if g.bibrec.is_processed %} {{ _('Processed Record') }}
+    {%- endif -%}</div>
+  {% endif %}
+  {% endblock %}
+
+  {% block record_tabs %}
+  {% endblock %}
+
+  <div id="record_content">
+  {% block record_content %}
+    <!-- record content -->
+  {% endblock %}
+  </div>
+<div style="clear: both;"></div>
+{% endblock %}

--- a/inspire/config.py
+++ b/inspire/config.py
@@ -226,7 +226,6 @@ SEARCH_ELASTIC_KEYWORD_MAPPING = {
     },
     "abstract": ["abstract.summary"],
     "collection": ["_collections"],
-    "collaboration": ["collaboration.collaboration"],
     "affiliation": ["authors.affiliation"],
     "reportnumber": ["report_number.value"],
     "experiment": ["accelerator_experiment.experiment"],

--- a/inspire/dojson/conferences/fields/bd1xx.py
+++ b/inspire/dojson/conferences/fields/bd1xx.py
@@ -125,3 +125,17 @@ def transparencies(self, key, value):
 def url(self, key, value):
     """Conference transparencies."""
     return value.get('u')
+
+
+@conferences.over('sessions', '^8564')
+@utils.for_each_value
+def sessions(self, key, value):
+    """Conference sessions."""
+    return value.get('t')
+
+
+@conferences.over('extra_place_info', '^270')
+@utils.for_each_value
+def extra_place_info(self, key, value):
+    """Conference extra place info."""
+    return value.get('b')

--- a/inspire/dojson/experiments/fields/bd1xx.py
+++ b/inspire/dojson/experiments/fields/bd1xx.py
@@ -41,6 +41,13 @@ def affiliation(self, key, value):
     return value.get("u")
 
 
+@experiments.over('contact_email', '^270..')
+@utils.for_each_value
+def contact_email(self, key, value):
+    """Contact email of experiment."""
+    return value.get("m")
+
+
 @experiments.over('title', '^245[10_][0_]')
 @utils.for_each_value
 @utils.filter_values
@@ -80,8 +87,58 @@ def spokesperson(self, key, value):
     return value.get("a")
 
 
+@experiments.over('collaboration', '^710..')
+def collaboration(self, key, value):
+    """Collaboration of experiment."""
+    return value.get("g")
+
+
 @experiments.over('urls', '^856.[10_28]')
 @utils.for_each_value
 def urls(self, key, value):
     """URLs."""
     return value.get('u')
+
+
+@experiments.over('related_experiments', '^510')
+@utils.for_each_value
+def related_experiments(self, key, value):
+    """Related experiments."""
+    try:
+        recid = int(value.get('0'))
+    except (TypeError, ValueError):
+        recid = None
+    return {
+        'name': value.get('a'),
+        'recid': recid
+    }
+
+
+@experiments.over('date_started', '^046..')
+def date_started(self, key, value):
+    """Date created."""
+    def get_value(value):
+        return value.get('s')
+
+    date_created = self.get('date_created', [])
+
+    for element in value:
+        if 's' in element:
+            date_created.append(get_value(element))
+    if date_created:
+        return date_created[0]
+
+
+@experiments.over('date_completed', '^046..')
+def date_completed(self, key, value):
+    """Date created."""
+    def get_value(value):
+        return value.get('t')
+
+    date_completed = self.get('date_completed', [])
+
+    for element in value:
+        if 't' in element:
+            date_completed.append(get_value(element))
+    if date_completed:
+        return date_completed[0]

--- a/inspire/dojson/experiments/schemas/experiments-0.0.1.json
+++ b/inspire/dojson/experiments/schemas/experiments-0.0.1.json
@@ -22,6 +22,10 @@
             "title": "Collaboration",
             "type": "string"
         },
+        "contact_email": {
+            "title": "Contact email",
+            "type": "string"
+        },
         "curated_relation": {
             "title": "Curated relation",
             "type": "boolean"

--- a/inspire/dojson/institutions/fields/bd1xx.py
+++ b/inspire/dojson/institutions/fields/bd1xx.py
@@ -165,3 +165,10 @@ def public_notes(self, key, value):
 def urls(self, key, value):
     """Contact person."""
     return value.get('u')
+
+
+@institutions.over('historical_data', '^6781..')
+@utils.for_each_value
+def historical_data(self, key, value):
+    """Historical data."""
+    return value.get('a')

--- a/inspire/ext/formatter_jinja_filters/record.py
+++ b/inspire/ext/formatter_jinja_filters/record.py
@@ -26,6 +26,7 @@ from inspire.utils.bibtex import Bibtex
 from inspire.utils.latex import Latex
 from inspire.utils.cv_latex import Cv_latex
 from inspire.utils.cv_latex_html_text import Cv_latex_html_text
+from invenio_search.api import Query
 
 
 def email_links(value):
@@ -132,7 +133,7 @@ def cv_latex_html_text(record, format_type):
 
 def conference_date(record):
     if 'date' in record and record['date']:
-        return record['date'] + '.'
+        return record['date']
     from datetime import datetime
     out = ''
     opening_date = record['opening_date']
@@ -144,21 +145,71 @@ def conference_date(record):
             out += opening_date.split('-')[2] + '-' +\
                 closing_date.split('-')[2] +\
                 ' ' + converted_opening_date.strftime('%b') +\
-                ' ' + opening_date.split('-')[0] + '.'
+                ' ' + opening_date.split('-')[0]
         else:
             out += opening_date.split('-')[2] + ' '\
                 + converted_opening_date.strftime('%b') + ' - ' +\
                 closing_date.split('-')[2] + ' ' +\
                 converted_closing_date.strftime('%b') + ' ' +\
-                opening_date.split('-')[0] + '.'
+                opening_date.split('-')[0]
     else:
         out += opening_date.split('-')[2] + ' ' +\
             converted_opening_date.strftime('%b') + ' '\
             + opening_date.split('-')[0] + ' - ' + \
             closing_date.split('-')[2] + ' ' +\
             converted_closing_date.strftime('%b') + ' ' +\
-            closing_date.split('-')[0] + '.'
+            closing_date.split('-')[0]
     return out
+
+
+def experiment_date(record):
+    result = []
+    if 'date_started' in record:
+        result.append('Started: ' + record['date_started'])
+    if 'date_completed' in record:
+        if record['date_completed'] == '9999':
+            result.append('Still Running')
+        else:
+            result.append('Completed: ' + record['date_completed'])
+    if result:
+        return ', '.join(r for r in result)
+
+
+def proceedings_link(record):
+    cnum = record['cnum']
+    out = ''
+    if not cnum:
+        return out
+    search_result = Query("cnum:%s and 980__a:proceedings" % (cnum,)).\
+        search().recids
+    if search_result:
+        if len(search_result) > 1:
+            from invenio.legacy.bibrecord import get_fieldvalues
+            proceedings = []
+            for i, recid in enumerate(search_result):
+                doi = get_fieldvalues(recid, '0247_a')
+                if doi:
+                    proceedings.append('<a href="/record/%(ID)s">#%(number)s</a> (DOI: <a href="http://dx.doi.org/%(doi)s">%(doi)s</a>)'
+                                       % {'ID': recid, 'number': i + 1, 'doi': doi[0]})
+                else:
+                    proceedings.append(
+                        '<a href="/record/%(ID)s">#%(number)s</a>' % {'ID': recid, 'number': i + 1})
+                out = 'Proceedings: '
+                out += ', '.join(proceedings)
+        elif len(search_result) == 1:
+            out += '<a href="/record/' + str(search_result[0]) + \
+                '">Proceedings</a>'
+    return out
+
+
+def experiment_link(record):
+    result = []
+    if record['related_experiments']:
+        for element in record['related_experiments']:
+            result.append(
+                '<a href=/search?cc=Experiments&p=experiment_name:' +
+                element['name'] + '>' + element['name'] + '</a>')
+    return result
 
 
 def get_filters():
@@ -180,4 +231,7 @@ def get_filters():
         'cv_latex': cv_latex,
         'cv_latex_html_text': cv_latex_html_text,
         'conference_date': conference_date,
+        'experiment_date': experiment_date,
+        'proceedings_link': proceedings_link,
+        'experiment_link': experiment_link,
     }

--- a/inspire/modules/formatter/output_formats/hd.yml
+++ b/inspire/modules/formatter/output_formats/hd.yml
@@ -4,4 +4,9 @@ description: HTML detailed output format, used for Detailed record pages.
 name: HTML detailed
 rules:
 - {field: collections.primary, template: Author_HTML_detailed.tpl, value: 'AUTHOR'}
+- {field: collections.primary, template: Conference_HTML_detailed.tpl, value: 'CONFERENCES'}
+- {field: collections.primary, template: Journal_HTML_detailed.tpl, value: 'JOURNALS'}
+- {field: collections.primary, template: Institution_HTML_detailed.tpl, value: 'INSTITUTION'}
+- {field: collections.primary, template: Job_HTML_detailed.tpl, value: 'JOB'}
+- {field: collections.primary, template: Experiment_HTML_detailed.tpl, value: 'EXPERIMENT'}
 visibility: 0


### PR DESCRIPTION
* institutions: Missing links for Related institution, Parent institution, people, expreriments.
Missing BFE_INSPIRE_INST_SECONDARY_ADDRESS and BFE_INSPIRE_INST_CHILDREN implementation.

* conferences: Contributions link missing. Missing BFE_INSPIRE_CONFERENCES_OTHER_CONF, field 6531a(No record returned), field 773x.

* jobs: Missing creation date(BFE_INSPIRE_DATE_CREATED).

* experiments: Missing  Citesummary link.

Signed-off-by: Ioannis Tsanaktsidis <ioannis.tsanaktsidis@cern.ch>