### PR TITLE
base: landing page route change

### DIFF
--- a/inspirehep/base/views.py
+++ b/inspirehep/base/views.py
@@ -84,7 +84,8 @@ def faq():
 
 @blueprint.route('/literature', methods=['GET', ])
 @blueprint.route('/collection/literature', methods=['GET', ])
-def hep():
+@blueprint.route('/', methods=['GET', 'POST'])
+def index():
     """View for literature collection landing page."""
     collection = {'name': 'hep'}
     return render_template('search/collection_literature.html',


### PR DESCRIPTION
* Shadows / view to directly render the Literature search page as
  landing page.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>