### PR TITLE
ext: error pages handler

### DIFF
--- a/inspirehep/base/templates/500.html
+++ b/inspirehep/base/templates/500.html
@@ -1,0 +1,38 @@
+{#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#}
+{% extends "page.html" %}
+{% set title = None %}
+{% block body %}
+
+<div class="row">
+  <div class="col-md-offset-3 col-md-6 alert alert-danger" align="center">
+    <div class="page-header">
+      <h1>{{ _("Whoops! An error happened!") }}</h1>
+    </div>
+    <p>
+    {{ _("Our administrators are informed of this problem.") }}<br/>
+    {{ _("Click the following link to go to back to the main page or go back in your browser and try again:") }}
+    </p>
+    <p>
+      <a href="/">{{ _("Main page") }}</a>
+    </p>
+  </div>
+</div>
+
+{% endblock %}

--- a/inspirehep/base/templates/header.html
+++ b/inspirehep/base/templates/header.html
@@ -1,20 +1,20 @@
 {#
-## This file is part of INSPIRE.
-## Copyright (C) 2014, 2015, 2016 CERN.
-##
-## INSPIRE is free software; you can redistribute it and/or
-## modify it under the terms of the GNU General Public License as
-## published by the Free Software Foundation; either version 2 of the
-## License, or (at your option) any later version.
-##
-## INSPIRE is distributed in the hope that it will be useful, but
-## WITHOUT ANY WARRANTY; without even the implied warranty of
-## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-## General Public License for more details.
-##
-## You should have received a copy of the GNU General Public License
-## along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
-## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+# This file is part of INSPIRE.
+# Copyright (C) 2014, 2015, 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 #}
 
 {#
@@ -35,7 +35,7 @@
 {# Work-around for collection name #}
 
 {% if collection_name is not defined and collection is defined %}
- {% set collection_name = collection.name %}
+ {% set collection_name = collection.name | sanitize_collection_name %}
 {% else %}
   {% set collection_name = '' %}
 {% endif %}
@@ -50,18 +50,18 @@
         <span class="icon-bar"></span>
       </button>
       <a class="navbar-brand" href="{{ url_for('collections.index') }}">
-        <span id="{{ collection_name | sanitize_collection_name }}-collection">
+        <span id="{{ collection_name }}-collection">
           {% include 'labs-logo.svg' %}
         </span>
       </a>
       {% if request.endpoint in ['search.search', 'record.metadata'] %}
-        <div id="top-search-bar-small" class="col-sm-5 {{collection.name}}">
+        <div id="top-search-bar-small" class="col-sm-5 {{collection_name}}">
           {% include "search/form/form.html" %}
         </div>
       {% endif %}
     </div>
     {% if request.endpoint in ['search.search', 'record.metadata'] %}
-      <div id="top-search-bar-full" class="col-md-4 col-lg-5 {{collection.name}}">
+      <div id="top-search-bar-full" class="col-md-4 col-lg-5 {{collection_name}}">
         {% include "search/form/form.html" %}
       </div>
     {% endif %}

--- a/inspirehep/base/templates/search/form/controls.html
+++ b/inspirehep/base/templates/search/form/controls.html
@@ -1,6 +1,6 @@
 {#
 # This file is part of INSPIRE.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # INSPIRE is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -28,7 +28,7 @@
        type="text"
        tabindex="1"
        value="{{ request.args.get('p', '') }}"
-       placeholder="Search {{collection.name | sanitize_collection_name }}"
+       placeholder="Search {{ collection_name }}"
        {%- if request.endpoint != 'record.metadata' %}
        autofocus
        {%- endif -%}/>
@@ -39,7 +39,7 @@
 
 {%- block search_form_ctrls_button -%}
   <span class="input-group-btn">
-  <button name="action_search" tabindex="2" type="submit" class="btn btn-primary btn-inline-icon-hide-sm {{collection.name | sanitize_collection_name }}" id="search-form-button">
+  <button name="action_search" tabindex="2" type="submit" class="btn btn-primary btn-inline-icon-hide-sm {{ collection_name }}" id="search-form-button">
     <i class="glyphicon glyphicon-search"></i>
   </button>
 </span>

--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -73,6 +73,7 @@ EXTENSIONS = [
     'inspirehep.ext.jinja_filters.record',
     'inspirehep.ext.redis.client',
     'inspirehep.ext.deprecation_warnings:disable_deprecation_warnings',
+    'inspirehep.ext.error_pages',
 ]
 
 PACKAGES = [

--- a/inspirehep/ext/error_pages.py
+++ b/inspirehep/ext/error_pages.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Hook in error handlers."""
+
+from flask import render_template
+
+
+def setup_app(app):
+    @app.errorhandler(500)
+    def error_500(e):
+        return render_template("500.html"), 500
+    return app


### PR DESCRIPTION
* Adds a preliminary 500 error page.

* Fixes issues with collection name in templates when collection
  object is not available.

We should improve the text/look, but this acts as a preliminary page at least instead of good ol white Internal Server Error page.

![Screenshot](https://www.dropbox.com/s/jx87p589y2npz95/Screenshot%202016-01-21%2017.54.42.png?dl=1)