### PR TITLE
migrator: migrate out of Celery

### DIFF
--- a/inspirehep/modules/migrator/manage.py
+++ b/inspirehep/modules/migrator/manage.py
@@ -87,8 +87,13 @@ def populate(records, collections, file_input=None, remigrate=False,
     elif file_input:
         print("Migrating records from file: {0}".format(file_input))
 
-        migrate.delay(os.path.abspath(file_input), broken_output=broken_output,
-                      dry_run=dry_run)
+        from invenio_celery.utils import disable_queue, enable_queue
+        disable_queue("celery")
+        try:
+            migrate(os.path.abspath(file_input), broken_output=broken_output,
+                    dry_run=dry_run)
+        finally:
+            enable_queue("celery")
     else:
         legacy_base_url = current_app.config.get("CFG_INSPIRE_LEGACY_BASEURL")
         print(

--- a/inspirehep/modules/migrator/tasks.py
+++ b/inspirehep/modules/migrator/tasks.py
@@ -134,7 +134,7 @@ def migrate(source, broken_output=None, dry_run=False):
         fd = open(source)
 
     for i, chunk in enumerate(chunker(split_stream(fd), CHUNK_SIZE)):
-        logger.info("Processed {} records".format(i * CHUNK_SIZE))
+        print("Processed {} records".format(i * CHUNK_SIZE))
         chunk_broken_output = None
         if broken_output:
             chunk_broken_output = "{}-{}".format(broken_output, i)


### PR DESCRIPTION
* No longer schedules the parent migration task in Celery. Instead,
  suspend Celery, so that the chunks are quickly loaded into
  RabbitMQ and then processed as fast as possible.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>