### PR TITLE
WIP authors: tokenizer additions

### DIFF
--- a/inspirehep/base/searchext/mappings/hep.json
+++ b/inspirehep/base/searchext/mappings/hep.json
@@ -5,6 +5,11 @@
                 "asciifold_with_orig": {
                     "type": "icu_folding",
                     "preserve_original": true
+                },
+                "whitespace_remove": {
+                    "type": "pattern_replace",
+                    "pattern": "[ \t]{2,}",
+                    "replacement": " "
                 }
             },
             "analyzer": {
@@ -14,6 +19,16 @@
                     "filter": [
                         "asciifold_with_orig",
                         "lowercase"
+                    ]
+                },
+                "no_tokenizing_analyzer": {
+                    "type": "custom",
+                    "tokenizer": "keyword",
+                    "filter": [
+                        "asciifold_with_orig",
+                        "lowercase",
+                        "whitespace_remove",
+                        "trim"
                     ]
                 }
             }
@@ -221,6 +236,7 @@
                     "properties": {
                         "full_name": {
                             "type": "string",
+                            "analyzer": "no_tokenizing_analyzer",
                             "copy_to": ["exactauthor"]
                         },
                         "affiliations": {
@@ -237,7 +253,7 @@
                         },
                         "name_variations":{
                           "type": "string",
-                          "index": "not_analyzed",
+                          "analyzer": "no_tokenizing_analyzer",
                           "copy_to": ["global_fulltext", "author"]
                         },
                         "signature_block": {

--- a/inspirehep/modules/authors/utils.py
+++ b/inspirehep/modules/authors/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # INSPIRE is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -203,7 +203,7 @@ def parse_scanned_author_for_phrases(scanned):
                 continue
             retval.append(first + ' ' + last + title_word)
             retval.append(last + ', ' + first + title_word)
-
+        retval += lastlist
         return retval
 
     last_parts = scanned['lastnames']

--- a/tests/test_bai.py
+++ b/tests/test_bai.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # INSPIRE is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -68,6 +68,7 @@ class BaiTests(InvenioTestCase):
         token_list = author_tokenize("Ellis Richard")
         self.assertEqual(token_list, ['E Richard',
                                       'Ellis Richard',
+                                      'Richard',
                                       'Richard E',
                                       'Richard Ellis',
                                       'Richard, E',


### PR DESCRIPTION
    * Name tokenizer now includes the last name in the name variations.

    * Adds a new analyzer that generates one token for every input.

    * Adds a new filter that replaces multiple whitespaces with a single one.

    * Adds the trim filter that trims the input for authors.

Signed-off-by: Panos Paparrigopoulos <panos.paparrigopoulos@cern.ch>