### PR TITLE
honcho: delayed start

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
-web: inveniomanage runserver
-cache: redis-server
-worker: celery worker -E -A invenio_celery.celery --loglevel=INFO --workdir=$VIRTUAL_ENV
-workermon: flower --broker=amqp://guest:guest@localhost:5672//
+web: sleep 10 && inveniomanage runserver
+cache: sleep 10 && redis-server
+worker: sleep 10 && celery worker -E -A invenio_celery.celery --loglevel=INFO --workdir=$VIRTUAL_ENV
+workermon: sleep 10 && flower --broker=amqp://guest:guest@localhost:5672//
 indexer: elasticsearch --config=elasticsearch.yml --path.data="$VIRTUAL_ENV/var/data/elasticsearch"  --path.logs="$VIRTUAL_ENV/var/log/elasticsearch"

--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,7 @@ service mysql start
 service redis-server start
 service rabbitmq-server start
 /elasticsearch-"${ES_VERSION}"/bin/elasticsearch --path.plugins="/elasticsearch-${ES_VERSION}/plugins" 1> /dev/null &
+sleep 10
 
 # Needed to fix Python 2.7.9 TypeError with Jinja2.
 # See: https://github.com/inveniosoftware/invenio/issues/2862#issuecomment-90508434


### PR DESCRIPTION
* Starts first elasticsearch, sleep 10 seconds and then starts all
  the other depending processes, thus working around sniffing
  timeouts.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>