### PR TITLE
global: toast message changes

### DIFF
--- a/inspirehep/base/static/js/notification.js
+++ b/inspirehep/base/static/js/notification.js
@@ -24,14 +24,37 @@
    'toastr',
  ], function(toastr) {
    'use strict';
+
+   function createCookie(name, value, days) {
+     if (days) {
+       var date = new Date();
+       date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+       var expires = "; expires=" + date.toGMTString();
+     } else var expires = "";
+     document.cookie = name + "=" + value + expires + "; path=/";
+   }
+
+   function readCookie(name) {
+     var nameEQ = name + "=";
+     var ca = document.cookie.split(';');
+     for (var i = 0; i < ca.length; i++) {
+       var c = ca[i];
+       while (c.charAt(0) == ' ') c = c.substring(1, c.length);
+       if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length, c.length);
+     }
+     return null;
+   }
+
    toastr.options.closeButton = true;
    toastr.options.timeOut = 0;
    toastr.options.extendedTimeOut = 0;
    toastr.options.positionClass = "toast-top-right";
    toastr.options.onHidden = function() {
-     sessionStorage.setItem('notificationdismissed', true);
+     createCookie('notificationDismissed', 'true', '10');
    };
-   var dismissed = sessionStorage.getItem('notificationdismissed');
+   toastr.options.tapToDismiss = false;
+
+   var dismissed = readCookie('notificationDismissed');
    if (!dismissed) {
      toastr.info('You can go back to INSPIRE HEP any time - just <a href="http://inspirehep.net">click here</a>', 'Welcome to INSPIRE Labs!')
    }

--- a/inspirehep/base/static/less/base/core.less
+++ b/inspirehep/base/static/less/base/core.less
@@ -54,3 +54,11 @@ body {
 .breadcrumb > li:first-child {
     margin-left: -15px;
 }
+
+/* Toast message styling
+================================================== */
+
+.toast-top-right {
+    top: 128px !important;
+    right: 30px !important;
+}


### PR DESCRIPTION
* Adds cookie to avoid seeing toast message more than once.
  Expiration is set to 10 days. (closes #584)

* Changes toast position to not interfere with Login button.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>