### PR TITLE
deposit: add submitter as source for titles

### DIFF
--- a/inspirehep/modules/deposit/workflows/literature.py
+++ b/inspirehep/modules/deposit/workflows/literature.py
@@ -299,6 +299,11 @@ class literature(SIPWorkflowMixin, SimpleRecordDeposition):
                     'title': title_crossref,
                     'source': "CrossRef"
                 })
+        try:
+            metadata['titles'][0]['source']
+        except KeyError:
+            # Title has no source, so should be the submitter
+            metadata['titles'][0]['source'] = "submitter"
 
         # ============================
         # Conference name


### PR DESCRIPTION
* If a title does not come from arXiv or Crossref, add the submitter as
  a source.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>