### PR TITLE
filters: number of records per collection fix

### DIFF
--- a/inspirehep/ext/jinja_filters/record.py
+++ b/inspirehep/ext/jinja_filters/record.py
@@ -313,7 +313,7 @@ def setup_app(app):
     @app.template_filter()
     def number_of_records(collection_name):
         """Returns number of records for the collection."""
-        return len(Query("collection:" + collection_name).
+        return len(Query("").
                    search(collection=collection_name))
 
     @app.template_filter()


### PR DESCRIPTION
* Modifies the query to report the correct total number of records
  on each collection landing page.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>