### PR TITLE
global: remove search API recids usage

### DIFF
--- a/inspire/ext/jinja_filters/record.py
+++ b/inspire/ext/jinja_filters/record.py
@@ -202,8 +202,8 @@ def setup_app(app):
         if not cnum:
             return out
         search_result = Query("cnum:%s and 980__a:proceedings" % (cnum,)).\
-            search().recids
-        if search_result:
+            search()
+        if len(search_result):
             if len(search_result) > 1:
                 from invenio.legacy.bibrecord import get_fieldvalues
                 proceedings = []
@@ -217,7 +217,7 @@ def setup_app(app):
                             '<a href="/record/%(ID)s">#%(number)s</a>' % {'ID': recid, 'number': i + 1})
                     out = 'Proceedings: '
                     out += ', '.join(proceedings)
-            elif len(search_result) == 1:
+            else:
                 out += '<a href="/record/' + str(search_result[0]) + \
                     '">Proceedings</a>'
         return out
@@ -265,8 +265,8 @@ def setup_app(app):
     @app.template_filter()
     def link_to_hep_affiliation(record):
         reccnt = Query("affiliation:%s" % (record['ICN'],))\
-            .search().recids
-        if len(reccnt) > 0:
+            .search()
+        if len(reccnt):
             if len(reccnt) == 1:
                 return str(len(reccnt)) + ' Paper from ' +\
                     str(record['ICN'])
@@ -333,7 +333,7 @@ def setup_app(app):
     def number_of_records(collection_name):
         """Returns number of records for the collection."""
         return len(Query("collection:" + collection_name).
-                   search(collection=collection_name).recids)
+                   search(collection=collection_name))
 
     @app.template_filter()
     def sanitize_arxiv_pdf(arxiv_value):

--- a/inspire/utils/bibtex_booktitle.py
+++ b/inspire/utils/bibtex_booktitle.py
@@ -48,11 +48,11 @@ def generate_booktitle(record):
                     if acronym:
                         booktitle = "%s: %s" % (rn, acronym, )
                     else:
-                        recids = Query(
+                        records = Query(
                             "reportnumber:%s" % (rn,)
-                        ).search().recids
-                        if recids:
-                            rec = get_record(recids[0])
+                        ).search().records()
+                        if records:
+                            rec = records[0]
                             for title in rec['titles']:
                                 booktitle = title.get('title', "")
                                 if title.get('subtitle'):


### PR DESCRIPTION
* NOTE: Invenio search API recids property should not be used with
  ElasticSearch 2.0 as size cannot be bigger than 10000.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>