### PR TITLE
migrator: simpler add_citation_counts()

### DIFF
--- a/inspirehep/modules/migrator/manage.py
+++ b/inspirehep/modules/migrator/manage.py
@@ -73,12 +73,10 @@ def populate(file_input=None,
 
 
 @manager.command
-def count_citations(test_mode=False):
+def count_citations():
     """Adds field citation_count to every record in 'HEP' and calculates its proper value."""
     print("Adding citation_count to all records")
-    cit_task = add_citation_counts.delay()
-    if test_mode:
-        cit_task.wait()
+    add_citation_counts()
 
 
 @manager.command

--- a/inspirehep/modules/migrator/tasks.py
+++ b/inspirehep/modules/migrator/tasks.py
@@ -70,7 +70,7 @@ from .utils import rename_object_action, reset_workflow_object_states
 
 logger = get_task_logger(__name__)
 
-CHUNK_SIZE = 1000
+CHUNK_SIZE = 100
 LARGE_CHUNK_SIZE = 10000
 
 split_marc = re.compile('<record.*?>.*?</record>', re.DOTALL)
@@ -263,6 +263,10 @@ def add_citation_counts():
             for reference in references:
                 recid = reference.get('recid')
                 if recid:
+                    if isinstance(recid, list):
+                        # Sometimes there is more than one recid in the
+                        # reference.
+                        recid = recid.pop()
                     unique_refs_ids.add(recid)
 
         for unique_refs_id in unique_refs_ids:

--- a/install.sh
+++ b/install.sh
@@ -47,4 +47,4 @@ celery worker -E -A invenio_celery.celery --workdir=$VIRTUAL_ENV 1> /dev/null &
 inveniomanage migrator populate -f inspirehep/demosite/data/demo-records.xml.gz -w True
 
 # Add field citation_count to records
-inveniomanage migrator count_citations -t
+inveniomanage migrator count_citations


### PR DESCRIPTION
* Don't schedule in Celery the global add_citation_counts().

* Workarounds references having more than one recid.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>