### PR TITLE
searchext: add missing data mapping

### DIFF
--- a/inspirehep/base/searchext/mappings/data.json
+++ b/inspirehep/base/searchext/mappings/data.json
@@ -1,0 +1,82 @@
+{
+    "settings": {
+        "analysis": {
+            "filter": {
+                "asciifold_with_orig": {
+                    "type": "asciifolding",
+                    "preserve_original": true
+                },
+                "synonyms_kbr": {
+                    "type": "synonym",
+                    "synonyms": [
+                        "production => creation"
+                    ]
+                },
+                "word_delimiter_orig" : {
+                    "type" : "word_delimiter",
+                    "preserve_original": true
+                }
+            },
+            "analyzer": {
+                "natural_text": {
+                    "type": "custom",
+                    "tokenizer":  "standard",
+                    "filter": [
+                        "asciifold_with_orig",
+                        "lowercase",
+                        "synonyms_kbr"
+                    ]
+                },
+                "autocomplete_analyzer": {
+                    "type": "custom",
+                    "tokenizer": "whitespace",
+                    "filter": [
+                        "lowercase",
+                        "word_delimiter_orig"
+                    ]
+                },
+                "basic_analyzer": {
+                    "type": "custom",
+                    "tokenizer": "standard",
+                    "filter": [
+                        "asciifold_with_orig",
+                        "lowercase"
+                    ]
+                }
+            }
+        },
+        "index.percolator.map_unmapped_fields_as_string": true
+    },
+    "mappings": {
+        "record": {
+            "_all": {"enabled": false},
+            "date_detection": false,
+            "numeric_detection": false,
+            "dynamic_templates": [
+                {"default": {
+                    "match_mapping_type": "string",
+                    "mapping": {
+                        "analyzer": "basic_analyzer",
+                        "type": "string",
+                        "copy_to": "global_default"
+                    }
+                }
+                }
+            ],
+            "properties": {
+                "global_fulltext": {
+                    "type": "string",
+                    "analyzer": "natural_text"
+                },
+                "global_default": {
+                    "type": "string",
+                    "analyzer": "basic_analyzer"
+                },
+                "_collections": {
+                    "type": "string",
+                    "index": "not_analyzed"
+                }
+            }
+        }
+    }
+}

--- a/inspirehep/manage.py
+++ b/inspirehep/manage.py
@@ -149,12 +149,7 @@ def delete_indices():
         cfg['WORKFLOWS_HOLDING_PEN_ES_PREFIX'] + name for name in list(indices)
     ]
     indices.update(holdingpen_indices)
-    click.echo(click.style('Going to delete ALL indices...', fg='red'), nl=False)
-    click.echo('Continue? [yn] ', nl=False)
-    c = click.getchar()
-    click.echo()
-    if c == 'n':
-        return
+    click.echo(click.style('Deleting ALL indices...', fg='red'), nl=False)
     with click.progressbar(indices) as indices_to_delete:
         for index in indices_to_delete:
             es.indices.delete(index=index, ignore=404)


### PR DESCRIPTION
Avoid exception in ElasticSearch when accessing Holding Pen due to missing mappings.