### PR TITLE
search: enable debug

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 web: inveniomanage runserver
 cache: redis-server
-worker: celery worker -E -A invenio_celery.celery --loglevel=INFO --workdir=$VIRTUAL_ENV
+worker: celery worker -E -A invenio_celery.celery --loglevel=DEBUG --workdir=$VIRTUAL_ENV
 workermon: flower --broker=amqp://guest:guest@localhost:5672//
 indexer: elasticsearch -Dcluster.name="inspire" -Ddiscovery.zen.ping.multicast.enabled=false -Dpath.data="$VIRTUAL_ENV/var/data/elasticsearch"  -Dpath.logs="$VIRTUAL_ENV/var/log/elasticsearch"

--- a/base.requirements.txt
+++ b/base.requirements.txt
@@ -14,5 +14,5 @@ git+https://github.com/inspirehep/invenio-deposit.git@master#egg=invenio-deposit
 git+https://github.com/inspirehep/invenio-ext@master#egg=invenio-ext==0.3.3.dev20151125
 git+https://github.com/inspirehep/invenio-oaiharvester@master#egg=invenio-oaiharvester==0.1.2.dev20151113
 git+https://github.com/inspirehep/invenio-records@master#egg=invenio-records==0.3.5.dev20151209
-git+https://github.com/inspirehep/invenio-search@master#egg=invenio-search==0.1.6.dev20151125
+git+https://github.com/inspirehep/invenio-search@master#egg=invenio-search==0.1.6.dev20151211
 git+https://github.com/inspirehep/invenio-workflows@master#egg=invenio-workflows==0.1.3.dev20151210


### PR DESCRIPTION
* Upgrades invenio-search dependency to include
  inspirehep/invenio-search#9.

* Amends honcho's Procfile to enable Celery DEBUG by default, so that
  it is possible to see on the log how queries are interpreted.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>