### PR TITLE
dojson: support enhanced marcxml links

### DIFF
--- a/inspirehep/base/searchext/mappings/hep.json
+++ b/inspirehep/base/searchext/mappings/hep.json
@@ -173,14 +173,17 @@
                     "index": "not_analyzed"
                 },
                 "collaboration": {
-                    "type": "string",
-                    "fields" : {
-                        "raw" : {
+                    "type": "object",
+                    "properties" : {
+                        "value" : {
                             "type" : "string",
-                            "index" : "not_analyzed"
+                            "index" : "not_analyzed",
+                            "copy_to": ["global_fulltext"]
+                        },
+                        "recid":{
+                            "type": "integer"
                         }
-                    },
-                    "copy_to": ["global_fulltext"]
+                    }
                 },
                 "collections": {
                     "type": "object",
@@ -226,6 +229,9 @@
                                 "value": {
                                     "type": "string",
                                     "copy_to": ["affiliation"]
+                                },
+                                "recid": {
+                                    "type": "integer"
                                 }
                             }
                         },
@@ -301,6 +307,9 @@
                             "type": "string",
                             "index": "not_analyzed",
                             "copy_to": ["cnum"]
+                        },
+                        "journal_recid": {
+                            "type": "integer"
                         }
                     }
                 },

--- a/inspirehep/base/templates/format/record/Inspire_Default_HTML_general_macros.tpl
+++ b/inspirehep/base/templates/format/record/Inspire_Default_HTML_general_macros.tpl
@@ -31,9 +31,11 @@
 {% macro render_record_authors(is_brief, number_of_displayed_authors=10, show_affiliations=true) %}
   {% if record.collaboration %}
     {% set collaboration_displayed = [] %}
-    {% for collaboration in record.collaboration if collaboration != None %}
-      <a href="/search?p=collaboration:'{{ collaboration }}'">{{ collaboration }}</a>
+    {% for collaboration in record.collaboration %}
+      {% if collaboration['value'] %}
+      <a href="/search?p=collaboration:'{{ collaboration['value'] }}'">{{ collaboration['value'] }}</a>
       {% do collaboration_displayed.append(1) %}
+      {% endif %}
       {% if not loop.last %}
         and
       {% endif %}

--- a/inspirehep/dojson/hep/fields/bd1xx.py
+++ b/inspirehep/dojson/hep/fields/bd1xx.py
@@ -36,10 +36,22 @@ def authors(self, key, value):
 
     def get_value(value):
         affiliations = []
+        curated_relation = False
         if value.get('u'):
+            recid = ''
+            try:
+                recid = int(value.get('z'))
+            except:
+                pass
             affiliations = list(set(utils.force_list(
                 value.get('u'))))
-            affiliations = [{'value': aff} for aff in affiliations]
+            affiliations = [{'value': aff, 'recid': recid} for
+                            aff in affiliations]
+        if value.get('y'):
+            if value.get('y') == '1':
+                curated_relation = True
+        elif value.get('z'):
+            curated_relation = True
         ret = {
             'full_name': value.get('a'),
             'role': value.get('e'),
@@ -52,7 +64,7 @@ def authors(self, key, value):
             'profile': inspire_dojson_utils.create_profile_url(
                 value.get('x')
             ),
-            'claimed': value.get('y')
+            'curated_relation': curated_relation
         }
         # HACK: This is to workaround broken records where multiple authors
         # got meshed up together.
@@ -94,7 +106,7 @@ def authors2marc(self, key, value):
             'm': value.get('email'),
             'u': affiliations,
             'x': value.get('recid'),
-            'y': value.get('claimed')
+            'y': value.get('curated_relation')
         }
 
     if len(value) > 1:

--- a/inspirehep/dojson/hep/fields/bd5xx.py
+++ b/inspirehep/dojson/hep/fields/bd5xx.py
@@ -92,11 +92,16 @@ def hidden_note2marc(self, key, value):
 @utils.filter_values
 def thesis(self, key, value):
     """Get Thesis Information."""
+    curated_relation = False
+    if value.get('z'):
+        curated_relation = True
     return {
         'defense_date': value.get('a'),
         'degree_type': value.get('b'),
         'university': value.get('c'),
-        'date': value.get('d')
+        'date': value.get('d'),
+        'recid': value.get('z'),
+        'curated_relation': curated_relation,
     }
 
 

--- a/inspirehep/dojson/hep/fields/bd6xx.py
+++ b/inspirehep/dojson/hep/fields/bd6xx.py
@@ -78,9 +78,20 @@ def free_keywords2marc(self, key, value):
 @utils.filter_values
 def accelerator_experiments(self, key, value):
     """The accelerator/experiment related to this record."""
+    recid = ''
+    curated_relation = False
+    if '0' in value:
+        try:
+            recid = int(value.get('0'))
+        except (TypeError, ValueError, AttributeError):
+            pass
+    if recid:
+        curated_relation = True
     return {
+        'recid': recid,
         'accelerator': value.get('a'),
         'experiment': value.get('e'),
+        'curated_relation': curated_relation
     }
 
 

--- a/inspirehep/dojson/hep/fields/bd70x75x.py
+++ b/inspirehep/dojson/hep/fields/bd70x75x.py
@@ -57,7 +57,16 @@ def thesis_supervisor2marc(self, key, value):
 def collaboration(self, key, value):
     """Added Entry-Corporate Name."""
     def get_value(value):
-        return value.get('g')
+        recid = ''
+        if '0' in value:
+            try:
+                recid = int(value.get('0'))
+            except:
+                pass
+        return {
+            'value': value.get('g'),
+            'recid': recid
+        }
     collaboration = self.get('collaboration', [])
     if isinstance(value, list):
         filtered_value = [dict(t) for t in

--- a/inspirehep/dojson/hep/fields/bd76x78x.py
+++ b/inspirehep/dojson/hep/fields/bd76x78x.py
@@ -34,6 +34,7 @@ def publication_info(self, key, value):
     """Publication info about record."""
     year = ''
     recid = ''
+    journal_recid = ''
     if 'y' in value:
         try:
             year = int(value.get('y'))
@@ -41,17 +42,20 @@ def publication_info(self, key, value):
             # Some crap in they year :-(
             pass
     try:
-        if '0' in value:
-            if isinstance(value['0'], list):
-                recid = int(value['0'][0])
+        if '2' in value:
+            if isinstance(value.get('2'), list):
+                recid = int(value.get('2')[0])
             else:
-                recid = int(value.get('0'))
+                recid = int(value.get('2'))
+        if '1' in value:
+            journal_recid = int(value.get('1'))
     except:
         # Some crap in the recid :-(
         pass
     return {
         'recid': recid,
         'page_artid': value.get('c'),
+        'journal_recid': journal_recid,
         'journal_issue': value.get('n'),
         'conf_acronym': value.get('o'),
         'journal_title': value.get('p'),

--- a/inspirehep/dojson/hep/model.py
+++ b/inspirehep/dojson/hep/model.py
@@ -24,15 +24,28 @@
 
 import types
 from dojson import Overdo
+from dojson.utils import force_list
+
+
+def add_book_info(record, blob):
+    """Add link to the appropriate book record."""
+    collections = [c['primary'].lower() for c in record['collections']]
+    if 'bookchapter' in collections:
+        pubinfos = force_list(blob.get("773__", []))
+        for pubinfo in pubinfos:
+            if pubinfo.get('0'):
+                record['book'] = {
+                    'recid': int(pubinfo['0'])
+                }
 
 
 def custom_do(self, blob):
     """Custom do function that allows extra post-processing."""
     record = self._do(blob)
+    add_book_info(record, blob)
     return record
 
 hep = Overdo()
 hep._do = hep.do
 hep.do = types.MethodType(custom_do, hep)
-
 hep2marc = Overdo()

--- a/inspirehep/dojson/hep/schemas/hep-0.0.1.json
+++ b/inspirehep/dojson/hep/schemas/hep-0.0.1.json
@@ -382,6 +382,10 @@
                     "page_artid": {
                         "type": "string",
                         "description": "FIXME: for ejournals this could be the page index, but there is no realiable way to know whether something is a page index or a first page, does it?"
+                    },
+                    "journal_recid": {
+                        "type": "integer",
+                        "description": "Record ID of corresponding Journal"
                     }
                 }
             },

--- a/inspirehep/dojson/hepnames/fields/bd1xx.py
+++ b/inspirehep/dojson/hepnames/fields/bd1xx.py
@@ -266,14 +266,19 @@ def positions(self, key, value):
     In dates field you can put months in addition to years. In this case you
     have to follow the convention `mth-year`. For example: `10-2012`.
     """
+    curated_relation = False
+    if value.get('z'):
+        curated_relation = True
     return {
-        'institution': {'name': value.get('a')} if value.get('a') else None,
+        'institution': {'name': value.get('a'), 'recid': value.get('z')} if
+        value.get('a') else None,
         'rank': value.get('r'),
         'start_date': value.get('s'),
         'end_date': value.get('t'),
         'email': value.get('m'),
         'old_email': value.get('o'),
-        'status': value.get('z')
+        'status': value.get('z'),
+        'curated_relation': curated_relation,
     }
 
 

--- a/inspirehep/dojson/jobs/fields/bd1xx.py
+++ b/inspirehep/dojson/jobs/fields/bd1xx.py
@@ -127,9 +127,12 @@ def experiments(self, key, value):
 @utils.filter_values
 def institution(self, key, value):
     """Institution info."""
+    curated_relation = False
+    if value.get('z'):
+        curated_relation - True
     return {
-        # 'curated_relation': value.get('a'),
-        # 'recid': value.get('c')
+        'curated_relation': curated_relation,
+        'recid': value.get('z'),
         'name': value.get('a'),
     }
 

--- a/inspirehep/utils/bibtex.py
+++ b/inspirehep/utils/bibtex.py
@@ -318,8 +318,8 @@ class Bibtex(Export):
         collaboration = ''
         if 'collaboration' in self.record:
             try:
-                collaboration = self.record['collaboration'][0]
-            except IndexError:
+                collaboration = self.record['collaboration'][0]['value']
+            except (IndexError, KeyError):
                 pass
         return collaboration
 

--- a/inspirehep/utils/cv_latex.py
+++ b/inspirehep/utils/cv_latex.py
@@ -93,7 +93,7 @@ class Cv_latex(Export):
                 if 'collaboration' in self.record:
                     try:
                         if 'collaboration' in self.record:
-                            collaboration = self.record['collaboration'][0]
+                            collaboration = self.record['collaboration'][0]['value']
                             if 'Collaboration' in collaboration:
                                 out += u' {\it et al.} [' + \
                                     collaboration + '].\n'

--- a/inspirehep/utils/cv_latex_html_text.py
+++ b/inspirehep/utils/cv_latex_html_text.py
@@ -96,7 +96,8 @@ class Cv_latex_html_text(Export):
             elif len(value) > 8:
                 if 'collaboration' in self.record:
                     try:
-                        collaboration = self.record['collaboration'][0]
+                        collaboration = self.record[
+                            'collaboration'][0]['value']
                         if 'Collaboration' in collaboration:
                             out += u'By ' + collaboration + '({1} et al.).{2}'.format(
                                 field, value[0], self.separator

--- a/inspirehep/utils/latex.py
+++ b/inspirehep/utils/latex.py
@@ -93,7 +93,7 @@ class Latex(Export):
                 if 'collaboration' in self.record:
                     try:
                         collaboration = self.\
-                            record['collaboration'][0]
+                            record['collaboration'][0]['value']
                         if 'Collaboration' in collaboration:
                             out += u' {{\it et al.}} [' + collaboration +\
                                 '],\n'

--- a/tests/fixtures/test_hep_book.xml
+++ b/tests/fixtures/test_hep_book.xml
@@ -1,0 +1,783 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+<record>
+  <controlfield tag="001">1409247</controlfield>
+  <controlfield tag="005">20151213195707.0</controlfield>
+  <datafield tag="024" ind1="7" ind2=" ">
+    <subfield code="2">DOI</subfield>
+    <subfield code="a">10.1007/978-3-319-21353-8_1</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">Fredenhagen:2015utr</subfield>
+    <subfield code="9">INSPIRETeX</subfield>
+  </datafield>
+  <datafield tag="650" ind1="1" ind2="7">
+    <subfield code="2">INSPIRE</subfield>
+    <subfield code="9">submitter</subfield>
+    <subfield code="a">Theory-HEP</subfield>
+  </datafield>
+  <datafield tag="773" ind1=" " ind2=" ">
+    <subfield code="0">1409249</subfield>
+    <subfield code="c">1-30</subfield>
+    <subfield code="y">2015</subfield>
+  </datafield>
+  <datafield tag="520" ind1=" " ind2=" ">
+    <subfield code="a">The algebraic approach to quantum field theory is reviewed, and its aims, successes and limitations are discussed.</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">*Temporary entry*</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">30</subfield>
+  </datafield>
+  <datafield tag="909" ind1="C" ind2="O">
+    <subfield code="o">oai:inspirehep.net:1409247</subfield>
+    <subfield code="p">INSPIRE:HEP</subfield>
+  </datafield>
+  <datafield tag="980" ind1=" " ind2=" ">
+    <subfield code="a">HEP</subfield>
+  </datafield>
+  <datafield tag="980" ind1=" " ind2=" ">
+    <subfield code="a">BookChapter</subfield>
+  </datafield>
+  <datafield tag="980" ind1=" " ind2=" ">
+    <subfield code="a">CORE</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">1093553</subfield>
+    <subfield code="h">Alazzawi, S.</subfield>
+    <subfield code="m">: Deformation of fermionic quantum field theories and integrable models</subfield>
+    <subfield code="o">1</subfield>
+    <subfield code="s">Lett.Math.Phys.,103,37-58</subfield>
+    <subfield code="y">2012</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="h">Alazzawi, S</subfield>
+    <subfield code="m">: Deformation of quantum field theories and the construction of interacting models. PhD thesis, University of Vienna</subfield>
+    <subfield code="o">2</subfield>
+    <subfield code="y">2015</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">1122534</subfield>
+    <subfield code="h">Almheiri, A., Marolf, D., Polchinski, J., Sully, J.</subfield>
+    <subfield code="m">: Black holes: complementarity or firewalls?</subfield>
+    <subfield code="o">3</subfield>
+    <subfield code="s">JHEP,1302,062</subfield>
+    <subfield code="y">2013</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">283787</subfield>
+    <subfield code="h">Altherr, T.</subfield>
+    <subfield code="m">: Infrared problem in gϕ4 theory at finite temperature</subfield>
+    <subfield code="o">4</subfield>
+    <subfield code="s">Phys.Lett.,B238,360</subfield>
+    <subfield code="y">1990</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="h">Araki, H.</subfield>
+    <subfield code="m">: A lattice of von Neumann algebras associated with the quantum theory of a free Bose field</subfield>
+    <subfield code="o">5</subfield>
+    <subfield code="s">J.Math.Phys.,4,1343</subfield>
+    <subfield code="y">1963</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="h">Araki, H.</subfield>
+    <subfield code="m">: Von Neumann algebras of local observables for free scalar field</subfield>
+    <subfield code="o">6</subfield>
+    <subfield code="s">J.Math.Phys.,5,1</subfield>
+    <subfield code="y">1964</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">689540</subfield>
+    <subfield code="h">Araki, H., Zsidó, L.</subfield>
+    <subfield code="m">: Extension of the structure theorem of borchers and its application to half-sided modular inclusions</subfield>
+    <subfield code="o">7</subfield>
+    <subfield code="s">Rev.Math.Phys.,17,491</subfield>
+    <subfield code="y">2005</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">1264558</subfield>
+    <subfield code="h">Barata, J.C.A., Jäkel, C.D., Mund, J.</subfield>
+    <subfield code="m">: The (φ)2 model on the de sitter space</subfield>
+    <subfield code="o">8</subfield>
+    <subfield code="r">arXiv:1311.2905 [math-ph]</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">1299577</subfield>
+    <subfield code="h">Becker, C., Schenkel, A., Szabo, R.J.</subfield>
+    <subfield code="m">: Differential cohomology and locally covariant quantum field theory</subfield>
+    <subfield code="o">9</subfield>
+    <subfield code="r">arXiv:1406.1514 [hep-th]</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">1236617</subfield>
+    <subfield code="h">Benini, M., Dappiaggi, C., Hack, T.-P.</subfield>
+    <subfield code="m">: Quantum field theory on curved backgrounds—a primer</subfield>
+    <subfield code="o">10</subfield>
+    <subfield code="s">Int.J.Mod.Phys.,A28,1330023</subfield>
+    <subfield code="y">2013</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">102924</subfield>
+    <subfield code="h">Bisognano, J.J., Wichmann, E.H.</subfield>
+    <subfield code="m">: On the duality condition for a hermitian scalar field</subfield>
+    <subfield code="o">11</subfield>
+    <subfield code="s">J.Math.Phys.,16,985</subfield>
+    <subfield code="y">1975</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="h">Borchers, H.J.</subfield>
+    <subfield code="m">: A remark on a theorem of B. Misra</subfield>
+    <subfield code="o">12</subfield>
+    <subfield code="s">Commun.Math.Phys.,4,315-323</subfield>
+    <subfield code="y">1967</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">29380</subfield>
+    <subfield code="h">Borchers, H.J.</subfield>
+    <subfield code="m">: The CPT theorem in two-dimensional theories of local observables</subfield>
+    <subfield code="o">13</subfield>
+    <subfield code="s">Commun.Math.Phys.,143,315</subfield>
+    <subfield code="y">1992</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">538702</subfield>
+    <subfield code="h">Borchers, H.J.</subfield>
+    <subfield code="m">: On revolutionizing quantum field theory with Tomita’s modular</subfield>
+    <subfield code="o">14</subfield>
+    <subfield code="s">J.Math.Phys.,41,3604</subfield>
+    <subfield code="y">2000</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">811019</subfield>
+    <subfield code="h">Brunetti, R., Duetsch, M., Fredenhagen, K.</subfield>
+    <subfield code="m">: Perturbative algebraic quantum field theory and the renormalization groups</subfield>
+    <subfield code="o">15</subfield>
+    <subfield code="s">Adv.Theor.Math.Phys.,13,1541</subfield>
+    <subfield code="y">2009</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">497168</subfield>
+    <subfield code="h">Brunetti, R., Fredenhagen, K.</subfield>
+    <subfield code="m">: Microlocal analysis and interacting quantum field theories: renormalization on physical backgrounds</subfield>
+    <subfield code="o">16</subfield>
+    <subfield code="s">Commun.Math.Phys.,208,623</subfield>
+    <subfield code="y">2000</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">401541</subfield>
+    <subfield code="h">Brunetti, R., Fredenhagen, K., Kohler, M.</subfield>
+    <subfield code="m">: The Microlocal spectrum condition and Wick polynomials of free fields on curved space-times</subfield>
+    <subfield code="o">17</subfield>
+    <subfield code="s">Commun.Math.Phys.,180,633</subfield>
+    <subfield code="y">1996</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">1237092</subfield>
+    <subfield code="h">Brunetti, R., Fredenhagen, K., Rejzner, K.</subfield>
+    <subfield code="m">: Quantum gravity from the point of view of locally covariant quantum field theory</subfield>
+    <subfield code="o">18</subfield>
+    <subfield code="r">arXiv:1306.1058 [math-ph]</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">568713</subfield>
+    <subfield code="h">Brunetti, R., Fredenhagen, K., Verch, R.</subfield>
+    <subfield code="m">: The generally covariant locality principle: a new paradigm for local quantum field theory</subfield>
+    <subfield code="o">19</subfield>
+    <subfield code="s">Commun.Math.Phys.,237,31</subfield>
+    <subfield code="y">2003</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">584047</subfield>
+    <subfield code="h">Brunetti, R., Guido, D., Longo, R.</subfield>
+    <subfield code="m">: Modular localization and wigner particles</subfield>
+    <subfield code="o">20</subfield>
+    <subfield code="s">Rev.Math.Phys.,14,759</subfield>
+    <subfield code="y">2002</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">778036</subfield>
+    <subfield code="h">Brunetti, R., Ruzzi, G.</subfield>
+    <subfield code="m">: Quantum charges and spacetime topology: the emergence of new superselection sectors</subfield>
+    <subfield code="o">21</subfield>
+    <subfield code="s">Commun.Math.Phys.,287,523</subfield>
+    <subfield code="y">2009</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">80387</subfield>
+    <subfield code="h">Buchholz, D.</subfield>
+    <subfield code="m">: Product states for local algebras</subfield>
+    <subfield code="o">22</subfield>
+    <subfield code="s">Commun.Math.Phys.,36,287</subfield>
+    <subfield code="y">1974</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">108808</subfield>
+    <subfield code="h">Buchholz, D.</subfield>
+    <subfield code="m">: Collision theory for massless bosons</subfield>
+    <subfield code="o">23</subfield>
+    <subfield code="s">Commun.Math.Phys.,52,147</subfield>
+    <subfield code="y">1977</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">176516</subfield>
+    <subfield code="h">Buchholz, D.</subfield>
+    <subfield code="m">: The physical state space of quantum electrodynamics</subfield>
+    <subfield code="o">24</subfield>
+    <subfield code="s">Commun.Math.Phys.,85,49</subfield>
+    <subfield code="y">1982</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">229635</subfield>
+    <subfield code="h">Buchholz, D.</subfield>
+    <subfield code="m">: Gauss’ law and the infraparticle problem</subfield>
+    <subfield code="o">25</subfield>
+    <subfield code="s">Phys.Lett.,B174,331</subfield>
+    <subfield code="y">1986</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">167308</subfield>
+    <subfield code="h">Buchholz, D., Fredenhagen, K.</subfield>
+    <subfield code="m">: Locality and the structure of particle states</subfield>
+    <subfield code="o">26</subfield>
+    <subfield code="s">Commun.Math.Phys.,84,1</subfield>
+    <subfield code="y">1982</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">238025</subfield>
+    <subfield code="h">Buchholz, D., Fredenhagen, K., D’Antoni, C.</subfield>
+    <subfield code="m">: The universal structure of local algebras</subfield>
+    <subfield code="o">27</subfield>
+    <subfield code="s">Commun.Math.Phys.,111,123</subfield>
+    <subfield code="y">1987</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">262327</subfield>
+    <subfield code="h">Buchholz, D., Junglas, P.</subfield>
+    <subfield code="m">: On the existence of equilibrium states in local quantum field theory</subfield>
+    <subfield code="o">28</subfield>
+    <subfield code="s">Commun.Math.Phys.,121,255</subfield>
+    <subfield code="y">1989</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="h">Buchholz, D., Stœrmer, E.</subfield>
+    <subfield code="m">: Superposition, transition probabilities and primitive observables in infinite quantum systems</subfield>
+    <subfield code="o">29</subfield>
+    <subfield code="r">arXiv:1411.2100 [math-ph]</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">227322</subfield>
+    <subfield code="h">Buchholz, D., Wichmann, E.H.</subfield>
+    <subfield code="m">: Causal independence and the energy level density of states in local quantum field theory</subfield>
+    <subfield code="o">30</subfield>
+    <subfield code="s">Commun.Math.Phys.,106,321</subfield>
+    <subfield code="y">1986</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">855161</subfield>
+    <subfield code="h">Buchholz, D., Lechner, G., Summers, S.J.</subfield>
+    <subfield code="m">: Warped convolutions, rieffel deformations and the construction of quantum field theories</subfield>
+    <subfield code="o">31</subfield>
+    <subfield code="s">Commun.Math.Phys.,304,95</subfield>
+    <subfield code="y">2011</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">1227825</subfield>
+    <subfield code="h">Buchholz, D., Roberts, J.E.</subfield>
+    <subfield code="m">: New light on infrared problems: sectors, statistics, symmetries and spectrum</subfield>
+    <subfield code="o">32</subfield>
+    <subfield code="s">Commun.Math.Phys.,330,935</subfield>
+    <subfield code="y">2014</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">392197</subfield>
+    <subfield code="h">Buchholz, D., Verch, R.</subfield>
+    <subfield code="m">: Scaling algebras and renormalization group in algebraic quantum field theory</subfield>
+    <subfield code="o">33</subfield>
+    <subfield code="s">Rev.Math.Phys.,7,1195</subfield>
+    <subfield code="y">1995</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">1334927</subfield>
+    <subfield code="h">Buchholz, D., Verch, R.</subfield>
+    <subfield code="m">: Macroscopic aspects of the Unruh effect</subfield>
+    <subfield code="o">34</subfield>
+    <subfield code="r">arXiv:1412.5892 [gr-qc]</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">374105</subfield>
+    <subfield code="h">Connes, A., Rovelli, C.</subfield>
+    <subfield code="m">: Von neumann algebra automorphisms and time thermodynamics relation in general covariant quantum theories</subfield>
+    <subfield code="o">35</subfield>
+    <subfield code="s">Class.Quant.Grav.,11,2899</subfield>
+    <subfield code="y">1994</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="h">Dimock, J.</subfield>
+    <subfield code="m">: Algebras of local observables on a manifold</subfield>
+    <subfield code="o">36</subfield>
+    <subfield code="s">Commun.Math.Phys.,77,219-228</subfield>
+    <subfield code="y">1980</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="h">Dimock, J.</subfield>
+    <subfield code="m">: Dirac quantum fields on a manifold</subfield>
+    <subfield code="o">37</subfield>
+    <subfield code="s">Trans.Am.Math.Soc.,269,133</subfield>
+    <subfield code="y">1982</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">688127</subfield>
+    <subfield code="h">Dittrich, B.</subfield>
+    <subfield code="m">: Partial and complete observables for canonical general relativity</subfield>
+    <subfield code="o">38</subfield>
+    <subfield code="s">Class.Quant.Grav.,23,6155</subfield>
+    <subfield code="y">2006</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">182681</subfield>
+    <subfield code="h">Doplicher, S.</subfield>
+    <subfield code="m">: Local aspects of superselection rules</subfield>
+    <subfield code="o">39</subfield>
+    <subfield code="s">Commun.Math.Phys.,85,73</subfield>
+    <subfield code="y">1982</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">55090</subfield>
+    <subfield code="h">Doplicher, S., Haag, R., Roberts, J.E.</subfield>
+    <subfield code="m">: Fields, observables and gauge transformations 1</subfield>
+    <subfield code="o">40</subfield>
+    <subfield code="s">Commun.Math.Phys.,13,1</subfield>
+    <subfield code="y">1969</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">57049</subfield>
+    <subfield code="h">Doplicher, S., Haag, R., Roberts, J.E.</subfield>
+    <subfield code="m">: Fields, observables and gauge transformations 2</subfield>
+    <subfield code="o">41</subfield>
+    <subfield code="s">Commun.Math.Phys.,15,173</subfield>
+    <subfield code="y">1969</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">67575</subfield>
+    <subfield code="h">Doplicher, S., Haag, R., Roberts, J.E.</subfield>
+    <subfield code="m">: Local observables and particle statistics 1</subfield>
+    <subfield code="o">42</subfield>
+    <subfield code="s">Commun.Math.Phys.,23,199</subfield>
+    <subfield code="y">1971</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">83639</subfield>
+    <subfield code="h">Doplicher, S., Haag, R., Roberts, J.E.</subfield>
+    <subfield code="m">: Local observables and particle statistics 2</subfield>
+    <subfield code="o">43</subfield>
+    <subfield code="s">Commun.Math.Phys.,35,49</subfield>
+    <subfield code="y">1974</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">193012</subfield>
+    <subfield code="h">Doplicher, S., Longo, R.</subfield>
+    <subfield code="m">: Local aspects of superselection rules II</subfield>
+    <subfield code="o">44</subfield>
+    <subfield code="s">Commun.Math.Phys.,88,399</subfield>
+    <subfield code="y">1983</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="h">Doplicher, S., Roberts, J.E.</subfield>
+    <subfield code="m">: A new duality theory for compact groups. Inventiones Math. 98, 157</subfield>
+    <subfield code="o">45</subfield>
+    <subfield code="y">1989</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">303651</subfield>
+    <subfield code="h">Doplicher, S., Roberts, J.E.</subfield>
+    <subfield code="m">: Why there is a field algebra with a compact gauge group describing the superselection structure in particle physics</subfield>
+    <subfield code="o">46</subfield>
+    <subfield code="s">Commun.Math.Phys.,131,51</subfield>
+    <subfield code="y">1990</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">4134</subfield>
+    <subfield code="h">Driessler, W.</subfield>
+    <subfield code="m">: On the type of local algebras in quantum field theory</subfield>
+    <subfield code="o">47</subfield>
+    <subfield code="s">Commun.Math.Phys.,53,295</subfield>
+    <subfield code="y">1977</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">667609</subfield>
+    <subfield code="h">Dybalski, W.</subfield>
+    <subfield code="m">: Haag-Ruelle scattering theory in presence of massless particles</subfield>
+    <subfield code="o">48</subfield>
+    <subfield code="s">Lett.Math.Phys.,72,27</subfield>
+    <subfield code="y">2005</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">1250467</subfield>
+    <subfield code="h">Dybalski, W., Gérard, C.</subfield>
+    <subfield code="m">: A criterion for asymptotic completeness in local relativistic QFT</subfield>
+    <subfield code="o">49</subfield>
+    <subfield code="s">Commun.Math.Phys.,332,1167</subfield>
+    <subfield code="y">2014</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">90662</subfield>
+    <subfield code="h">Enss, V.</subfield>
+    <subfield code="m">: Characterization of particles by means of local observables in the relativistic quantum theory</subfield>
+    <subfield code="o">50</subfield>
+    <subfield code="s">Commun.Math.Phys.,45,35</subfield>
+    <subfield code="y">1975</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">483728</subfield>
+    <subfield code="h">Florig, M.</subfield>
+    <subfield code="m">: On Borchers’ theorem</subfield>
+    <subfield code="o">51</subfield>
+    <subfield code="s">Lett.Math.Phys.,46,289-293</subfield>
+    <subfield code="y">1998</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">153268</subfield>
+    <subfield code="h">Fredenhagen, K.</subfield>
+    <subfield code="m">: On the existence of anti-particles</subfield>
+    <subfield code="o">52</subfield>
+    <subfield code="s">Commun.Math.Phys.,79,141</subfield>
+    <subfield code="y">1981</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">201449</subfield>
+    <subfield code="h">Fredenhagen, K.</subfield>
+    <subfield code="m">: On the modular structure of local algebras of observables</subfield>
+    <subfield code="o">53</subfield>
+    <subfield code="s">Commun.Math.Phys.,97,79</subfield>
+    <subfield code="y">1985</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">278101</subfield>
+    <subfield code="h">Fredenhagen, K., Haag, R.</subfield>
+    <subfield code="m">: On the derivation of hawking radiation associated with the formation of a black hole</subfield>
+    <subfield code="o">54</subfield>
+    <subfield code="s">Commun.Math.Phys.,127,273</subfield>
+    <subfield code="y">1990</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">942836</subfield>
+    <subfield code="h">Fredenhagen, K., Rejzner, K.</subfield>
+    <subfield code="m">: Batalin-Vilkovisky formalism in perturbative algebraic quantum field theory</subfield>
+    <subfield code="o">55</subfield>
+    <subfield code="s">Commun.Math.Phys.,317,697</subfield>
+    <subfield code="y">2013</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">1334513</subfield>
+    <subfield code="h">Fredenhagen, K., Rejzner, K.</subfield>
+    <subfield code="m">: QFT on curved spacetimes: axiomatic framework and examples</subfield>
+    <subfield code="o">56</subfield>
+    <subfield code="r">arXiv:1412.5125 [math-ph]</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">1240124</subfield>
+    <subfield code="h">Fredenhagen, K., Lindner, F.</subfield>
+    <subfield code="m">: Construction of KMS states in perturbative QFT and renormalized hamiltonian dynamics</subfield>
+    <subfield code="o">57</subfield>
+    <subfield code="s">Commun.Math.Phys.,332,895</subfield>
+    <subfield code="y">2014</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">267078</subfield>
+    <subfield code="h">Fredenhagen, K., Rehren, K.H., Schroer, B.</subfield>
+    <subfield code="m">: Superselection sectors with braid group statistics and exchange algebras 1. Gen. Theor</subfield>
+    <subfield code="o">58</subfield>
+    <subfield code="s">Commun.Math.Phys.,125,201</subfield>
+    <subfield code="y">1989</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">747070</subfield>
+    <subfield code="h">Georgi, H.</subfield>
+    <subfield code="m">: Unparticle physics</subfield>
+    <subfield code="o">59</subfield>
+    <subfield code="s">Phys.Rev.Lett.,98,221601</subfield>
+    <subfield code="y">2007</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="h">Glimm, J., Jaffe, A.M.</subfield>
+    <subfield code="m">: Collected Papers: Constructive Quantum Field Theory. Selected Papers, vol. 2, 533 p Boston  (Contemporary Physicists)</subfield>
+    <subfield code="o">60</subfield>
+    <subfield code="p">Birkhaeuser</subfield>
+    <subfield code="y">1985</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">883036</subfield>
+    <subfield code="h">Haag, R.</subfield>
+    <subfield code="m">: Discussion des et des propriétés asymptotiques d’une théorie des champs locales avec particules composés. In: Les problémes mathématiques de la théorie quantique des champs. Colloques internationaux du CNRS, Paris. vol. 75, pp. 151-162. The english original appeared in R. Haag Discussion of the ‘axioms’ and the asymptotic properties of a local field theory with composite particles</subfield>
+    <subfield code="o">61</subfield>
+    <subfield code="s">Eur.Phys.J.,H35,243</subfield>
+    <subfield code="t">axiomes</subfield>
+    <subfield code="y">2010</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">9166</subfield>
+    <subfield code="h">Haag, R.</subfield>
+    <subfield code="m">: Quantum field theories with composite particles and asymptotic conditions</subfield>
+    <subfield code="o">62</subfield>
+    <subfield code="s">Phys.Rev.,112,669</subfield>
+    <subfield code="y">1958</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">338216</subfield>
+    <subfield code="h">Haag, R</subfield>
+    <subfield code="m">: 356 p Berlin  (Texts and monographs in physics)</subfield>
+    <subfield code="o">63</subfield>
+    <subfield code="p">Springer</subfield>
+    <subfield code="t">Local quantum physics: Fields, particles, algebras</subfield>
+    <subfield code="y">1992</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">9124</subfield>
+    <subfield code="h">Haag, R., Kastler, D.</subfield>
+    <subfield code="m">: An algebraic approach to quantum field</subfield>
+    <subfield code="o">64</subfield>
+    <subfield code="s">J.Math.Phys.,5,848</subfield>
+    <subfield code="y">1964</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="h">Haag, R., Swieca, J.</subfield>
+    <subfield code="m">: When does a quantum field theory describe particles?</subfield>
+    <subfield code="o">65</subfield>
+    <subfield code="s">Commun.Math.Phys.,1,308</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="h">Haagerup, U.</subfield>
+    <subfield code="m">: Connes bizentralizer problem and uniqueness of the injective factor of type III-1</subfield>
+    <subfield code="o">66</subfield>
+    <subfield code="s">Acta Math.,158,95-148</subfield>
+    <subfield code="y">1987</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">530483</subfield>
+    <subfield code="h">Halvorson, H.</subfield>
+    <subfield code="m">: Reeh-Schlieder defeats Newton-Wigner: on alternative localization schemes in relativistic quantum field theory</subfield>
+    <subfield code="o">67</subfield>
+    <subfield code="r">quant-ph/0007060</subfield>
+    <subfield code="s">Phil.Sci.,68,111</subfield>
+    <subfield code="y">2001</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">710646</subfield>
+    <subfield code="h">Halvorson, H., Muger, M.</subfield>
+    <subfield code="m">: Algebraic quantum field theory</subfield>
+    <subfield code="o">68</subfield>
+    <subfield code="r">math-ph/0602036</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">554314</subfield>
+    <subfield code="h">Hollands, S., Wald, R.M.</subfield>
+    <subfield code="m">: Local wick polynomials and time ordered products of quantum fields in curved space-time</subfield>
+    <subfield code="o">69</subfield>
+    <subfield code="s">Commun.Math.Phys.,223,289</subfield>
+    <subfield code="y">2001</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">567563</subfield>
+    <subfield code="h">Hollands, S., Wald, R.M.</subfield>
+    <subfield code="m">: Existence of local covariant time ordered products of quantum fields in curved space-time</subfield>
+    <subfield code="o">70</subfield>
+    <subfield code="s">Commun.Math.Phys.,231,309</subfield>
+    <subfield code="y">2002</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">1276500</subfield>
+    <subfield code="h">Hollands, S., Wald, R.M.</subfield>
+    <subfield code="m">: Quantum fields in curved spacetime</subfield>
+    <subfield code="o">71</subfield>
+    <subfield code="r">arXiv:1401.2026 [gr-qc]</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">188692</subfield>
+    <subfield code="h">Jones, V.F.R.</subfield>
+    <subfield code="m">: Index for subfactors</subfield>
+    <subfield code="o">72</subfield>
+    <subfield code="s">Invent.Math.,72,1-25</subfield>
+    <subfield code="y">1983</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">134274</subfield>
+    <subfield code="h">Kay, B.S.</subfield>
+    <subfield code="m">: Linear spin-zero quantum fields in external gravitational and scalar fields</subfield>
+    <subfield code="o">73</subfield>
+    <subfield code="s">Commun.Math.Phys.,62,55-70</subfield>
+    <subfield code="y">1978</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">132842</subfield>
+    <subfield code="h">Kay, B.S.</subfield>
+    <subfield code="m">: The casimir effect without MAGIC</subfield>
+    <subfield code="o">74</subfield>
+    <subfield code="s">Phys.Rev.,D20,3052</subfield>
+    <subfield code="y">1979</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">616945</subfield>
+    <subfield code="h">Kawahigashi, Y., Longo, R.</subfield>
+    <subfield code="m">: Classification of two-dimensional local conformal nets with c less than 1 and 2 cohomology vanishing for tensor categories</subfield>
+    <subfield code="o">75</subfield>
+    <subfield code="s">Commun.Math.Phys.,244,63</subfield>
+    <subfield code="y">2004</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">1351901</subfield>
+    <subfield code="h">Khavkine, I.</subfield>
+    <subfield code="m">: Local and gauge invariant observables in gravity</subfield>
+    <subfield code="o">76</subfield>
+    <subfield code="r">arXiv:1503.03754 [gr-qc]</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">1326129</subfield>
+    <subfield code="h">Khavkine, I., Moretti, V.</subfield>
+    <subfield code="m">: Continuous and analytic dependence is an unnecessary requirement in renormalization of locally covariant QFT</subfield>
+    <subfield code="o">77</subfield>
+    <subfield code="r">arXiv:1411.1302 [gr-qc]</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">708454</subfield>
+    <subfield code="h">Lechner, G.</subfield>
+    <subfield code="m">: Construction of quantum field theories with factorizing s-matrices</subfield>
+    <subfield code="o">78</subfield>
+    <subfield code="s">Commun.Math.Phys.,277,821</subfield>
+    <subfield code="y">2008</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="h">Lindner, F.</subfield>
+    <subfield code="m">: Perturbative algebraic quantum field theory at finite temperature. PhD thesis, University of Hamburg</subfield>
+    <subfield code="o">79</subfield>
+    <subfield code="y">2013</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">290326</subfield>
+    <subfield code="h">Longo, R.</subfield>
+    <subfield code="m">: Index of subfactors and statistics of quantum fields I</subfield>
+    <subfield code="o">80</subfield>
+    <subfield code="s">Commun.Math.Phys.,126,217</subfield>
+    <subfield code="y">1989</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">697902</subfield>
+    <subfield code="h">Mund, J., Schroer, B., Yngvason, J.</subfield>
+    <subfield code="m">: String-localized quantum fields and modular localization</subfield>
+    <subfield code="o">81</subfield>
+    <subfield code="s">Commun.Math.Phys.,268,621</subfield>
+    <subfield code="y">2006</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">431612</subfield>
+    <subfield code="h">Radzikowski, M.J.</subfield>
+    <subfield code="m">: Micro-local approach to the Hadamard condition in quantum field theory on curved space-time</subfield>
+    <subfield code="o">82</subfield>
+    <subfield code="s">Commun.Math.Phys.,179,529</subfield>
+    <subfield code="y">1996</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="h">Reeh, H., Schlieder, S.</subfield>
+    <subfield code="m">: Bemerkungen zur Unitäräquivalenz von Lorentzinvarianten Feldern</subfield>
+    <subfield code="o">83</subfield>
+    <subfield code="s">Nuovo Cim.,22,1051</subfield>
+    <subfield code="y">1961</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">563897</subfield>
+    <subfield code="h">Rovelli, C.</subfield>
+    <subfield code="m">: Partial observables</subfield>
+    <subfield code="o">84</subfield>
+    <subfield code="s">Phys.Rev.,D65,124013</subfield>
+    <subfield code="y">2002</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="h">Ruelle, D.</subfield>
+    <subfield code="m">: On the asymptotic condition in quantum field theory MathSciNet</subfield>
+    <subfield code="o">85</subfield>
+    <subfield code="s">Helv.Phys.Acta,35,147</subfield>
+    <subfield code="y">1962</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">616339</subfield>
+    <subfield code="h">Ruzzi, G.</subfield>
+    <subfield code="m">: Essential properties of the vacuum sector for a theory of superselection sectors</subfield>
+    <subfield code="o">86</subfield>
+    <subfield code="s">Rev.Math.Phys.,15,1255-1283</subfield>
+    <subfield code="y">2003</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">76387</subfield>
+    <subfield code="h">Schrader, R.</subfield>
+    <subfield code="m">: Yukawa quantum field theory in two space-time dimensions without cutoffs</subfield>
+    <subfield code="o">87</subfield>
+    <subfield code="s">Annals Phys.,70,412</subfield>
+    <subfield code="y">1972</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">38067</subfield>
+    <subfield code="h">Steinmann, O.</subfield>
+    <subfield code="m">: Perturbative quantum field theory at positive temperatures: an axiomatic approach</subfield>
+    <subfield code="o">88</subfield>
+    <subfield code="s">Commun.Math.Phys.,170,405</subfield>
+    <subfield code="y">1995</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">1094230</subfield>
+    <subfield code="h">Summers, S.J.</subfield>
+    <subfield code="m">: A perspective on constructive quantum field theory</subfield>
+    <subfield code="o">89</subfield>
+    <subfield code="r">arXiv:1203.3991 [math-ph]</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">117815</subfield>
+    <subfield code="h">Unruh, W.G.</subfield>
+    <subfield code="m">: Notes on black hole evaporation</subfield>
+    <subfield code="o">90</subfield>
+    <subfield code="s">Phys.Rev.,D14,870</subfield>
+    <subfield code="y">1976</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">553626</subfield>
+    <subfield code="h">Verch, R.</subfield>
+    <subfield code="m">: A spin statistics theorem for quantum fields on curved space-time manifolds in a generally covariant framework</subfield>
+    <subfield code="o">91</subfield>
+    <subfield code="s">Commun.Math.Phys.,223,261</subfield>
+    <subfield code="y">2001</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="h">Wald, R.M.</subfield>
+    <subfield code="m">: Quantum Field Theory in Curved Space-time and Black Hole Thermodynamics. University of Pr, Chicago</subfield>
+    <subfield code="o">92</subfield>
+    <subfield code="y">1994</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">336685</subfield>
+    <subfield code="h">Wiesbrock, H.W.</subfield>
+    <subfield code="m">: Half sided modular inclusions of von Neumann algebras</subfield>
+    <subfield code="o">93</subfield>
+    <subfield code="s">Commun.Math.Phys.,157,83</subfield>
+    <subfield code="s">Commun.Math.Phys.,184,683</subfield>
+    <subfield code="y">1993</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="0">1277186</subfield>
+    <subfield code="h">Yngvason, J.</subfield>
+    <subfield code="m">: Localization and entanglement in relativistic quantum physics</subfield>
+    <subfield code="o">94</subfield>
+    <subfield code="r">arXiv:1401.2652 [quant-ph]</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="6">
+    <subfield code="a">0-1-0-1-0-0-0</subfield>
+    <subfield code="t">2015-12-13 19:33:10</subfield>
+    <subfield code="v">Invenio/1.1.2.1260-aa76f refextract/1.5.44</subfield>
+  </datafield>
+  <datafield tag="100" ind1=" " ind2=" ">
+    <subfield code="a">Fredenhagen, Klaus</subfield>
+  </datafield>
+  <datafield tag="245" ind1=" " ind2=" ">
+    <subfield code="9">CrossRef</subfield>
+    <subfield code="a">An Introduction to Algebraic Quantum Field Theory</subfield>
+  </datafield>
+</record>
+</collection>

--- a/tests/fixtures/test_hep_record.xml
+++ b/tests/fixtures/test_hep_record.xml
@@ -50,7 +50,7 @@
     <subfield code="j">External_id</subfield>
     <subfield code="m">mail</subfield>
     <subfield code="x">profile</subfield>
-    <subfield code="y">claimed</subfield>
+    <subfield code="y">1</subfield>
   </datafield>
   <datafield tag="110" ind1=" " ind2=" ">
     <subfield code="a">CMS Collaboration</subfield>

--- a/tests/test_hep.py
+++ b/tests/test_hep.py
@@ -34,9 +34,16 @@ class HepRecordsTests(InvenioTestCase):
                                                          'fixtures',
                                                          'test_hep_record.xml')
                                                      )
+        self.book_marcxml = pkg_resources.resource_string('tests',
+                                                     os.path.join(
+                                                         'fixtures',
+                                                         'test_hep_book.xml')
+                                                     )
         record = create_record(self.marcxml)
+        book_record = create_record(self.book_marcxml)
 
         self.marcxml_to_json = hep.do(record)
+        self.marcxml_to_json_book = hep.do(book_record)
         self.json_to_marc = hep2marc.do(self.marcxml_to_json)
 
     def test_isbns(self):
@@ -114,11 +121,13 @@ class HepRecordsTests(InvenioTestCase):
                          self.json_to_marc['100']['j'])
         self.assertEqual(self.marcxml_to_json['authors'][0]['email'],
                          self.json_to_marc['100']['m'])
-        self.assertEqual(self.marcxml_to_json['authors'][0]['affiliations'][0]['value'],
+        self.assertEqual(self.marcxml_to_json['authors'][0]['affiliations'][0]
+                         ['value'],
                          self.json_to_marc['100']['u'][0])
         self.assertEqual(self.marcxml_to_json['authors'][0]['recid'],
                          self.json_to_marc['100']['x'])
-        self.assertEqual(self.marcxml_to_json['authors'][0]['claimed'],
+        self.assertEqual(self.marcxml_to_json['authors'][0]
+                         ['curated_relation'],
                          self.json_to_marc['100']['y'])
 
     def test_corporate_author(self):
@@ -487,6 +496,11 @@ class HepRecordsTests(InvenioTestCase):
                          self.json_to_marc['999C6'][0]['c'])
         self.assertEqual(self.marcxml_to_json['refextract'][0]['source'],
                          self.json_to_marc['999C6'][0]['s'])
+
+    def test_book_link(self):
+        """Test if the link to the book recid is generated correctly."""
+        self.assertEqual(self.marcxml_to_json_book['book']['recid'],
+                         1409249)
 
 TEST_SUITE = make_test_suite(HepRecordsTests)
 


### PR DESCRIPTION
* 100/700 $x with Record ID of linked HepName,
          $y with True/False if the signature is claimed
          $z with Record ID of institution

* 371/110 $z with Record ID of institution

* 502 $z with Record ID of institution

* 999C5 $0 with on the fly discovered Record IDs (not for books)

* 773 $0 with Record ID of corresponding Book or Proceeding
	  $1 with Record ID of corresponding Journal
	  $2 with Record ID of corresponding Conference

* 693/710 $0 with Record ID of corresponding experiment

* Closes #485.

Signed-off-by: Ioannis Tsanaktsidis <ioannis.tsanaktsidis@cern.ch>
Co-authored-by: Javier Martin Montull <javier.martin.montull@cern.ch>