### PR TITLE
dojson: valid schema

### DIFF
--- a/inspirehep/dojson/hep/schemas/hep-0.0.1.json
+++ b/inspirehep/dojson/hep/schemas/hep-0.0.1.json
@@ -985,7 +985,7 @@
             "items": {
                 "type": "string",
                 "description": "FIXME: we shall provide the ISO enum",
-                "title": "Language",
+                "title": "Language"
             }
         },
         "page_nr": {
@@ -1084,7 +1084,7 @@
                 "properties": {
                     "source": {
                         "type": "string",
-                        "description": "Provenance of the persistent identifier",
+                        "description": "Provenance of the persistent identifier"
                     },
                     "type": {
                         "type": "string",


### PR DESCRIPTION
* Removes two unintended commas from the json schema to make it valid.

Signed-off-by: Panos Paparrigopoulos <panos.paparrigopoulos@cern.ch>