### PR TITLE
elasticsearch: doi mapping addition

### DIFF
--- a/inspirehep/base/searchext/mappings/hep.json
+++ b/inspirehep/base/searchext/mappings/hep.json
@@ -73,6 +73,15 @@
                     "type": "string",
                     "copy_to": ["experimentautocomplete"]
                 },
+                "dois": {
+                    "type": "object",
+                        "properties": {
+                            "value": {
+                                "type": "string",
+                                "index": "not_analyzed"
+                            }
+                    }
+                },
                 "report_numbers": {
                     "type": "object",
                     "properties": {


### PR DESCRIPTION
* Adds doi mapping as non-analyzed.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>