### PR TITLE
formatter: render the appropriate authors detailed template

### DIFF
--- a/inspire/modules/formatter/output_formats/hd.yml
+++ b/inspire/modules/formatter/output_formats/hd.yml
@@ -3,7 +3,7 @@ default: Inspire_Default_HTML_detailed.tpl
 description: HTML detailed output format, used for Detailed record pages.
 name: HTML detailed
 rules:
-- {field: collections.primary, template: Author_HTML_detailed.tpl, value: 'AUTHOR'}
+- {field: collections.primary, template: Author_HTML_detailed.tpl, value: 'HEPNAMES'}
 - {field: collections.primary, template: Conference_HTML_detailed.tpl, value: 'CONFERENCES'}
 - {field: collections.primary, template: Journal_HTML_detailed.tpl, value: 'JOURNALS'}
 - {field: collections.primary, template: Institution_HTML_detailed.tpl, value: 'INSTITUTION'}


### PR DESCRIPTION
* Resolves an issue where the default template was incorrectly rendered, instead of the authors template. (adresses #507)

Signed-off-by: Nick Papoutsis <admin@nils.gr>