### PR TITLE
dojson: publication info record ids improvement

### DIFF
--- a/inspirehep/base/searchext/mappings/hep.json
+++ b/inspirehep/base/searchext/mappings/hep.json
@@ -300,7 +300,10 @@
                         "year": {
                             "type": "integer"
                         },
-                        "recid": {
+                        "parent_recid": {
+                            "type": "integer"
+                        },
+                        "conference_recid": {
                             "type": "integer"
                         },
                         "cnum": {

--- a/inspirehep/dojson/hep/fields/bd76x78x.py
+++ b/inspirehep/dojson/hep/fields/bd76x78x.py
@@ -33,8 +33,9 @@ from ..model import hep, hep2marc
 def publication_info(self, key, value):
     """Publication info about record."""
     year = ''
-    recid = ''
+    parent_recid = ''
     journal_recid = ''
+    conference_recid = ''
     if 'y' in value:
         try:
             year = int(value.get('y'))
@@ -42,20 +43,29 @@ def publication_info(self, key, value):
             # Some crap in they year :-(
             pass
     try:
+        if '0' in value:
+            if isinstance(value.get('0'), list):
+                parent_recid = int(value.get('0')[0])
+            else:
+                parent_recid = int(value.get('0'))
+        if '1' in value:
+            if isinstance(value.get('1'), list):
+                journal_recid = int(value.get('1')[0])
+            else:
+                journal_recid = int(value.get('1'))
         if '2' in value:
             if isinstance(value.get('2'), list):
-                recid = int(value.get('2')[0])
+                conference_recid = int(value.get('2')[0])
             else:
-                recid = int(value.get('2'))
-        if '1' in value:
-            journal_recid = int(value.get('1'))
+                conference_recid = int(value.get('2'))
     except:
         # Some crap in the recid :-(
         pass
     return {
-        'recid': recid,
-        'page_artid': value.get('c'),
+        'parent_recid': parent_recid,
         'journal_recid': journal_recid,
+        'conference_recid': conference_recid,
+        'page_artid': value.get('c'),
         'journal_issue': value.get('n'),
         'conf_acronym': value.get('o'),
         'journal_title': value.get('p'),
@@ -76,7 +86,7 @@ def publication_info(self, key, value):
 def publication_info2marc(self, key, value):
     """Publication info about record."""
     return {
-        '0': value.get('recid'),
+        '0': value.get('parent_recid'),
         'c': value.get('page_artid'),
         'n': value.get('journal_issue'),
         'o': value.get('conf_acronym'),

--- a/inspirehep/dojson/hep/schemas/hep-0.0.1.json
+++ b/inspirehep/dojson/hep/schemas/hep-0.0.1.json
@@ -364,9 +364,23 @@
                     "cnum": {
                         "type": "string"
                     },
-                    "recid": {
+                    "note": {
+                        "type": "string"
+                    },
+                    "parent_recid": {
                         "type": "integer",
-                        "description": "Record ID of the conference"
+                        "description": "Record ID of the parent this record is part of"
+                    },
+                    "journal_recid": {
+                        "type": "integer",
+                        "description": "Record ID of corresponding Journal"
+                    },
+                    "conference_recid": {
+                        "type": "integer",
+                        "description": "Record ID of corresponding Conference"
+                    },
+                    "reportnumber": {
+                        "type": "string"
                     },
                     "year": {
                         "minimum": 1000,
@@ -382,10 +396,6 @@
                     "page_artid": {
                         "type": "string",
                         "description": "FIXME: for ejournals this could be the page index, but there is no realiable way to know whether something is a page index or a first page, does it?"
-                    },
-                    "journal_recid": {
-                        "type": "integer",
-                        "description": "Record ID of corresponding Journal"
                     }
                 }
             },

--- a/tests/test_hep.py
+++ b/tests/test_hep.py
@@ -363,7 +363,7 @@ class HepRecordsTests(InvenioTestCase):
                          [0]['journal_volume'],
                          self.json_to_marc['773'][0]['v'])
         self.assertEqual(self.marcxml_to_json['publication_info']
-                         [0]['recid'],
+                         [0]['parent_recid'],
                          self.json_to_marc['773'][0]['0'])
         self.assertEqual(self.marcxml_to_json['publication_info']
                          [0]['year'],


### PR DESCRIPTION
* Takes into consideration all possible record ids that can be present
  in the publication information.

* Amends json schema accordingly.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>