### PR TITLE
search: topcite keyword

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -390,7 +390,9 @@ SEARCH_ELASTIC_KEYWORD_MAPPING = {
     "address": ["corporate_author"],
     "datecreated": ["creation_modification_date.creation_date"],
     "datemodified": ["creation_modification_date.modification_date"],
-    "recid": ["control_number"]
+    "recid": ["control_number"],
+    "cited": ["citation_count"],
+    "topcite": ["citation_count"]
 }
 
 FACETS_SIZE_LIMIT = 10


### PR DESCRIPTION
* Adds `topcite` and `cited` keyword support.

* Should be merged with inspirehep/invenio-query-parser#11 .

* Closes box no.9 of #817.

Signed-off-by: Panos Paparrigopoulos <panos.paparrigopoulos@cern.ch>