### PR TITLE
format: detailed HEP record MathJax rendering

### DIFF
--- a/inspire/base/templates/format/record/Inspire_Default_HTML_detailed.tpl
+++ b/inspire/base/templates/format/record/Inspire_Default_HTML_detailed.tpl
@@ -21,9 +21,10 @@
 
 {% from "format/record/Inspire_HTML_detailed_macros.tpl" import record_buttons, record_collection_heading, record_title, record_collections, record_publication_info, record_doi, record_links, detailed_record_abstract, record_keywords, record_references, record_citations with context %}
 
-{% from "format/record/Inspire_Default_HTML_general_macros.tpl" import render_record_authors, record_cite_modal, record_arxiv with context %}
+{% from "format/record/Inspire_Default_HTML_general_macros.tpl" import mathjax, render_record_authors, record_cite_modal, record_arxiv with context %}
 
 {% block header %}
+  {{ mathjax() | safe }}
   {{ record_cite_modal() }}
   <div id="{{record.collections | record_current_collection("") }}" class="record-collection-heading ellipsis">
     {{ record_collection_heading() }}

--- a/inspire/base/templates/format/record/Inspire_Default_HTML_general_macros.tpl
+++ b/inspire/base/templates/format/record/Inspire_Default_HTML_general_macros.tpl
@@ -180,3 +180,24 @@
   </div>
   <!-- END MODAL -->
 {% endmacro %}
+
+{% macro mathjax() %}
+{% set version = '2.5.3' %}
+<script src="//cdnjs.cloudflare.com/ajax/libs/mathjax/{{version}}/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/javascript">
+    require([
+      "jquery",
+      ], function ($) {
+          $(document).ready(function () {
+            MathJax.Hub.Config({
+                tex2jax: {inlineMath: [['$', '$'], ['\\(', '\\)']],
+                processEscapes: true},
+                showProcessingMessages: false,
+                messageStyle: "none"
+            });
+            MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
+          })
+      }
+    );
+</script>
+{% endmacro %}

--- a/inspire/base/templates/search/search.html
+++ b/inspire/base/templates/search/search.html
@@ -19,23 +19,9 @@
 
 {% extends "search/search_base.html" %}
 
+{% from "format/record/Inspire_Default_HTML_general_macros.tpl" import mathjax %}
+
 {%- block javascript %}
 {{ super() }}
-<script src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
-<script type="text/javascript">
-    require([
-      "jquery",
-      ], function ($) {
-          $(document).ready(function () {
-            MathJax.Hub.Config({
-                tex2jax: {inlineMath: [['$', '$'], ['\\(', '\\)']],
-                processEscapes: true},
-                showProcessingMessages: false,
-                messageStyle: "none"
-            });
-            MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
-          })
-      }
-    );
-</script>
+{{ mathjax() | safe }}
 {% endblock %}


### PR DESCRIPTION
* Loads MathJax from CDN in detailed HEP records. (closes #489)

Signed-off-by: Nick Papoutsis <admin@nils.gr>