### PR TITLE
records/migrator: Force import

### DIFF
--- a/inspire/modules/migrator/manage.py
+++ b/inspire/modules/migrator/manage.py
@@ -61,7 +61,9 @@ manager = Manager(description=__doc__)
                 help='Specific collections to migrate.')
 @manager.option('-t', '--input-type', dest='input_type', default='marcxml',
                 help="Format of input file.")
-def populate(records, collections, file_input=None, input_type=None):
+@manager.option('--force', action='store_true', dest='force_import', default=None,
+                help="Force records that are not registered to import on the system")
+def populate(records, collections, file_input=None, input_type=None, force_import=None):
     """Train a set of records from the command line.
 
     Usage: inveniomanage predicter train -r /path/to/json -o model.pickle
@@ -80,7 +82,9 @@ def populate(records, collections, file_input=None, input_type=None):
 
     if file_input:
         print("Migrating records from file: {0}".format(file_input))
-        # FIXME: Add hook to allow for pre-allocation of IDs (--force)
+        if force_import:
+            # Load signal handler
+            from inspire.modules.records.receivers import insert_record
         processor = current_app.config['RECORD_PROCESSORS'][input_type]
         if isinstance(processor, six.string_types):
             processor = import_string(processor)
@@ -90,6 +94,10 @@ def populate(records, collections, file_input=None, input_type=None):
             Record.create(data)
         else:
             [Record.create(item) for item in data]
+        if force_import:
+            # Disable signal handler
+            from inspire.modules.records.receivers import remove_handler
+            remove_handler()
     else:
         legacy_base_url = current_app.config.get("CFG_INSPIRE_LEGACY_BASEURL")
         print(

--- a/inspire/modules/records/__init__.py
+++ b/inspire/modules/records/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2015 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.

--- a/inspire/modules/records/receivers.py
+++ b/inspire/modules/records/receivers.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2015 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from invenio.ext.sqlalchemy import db
+
+from invenio_records.models import Record
+
+from invenio_records.signals import before_record_insert
+
+
+@before_record_insert.connect
+def insert_record(sender, *args, **kwargs):
+    """Hack record insertion to add unregistered records.
+
+    This handler is imported when --force flag is used.
+    Example: inveniomanage migrator populate -f inspire/demosite/data/demo-records.xml --force
+    """
+    if 'control_number' in sender:
+        control_number = sender['control_number']
+        control_number = int(control_number)
+        # Searches if record already exists.
+        record = Record.query.filter_by(id=control_number).first()
+        if record is None:
+            # Adds the record to the db.
+            rec = Record(id=control_number)
+            db.session.add(rec)
+            db.session.commit()
+
+
+def remove_handler():
+    """Disconnects the signal handler."""
+    before_record_insert.disconnect(insert_record)


### PR DESCRIPTION
* Adds a signal handler to force import records with recids that
  are not registered in the system.

* Adds a --force flag to enable the signal handler.

Signed-off-by: Panos Paparrigopoulos <panos.paparrigopoulos@cern.ch>