### PR TITLE
dojson: fix reference conversion

### DIFF
--- a/inspirehep/dojson/hep/fields/bd90x99x.py
+++ b/inspirehep/dojson/hep/fields/bd90x99x.py
@@ -32,24 +32,15 @@ from ..model import hep, hep2marc
 @utils.filter_values
 def references(self, key, value):
     """Produce list of references."""
-    try:
-        recid = int(value.get('0'))
-        number = int(value.get('o'))
-        year = int(value.get('y'))
-    except (TypeError, ValueError):
-        recid = None
-        number = None
-        year = None
-
     return {
-        'recid': recid,
+        'recid': value.get('0'),
         'texkey': value.get('1'),
         'doi': value.get('a'),
         'collaboration': value.get('c'),
         'editors': value.get('e'),
         'authors': value.get('h'),
         'misc': value.get('m'),
-        'number': number,
+        'number': value.get('o'),
         'isbn': value.get('i'),
         'publisher': value.get('p'),
         'maintitle': value.get('q'),
@@ -58,7 +49,7 @@ def references(self, key, value):
         'url': value.get('u'),
         'journal_pubnote': value.get('s'),
         'raw_reference': value.get('x'),
-        'year': year,
+        'year': value.get('y'),
     }
 
 

--- a/tests/test_citation_counts.py
+++ b/tests/test_citation_counts.py
@@ -128,7 +128,7 @@ class CitationTestsOnRecordUpdate(InvenioTestCase):
 
         self.test_recid = u'1196797'
         record = get_record(recid=self.test_recid)
-        self.removed_reference_recid = 454197
+        self.removed_reference_recid = u'454197'
         self.citation_count_before_update = Query('control_number:' + str(self.removed_reference_recid))\
             .search().records()[0]['citation_count']
 


### PR DESCRIPTION
* Fixes case where a missing number in a citation would not add recids.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>