### PR TITLE
search: mathjax rendering

### DIFF
--- a/inspire/base/templates/search/search.html
+++ b/inspire/base/templates/search/search.html
@@ -1,0 +1,41 @@
+{#
+## This file is part of INSPIRE.
+## Copyright (C) 2015 CERN.
+##
+## INSPIRE is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## INSPIRE is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#}
+
+{% extends "search/search_base.html" %}
+
+{%- block javascript %}
+{{ super() }}
+<script src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/javascript">
+    require([
+      "jquery",
+      ], function ($) {
+          $(document).ready(function () {
+            MathJax.Hub.Config({
+                tex2jax: {inlineMath: [['$', '$'], ['\\(', '\\)']],
+                processEscapes: true},
+                showProcessingMessages: false,
+                messageStyle: "none"
+            });
+            MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
+          })
+      }
+    );
+</script>
+{% endblock %}


### PR DESCRIPTION
* Loads MathJax from cdn and renders search results. (closes #283)

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>