### PR TITLE
authors: skip uuid if already present

### DIFF
--- a/inspirehep/modules/authors/receivers.py
+++ b/inspirehep/modules/authors/receivers.py
@@ -72,7 +72,9 @@ def assign_uuid(sender, *args, **kwargs):
     authors = sender.get('authors', [])
 
     for author in authors:
-        author['uuid'] = str(uuid.uuid4())
+        # Skip if a record was already populated with uuids.
+        if 'uuid' not in author:
+            author['uuid'] = str(uuid.uuid4())
 
 
 @before_record_index.connect


### PR DESCRIPTION
* Skips assignation of uuid if a given signature has already one.

Signed-off-by: Grzegorz Jacenków <grzegorz.jacenkow@cern.ch>