### PR TITLE
dojson: hepnames name fix

### DIFF
--- a/inspirehep/dojson/hepnames/fields/bd1xx.py
+++ b/inspirehep/dojson/hepnames/fields/bd1xx.py
@@ -252,17 +252,26 @@ def positions(self, key, value):
     have to follow the convention `mth-year`. For example: `10-2012`.
     """
     curated_relation = False
-    if value.get('z'):
-        curated_relation = True
+    recid = ''
+    status = ''
+    recid_status = utils.force_list(value.get('z'))
+    if recid_status:
+        for val in recid_status:
+            if val.lower() == 'current':
+                status = val
+            elif type(val) is int:
+                recid = val
+                curated_relation = True
+
     return {
-        'institution': {'name': value.get('a'), 'recid': value.get('z')} if
+        'institution': {'name': value.get('a'), 'recid': recid} if
         value.get('a') else None,
         'rank': value.get('r'),
         'start_date': value.get('s'),
         'end_date': value.get('t'),
         'email': value.get('m'),
         'old_email': value.get('o'),
-        'status': value.get('z'),
+        'status': status,
         'curated_relation': curated_relation,
     }
 


### PR DESCRIPTION
* Properly deals with the case when a MARCXML field has two $$z
  subfields, one for the recid and one for the status.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>