### PR TITLE
format: detailed HEP record fixes

### DIFF
--- a/inspirehep/base/static/js/citation_modal.js
+++ b/inspirehep/base/static/js/citation_modal.js
@@ -1,0 +1,68 @@
+/*
+ ** This file is part of INSPIRE.
+ ** Copyright (C) 2015 CERN.
+ **
+ ** INSPIRE is free software: you can redistribute it and/or modify
+ ** it under the terms of the GNU General Public License as published by
+ ** the Free Software Foundation, either version 3 of the License, or
+ ** (at your option) any later version.
+ **
+ ** INSPIRE is distributed in the hope that it will be useful,
+ ** but WITHOUT ANY WARRANTY; without even the implied warranty of
+ ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ ** GNU General Public License for more details.
+ **
+ ** You should have received a copy of the GNU General Public License
+ ** along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+ **
+ ** In applying this licence, CERN does not waive the privileges and immunities
+ ** granted to it by virtue of its status as an Intergovernmental Organization
+ ** or submit itself to any jurisdiction.
+ */
+ 
+define(
+  [
+    'jquery',
+    'flight/lib/component',
+    'bootstrap'
+  ],
+  function($, defineComponent) {
+    'use strict';
+
+    return defineComponent(CitationsModal);
+
+    function CitationsModal() {
+
+      $('.dropdown-cite, .bibtex').click(function(ev) {
+        $.getJSON('/formatter/bibtex', {
+          recid: $(ev.target).data("recid")
+        }, function(data) {
+          $("#text" + data.recid).text(data.result);
+          $("#format" + data.recid).text('BibTex')
+          $("#download" + data.recid).attr("href", "/formatter/download-bibtex/" + data.recid)
+        })
+      })
+
+      $('.latex_eu').click(function(ev) {
+        $.getJSON('/formatter/latex', {
+          recid: $(ev.target).data("recid"),
+          latex_format: 'latex_eu'
+        }, function(data) {
+          $("#text" + data.recid).text(data.result);
+          $("#format" + data.recid).text('LaTex(EU)')
+          $("#download" + data.recid).attr("href", "/formatter/download-latex/latex_eu/" + data.recid)
+        })
+      })
+
+      $('.latex_us').click(function(ev) {
+        $.getJSON('/formatter/latex', {
+          recid: $(ev.target).data("recid"),
+          latex_format: 'latex_us'
+        }, function(data) {
+          $("#text" + data.recid).text(data.result);
+          $("#format" + data.recid).text('LaTex(US)')
+          $("#download" + data.recid).attr("href", "/formatter/download-latex/latex_us/" + data.recid)
+        })
+      })
+    }
+  });

--- a/inspirehep/base/static/js/detailed_record_init.js
+++ b/inspirehep/base/static/js/detailed_record_init.js
@@ -1,6 +1,6 @@
 /*
  * This file is part of INSPIRE.
- * Copyright (C) 2014 CERN.
+ * Copyright (C) 2015 CERN.
  *
  * INSPIRE is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,7 +21,8 @@
  */
 
 require([
-  "js/plots"
+  "js/plots",
+  "js/citation_modal"
 ], function() {
   // Needed to have the JavaScript available when ASSETS_DEBUG=False.
 });

--- a/inspirehep/base/static/js/search/search_results.js
+++ b/inspirehep/base/static/js/search/search_results.js
@@ -1,8 +1,31 @@
+/*
+ ** This file is part of INSPIRE.
+ ** Copyright (C) 2015 CERN.
+ **
+ ** INSPIRE is free software: you can redistribute it and/or modify
+ ** it under the terms of the GNU General Public License as published by
+ ** the Free Software Foundation, either version 3 of the License, or
+ ** (at your option) any later version.
+ **
+ ** INSPIRE is distributed in the hope that it will be useful,
+ ** but WITHOUT ANY WARRANTY; without even the implied warranty of
+ ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ ** GNU General Public License for more details.
+ **
+ ** You should have received a copy of the GNU General Public License
+ ** along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+ **
+ ** In applying this licence, CERN does not waive the privileges and immunities
+ ** granted to it by virtue of its status as an Intergovernmental Organization
+ ** or submit itself to any jurisdiction.
+ */
+
 define(
   [
     'jquery',
     'flight/lib/component',
-    'bootstrap'
+    'bootstrap',
+    'js/citation_modal'
   ],
   function($, defineComponent) {
     'use strict';
@@ -51,38 +74,6 @@ define(
             obj['url'] = '/formatter/export-as/bibtex/';
         }
         return obj;
-      }
-
-      this.onDownloadBibtex = function(ev) {
-        $.getJSON('/formatter/bibtex', {
-          recid: $(ev.target).data("recid")
-        }, function(data) {
-          $("#text" + data.recid).text(data.result);
-          $("#format" + data.recid).text('BibTex')
-          $("#download" + data.recid).attr("href", "/formatter/download-bibtex/" + data.recid)
-        });
-      }
-
-      this.onDownloadLatexEu = function(ev) {
-        $.getJSON('/formatter/latex', {
-          recid: $(ev.target).data("recid"),
-          latex_format: 'latex_eu'
-        }, function(data) {
-          $("#text" + data.recid).text(data.result);
-          $("#format" + data.recid).text('LaTex(EU)')
-          $("#download" + data.recid).attr("href", "/formatter/download-latex/latex_eu/" + data.recid)
-        });
-      }
-
-      this.onDownloadLatexUs = function(ev) {
-        $.getJSON('/formatter/latex', {
-          recid: $(ev.target).data("recid"),
-          latex_format: 'latex_us'
-        }, function(data) {
-          $("#text" + data.recid).text(data.result);
-          $("#format" + data.recid).text('LaTex(US)')
-          $("#download" + data.recid).attr("href", "/formatter/download-latex/latex_us/" + data.recid)
-        });
       }
 
       this.initExportDropdown = function() {
@@ -258,9 +249,6 @@ define(
       this.after('initialize', function() {
         sList = [];
         $('[data-toggle="tooltip"]').tooltip()
-        this.on(".dropdown-cite, .bibtex", "click", this.onDownloadBibtex);
-        this.on(".latex_eu", "click", this.onDownloadLatexEu);
-        this.on(".latex_us", "click", this.onDownloadLatexUs);
         this.on("#export-select-all", "click", this.onExportSelectAll);
         this.on("#checkbox-parent > input[type=checkbox]", "change", this.onCheckboxChange);
         this.on("#download-format", "click", this.onExportAs);

--- a/inspirehep/base/static/less/format/detailed-record.less
+++ b/inspirehep/base/static/less/format/detailed-record.less
@@ -292,32 +292,22 @@ body {
     z-index: 0;
 }
 
-@media screen and (min-width: @screen-sm-min) {
-    .cite-modal {
-        width: 900px;
-    }
-    #record-keywords {
-        margin-top: 20px;
-    }
-}
-
 .cite-modal {
-    width: 75%;
     font-weight: normal;
     text-align: left;
-} 
 
-#citeModalLabel {
-    margin-bottom: 10px;
-}  
+    #citeModalLabel {
+        margin-bottom: 10px;
+    }
+
+    .pointer {
+        cursor:pointer;
+    }
+} 
 
 #record-title, .journal,
 #external_links, #doi-eprint-experiment, {
     color: @blue-purple;
-}
-
-#external_links {
-    float: left;
 }
 
 .journal {
@@ -496,7 +486,6 @@ body {
 
 #doi-eprint-experiment {
     margin-top: 25px;
-    margin-bottom: 15px;
     padding-bottom: 20px;
 
     .doi, .eprint {

--- a/inspirehep/base/templates/format/record/Inspire_Default_HTML_detailed.tpl
+++ b/inspirehep/base/templates/format/record/Inspire_Default_HTML_detailed.tpl
@@ -39,15 +39,14 @@
     <div id="doi-eprint-experiment">
       {{ record_doi() }}
       {{ record_arxiv(is_brief=false) }}
+      <div class="cite-pdf-buttons">
+        <div class="btn-group">
+          {{ record_buttons() }}
+        </div>
+      </div>
     </div>
-    <hr/>
     <div id="external_links">
       {{ record_links() }}
-    </div>
-    <div class="cite-pdf-buttons">
-      <div class="btn-group">
-        {{ record_buttons() }}
-      </div>
     </div>
   </div>
 

--- a/inspirehep/base/templates/format/record/Inspire_HTML_detailed_macros.tpl
+++ b/inspirehep/base/templates/format/record/Inspire_HTML_detailed_macros.tpl
@@ -17,7 +17,7 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 #}
 
-{% from "format/record/Inspire_Default_HTML_general_macros.tpl" import record_cite_modal, record_abstract with context %}
+{% from "format/record/Inspire_Default_HTML_general_macros.tpl" import record_abstract with context %}
 {% from "records/Inspire_Default_HTML_detailed_macros.tpl" import search_current_collection with context %}
 
 {% macro record_collection_heading() %}


### PR DESCRIPTION
- [x] Rearranges the way external links are shown.

- [x] Restores cite record functionality.

- [x] Removes space before keywords.

- [x] Resolves error with `Uncaught Error: undefined missing js/citation_modal` when `ASSETS_DEBUG=False`

Signed-off-by: Nick Papoutsis <admin@nils.gr>