### PR TITLE
authors: phonetic name notation

### DIFF
--- a/inspire/base/searchext/mappings/hep.json
+++ b/inspire/base/searchext/mappings/hep.json
@@ -121,7 +121,8 @@
                     "type": "string"
                 },
                 "authors": {
-                    "type": "object",
+                    "type": "nested",
+                    "include_in_parent": true,
                     "properties": {
                         "full_name": {
                             "type": "string",
@@ -134,6 +135,9 @@
                           "type": "string",
                           "index": "not_analyzed",
                           "copy_to": "global_fulltext"
+                        },
+                        "signature_block": {
+                            "type": "string"
                         }
                     }
                 },

--- a/inspire/dojson/hep/schemas/hep-0.0.1.json
+++ b/inspire/dojson/hep/schemas/hep-0.0.1.json
@@ -736,7 +736,8 @@
                     "uuid": {
                         "title": "UUID",
                         "description": "Universally unique identifier of the author.",
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
                     },
                     "full_name": {
                         "title": "Author name",
@@ -841,7 +842,7 @@
                         "description": "Status whether the paper was claimed by the author.",
                         "type": "boolean"
                     },
-                    "ml_block": {
+                    "signature_block": {
                         "title": "Phonetic name",
                         "description": "Phonetic notation of the author's name.",
                         "type": "string"

--- a/inspire/modules/authors/receivers.py
+++ b/inspire/modules/authors/receivers.py
@@ -17,13 +17,52 @@
 # along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
+import numpy as np
 import uuid
 
+from beard.clustering import block_phonetic
 from invenio_records.signals import (
     before_record_index,
     before_record_insert,
-    before_record_update,
 )
+
+
+@before_record_index.connect
+def assign_signature_block(recid, json):
+    """Assign phonetic block to each signature.
+
+    The method extends the given signature with a phonetic
+    notation of the author's full name, based on
+    nysiis algorithm. The phonetic block is assigned before
+    the signature is indexed by an elasticsearch instance.
+    """
+    authors = json.get('authors', [])
+
+    for author in authors:
+        if 'full_name' in author:
+            name = {'author_name': author['full_name']}
+
+            signature_block = block_phonetic(
+                np.array([name], dtype=np.object).reshape(-1, 1),
+                threshold=0,
+                phonetic_algorithm='nysiis'
+            )
+
+            author['signature_block'] = signature_block[0]
+
+
+@before_record_insert.connect
+def assign_uuid(sender, *args, **kwargs):
+    """Assign uuid to each signature.
+
+    The method assigns to each signature a universally unique
+    identifier based on Python's built-in uuid4. The identifier
+    is allocated during the inseration of a new record.
+    """
+    authors = sender.get('authors', [])
+
+    for author in authors:
+        author['uuid'] = str(uuid.uuid4())
 
 
 @before_record_index.connect
@@ -32,7 +71,8 @@ def generate_name_variatons(recid, json):
     Adds a field for all the possible variations of an authors name
 
     :param recid: The id of the record that is going to be indexed.
-    :param json: The json representation of the record that is going to be indexed.
+    :param json: The json representation of the record that is going to be
+                 indexed.
     """
     from inspire.modules.authors.utils import author_tokenize
     authors = json.get("authors")
@@ -41,17 +81,3 @@ def generate_name_variatons(recid, json):
             name = author.get("full_name")
             if name:
                 author.update({"name_variations": author_tokenize(name)})
-
-
-@before_record_insert.connect
-@before_record_update.connect
-def assign_uuid(sender, *args, **kwargs):
-    """Assign uuid to each author of a HEP paper."""
-    if 'authors' in sender:
-        authors = sender['authors']
-
-        for author in authors:
-            if 'uuid' not in author:
-                author['uuid'] = str(uuid.uuid4())
-
-        sender['authors'] = authors


### PR DESCRIPTION
* Adds assign_signature_block in receivers.py resposible for
  assigning phonetic names of authors (signatures) in HEP
  collection. The blocks are assigned on before_record_index
  signal.

* Renames HEP schema ml_block to signature_block.

* Cleans up assign_uuid in receivers.py. Removes
  before_record_update signal.

* Extends HEP schema with regex pattern for uuid.

Signed-off-by: Grzegorz Jacenków <grzegorz.jacenkow@cern.ch>