### PR TITLE
workflows: safe arXiv file handling

### DIFF
--- a/inspirehep/modules/workflows/workflows/process_record_arxiv.py
+++ b/inspirehep/modules/workflows/workflows/process_record_arxiv.py
@@ -101,5 +101,5 @@ class process_record_arxiv(hep_ingestion):
         filter_core_keywords(filter_kb="antihep"),
         # Predict action for a generic HEP paper based only on title
         # and abstract.
-        guess_coreness("new_astro_model.pickle")
+        guess_coreness("new_astro_model.pickle", top_words=10)
     ]

--- a/inspirehep/utils/arxiv.py
+++ b/inspirehep/utils/arxiv.py
@@ -24,19 +24,25 @@
 
 import os
 
+from werkzeug import secure_filename
+
 from .helpers import download_file
 
 
 def get_tarball(arxiv_id, output_directory):
     """Make a robotupload request."""
-    output_file = os.path.join(output_directory, "{0}.tar.gz".format(arxiv_id))
+    output_file = os.path.join(
+        output_directory, secure_filename("{0}.tar.gz".format(arxiv_id))
+    )
     url = "http://arxiv.org/e-print/{0}".format(arxiv_id)
     return download_file(url, output_file)
 
 
 def get_pdf(arxiv_id, output_directory):
     """Make a robotupload request."""
-    output_file = os.path.join(output_directory, "{0}.pdf".format(arxiv_id))
+    output_file = os.path.join(
+        output_directory, secure_filename("{0}.pdf".format(arxiv_id))
+    )
     url = "http://arxiv.org/pdf/{0}".format(arxiv_id)
     return download_file(url, output_file)
 


### PR DESCRIPTION
* Fixes an issue where old arXiv IDs generated bad filenames for
  downloaded tarball and PDF.

* Adds top_words statistics to arXiv predictions.

Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>