### PR TITLE
elasticsearch: ICU plugin

### DIFF
--- a/inspire/base/searchext/mappings/hep.json
+++ b/inspire/base/searchext/mappings/hep.json
@@ -3,29 +3,14 @@
         "analysis": {
             "filter": {
                 "asciifold_with_orig": {
-                    "type": "asciifolding",
+                    "type": "icu_folding",
                     "preserve_original": true
-                },
-                "synonyms_kbr": {
-                    "type": "synonym",
-                    "synonyms": [
-                        "production => creation"
-                    ]
                 }
             },
             "analyzer": {
-                "natural_text": {
-                    "type": "custom",
-                    "tokenizer":  "standard",
-                    "filter": [
-                        "asciifold_with_orig",
-                        "lowercase",
-                        "synonyms_kbr"
-                    ]
-                },
                 "basic_analyzer": {
                     "type": "custom",
-                    "tokenizer": "standard",
+                    "tokenizer": "icu_tokenizer",
                     "filter": [
                         "asciifold_with_orig",
                         "lowercase"
@@ -53,8 +38,7 @@
             ],
             "properties": {
                 "global_fulltext": {
-                    "type": "string",
-                    "analyzer": "natural_text"
+                    "type": "string"
                 },
                 "global_default": {
                     "type": "string",
@@ -143,8 +127,7 @@
                     "properties": {
                         "full_name": {
                             "type": "string",
-                            "copy_to": ["exactauthor"],
-                            "analyzer": "natural_text"
+                            "copy_to": ["exactauthor"]
                         },
                         "affiliation": {
                             "type": "string"

--- a/inspire/testsuite/test_ICU.py
+++ b/inspire/testsuite/test_ICU.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2015 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+from invenio.testsuite import InvenioTestCase
+
+
+class IcuPluginTests(InvenioTestCase):
+
+    def test_icu(self):
+        from invenio_ext.es import es
+        self.assertTrue('analysis-icu' in es.cat.plugins())


### PR DESCRIPTION
* Removes unused analyzers from elasticsearcg configuration

* Uses ICU plugin to deal with non-ascii characters.
  NOTE: The plugin must be installed in the elasticsearch root directory
  by running "bin/plugin -install elasticsearch/elasticsearch-
  analysis-icu/2.7.0"

Signed-off-by: Panos Paparrigopoulos <panos.paparrigopoulos@cern.ch>