### PR TITLE
workflows: holding pen list fix

### DIFF
--- a/inspire/base/templates/format/record/Holding_Pen_HTML_detailed_macros.tpl
+++ b/inspire/base/templates/format/record/Holding_Pen_HTML_detailed_macros.tpl
@@ -41,7 +41,9 @@
 
 
 {% macro get_abstract(record) %}
-    {% if record.abstracts %}
-       {{ record['abstracts'][0]['value'] }}
+    {% if record['abstract'] is mapping %}
+       {{ record['abstract']['value'] }}
+    {% else %}
+       {{ record['abstract'][0]['value'] }}
     {% endif %}
 {% endmacro %}

--- a/inspire/modules/workflows/templates/workflows/list.html
+++ b/inspire/modules/workflows/templates/workflows/list.html
@@ -24,7 +24,7 @@
   <div class="pull-left">
     <p class="text-muted">Ctrl+A: Select all, Esc: Deselect</p>
   </div>
-  <div id="batch-action-buttons" class="pull-right hidden">
+  <div class="pull-right hidden batch-action-buttons">
     <span class="text-muted">{{ _("For all selected") }}: </span>
     <div class="btn-group" role="group">
       <button class="btn btn-success arxiv-approval-action-accept batch-button" role="button" data-value="accept_core">
@@ -53,4 +53,23 @@
         <li><a class="task-btn" name="relevance_score">{{ _("Least relevant")}}</a></li>
     </ul>
   </li>
+{% endblock %}
+
+{% block batch_action_buttons_bottom %}
+<div>
+  <div class="pull-right batch-action-buttons hidden">
+  <span class="text-muted">{{ _("For all selected") }}: </span>
+  <div class="btn-group" role="group">
+    <button class="btn btn-success arxiv-approval-action-accept batch-button" role="button" data-value="accept_core">
+      <i class="fa fa-check"></i> CORE
+    </button>
+    <button class="btn btn-warning arxiv-approval-action-accept batch-button" role="button" data-value="accept">
+      <i class="fa fa-check"></i> Accept
+    </button>
+    <button class="btn btn-danger arxiv-approval-action-reject batch-button"  role="button" data-value="reject">
+      <i class="fa fa-times"></i> Reject
+    </button>
+  </div>
+  </div>
+</div>
 {% endblock %}

--- a/inspire/modules/workflows/workflows/process_record_arxiv.py
+++ b/inspire/modules/workflows/workflows/process_record_arxiv.py
@@ -182,7 +182,7 @@ class process_record_arxiv(RecordWorkflow, DepositionType):
                 else:
                     categories.append(category_list)
             categories = list(OrderedDict.fromkeys(categories))  # Unique only
-            abstract = record.get("abstracts.value", [""])[0]
+            abstract = record.get("abstract.value", [""])[0]
             authors = record.get("authors", [])
         return render_template('workflows/styles/harvesting_record.html',
                                object=bwo,
@@ -251,7 +251,7 @@ class process_record_arxiv(RecordWorkflow, DepositionType):
         This object will be used for indexing and be the basis for display
         in Holding Pen.
         """
-        if isinstance(obj.data, six.text_type):
+        if isinstance(obj.get_data(), six.text_type):
             return {}
         model = cls.model(obj)
         return get_record_from_model(model).dumps()  # Turn into pure dict


### PR DESCRIPTION
* Makes changes to allow batch buttons to appear
   under the list

* A couple of bug fixes on process_record_arxiv
  to match the new data model.

Signed-off-by: Ilias Koutsakis <ilias.koutsakis@cern.ch>

Conflicts:
	inspire/base/templates/format/record/Holding_Pen_HTML_detailed_macros.tpl
	inspire/modules/workflows/workflows/process_record_arxiv.py