### PR TITLE
WIP records/citations: Test fixes

### DIFF
--- a/inspire/modules/citations/models.py
+++ b/inspire/modules/citations/models.py
@@ -22,7 +22,6 @@
 from datetime import datetime
 
 from invenio.ext.sqlalchemy import db
-from invenio.ext.sqlalchemy.utils import session_manager
 
 
 class Citation(db.Model):
@@ -37,7 +36,6 @@ class Citation(db.Model):
         self.citer = citer
         self.last_updated = last_updated
 
-    @session_manager
     def save(self):
         db.session.merge(self)
 
@@ -67,9 +65,8 @@ class Citation_Log(db.Model):
         self.action_date = action_date
         self.citation_type = citation_type
 
-    @session_manager
     def save(self):
-        """ Saves the new log entry to the database.
+        """ Adds the new log entry to the current session.
 
             It's also responsible for adding or removing the citation from
             rnkCITATIONDICT table.

--- a/inspire/modules/citations/tasks.py
+++ b/inspire/modules/citations/tasks.py
@@ -30,6 +30,8 @@ from invenio.base.globals import cfg
 
 from invenio.celery import celery
 
+from invenio.ext.sqlalchemy import db
+
 from invenio_records.api import get_record
 
 import requests
@@ -48,6 +50,8 @@ def update_records_citations(new_citations):
         rec = get_record(id)
         if rec is not None:
             rec.update({"references_id": list(citees)})
+            rec.commit()
+            db.session.flush()
         else:
             current_app.logger.exception(
                 "citations: record with id:%d not found", id)

--- a/inspire/modules/citations/testsuite/test_citations.py
+++ b/inspire/modules/citations/testsuite/test_citations.py
@@ -25,6 +25,8 @@ from inspire.modules.citations.models import Citation, Citation_Log
 
 from invenio.base.globals import cfg
 
+from invenio.ext.sqlalchemy import db
+
 from invenio.testsuite import InvenioTestCase
 
 
@@ -32,14 +34,12 @@ class CitationsTests(InvenioTestCase):
 
     """Test citations connection."""
 
-    setup_flag = True
-    citations_dump = None
-    citations_log_dump = None
-
     @httpretty.activate
     def setUp(self):
         """ Initialises test by adding dummy log entries """
         from inspire.modules.citations.tasks import update_citations_log
+        from invenio_records.api import Record
+        self.trans = db.session.begin_nested()
         data = u'[[1, 2, 1, "added", "2013-04-25 04:20:30"],[2, 3, 1, "added", "2013-04-25 04:20:30"],[3, 5, 1, "added", "2013-04-25 04:20:30"],[4, 4, 2, "added", "2013-04-25 04:20:30"],[5, 5, 2, "added", "2013-04-25 04:20:30"],[6, 6, 2, "added", "2013-04-25 04:20:30"],[7, 10, 4, "added", "2013-04-25 04:20:30"],[8, 5, 1, "removed", "2013-04-25 04:20:30"],[9, 5, 4, "added", "2013-04-25 04:20:30"],[10, 6, 4, "added", "2013-04-25 04:20:30"],[11, 3, 4, "added", "2013-04-25 04:20:31"],[12, 8, 5, "added", "2013-04-25 04:20:31"],[13, 10, 4, "removed", "2013-04-25 04:20:31"],[14, 7, 6, "added", "2013-04-25 04:20:31"],[15, 9, 6, "added", "2013-04-25 04:20:31"],[16, 10, 6, "added", "2013-04-25 04:20:31"],[17, 1, 7, "added", "2013-04-25 04:20:31"],[18, 8, 7, "added", "2013-04-25 04:20:31"],[19, 10, 7, "added", "2013-04-25 04:20:31"],[20, 3, 8, "added", "2013-04-25 04:20:31"],[21, 10, 9, "added", "2013-04-25 04:20:31"],[22, 3, 9, "added", "2013-04-25 04:20:31"],[23, 3, 8, "removed", "2013-04-25 04:20:31"],[24, 1, 10, "added", "2013-04-25 04:20:31"],[25, 2, 10, "added", "2013-04-25 04:20:31"],[26, 3, 10, "added", "2013-04-25 04:20:31"]]'
         # Mocks two responses. The first one contains the dummy data and the second an empty list
         # to force update_citations_log() to terminate.
@@ -51,22 +51,13 @@ class CitationsTests(InvenioTestCase):
                 httpretty.Response(body='[]', status=200),
             ]
         )
-        if self.setup_flag:
-            self.citations_dump = Citation.query.all()
-            self.citations_log_dump = Citation_Log.query.all()
-            self.setup_flag = False
-        Citation.query.delete()
-        Citation_Log.query.delete()
+        for i in range(10):
+            Record.create({'control_number': i + 1})
         update_citations_log()
 
     def tearDown(self):
         """Deletes all data used for testing"""
-        Citation.query.delete()
-        Citation_Log.query.delete()
-        for cit in self.citations_log_dump:
-            cit.save
-        for cit in self.citations_dump:
-            cit.save()
+        self.trans.rollback()
 
     def test_citations_rnkCITATIONDICT(self):
         """Test if rnkCITATIONDICT(Citations) is populated corectly"""

--- a/inspire/modules/records/__init__.py
+++ b/inspire/modules/records/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2015 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+from inspire.modules.records.receivers import insert_record

--- a/inspire/modules/records/receivers.py
+++ b/inspire/modules/records/receivers.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2015 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+from invenio.ext.sqlalchemy import db
+
+from invenio_records.models import Record
+
+from invenio_records.signals import before_record_insert
+
+
+@before_record_insert.connect
+def insert_record(sender, *args, **kwargs):
+    """Hack record insertion to add unregistered records.
+
+    This handler is imported when --force flag is used.
+    Example: inveniomanage migrator populate -f inspire/demosite/data/demo-records.xml --force
+    """
+    if 'control_number' in sender:
+        control_number = sender['control_number']
+        control_number = int(control_number)
+        # Searches if record already exists.
+        record = Record.query.filter_by(id=control_number).first()
+        if record is None:
+            # Adds the record to the db.
+            rec = Record(id=control_number)
+            db.session.add(rec)
+
+
+def remove_handler():
+    """Disconnects the signal handler."""
+    before_record_insert.disconnect(insert_record)


### PR DESCRIPTION
* Fixes tests to use nested sessions and preserve data.
  (closes #357 addresses #426)

* Merges the before_record_insert signal handler from #395

* Changes on the citations are no longer committed to the db.

Signed-off-by: Panos Paparrigopoulos <panos.paparrigopoulos@cern.ch>