### PR TITLE
feedback: disallow anonymous feedback

### DIFF
--- a/inspirehep/base/static/js/feedback/templates/email.mustache
+++ b/inspirehep/base/static/js/feedback/templates/email.mustache
@@ -1,0 +1,22 @@
+{{!
+  This file is part of INSPIRE.
+  Copyright (C) 2016 CERN.
+
+  INSPIRE is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License as
+  published by the Free Software Foundation; either version 2 of the
+  License, or (at your option) any later version.
+
+  INSPIRE is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+  59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+}}
+<div class="form-group">
+  <label for="feedbackModalReplytoaddr" class="control-label required">{{label}}</label>
+  <input id="feedbackModalReplytoaddr" class="form-control" type="email"/>
+</div>

--- a/inspirehep/base/static/js/feedback/templates/modal.mustache
+++ b/inspirehep/base/static/js/feedback/templates/modal.mustache
@@ -1,6 +1,6 @@
 {{!
   This file is part of INSPIRE.
-  Copyright (C) 2015 CERN.
+  Copyright (C) 2015, 2016 CERN.
 
   INSPIRE is free software; you can redistribute it and/or
   modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 <div class="modal fade in" id="feedbackModal" tabindex="-1" role="dialog" aria-labelledby="feedbackModalTitle" aria-hidden="false">
   <div class="modal-dialog">
     <div class="modal-content">
-      <div class="modal-header">
+      <div id="feedbackModalHeader" class="modal-header">
         <button type="button" class="close" data-dismiss="modal">
           <span aria-hidden="true">×</span>
 	  <span class="sr-only">{{close}}</span>
@@ -28,14 +28,18 @@
       </div>
       <form id="feedbackModalForm">
         <div class="modal-body">
-          <div id="feedbackModalErrors"></div>
+          <div id="feedbackModalError"></div>
+          <div id="feedbackModalEmail"></div>
           <div class="form-group">
-            <label for="feedbackModalBody" class="control-label required">{{label}}</label>
-            <textarea id="feedbackModalBody" class="form-control"></textarea>
+            <label for="feedbackModalFeedback" class="control-label required">{{label}}</label>
+            <textarea id="feedbackModalFeedback" class="form-control"></textarea>
+            <p class="text-muted">{{{clarification}}}</p>
           </div>
         </div>
         <div class="modal-footer">
-          <button type="submit" class="btn btn-warning">{{button}}</button>
+          <button type="submit" class="btn btn-warning">
+            {{button}} <i class="fa fa-paper-plane-o"></i>
+          </button>
         </div>
       </form>
     </div>

--- a/inspirehep/base/static/less/feedback/button.less
+++ b/inspirehep/base/static/less/feedback/button.less
@@ -18,12 +18,17 @@
 //  * 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 //  */
 
+@import (reference) "../inspire.less";
+
+
 .feedback-fixed-left {
     position: fixed;
-    left: -45px;
+    left: -48px;
     display: block;
     top: 50%;
     margin-right: 53px;
+    border-top-right-radius: @border-radius-base;
+    border-top-left-radius: @border-radius-base;
 }
 
 .feedback-transform {

--- a/inspirehep/base/static/less/feedback/modal.less
+++ b/inspirehep/base/static/less/feedback/modal.less
@@ -1,7 +1,7 @@
 /**
  *
  * This file is part of INSPIRE.
- * Copyright (C) 2015 CERN.
+ * Copyright (C) 2015, 2016 CERN.
  *
  * INSPIRE is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -18,11 +18,31 @@
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
  */
 
-#feedbackModalForm .control-label.required:after {
-    content: ' *';
-    color: red;
+@import (reference) "../inspire.less";
+
+
+#feedbackModalError {
+    margin-bottom: 8px;
 }
 
-#feedbackModalForm .form-control {
+#feedbackModalEmail {
+    margin-bottom: 8px;
+}
+
+#feedbackModalForm p {
+    font-size: 12px;
+    margin-top: 4px;
+}
+
+#feedbackModalForm .control-label {
+    font-weight: normal;
+}
+
+#feedbackModalForm .control-label.required:after {
+    content: " *";
+    color: @brand-warning;
+}
+
+#feedbackModalFeedback {
     height: 100px;
 }


### PR DESCRIPTION
As requested in #465, disallow anonymous feedback. Instead of implementing the solution proposed by @jmartinm I decided for another flow:

If the user is logged in, she can submit her feedback exactly like today. If the user is not logged in, when she tries to submit her feedback, a new field is added to the popup, requesting the email.