### PR TITLE
elasticsearch: elastic configuration additions

### DIFF
--- a/inspire/base/searchext/mappings/hep.json
+++ b/inspire/base/searchext/mappings/hep.json
@@ -131,6 +131,11 @@
                         },
                         "affiliation": {
                             "type": "string"
+                        },
+                        "name_variations":{
+                          "type": "string",
+                          "index": "not_analyzed",
+                          "copy_to": "global_fulltext"
                         }
                     }
                 },

--- a/inspire/dojson/hep/schemas/hep-0.0.1.json
+++ b/inspire/dojson/hep/schemas/hep-0.0.1.json
@@ -750,6 +750,11 @@
                         "description": "FIXME: needed for import only",
                         "format": ".+, .+"
                     },
+                    "name_variations": {
+                        "title": "Author name variations",
+                        "type": "string",
+                        "description": "All possible variations of the authors full name."
+                    },
                     "affiliations": {
                         "uniqueItems": true,
                         "items": {


### PR DESCRIPTION
    * Adds configuration for author name variations field.

    * This needs to be merged together with #529 and
       inspirehep/invenio-search#2

    Signed-off-by: Panos Paparrigopoulos <panos.paparrigopoulos@cern.ch>