### PR TITLE
caching: add caching and cache management (invalidation)

### DIFF
--- a/inspirehep/base/templates/citations.html
+++ b/inspirehep/base/templates/citations.html
@@ -21,8 +21,14 @@
 
 {% from "format/record/Inspire_Default_HTML_general_macros.tpl" import render_record_authors, render_record_title with context %}
 
+{% from "format/record/Cache_HTML_macros.tpl" import cache_if_not_debug %}
+
 <div class="reference-record">
-    <div class="reference-title"><a href="/record/{{record.recid}}">{{ render_record_title() }}</a></div>
+    <div class="reference-title">
+    {% call cache_if_not_debug('record_oneline', record['control_number']) %}
+        <a href="/record/{{record.recid}}">{{ render_record_title() }}</a></div>
     <div class="reference-authors">{{ render_record_authors(is_brief=true, show_affiliations=false) | safe }}</div>
     <div class="reference-journal">{{ record_publication_info() | safe }}</div>
+    {% endcall %}
 </div>
+

--- a/inspirehep/base/templates/format/record/Cache_HTML_macros.tpl
+++ b/inspirehep/base/templates/format/record/Cache_HTML_macros.tpl
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
-#
+{#
 # This file is part of INSPIRE.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2016 CERN.
 #
 # INSPIRE is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -16,5 +15,15 @@
 # You should have received a copy of the GNU General Public License
 # along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#}
 
-from .receivers import *
+{% macro cache_if_not_debug(template_name, recid) %}
+  {% set content=caller() %}
+    {%  if not config.DEBUG %}
+      {% cache timeout | long_timeout, template_name, recid %}
+        {{  content }}
+      {% endcache %}
+    {% else %}
+      {{ content }}
+    {%  endif %}
+{% endmacro %}

--- a/inspirehep/base/templates/format/record/Inspire_Default_HTML_brief.tpl
+++ b/inspirehep/base/templates/format/record/Inspire_Default_HTML_brief.tpl
@@ -21,7 +21,10 @@
 
 {% from "format/record/Inspire_Default_HTML_brief_macros.tpl" import record_journal_info, render_doi, record_journal_info_and_doi with context %}
 
+{% from "format/record/Cache_HTML_macros.tpl" import cache_if_not_debug %}
+
 {% block record_header %}
+{% call cache_if_not_debug('record_brief', record['control_number']) %}
 <div class="row">
   <div class="col-md-12">
     <div id="panel-default-brief" class="panel panel-default" >
@@ -125,4 +128,6 @@
     </div>
   </div>
 </div>
+{% endcall %}
+
 {% endblock %}

--- a/inspirehep/base/templates/format/record/Inspire_Default_HTML_detailed.tpl
+++ b/inspirehep/base/templates/format/record/Inspire_Default_HTML_detailed.tpl
@@ -1,6 +1,6 @@
 {#
 # This file is part of INSPIRE.
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # INSPIRE is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as

--- a/inspirehep/base/templates/references.html
+++ b/inspirehep/base/templates/references.html
@@ -1,6 +1,6 @@
 {#
 # This file is part of INSPIRE.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # INSPIRE is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -21,16 +21,20 @@
 
 {% from "format/record/Inspire_Default_HTML_general_macros.tpl" import render_record_authors, render_record_title with context %}
 
+{% from "format/record/Cache_HTML_macros.tpl" import cache_if_not_debug %}
+
 <div class="reference-record">
   {% if record %}
       <div class="reference-title">
         {% if reference['number'] %}
           [{{ reference['number'] }}]
         {% endif %}
+        {% call cache_if_not_debug('record_oneline', record['control_number']) %}
         <a href="/record/{{record.recid}}">{{ render_record_title() }}</a>
       </div>
       <div class="reference-authors">{{ render_record_authors(is_brief=false, show_affiliations=false) | safe }}</div>
       <div class="reference-journal">{{ record_publication_info() | safe }}</div>
+        {% endcall %}
   {% else %}
     <div class="reference-title">
       {% if reference['number'] %}

--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -72,6 +72,8 @@ EXTENSIONS = [
     'inspirehep.ext.jinja_filters.general',
     'inspirehep.ext.jinja_filters.record',
     'inspirehep.ext.redis.client',
+    'inspirehep.ext.cache_manager.cache',
+    'inspirehep.ext.cache_manager.manager',
     'inspirehep.ext.deprecation_warnings:disable_deprecation_warnings',
     'inspirehep.ext.error_pages',
 ]
@@ -596,3 +598,16 @@ WORKFLOWS_HOLDING_PEN_ES_PROPERTIES = {
 }
 """Updates default properties that should be added to the Holding Pen index
 mappings."""
+
+CACHED_VIEWS = {
+    'record_oneline': {
+        'type': 'jinja_cache',
+        'template_name': 'record_oneline',
+        'kwargs': ['recid']
+    },
+    'record_brief': {
+        'type': 'jinja_cache',
+        'template_name': 'record_brief',
+        'kwargs': ['recid']
+    }
+}

--- a/inspirehep/ext/cache_manager/__init__.py
+++ b/inspirehep/ext/cache_manager/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -22,32 +22,9 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-from invenio_ext.template import render_template_to_string
+from .proxy import cache_manager
+from .receivers import *
 
-from invenio_search.api import Query
-
-
-def render_citations(recid):
-    """Citation export for single record in datatables format.
-
-        :returns: list
-            List of lists where every item represents a datatables row.
-            A row consists of [reference, num_citations]
-    """
-    out = []
-    row = []
-    es_query = Query('refersto:' + str(recid)).search()
-    es_query.body.update({
-        'sort': [{'citation_count': {'order': 'desc'}}],
-        'size': 9999
-    })
-    citations = es_query.records()
-
-    for citation in citations:
-        row.append(render_template_to_string("citations.html",
-                                             record=citation, reference=None))
-        row.append(citation.get('citation_count', ''))
-        out.append(row)
-        row = []
-
-    return out
+__all__ = (
+    'cache_manager'
+)

--- a/inspirehep/ext/cache_manager/cache.py
+++ b/inspirehep/ext/cache_manager/cache.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+import functools
+
+from flask import current_app, request
+
+from flask_cache import Cache
+
+
+class InspireCache(Cache):
+    """Extends Cache from Flask Cache and adds mode-checking (debug or not) for memoize and cached methods.
+
+    The parameters in both inspire_memoize and inspire_cached are the same
+    as the parameters of the original methods in Flask Cache class
+
+    """
+
+    def inspire_memoize(self, timeout=None, make_name=None, unless=None):
+        def memoize(f):
+            @functools.wraps(f)
+            def decorated_function(*args, **kwargs):
+                if not current_app.debug:
+                    #: bypass cache
+                    if callable(unless) and unless() is True:
+                        return f(*args, **kwargs)
+
+                    try:
+                        cache_key = decorated_function.make_cache_key(f, *args, **kwargs)
+                        rv = self.cache.get(cache_key)
+                    except Exception:
+                        if current_app.debug:
+                            raise
+                        current_app.logger.exception("Exception possibly due to cache backend.")
+                        return f(*args, **kwargs)
+
+                    if rv is None:
+                        rv = f(*args, **kwargs)
+                        try:
+                            self.cache.set(cache_key, rv, timeout=decorated_function.cache_timeout)
+                        except Exception:
+                            if current_app.debug:
+                                raise
+                            current_app.logger.exception("Exception possibly due to cache backend.")
+                    return rv
+                else:
+                    rv = f(*args, **kwargs)
+                    return rv
+
+            decorated_function.uncached = f
+            decorated_function.cache_timeout = timeout
+            decorated_function.make_cache_key = self._memoize_make_cache_key(make_name, decorated_function)
+            decorated_function.delete_memoized = lambda: self.delete_memoized(f)
+
+            return decorated_function
+        return memoize
+
+    def inspire_cached(self, timeout=None, key_prefix='view/%s', unless=None):
+        def decorator(f):
+            @functools.wraps(f)
+            def decorated_function(*args, **kwargs):
+                if not current_app.debug:
+                    #: Bypass the cache entirely.
+                    if callable(unless) and unless() is True:
+                        return f(*args, **kwargs)
+
+                    try:
+                        cache_key = decorated_function.make_cache_key(*args, **kwargs)
+                        rv = self.cache.get(cache_key)
+                    except Exception:
+                        if current_app.debug:
+                            raise
+                        current_app.logger.exception("Exception possibly due to cache backend.")
+                        return f(*args, **kwargs)
+
+                    if rv is None:
+                        rv = f(*args, **kwargs)
+                        try:
+                            self.cache.set(cache_key, rv, timeout=decorated_function.cache_timeout)
+                        except Exception:
+                            if current_app.debug:
+                                raise
+                            current_app.logger.exception("Exception possibly due to cache backend.")
+                            return f(*args, **kwargs)
+                    return rv
+                else:
+                    rv = f(*args, **kwargs)
+                    return rv
+
+            def make_cache_key(*args, **kwargs):
+                if callable(key_prefix):
+                    cache_key = key_prefix()
+                elif '%s' in key_prefix:
+                    cache_key = key_prefix % request.path
+                else:
+                    cache_key = key_prefix
+
+                return cache_key
+
+            decorated_function.uncached = f
+            decorated_function.cache_timeout = timeout
+            decorated_function.make_cache_key = make_cache_key
+
+            return decorated_function
+        return decorator
+
+
+inspire_cache = InspireCache()
+
+__all__ = ['inspire_cache', 'setup_app']
+
+
+def setup_app(app):
+    """Setup cache extension."""
+
+    app.config.setdefault('CACHE_TYPE',
+                          app.config.get('CFG_FLASK_CACHE_TYPE', 'redis'))
+    # if CACHE_KEY_PREFIX is not specified then CFG_DATABASE_NAME:: is used.
+    prefix = app.config.get('CFG_DATABASE_NAME', '')
+    if prefix:
+        prefix += '::'
+    app.config.setdefault('CACHE_KEY_PREFIX', prefix)
+    inspire_cache.init_app(app)
+    return app

--- a/inspirehep/ext/cache_manager/manager.py
+++ b/inspirehep/ext/cache_manager/manager.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+from flask import current_app
+
+from werkzeug.utils import import_string
+
+from .utils import CachedInvalidator, JinjaCacheInvalidator, MemoizedInvalidator
+
+
+class InspireCacheManager(object):
+    """Class designed to invalidate different types of cache (all types provided by Flask Cache)
+     with Redis as the cache backend"""
+
+    def __init__(self, app=None, cache=None, views={}):
+        """
+            Parameters
+        ----------
+        app : Flask application object
+        cache : Flask Cache object
+        views : dict
+            Views being cached by cache (Flask Cache object). See the 'views' dict sample below:
+            {
+                'main_page': {
+                    'type': 'cached',
+                    'function_reference': 'app.views.main_view'
+                },
+
+                'view_with_have_calculations': {
+                    'type': 'memoize',
+                    'function_reference': 'app.views.extremely_heavy_view'
+                },
+
+                'view_done_with_jinja': {
+                    'type': 'jinja_cache',
+                    'template_name': 'jinja_view',
+                    'kwargs': ['view_ID']
+                }
+            }
+
+            Each view should have 'type' of either 'cached', 'memoize' or 'jinja_cache' value
+            (three types of cache provided by Flask Cache).
+
+            For 'cached' and 'memoized' the field 'function_reference' has to be also defined.
+
+            For 'jinja_cache' two extra fields need to be defined:
+                - 'template_name' which is the name associated with the cached template
+                - 'kwargs' is the list of key_arguments names used to parametrize cached template
+                    e.g. view_id, index etc.
+
+        """
+        self.jinja_invalidator = JinjaCacheInvalidator(cache)
+        self.memoized_invalidator = MemoizedInvalidator(cache)
+        self.cached_invalidator = CachedInvalidator(cache)
+        self.cache_client = cache
+        self.app = app
+        self.views = None
+        if app is not None:
+            self.init_app(app)
+
+    def init_app(self, app, cache):
+
+        if app:
+            if not hasattr(app, 'extensions'):
+                app.extensions = {}
+
+            if self.cache_client is None:
+                self.cache_client = cache
+                self.jinja_invalidator = JinjaCacheInvalidator(cache)
+                self.memoized_invalidator = MemoizedInvalidator(cache)
+                self.cached_invalidator = CachedInvalidator(cache)
+
+            self.views = app.config.get('CACHED_VIEWS')
+            for view in self.views:
+                if self.views[view]['type'] in ['memoize', 'cached']:
+                    try:
+                        self.views[view]['function_reference'] = import_string(
+                            self.views[view]['function_reference'])
+                    except ImportError:
+                        current_app.logger.exception('Function reference {0} does not exist or is a method of a class '
+                                                     '(not supported)'.format(self.views[view]['function_reference']))
+
+        app.extensions['cache_manager.manager'] = self
+
+    def invalidate_view(self, view_name, *args, **kwargs):
+        """Invalidate view with certain name and arguments (e.g. recid, index etc.)"""
+        view_details = self.views.get(view_name)
+        if view_details:
+            if view_details['type'] == 'jinja_cache':
+                self.jinja_invalidator.invalidate(view_details['template_name'],
+                                                  keys=[kwargs[keyarg] for keyarg in view_details['kwargs']
+                                                        if kwargs.get(keyarg)])
+            elif view_details['type'] == 'cached':
+                self.cached_invalidator.invalidate(view_details['function_reference'])
+            elif view_details['type'] == 'memoize':
+                self.memoized_invalidator.invalidate(view_details['function_reference'], *args, **kwargs)
+        else:
+            current_app.logger.exception('View name not found. Please add it to config file.')
+
+    def invalidate_all_certain_views(self, view_name):
+        """Invalidate all views with certain name."""
+
+        view_details = self.views.get(view_name)
+        if view_details:
+            if view_details['type'] == 'jinja_cache':
+                how_many = self.jinja_invalidator.invalidate_all_of_certain_type(view_details['template_name'])
+            elif view_details['type'] == 'cached':
+                self.cached_invalidator.invalidate(view_details['function_reference'])
+                how_many = 1
+            elif view_details['type'] == 'memoize':
+                how_many = self.memoized_invalidator.invalidate_all_of_certain_type(view_details['function_reference'])
+            return how_many
+        else:
+            current_app.logger.exception('View name not found. Please add it to config file.')
+
+    def invalidate_all_cached_views(self):
+        """Invalidate all cached views."""
+        how_many_invalidated = 0
+        for view in self.views:
+            how_many_invalidated += self.invalidate_all_certain_views(view)
+        return how_many_invalidated
+
+
+def setup_app(app):
+    from inspirehep.ext.cache_manager.cache import inspire_cache
+    cache_manager = InspireCacheManager()
+    cache_manager.init_app(app, inspire_cache)

--- a/inspirehep/ext/cache_manager/proxy.py
+++ b/inspirehep/ext/cache_manager/proxy.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -22,32 +22,17 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-from invenio_ext.template import render_template_to_string
+"""Proxy for easier access to Redis instance"""
 
-from invenio_search.api import Query
+from flask import current_app
+
+from werkzeug.local import LocalProxy
 
 
-def render_citations(recid):
-    """Citation export for single record in datatables format.
+def _get_current_cache_manager_client():
+    """Return current cache_manager client."""
+    app = current_app._get_current_object()
+    return app.extensions['cache_manager.manager']
 
-        :returns: list
-            List of lists where every item represents a datatables row.
-            A row consists of [reference, num_citations]
-    """
-    out = []
-    row = []
-    es_query = Query('refersto:' + str(recid)).search()
-    es_query.body.update({
-        'sort': [{'citation_count': {'order': 'desc'}}],
-        'size': 9999
-    })
-    citations = es_query.records()
 
-    for citation in citations:
-        row.append(render_template_to_string("citations.html",
-                                             record=citation, reference=None))
-        row.append(citation.get('citation_count', ''))
-        out.append(row)
-        row = []
-
-    return out
+cache_manager = LocalProxy(_get_current_cache_manager_client)

--- a/inspirehep/ext/cache_manager/receivers.py
+++ b/inspirehep/ext/cache_manager/receivers.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Signal receivers for dealing with caching."""
+
+from inspirehep.modules.citations.signals import after_citation_count_update
+
+from invenio_records.signals import after_record_index
+
+from .tasks import invalidate_cache_on_citation_count_update, invalidate_cache_on_record_index
+
+
+@after_citation_count_update.connect
+def invalidate_on_citation_count_update(recid, *args, **kwargs):
+    # wait 3 seconds to make sure record with updated citation_count can be accessed from ES
+    invalidate_cache_on_citation_count_update.apply_async(args=[recid], countdown=3)
+
+
+@after_record_index.connect
+def invalidate_on_record_index(recid, *args, **kwargs):
+    # wait 3 seconds to make sure indexed record can be accessed from ES
+    invalidate_cache_on_record_index.apply_async(args=[recid], countdown=3)

--- a/inspirehep/ext/cache_manager/tasks.py
+++ b/inspirehep/ext/cache_manager/tasks.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2016 CERN.
 #
 # INSPIRE is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -17,4 +17,17 @@
 # along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-from .receivers import *
+from inspirehep.ext.cache_manager import cache_manager
+
+from invenio_celery import celery
+
+
+@celery.task
+def invalidate_cache_on_record_index(sender):
+    cache_manager.invalidate_view('record_oneline', recid=sender)
+    cache_manager.invalidate_view('record_brief', recid=sender)
+
+
+@celery.task
+def invalidate_cache_on_citation_count_update(sender):
+    cache_manager.invalidate_view('record_brief', recid=sender)

--- a/inspirehep/ext/cache_manager/utils.py
+++ b/inspirehep/ext/cache_manager/utils.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+from itertools import izip
+
+from flask_cache import make_template_fragment_key
+
+
+class JinjaCacheInvalidator(object):
+    """Class which helps to invalidate Jinja caches for certain templates."""
+    def __init__(self, cache):
+        self.cache_client = cache
+
+    def invalidate(self, template_name, keys):
+        """Invalidate template cache for certain keys (e.g. recid of the record)."""
+
+        cache_key = make_template_fragment_key(template_name, vary_on=[str(key) for key in keys])
+        self.cache_client.delete(cache_key)
+
+    def invalidate_many(self, template_names, keys):
+        """Invalidate many template cache for certain keys (e.g. recids of the records)."""
+
+        assert len(template_names) == len(keys)
+        cache_keys = []
+        for i, template_name in enumerate(template_names):
+            cache_keys.append(make_template_fragment_key(template_name, vary_on=[str(key) for key in keys[i]]))
+        self.cache_client.delete_many(*cache_keys)
+
+    def invalidate_all_of_certain_type(self, template_name):
+        """Invalidate all cache for certain template and delete it from Redis."""
+        template_key_base = make_template_fragment_key(template_name)
+        lua_script = "local keys = redis.call('KEYS', '*{0}_*') if #keys > 0 " \
+                     "then redis.call('DEL', unpack(keys)) end return #keys"\
+            .format(template_key_base)
+        lua_cleaner = self.cache_client.cache._client.register_script(lua_script)
+        how_many_invalidated = lua_cleaner()
+
+        return how_many_invalidated
+
+
+class CachedInvalidator(object):
+    """Class which helps to invalidate cached function decorated with flask_cache.cache.cached()."""
+    def __init__(self, cache):
+        self.cache_client = cache
+
+    def invalidate(self, function_reference, *args, **kwargs):
+        """Invalidate cached function passed by reference."""
+        cache_key = function_reference.make_cache_key()
+        self.cache_client.delete(cache_key)
+
+
+class MemoizedInvalidator(object):
+    """Class which helps to invalidate memoized function."""
+    def __init__(self, cache):
+        self.cache_client = cache
+
+    def invalidate(self, function_reference, *args, **kwargs):
+        """Invalidate memoized function for one set of arguments (e.g. recid and collection)."""
+
+        if args is not None:
+            self.cache_client.delete_memoized(function_reference, *args, **kwargs)
+
+    def invalidate_many(self, function_references, *args, **kwargs):
+        """Invalidate memoized function for many sets of arguments (e.g. recids and collections)."""
+
+        if args is not None:
+            how_many = len(function_references)
+            for argument_values in args:
+                assert len(argument_values) == how_many
+
+            for arguments in izip(function_references, *args):
+                self.cache_client.delete_memoized(*arguments)
+
+    def invalidate_all_of_certain_type(self, function_reference):
+        """Invalidate all cache for memoized function and delete it from Redis."""
+
+        # get the current hash for the memoized function; the hash will change after deleting all keys of this function
+        old_hash = self.cache_client._memoize_version(function_reference)
+
+        # change hash
+        self.cache_client.delete_memoized(function_reference)
+
+        # delete all keys connected with memoized function left in Redis
+        lua_script = "local keys = redis.call('KEYS', '*{0}') if #keys > 0 then redis.call('DEL', unpack(keys)) end" \
+                     "return #keys".format(old_hash[1])
+        lua_cleaner = self.cache_client.cache._client.register_script(lua_script)
+        how_many_invalidated = lua_cleaner()
+
+        return how_many_invalidated

--- a/inspirehep/ext/jinja_filters/record.py
+++ b/inspirehep/ext/jinja_filters/record.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of Invenio.
+# This file is part of INSPIRE.
 # Copyright (C) 2014, 2015, 2016 CERN.
 #
-# Invenio is free software; you can redistribute it and/or
+# INSPIRE is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of the
 # License, or (at your option) any later version.
 #
-# Invenio is distributed in the hope that it will be useful, but
+# INSPIRE is distributed in the hope that it will be useful, but
 # WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 import re
@@ -26,11 +26,9 @@ from flask import session
 from inspirehep.ext.jinja_filters.general import apply_template_on_array
 
 from inspirehep.utils.bibtex import Bibtex
-from inspirehep.utils.citations import Citation
 from inspirehep.utils.cv_latex import Cv_latex
 from inspirehep.utils.cv_latex_html_text import Cv_latex_html_text
 from inspirehep.utils.latex import Latex
-from inspirehep.utils.references import Reference
 
 from invenio_base.globals import cfg
 
@@ -136,14 +134,6 @@ def setup_app(app):
     @app.template_filter()
     def latex(record, latex_format):
         return Latex(record, latex_format).format()
-
-    @app.template_filter()
-    def references(record):
-        return Reference(record).references()
-
-    @app.template_filter()
-    def citations(record):
-        return Citation(record).citations()
 
     @app.template_filter()
     def cv_latex(record):
@@ -458,3 +448,7 @@ def setup_app(app):
     def split_author_name(name):
         new_name = name.split(',')
         return ' '.join(reversed(new_name))
+
+    @app.template_filter()
+    def long_timeout(timeout):
+        return 5184000  # 60 days

--- a/inspirehep/modules/citations/receivers.py
+++ b/inspirehep/modules/citations/receivers.py
@@ -17,7 +17,7 @@
 # along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-"""Signal receivers for invenio_records."""
+"""Signal receivers for dealing with citation count."""
 
 from invenio_records.signals import (
     after_record_insert,

--- a/inspirehep/modules/citations/signals.py
+++ b/inspirehep/modules/citations/signals.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2016 CERN.
 #
 # INSPIRE is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -17,4 +17,8 @@
 # along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-from .receivers import *
+from blinker import Namespace
+_signals = Namespace()
+
+after_citation_count_update = _signals.signal('after-citation-count-update')
+"""Signal sent after citation count has been updated."""

--- a/inspirehep/modules/citations/tasks.py
+++ b/inspirehep/modules/citations/tasks.py
@@ -19,6 +19,8 @@
 
 from invenio_celery import celery
 
+from .signals import after_citation_count_update
+
 
 @celery.task
 def update_citation_count_for_records(recids):
@@ -42,3 +44,4 @@ def update_citation_count(recid):
         es.update(index='hep', id=recid, doc_type='record', body={'doc': doc_update})
     except TransportError:
         pass
+    after_citation_count_update.send(recid)

--- a/inspirehep/utils/references.py
+++ b/inspirehep/utils/references.py
@@ -17,56 +17,53 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 #
 
+from invenio_ext.es import es
+
 from invenio_ext.template import render_template_to_string
 
 
-class Reference(object):
+def render_references(record):
+    """Reference export for single record in datatables format.
 
-    """Class used to output reference format in detailed record"""
+    :returns: list
+    List of lists where every item represents a datatables row.
+    A row consists of [reference, num_citations]
+    """
 
-    def __init__(self, record):
-        self.record = record
+    out = []
+    references = record.get('references')
+    if references:
+        refs_to_get_from_es = [
+            ref['recid'] for ref in references if ref.get('recid')
+        ]
+        records_from_es = []
 
-    def references(self):
-        """Reference export for single record in datatables format.
+        if refs_to_get_from_es:
+            records_from_es = es.mget(body={
+                "ids": refs_to_get_from_es
+            }, index="hep")['docs']
 
-        :returns: list
-            List of lists where every item represents a datatables row.
-            A row consists of [reference, num_citations]
-        """
-        from invenio_search.api import Query
+        refs_from_es = {
+            ref['_id']: ref['_source'] for ref in records_from_es
+        }
 
-        out = []
-        references = self.record.get('references')
-        if references:
-            refs_to_get_from_es = [
-                ref['recid'] for ref in references if ref.get('recid')
-            ]
-            es_query = ' or '.join(
-                ['control_number:' + str(recid) for recid in refs_to_get_from_es]
-            )
-            es_query = Query(es_query).search()
-            es_query.body.update({
-                'size': 9999
-            })
-            refs_from_es = {
-                record['control_number']: record for record in es_query.records()
-            }
+        for reference in references:
+            row = []
+            recid = reference.get('recid')
+            ref_record = refs_from_es.get(str(recid)) if recid else None
 
-            for reference in references:
-                row = []
-                if 'recid' in reference:
-                    recid = reference['recid']
-                    ref_record = refs_from_es.get(str(recid))
-                    if ref_record:
-                        row.append(render_template_to_string(
-                            "references.html",
-                            record=ref_record,
-                            reference=reference
-                        ))
-                        row.append(ref_record.get('citation_count', ''))
-                        out.append(row)
-                        continue
+            if recid and ref_record:
+                recid = reference['recid']
+                ref_record = refs_from_es.get(str(recid))
+                if ref_record:
+                    row.append(render_template_to_string(
+                        "references.html",
+                        record=ref_record,
+                        reference=reference
+                    ))
+                    row.append(ref_record.get('citation_count', ''))
+                    out.append(row)
+            else:
 
                 row.append(render_template_to_string(
                     "references.html",
@@ -74,4 +71,4 @@ class Reference(object):
                 row.append('')
                 out.append(row)
 
-        return out
+    return out

--- a/tests/test_cache_manager.py
+++ b/tests/test_cache_manager.py
@@ -1,0 +1,183 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+from flask_cache import make_template_fragment_key
+
+from inspirehep.ext.cache_manager.cache import inspire_cache
+
+from inspirehep.modules.citations.tasks import update_citation_count_for_records
+
+from invenio.testsuite import InvenioTestCase
+
+
+class CacheManagerTest(InvenioTestCase):
+
+    def cache_record_oneline_views(self):
+        from invenio_ext.template import render_template_to_string
+
+        for record in self.records:
+            render_template_to_string("citations.html", record=record, reference=None)
+
+    def cache_record_brief_search_views(self):
+        for recid in self.recids:
+            self.client.get("/search?cc=HEP&&p=control_number:{recid}".format(recid=str(recid)))
+
+    def check_if_record_oneline_view_cached(self, recid):
+        redis_key = make_template_fragment_key('record_oneline', vary_on=[str(recid)])
+        return inspire_cache.cache.get(redis_key) is not None
+
+    def check_if_record_brief_search_cached(self, recid):
+        redis_key = make_template_fragment_key('record_brief', vary_on=[str(recid)])
+        return inspire_cache.cache.get(redis_key) is not None
+
+    def setUp(self):
+        import copy
+        from invenio_records.api import get_record
+        from invenio_search.api import Query
+        import time
+        # SCENARIO:
+        # in this test we update record no. 1196797 changing its title and altering references
+        # (we remove one reference and add the other one)
+        #
+        # LINKS BEFORE TEST:
+        # 1291940 ---> 1196797 ---> 454197 <---1328493  1325552 ---> 1293923 ---> 955176
+        #
+        # LINKS AFTER TEST:
+        # 1291940 ---> 1196797 ---> 1293923 ---> 9551761   1325552 ---> 1293923    1328493 ---> 454197
+        #
+        # (A ---> B means that A refers to B)
+        #
+        # All 7 records should have cached before update of record 1196797 2 different types of views:
+        # record_oneline view and record_brief view.
+        # After the update they should have cached views according to the schema below:
+
+        self.expected_views_caching_after_update = {
+            '1196797': {
+                'record_oneline': False,
+                'record_brief_search': False
+            },
+            '1291940': {
+                'record_oneline': True,
+                'record_brief_search': True
+            },
+            '1328493': {
+                'record_oneline': True,
+                'record_brief_search': True
+            },
+            '454197': {
+                'record_oneline': True,
+                'record_brief_search': False
+            },
+            '1293923': {
+                'record_oneline': True,
+                'record_brief_search': False
+            },
+            '955176': {
+                'record_oneline': True,
+                'record_brief_search': True
+            },
+            '1325552':
+                {
+                'record_oneline': True,
+                'record_brief_search': True
+            }
+        }
+
+        self.recids = [1196797, 1291940, 1328493, 454197, 1293923, 955176, 1325552]
+        self.records = Query(' or '.join(['control_number:' + str(recid) for recid in self.recids])).search().records()
+        self.cache_record_brief_search_views()
+        self.cache_record_oneline_views()
+        self.changed_record_id = u'1196797'
+        self.removed_reference = u'454197'
+        self.added_reference = u'1293923'
+
+        record = get_record(self.changed_record_id)
+        self.old_title = copy.deepcopy(record['titles'][0]['title'])
+        self.old_references = copy.deepcopy(record['references'])
+
+        # change record's title
+        record['titles'][0]['title'] = u'Les Vacances du petit Nicolas'
+
+        # change record's references - stop referring to 454197, start - to 1293923
+        for ref in record['references']:
+            if ref.get('recid'):
+                if int(ref['recid']) == int(self.removed_reference):
+                    ref['recid'] = int(self.added_reference)
+
+        # commit changes
+        record.commit()
+
+        # wait few seconds to make sure InspireCacheManager has already done its job
+        time.sleep(10)
+
+    def tearDown(self):
+        from invenio_records.api import get_record
+        from invenio_search.api import Query
+        import time
+
+        # clear cache
+        inspire_cache.clear()
+
+        # undo changes in the record
+        record = get_record(self.changed_record_id)
+        record['references'] = self.old_references
+        record['titles'][0]['title'] = self.old_title
+        record.commit()
+
+        # make sure changes have been applied to ES and all citation_counts have been recalculated
+        timeout = 15  # [seconds]
+        timeout_start = time.time()
+        while time.time() < timeout_start + timeout:
+            es_record = Query('control_number:' + self.changed_record_id).search().records().pop()
+            references = [unicode(ref['recid']) for ref in es_record['references'] if ref.get('recid')]
+            title = es_record['titles'][0]['title']
+
+            if self.removed_reference in references \
+                    and self.added_reference not in references \
+                    and title == self.old_title:
+                break
+            else:
+                time.sleep(1)
+
+        update_citation_count_for_records.delay([int(self.removed_reference), int(self.added_reference)])
+
+        # make sure citation_counts have been updated
+        time.sleep(4)
+
+    def test_cache_management(self):
+        self.views_caching_after_update = {
+            str(recid):
+                {
+                'record_oneline': self.check_if_record_oneline_view_cached(recid),
+                'record_brief_search': self.check_if_record_brief_search_cached(recid)
+            }
+            for recid in self.recids
+        }
+        differences = []
+        for recid in self.expected_views_caching_after_update:
+            recids_views = self.views_caching_after_update.get(recid)
+            if recids_views:
+                for view in ['record_oneline', 'record_brief_search']:
+                    was_cached = recids_views.get(view)
+                    if was_cached != self.expected_views_caching_after_update[recid][view]:
+                        differences.append((recid, view, was_cached))
+            else:
+                differences.append((recid, 'all'))
+
+        self.failIf(differences)


### PR DESCRIPTION
* Adds caching and memoization to the following views:
  single-reference, single-citation, references, citations
  and brief search.

* Introduces InspireCache class which extends Flask Cache
  (adding conditional caching and memoization:
   e.g. cache/memoize when not in debug mode).

* Adds CacheManager extension which decides
  which cached views should be invalidated on record insert/update.

* Adds 'invalidate_cache' command to inspirehep in order to
  allow manual invalidation of certain views (references, citations etc.).

Signed-off-by: Tomasz Gargas <tomaszgy@gmail.com>