### PR TITLE
LESS: external links styling

### DIFF
--- a/inspirehep/base/static/less/base/core.less
+++ b/inspirehep/base/static/less/base/core.less
@@ -62,3 +62,23 @@ body {
     top: 128px !important;
     right: 30px !important;
 }
+
+/* External links styling
+================================================== */
+
+a[href^="http://"]:after, a[href^="https://"]:after {
+  content: "\f08e";
+  font-size: 80%;
+  font-family: FontAwesome;
+  font-weight: normal;
+  font-style: normal;
+  display: inline-block;
+  text-decoration: none;
+  padding-left: 3px;
+}
+
+a.no-external-icon:after {
+  content: "";
+  padding-left: 0;
+  display: inline;
+}

--- a/inspirehep/base/templates/format/record/Inspire_Default_HTML_brief.tpl
+++ b/inspirehep/base/templates/format/record/Inspire_Default_HTML_brief.tpl
@@ -96,7 +96,7 @@
               {% if record.get('arxiv_eprints') | is_list() %}
                 {% set eprints = record.get('arxiv_eprints') %}
                 {% for eprint in eprints %}
-                  <a type="button" class="btn custom-btn btn-warning link-to-pdf" href="http://arxiv.org/pdf/{{ eprint.get('value') | sanitize_arxiv_pdf }}"><i class="fa fa-eye"></i> PDF </a>
+                  <a type="button" class="btn custom-btn btn-warning link-to-pdf no-external-icon" href="http://arxiv.org/pdf/{{ eprint.get('value') | sanitize_arxiv_pdf }}">PDF</a>
                 {% endfor %}
               {% endif %}
             {% endif %}

--- a/inspirehep/base/templates/format/record/Inspire_Default_HTML_general_macros.tpl
+++ b/inspirehep/base/templates/format/record/Inspire_Default_HTML_general_macros.tpl
@@ -23,7 +23,7 @@
       data-placement="bottom"
       title="{{ author.get('affiliations')[0]['value'] }}"
     {% endif %}
-    href="http://inspirehep.net/author/profile/{{author.full_name}}?recid={{record['control_number']}}">
+    href="http://inspirehep.net/author/profile/{{author.full_name}}?recid={{record['control_number']}}" class="no-external-icon">
     {{ author.get('full_name') }}
   </a>
 {% endmacro %}

--- a/inspirehep/base/templates/format/record/Inspire_HTML_detailed_macros.tpl
+++ b/inspirehep/base/templates/format/record/Inspire_HTML_detailed_macros.tpl
@@ -55,7 +55,7 @@
     {% if record.get('arxiv_eprints') | is_list() %}
       {% set filtered_arxiv = record.get('arxiv_eprints') %}
       {% for report_number in filtered_arxiv %}
-        <a class="btn custom-btn btn-warning pdf-btn" href="http://arxiv.org/pdf/{{ report_number.get('value') | sanitize_arxiv_pdf }}" role="button" title="View PDF"><i class="fa fa-eye"></i> View PDF</a>
+        <a class="btn custom-btn btn-warning pdf-btn no-external-icon" href="http://arxiv.org/pdf/{{ report_number.get('value') | sanitize_arxiv_pdf }}" role="button" title="View PDF">View PDF</a>
       {% endfor %}
     {% endif %}
   {% endif %}


### PR DESCRIPTION
- [x] Add a relevant icon to all external links. (closes #585)
- [x] Add a `no-external-link` class to disable the icon in specific cases.
- [x] Apply aforementioned rule in authors, PDF
- [x] Add `https://`in the rule
- [x] Make icon smaller and more inline

Signed-off-by: Nick Papoutsis <admin@nils.gr>