### PR TITLE
dojson: strip empty values

### DIFF
--- a/inspirehep/dojson/processors.py
+++ b/inspirehep/dojson/processors.py
@@ -26,6 +26,7 @@ def convert_marcxml(source):
     """Convert MARC XML to JSON."""
     from dojson.contrib.marc21.utils import create_record, split_blob
 
+    from inspirehep.dojson.utils import strip_empty_values
     from inspirehep.dojson.hep import hep
     from inspirehep.dojson.institutions import institutions
     from inspirehep.dojson.journals import journals
@@ -37,20 +38,20 @@ def convert_marcxml(source):
     for data in split_blob(source.read()):
         record = create_record(data)
         if _collection_in_record(record, 'institution'):
-            yield institutions.do(record)
+            yield strip_empty_values(institutions.do(record))
         elif _collection_in_record(record, 'experiment'):
-            yield experiments.do(record)
+            yield strip_empty_values(experiments.do(record))
         elif _collection_in_record(record, 'journals'):
-            yield journals.do(record)
+            yield strip_empty_values(journals.do(record))
         elif _collection_in_record(record, 'hepnames'):
-            yield hepnames.do(record)
+            yield strip_empty_values(hepnames.do(record))
         elif _collection_in_record(record, 'job') or \
                 _collection_in_record(record, 'jobhidden'):
-            yield jobs.do(record)
+            yield strip_empty_values(jobs.do(record))
         elif _collection_in_record(record, 'conferences'):
-            yield conferences.do(record)
+            yield strip_empty_values(conferences.do(record))
         else:
-            yield hep.do(record)
+            yield strip_empty_values(hep.do(record))
 
 
 def _collection_in_record(record, collection):

--- a/inspirehep/dojson/utils.py
+++ b/inspirehep/dojson/utils.py
@@ -102,3 +102,22 @@ def create_valid_date(date):
         valid_date = ''
 
     return valid_date
+
+
+def strip_empty_values(obj):
+    """Recursively strips empty values."""
+
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            value = strip_empty_values(value)
+            if value or value is False or value == 0:
+                obj[key] = value
+            else:
+                del obj[key]
+        return obj
+    elif isinstance(obj, (list, tuple, set)):
+        new_obj = [strip_empty_values(v) for v in obj]
+        new_obj = [v for v in new_obj if v or v is False or v == 0]
+        return type(obj)(new_obj)
+    else:
+        return obj


### PR DESCRIPTION
* Introduces new step in dojson.processors, to remove any empty
  value, i.e. anything corresponding to "", None, an empty list or
  an empty dictionary. 0s and False are not considered empty values.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>