### PR TITLE
static: resources dropdown-menu fixes

### DIFF
--- a/inspirehep/base/static/js/dropdown-menu/dropdown-menu.js
+++ b/inspirehep/base/static/js/dropdown-menu/dropdown-menu.js
@@ -25,7 +25,7 @@
    'jquery-menu-aim',
  ], function($, $menuAim) {
    $(window).ready(function() {
-     var $menu = $(".dropdown-menu");
+     var $menu = $("#dropdown-menu-amazon");
 
      function activateSubmenu(row) {
        var $row = $(row),
@@ -61,6 +61,8 @@
 
      function doneResizing() {
        var wi = $(window).width();
+       $("#dropdown-amazon").removeClass('open');
+
        if (wi > 767) {
          $menu.menuAim({
            activate: activateSubmenu,
@@ -72,8 +74,7 @@
          });
          $(".move-down").css({
            "margin-top": "0px"
-         }); // change it to class! 
-         $(".dropdown").removeClass('open');
+         }); // change it to class!
          $(".popover").css({
            "display": "none"
          });
@@ -88,7 +89,7 @@
          arrowDefaultState("#sixth-arrow");
          arrowDefaultState("#seventh-arrow");
 
-         $(".dropdown-menu li").click(function(e) {
+         $("#dropdown-menu-amazon li").click(function(e) {
            e.stopPropagation();
          });
 
@@ -112,8 +113,7 @@
          $(".popover").css({
            "display": "none"
          });
-         $(".dropdown").removeClass('open');
-         $(".dropdown-toggle").off("click");
+         $("#dropdown-amazon .dropdown-toggle").off("click");
          $(".first-submenu-item, .second-submenu-item, .third-submenu-item," +
            ".fourth-submenu-item, .fifth-submenu-item, .sixth-submenu-item, .seventh-submenu-item").off();
 

--- a/inspirehep/base/static/less/base/header.less
+++ b/inspirehep/base/static/less/base/header.less
@@ -96,7 +96,7 @@ body {
         &.navbar-fixed-top {
             top: 65px;
         }
-        
+
         span+span {
             margin-left: 20px;
         }
@@ -383,7 +383,7 @@ body {
     margin-bottom: 8px;
 }
 
-@media only screen and (max-width : 767px){
+@media only screen and (max-width : @screen-sm-min){
     .dropdown-menu-amazon {
         position: absolute;
         top:100%;
@@ -520,8 +520,8 @@ body {
 }
 
 .custom-horizontal-line{
-    border-color:#cccccc; 
-    margin-top: 10px; 
+    border-color:#cccccc;
+    margin-top: 10px;
     margin-bottom: 0px;
 }
 
@@ -531,7 +531,7 @@ body {
 }
 
 .dropdown-menu-list {
-    height: 35px; 
+    height: 35px;
     border-left: 1px solid;
     border-width: 5px;
 }
@@ -541,12 +541,12 @@ body {
 }
 
 .text-link-decoration {
-    text-decoration: none; 
+    text-decoration: none;
     color:#444;
 }
 
 .text-link-decoration:hover {
-    text-decoration: none; 
+    text-decoration: none;
     color:#444;
 }
 
@@ -590,31 +590,31 @@ body {
 
 #conferences,
 #conferences-header {
-    background-color:@conferences-collection; 
+    background-color:@conferences-collection;
 }
 
 #journals,
 #journals-header {
-    background-color:@journals-collection; 
+    background-color:@journals-collection;
 }
 
 #experiments,
 #expreriments-header {
-    background-color:@experiments-collection; 
+    background-color:@experiments-collection;
 }
 
 #institutions,
 #institutions-header {
-    background-color:@institutions-collection; 
+    background-color:@institutions-collection;
 }
 
 #links-and-stats,
 #links-and-stats-header {
-    background-color:#53657F; 
+    background-color:#53657F;
 }
 
 .font-p {
-    font-size:13px; 
+    font-size:13px;
 }
 
 .popover-link {

--- a/inspirehep/base/templates/header.html
+++ b/inspirehep/base/templates/header.html
@@ -61,7 +61,7 @@
         <ul class="nav navbar-nav navbar-right">
 
             <!-- Nice dropdown  -->
-            <li class="dropdown">
+            <li id="dropdown-amazon" class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown"  href="#">Resources</a>
               <ul class="dropdown-menu dropdown-menu-amazon" id="dropdown-menu-amazon" role="menu">
                 <li data-submenu-id="jobs" class="first-submenu-item">


### PR DESCRIPTION
Updates the selectors used in the Resources dropdown menu so that the code does not affect other dropdown menus across the entire site. E.g. this was causing dropdowns in Holding Pen to malfunction.

PS: Be careful when using very generic selectors of bootstrap components that may be used elsewhere. Better always use id's to select with.

@ioannistsanaktsidis @nikpap 