### PR TITLE
honcho: revert Celery DEBUG

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 web: inveniomanage runserver
 cache: redis-server
-worker: celery worker -E -A invenio_celery.celery --loglevel=DEBUG --workdir=$VIRTUAL_ENV
+worker: celery worker -E -A invenio_celery.celery --loglevel=INFO --workdir=$VIRTUAL_ENV
 workermon: flower --broker=amqp://guest:guest@localhost:5672//
 indexer: elasticsearch -Dcluster.name="inspire" -Ddiscovery.zen.ping.multicast.enabled=false -Dpath.data="$VIRTUAL_ENV/var/data/elasticsearch"  -Dpath.logs="$VIRTUAL_ENV/var/log/elasticsearch"


### PR DESCRIPTION
* Reverts Celery DEBUG flag in Honcho's Procfile, since this is not
  really necessary to see requests being performed online.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>