### PR TITLE
workflows: port legacy convert_record_to_json

### DIFF
--- a/inspirehep/modules/workflows/workflows/oaiharvest_production_sync.py
+++ b/inspirehep/modules/workflows/workflows/oaiharvest_production_sync.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,13 +19,15 @@
 
 """Generic record process in harvesting with backwards compatibility."""
 
-from invenio_oaiharvester.tasks.records import convert_record_to_json
 from invenio_workflows.definitions import RecordWorkflow
 
 from inspirehep.modules.converter.tasks import (
     convert_record
 )
-from inspirehep.modules.workflows.tasks.upload import store_record
+from inspirehep.modules.workflows.tasks.upload import (
+    store_record,
+    convert_record_to_json,
+)
 
 
 class oaiharvest_production_sync(RecordWorkflow):

--- a/inspirehep/modules/workflows/workflows/process_record_arxiv.py
+++ b/inspirehep/modules/workflows/workflows/process_record_arxiv.py
@@ -44,7 +44,10 @@ from inspirehep.modules.workflows.tasks.classifier import (
 )
 from inspirehep.modules.workflows.workflows.hep_ingestion import hep_ingestion
 
-from invenio_oaiharvester.tasks.records import convert_record_to_json
+from inspirehep.modules.workflows.tasks.upload import (
+    convert_record_to_json,
+)
+
 from invenio_workflows.tasks.logic_tasks import workflow_if
 
 from inspirehep.modules.refextract.tasks import extract_journal_info

--- a/tests/workflows/harvesting_fixture.py
+++ b/tests/workflows/harvesting_fixture.py
@@ -20,8 +20,6 @@
 """Implements a workflow for testing."""
 
 
-from invenio_oaiharvester.tasks.records import convert_record_to_json
-
 from inspirehep.modules.converter.tasks import convert_record
 
 from inspirehep.modules.oaiharvester.tasks.arxiv import (
@@ -33,6 +31,10 @@ from inspirehep.modules.oaiharvester.tasks.arxiv import (
 
 from inspirehep.modules.refextract.tasks import extract_journal_info
 
+
+from inspirehep.modules.workflows.tasks.upload import (
+    convert_record_to_json,
+)
 from inspirehep.modules.workflows.workflows.hep_ingestion import hep_ingestion
 
 

--- a/tests/workflows/payload_fixture.py
+++ b/tests/workflows/payload_fixture.py
@@ -18,14 +18,14 @@
 
 """Implements a workflow for testing."""
 
-
-from invenio_oaiharvester.tasks.records import convert_record_to_json
-
 from invenio_deposit.models import DepositionType
 
 from inspirehep.modules.converter.tasks import convert_record
 
 from inspirehep.modules.workflows.models import create_payload
+from inspirehep.modules.workflows.tasks.upload import (
+    convert_record_to_json,
+)
 
 
 class payload_fixture(DepositionType):

--- a/tests/workflows/payload_model_fixture.py
+++ b/tests/workflows/payload_model_fixture.py
@@ -18,14 +18,14 @@
 
 """Implements a workflow for testing common data model."""
 
-
-from invenio_oaiharvester.tasks.records import convert_record_to_json
-
 from invenio_deposit.models import DepositionType
 
 from inspirehep.modules.converter.tasks import convert_record
 
 from inspirehep.modules.workflows.models import Payload, create_payload
+from inspirehep.modules.workflows.tasks.upload import (
+    convert_record_to_json,
+)
 
 
 def agnostic_task(obj, eng):


### PR DESCRIPTION
* Ports the "legacy" convert_record_to_json workflow task from
  invenio-oaiharvester as it will no longer be part of that module.

Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>