### PR TITLE
dojson: tests upgrade and deleted fields

### DIFF
--- a/inspirehep/dojson/common/base.py
+++ b/inspirehep/dojson/common/base.py
@@ -157,20 +157,59 @@ def creation_modification_date2marc(self, key, value):
 @journals.over('spires_sysnos', '^970..')
 @hepnames.over('spires_sysnos', '^970..')
 @jobs.over('spires_sysnos', '^970..')
-@utils.for_each_value
+@utils.ignore_value
 def spires_sysnos(self, key, value):
     """Old SPIRES number."""
-    return value.get('a')
+    value = utils.force_list(value)
+    sysnos = []
+    for val in value:
+        if 'a' in val:
+            # Only append if there is something
+            sysnos.append(val.get('a'))
+    return sysnos or None
 
 
 @hep2marc.over('970', 'spires_sysnos')
 @hepnames2marc.over('970', 'spires_sysnos')
-@utils.for_each_value
 def spires_sysnos2marc(self, key, value):
     """Old SPIRES number."""
-    return {
-        'a': value
-    }
+    # Special handing of shared end key in 970 with new_recid
+    value = utils.force_list(value)
+    existing_values = self.get('970', [])
+    existing_values.extend(
+        [{'a': val} for val in value]
+    )
+    return existing_values
+
+
+@hep.over('new_recid', '^970..')
+@conferences.over('new_recid', '^970..')
+@institutions.over('new_recid', '^970..')
+@experiments.over('new_recid', '^970..')
+@journals.over('new_recid', '^970..')
+@hepnames.over('new_recid', '^970..')
+@jobs.over('new_recid', '^970..')
+@utils.ignore_value
+def new_recid(self, key, value):
+    """Reference to new recid."""
+    value = utils.force_list(value)
+    for val in value:
+        if 'd' in val:
+            # Only return if there is a d subfield, otherwise let the loop go.
+            return val.get('d')
+
+
+@hep2marc.over('970', 'new_recid')
+@hepnames2marc.over('970', 'new_recid')
+def new_recid2marc(self, key, value):
+    """New recid."""
+    # Special handing of shared end key in 970 with spires_sysnos
+    value = utils.force_list(value)
+    existing_values = self.get('970', [])
+    existing_values.extend(
+        [{'d': val} for val in value]
+    )
+    return existing_values
 
 
 @hep.over('collections', '^980..')
@@ -204,20 +243,18 @@ def collections2marc(self, key, value):
     }
 
 
-@hep.over('deleted_recid', '^981..')
-@conferences.over('deleted_recid', '^981..')
-@institutions.over('deleted_recid', '^981..')
-@experiments.over('deleted_recid', '^981..')
-@journals.over('deleted_recid', '^981..')
-@hepnames.over('deleted_recid', '^981..')
-@jobs.over('deleted_recid', '^981..')
+@hep.over('deleted_recids', '^981..')
+@conferences.over('deleted_recids', '^981..')
+@institutions.over('deleted_recids', '^981..')
+@experiments.over('deleted_recids', '^981..')
+@journals.over('deleted_recids', '^981..')
+@hepnames.over('deleted_recids', '^981..')
+@jobs.over('deleted_recids', '^981..')
 @utils.for_each_value
-@utils.filter_values
-def deleted_recid(self, key, value):
-    """Collection this record belongs to."""
-    return {
-        'deleted_recid': value.get('a'),
-    }
+@utils.ignore_value
+def deleted_recids(self, key, value):
+    """Recid of deleted record this record is master for."""
+    return value.get('a')
 
 
 @hep.over('fft', '^FFT..')
@@ -256,12 +293,12 @@ def fft2marc(self, key, value):
     }
 
 
-@hep2marc.over('981', 'deleted_recid')
-@hepnames2marc.over('981', 'deleted_recid')
+@hep2marc.over('981', 'deleted_recids')
+@hepnames2marc.over('981', 'deleted_recids')
 @utils.for_each_value
 @utils.filter_values
-def deleted_recid2marc(self, key, value):
-    """Collection this record belongs to."""
+def deleted_recids2marc(self, key, value):
+    """Deleted recids."""
     return {
-        'a': value.get('deleted_recid'),
+        'a': value
     }

--- a/inspirehep/dojson/hep/schemas/hep-0.0.1.json
+++ b/inspirehep/dojson/hep/schemas/hep-0.0.1.json
@@ -969,6 +969,19 @@
             "description": "Whether this document can be cited. FIXME: can this be derived from other properties?",
             "title": "Citeable?"
         },
+        "deleted_recids": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "description": "List of deleted recids referring to this record",
+            "title": "Deleted Records"
+        },
+        "new_recid": {
+            "type": "string",
+            "description": "Master record that replaces this record",
+            "title": "New recid"
+        },
         "license": {
             "uniqueItems": true,
             "items": {

--- a/tests/fixtures/test_hep_record.xml
+++ b/tests/fixtures/test_hep_record.xml
@@ -214,6 +214,12 @@
     <subfield code="o">oai:inspirehep.net:1236510</subfield>
     <subfield code="p">INSPIRE:HEP</subfield>
   </datafield>
+  <datafield tag="970" ind1=" " ind2=" ">
+    <subfield code="d">12345</subfield>
+  </datafield>
+  <datafield tag="970" ind1=" " ind2=" ">
+    <subfield code="a">SPIRES-1234123</subfield>
+  </datafield>
   <datafield tag="980" ind1=" " ind2=" ">
     <subfield code="a">Published</subfield>
   </datafield>
@@ -225,6 +231,9 @@
   </datafield>
   <datafield tag="980" ind1=" " ind2=" ">
     <subfield code="a">arXiv</subfield>
+  </datafield>
+  <datafield tag="981" ind1=" " ind2=" ">
+    <subfield code="a">123</subfield>
   </datafield>
   <datafield tag="999" ind1="C" ind2="5">
     <subfield code="o">1</subfield>

--- a/tests/test_hep.py
+++ b/tests/test_hep.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # INSPIRE is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -18,491 +18,547 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 import pkg_resources
+
 import os
+
+import pytest
 
 from dojson.contrib.marc21.utils import create_record
 
-from invenio.testsuite import InvenioTestCase, make_test_suite, run_test_suite
-from inspirehep.dojson.hep import hep2marc, hep
+from inspirehep.dojson.hep import hep, hep2marc
 
 
-class HepRecordsTests(InvenioTestCase):
+@pytest.fixture
+def marcxml_to_json():
+    marcxml = pkg_resources.resource_string('tests',
+                                            os.path.join(
+                                                'fixtures',
+                                                'test_hep_record.xml')
+                                            )
+    record = create_record(marcxml)
+    return hep.do(record)
 
-    def setUp(self):
-        self.marcxml = pkg_resources.resource_string('tests',
-                                                     os.path.join(
-                                                         'fixtures',
-                                                         'test_hep_record.xml')
-                                                     )
-        self.book_marcxml = pkg_resources.resource_string('tests',
-                                                     os.path.join(
-                                                         'fixtures',
-                                                         'test_hep_book.xml')
-                                                     )
-        record = create_record(self.marcxml)
-        book_record = create_record(self.book_marcxml)
 
-        self.marcxml_to_json = hep.do(record)
-        self.marcxml_to_json_book = hep.do(book_record)
-        self.json_to_marc = hep2marc.do(self.marcxml_to_json)
+@pytest.fixture
+def marcxml_to_json_book():
+    marcxml = pkg_resources.resource_string('tests',
+                                            os.path.join(
+                                                'fixtures',
+                                                'test_hep_book.xml')
+                                            )
+    record = create_record(marcxml)
+    return hep.do(record)
 
-    def test_isbns(self):
-        """Test if isbns is created correctly"""
-        self.assertEqual(self.marcxml_to_json['isbns'][0]['value'],
-                         self.json_to_marc['020'][0]['a'])
-        self.assertEqual(self.marcxml_to_json['isbns'][0]['medium'],
-                         self.json_to_marc['020'][0]['b'])
 
-    def test_dois(self):
-        """Test if dois is created correctly"""
-        self.assertTrue(self.marcxml_to_json['dois'][0]['value'] in
-                        [p.get('a') for p in self.json_to_marc['024'] if 'a' in p])
+@pytest.fixture
+def json_to_marc(marcxml_to_json):
+    return hep2marc.do(marcxml_to_json)
 
-    def test_persistent_identifiers(self):
-        """Test if persistent_identifiers is created correctly"""
-        self.assertTrue(self.marcxml_to_json['persistent_identifiers'][0]['value'] in
-                        [p.get('a') for p in self.json_to_marc['024'] if 'a' in p])
 
-    def test_external_system_numbers(self):
-        """Test if system control number is created correctly"""
-        self.assertEqual(self.marcxml_to_json['external_system_numbers']
-                         [0]['institute'],
-                         self.json_to_marc['035'][0]['9'])
-        self.assertEqual(self.marcxml_to_json['external_system_numbers']
-                         [0]['value'],
-                         self.json_to_marc['035'][0]['a'])
-        self.assertEqual(self.marcxml_to_json['external_system_numbers']
-                         [0]['obsolete'],
-                         self.json_to_marc['035'][0]['z'])
+def test_isbns(marcxml_to_json, json_to_marc):
+    """Test if isbns is created correctly"""
+    assert marcxml_to_json['isbns'][0]['value'] == json_to_marc['020'][0]['a']
+    assert marcxml_to_json['isbns'][0]['medium'] == json_to_marc['020'][0]['b']
 
-    def test_report_numbers(self):
-        """Test if report number is created correctly"""
-        self.assertTrue(self.marcxml_to_json['report_numbers'][0]['source'] in
-                        [a.get('9') for a in self.json_to_marc['037'] if '9' in a])
-        self.assertTrue(self.marcxml_to_json['report_numbers'][0]['value'] in
-                        [a.get('a') for a in self.json_to_marc['037'] if 'a' in a])
 
-    def test_arxiv_eprints(self):
-        """Test if arxiv eprints is created correctly"""
-        self.assertEqual(self.marcxml_to_json['arxiv_eprints'][0]
-                         ['categories'],
-                         [c.get('c')[0] for c in self.json_to_marc['037'] if 'c' in c])
-        self.assertTrue(self.marcxml_to_json['arxiv_eprints'][0]['value'] in
-                        [a.get('a') for a in self.json_to_marc['037'] if 'a' in a])
+def test_dois(marcxml_to_json, json_to_marc):
+    """Test if dois is created correctly"""
+    assert (marcxml_to_json['dois'][0]['value'] in
+            [p.get('a') for p in json_to_marc['024'] if 'a' in p])
 
-    def test_languages(self):
-        """Test if languages is created correctly"""
-        self.assertEqual(self.marcxml_to_json['languages'][0],
-                         self.json_to_marc['041'][0]['a'])
 
-    def test_classification_number(self):
-        """Test if classification_number is created correctly"""
-        for index, val in enumerate(
-                self.marcxml_to_json['classification_number']):
-            self.assertEqual(val['classification_number'],
-                             self.json_to_marc['084'][index]['a'])
-            self.assertEqual(val['source'],
-                             self.json_to_marc['084'][index]['9'])
-            self.assertEqual(val['standard'],
-                             self.json_to_marc['084'][index]['2'])
+def test_spires_sysnos(marcxml_to_json, json_to_marc):
+    """Test if spires_sysnos is created correctly"""
+    assert (marcxml_to_json['spires_sysnos'][0] in
+            [p.get('a') for p in json_to_marc['970'] if 'a' in p])
 
-    def test_authors(self):
-        """Test if authors are created correctly"""
-        self.assertEqual(self.marcxml_to_json['authors'][0]['full_name'],
-                         self.json_to_marc['100']['a'])
-        self.assertEqual(self.marcxml_to_json['authors'][0]['role'],
-                         self.json_to_marc['100']['e'])
-        self.assertEqual(self.marcxml_to_json['authors']
-                         [0]['alternative_name'],
-                         self.json_to_marc['100']['q'])
-        self.assertEqual(self.marcxml_to_json['authors'][0]['inspire_id'],
-                         self.json_to_marc['100']['i'])
-        self.assertEqual(self.marcxml_to_json['authors'][0]['orcid'],
-                         self.json_to_marc['100']['j'])
-        self.assertEqual(self.marcxml_to_json['authors'][0]['email'],
-                         self.json_to_marc['100']['m'])
-        self.assertEqual(self.marcxml_to_json['authors'][0]['affiliations'][0]
-                         ['value'],
-                         self.json_to_marc['100']['u'][0])
-        self.assertEqual(self.marcxml_to_json['authors'][0]['recid'],
-                         self.json_to_marc['100']['x'])
-        self.assertEqual(self.marcxml_to_json['authors'][0]
-                         ['curated_relation'],
-                         self.json_to_marc['100']['y'])
 
-    def test_corporate_author(self):
-        """Test if corporate_author is created correctly"""
-        self.assertEqual(self.marcxml_to_json['corporate_author'][0],
-                         self.json_to_marc['110'][0]['a'])
+def test_deleted_recids(marcxml_to_json, json_to_marc):
+    """Test if deleted_recids is created correctly"""
+    assert (marcxml_to_json['deleted_recids'][0] in
+            [p.get('a') for p in json_to_marc['981'] if 'a' in p])
 
-    def test_title_variation(self):
-        """Test if title_variation is created correctly"""
-        self.assertEqual(self.marcxml_to_json['title_variation']
-                         [0],
-                         self.json_to_marc['210'][0]['a'])
 
-    def test_title_translation(self):
-        """Test if title_translation is created correctly"""
-        self.assertEqual(self.marcxml_to_json['title_translation']
-                         [0]['title'],
-                         self.json_to_marc['242'][0]['a'])
-        self.assertEqual(self.marcxml_to_json['title_translation']
-                         [0]['subtitle'],
-                         self.json_to_marc['242'][0]['b'])
+def test_new_recid(marcxml_to_json, json_to_marc):
+    """Test if deleted_recids is created correctly"""
+    assert (marcxml_to_json['new_recid'] in
+            [p.get('d') for p in json_to_marc['970'] if 'd' in p])
 
-    def test_title(self):
-        """Test if title is created correctly"""
-        self.assertEqual(self.marcxml_to_json['titles'][1]['title'],
-                         self.json_to_marc['245'][0]['a'])
 
-    def test_breadcrumb_title(self):
-        """Test if breadcrumb title is created correctly"""
-        titles = [d.get('a') for d in self.json_to_marc['245']]
-        self.assertTrue(self.marcxml_to_json['breadcrumb_title'] in titles)
+def test_persistent_identifiers(marcxml_to_json, json_to_marc):
+    """Test if persistent_identifiers is created correctly"""
+    assert (marcxml_to_json['persistent_identifiers'][0]['value'] in
+            [p.get('a') for p in json_to_marc['024'] if 'a' in p])
 
-    def test_title_arxiv(self):
-        """Test if title arxiv is created correctly"""
-        def get(key):
-            return [d.get(key) for d in self.marcxml_to_json['titles']]
 
-        self.assertTrue(self.json_to_marc['246']['9'] in get('source'))
-        self.assertTrue(self.json_to_marc['246']['b'] in get('subtitle'))
-        self.assertTrue(self.json_to_marc['246']['a'] in get('title'))
+def test_external_system_numbers(marcxml_to_json, json_to_marc):
+    """Test if system control number is created correctly"""
+    assert (marcxml_to_json['external_system_numbers'][0]['institute'] ==
+            json_to_marc['035'][0]['9'])
+    assert (marcxml_to_json['external_system_numbers'][0]['value'] ==
+            json_to_marc['035'][0]['a'])
+    assert (marcxml_to_json['external_system_numbers'][0]['obsolete'] ==
+            json_to_marc['035'][0]['z'])
 
-    def test_titles_old(self):
-        """Test if titles_old is created correctly"""
-        self.assertEqual(self.marcxml_to_json['titles_old'][0]['source'],
-                         self.json_to_marc['247'][0]['9'])
-        self.assertEqual(self.marcxml_to_json['titles_old'][0]['subtitle'],
-                         self.json_to_marc['247'][0]['b'])
-        self.assertEqual(self.marcxml_to_json['titles_old'][0]['title'],
-                         self.json_to_marc['247'][0]['a'])
 
-    def test_imprints(self):
-        """Test if imprints is created correctly"""
-        self.assertEqual(self.marcxml_to_json['imprints'][0]['place'],
-                         self.json_to_marc['260'][0]['a'])
-        self.assertEqual(self.marcxml_to_json['imprints'][0]['publisher'],
-                         self.json_to_marc['260'][0]['b'])
-        self.assertEqual(self.marcxml_to_json['imprints'][0]['date'],
-                         self.json_to_marc['260'][0]['c'])
+def test_report_numbers(marcxml_to_json, json_to_marc):
+    """Test if report number is created correctly"""
+    assert (marcxml_to_json['report_numbers'][0]['source'] in
+            [a.get('9') for a in json_to_marc['037'] if '9' in a])
+    assert (marcxml_to_json['report_numbers'][0]['value'] in
+            [a.get('a') for a in json_to_marc['037'] if 'a' in a])
 
-    def test_preprint_date(self):
-        """Test if preprint_date is created correctly"""
-        self.assertEqual(self.marcxml_to_json['preprint_date'],
-                         self.json_to_marc['269'][0]['c'])
 
-    def test_page_nr(self):
-        """Test if page_nr is created correctly"""
-        self.assertEqual(self.marcxml_to_json['page_nr'][0],
-                         self.json_to_marc['300'][0]['a'])
+def test_arxiv_eprints(marcxml_to_json, json_to_marc):
+    """Test if arxiv eprints is created correctly"""
+    assert (marcxml_to_json['arxiv_eprints'][0]['categories'] ==
+            [c.get('c')[0] for c in json_to_marc['037'] if 'c' in c])
+    assert (marcxml_to_json['arxiv_eprints'][0]['value'] in
+            [a.get('a') for a in json_to_marc['037'] if 'a' in a])
 
-    def test_book_series(self):
-        """Test if book_series is created correctly"""
-        self.assertEqual(self.marcxml_to_json['book_series'][0]['value'],
-                         self.json_to_marc['490'][0]['a'])
-        self.assertEqual(self.marcxml_to_json['book_series'][0]['volume'],
-                         self.json_to_marc['490'][0]['v'])
 
-    def test_public_notes(self):
-        """Test if public_notes is created correctly"""
-        self.assertEqual(self.marcxml_to_json['public_notes'][0]['value'],
-                         self.json_to_marc['500'][0]['a'])
-        self.assertEqual(self.marcxml_to_json['public_notes'][0]['source'],
-                         self.json_to_marc['500'][0]['9'])
+def test_languages(marcxml_to_json, json_to_marc):
+    """Test if languages is created correctly"""
+    assert marcxml_to_json['languages'][0] == json_to_marc['041'][0]['a']
 
-    def test_hidden_notes(self):
-        """Test if hidden_notes is created correctly"""
-        self.assertEqual(self.marcxml_to_json['hidden_notes'][0]['value'],
-                         self.json_to_marc['595'][0]['a'])
-        self.assertEqual(self.marcxml_to_json['hidden_notes'][0]
-                         ['cern_reference'],
-                         self.json_to_marc['595'][0]['b'])
-        self.assertEqual(self.marcxml_to_json['hidden_notes'][0]['cds'],
-                         self.json_to_marc['595'][0]['c'])
-        self.assertEqual(self.marcxml_to_json['hidden_notes'][0]['source'],
-                         self.json_to_marc['595'][0]['9'])
 
-    def test_thesis(self):
-        """Test if thesis is created correctly"""
-        self.assertEqual(self.marcxml_to_json['thesis'][0]['degree_type'],
-                         self.json_to_marc['502'][0]['b'])
-        self.assertEqual(self.marcxml_to_json['thesis'][0]
-                         ['university'],
-                         self.json_to_marc['502'][0]['c'])
-        self.assertEqual(self.marcxml_to_json['thesis'][0]['date'],
-                         self.json_to_marc['502'][0]['d'])
+def test_classification_number(marcxml_to_json, json_to_marc):
+    """Test if classification_number is created correctly"""
+    for index, val in enumerate(
+            marcxml_to_json['classification_number']):
+        assert (val['classification_number'],
+                json_to_marc['084'][index]['a'])
+        assert (val['source'],
+                json_to_marc['084'][index]['9'])
+        assert (val['standard'],
+                json_to_marc['084'][index]['2'])
 
-    def test_abstract(self):
-        """Test if abstract is created correctly"""
-        self.assertEqual(self.marcxml_to_json['abstracts'][0]['value'],
-                         self.json_to_marc['520'][0]['a'])
-        self.assertEqual(self.marcxml_to_json['abstracts'][0]
-                         ['source'],
-                         self.json_to_marc['520'][0]['9'])
 
-    def test_funding_info(self):
-        """Test if funding_info is created correctly"""
-        self.assertEqual(self.marcxml_to_json['funding_info'][0]['agency'],
-                         self.json_to_marc['536'][0]['a'])
-        self.assertEqual(self.marcxml_to_json['funding_info'][0]
-                         ['grant_number'],
-                         self.json_to_marc['536'][0]['c'])
-        self.assertEqual(self.marcxml_to_json['funding_info'][0]
-                         ['project_number'],
-                         self.json_to_marc['536'][0]['f'])
+def test_authors(marcxml_to_json, json_to_marc):
+    """Test if authors are created correctly"""
+    assert (marcxml_to_json['authors'][0]['full_name'],
+            json_to_marc['100']['a'])
+    assert (marcxml_to_json['authors'][0]['role'],
+            json_to_marc['100']['e'])
+    assert (marcxml_to_json['authors']
+            [0]['alternative_name'],
+            json_to_marc['100']['q'])
+    assert (marcxml_to_json['authors'][0]['inspire_id'],
+            json_to_marc['100']['i'])
+    assert (marcxml_to_json['authors'][0]['orcid'],
+            json_to_marc['100']['j'])
+    assert (marcxml_to_json['authors'][0]['email'],
+            json_to_marc['100']['m'])
+    assert (marcxml_to_json['authors'][0]['affiliations'][0]
+            ['value'],
+            json_to_marc['100']['u'][0])
+    assert (marcxml_to_json['authors'][0]['recid'],
+            json_to_marc['100']['x'])
+    assert (marcxml_to_json['authors'][0]
+            ['curated_relation'],
+            json_to_marc['100']['y'])
 
-    def test_licence(self):
-        """Test if license is created correctly"""
-        self.assertEqual(self.marcxml_to_json['license'][0]['license'],
-                         self.json_to_marc['540'][0]['a'])
-        self.assertEqual(self.marcxml_to_json['license'][0]['imposing'],
-                         self.json_to_marc['540'][0]['b'])
-        self.assertEqual(self.marcxml_to_json['license'][0]['url'],
-                         self.json_to_marc['540'][0]['u'])
-        self.assertEqual(self.marcxml_to_json['license'][0]['material'],
-                         self.json_to_marc['540'][0]['3'])
 
-    def test_acquisition_source(self):
-        """Test if acquisition_source is created correctly"""
-        self.assertEqual(self.marcxml_to_json['acquisition_source'][0]
-                         ['source'],
-                         self.json_to_marc['541'][0]['a'])
-        self.assertEqual(self.marcxml_to_json['acquisition_source'][0]
-                         ['email'],
-                         self.json_to_marc['541'][0]['b'])
-        self.assertEqual(self.marcxml_to_json['acquisition_source'][0]
-                         ['method'],
-                         self.json_to_marc['541'][0]['c'])
-        self.assertEqual(self.marcxml_to_json['acquisition_source'][0]['date'],
-                         self.json_to_marc['541'][0]['d'])
-        self.assertEqual(self.marcxml_to_json['acquisition_source'][0]
-                         ['submission_number'],
-                         self.json_to_marc['541'][0]['e'])
+def test_corporate_author(marcxml_to_json, json_to_marc):
+    """Test if corporate_author is created correctly"""
+    assert (marcxml_to_json['corporate_author'][0],
+            json_to_marc['110'][0]['a'])
 
-    def test_copyright(self):
-        """Test if copyright is created correctly"""
-        self.assertEqual(self.marcxml_to_json['copyright'][0]['material'],
-                         self.json_to_marc['542'][0]['3'])
-        self.assertEqual(self.marcxml_to_json['copyright'][0]['holder'],
-                         self.json_to_marc['542'][0]['d'])
-        self.assertEqual(self.marcxml_to_json['copyright'][0]['statement'],
-                         self.json_to_marc['542'][0]['f'])
-        self.assertEqual(self.marcxml_to_json['copyright'][0]['url'],
-                         self.json_to_marc['542'][0]['u'])
 
-    def test_subject_terms(self):
-        """Test if subject term is created correctly"""
-        self.assertEqual(self.marcxml_to_json['subject_terms'][0]['scheme'],
-                         self.json_to_marc['65017'][0]['2'])
-        self.assertEqual(self.marcxml_to_json['subject_terms'][0]['term'],
-                         self.json_to_marc['65017'][0]['a'])
-        self.assertEqual(self.marcxml_to_json['subject_terms'][0]['source'],
-                         self.json_to_marc['65017'][0]['9'])
+def test_title_variation(marcxml_to_json, json_to_marc):
+    """Test if title_variation is created correctly"""
+    assert (marcxml_to_json['title_variation']
+            [0],
+            json_to_marc['210'][0]['a'])
 
-    def test_free_keywords(self):
-        """Test if free_keywords is created correctly"""
-        self.assertEqual(self.marcxml_to_json['free_keywords'][0]['value'],
-                         self.json_to_marc['653'][0]['a'])
-        self.assertEqual(self.marcxml_to_json['free_keywords'][0]['source'],
-                         self.json_to_marc['653'][0]['9'])
 
-    def test_accelerator_experiments(self):
-        """Test if accelerator_experiment is created correctly"""
-        self.assertEqual(self.marcxml_to_json['accelerator_experiments'][0]
-                         ['accelerator'],
-                         self.json_to_marc['693'][0]['a'])
-        self.assertEqual(self.marcxml_to_json['accelerator_experiments'][0]
-                         ['experiment'],
-                         self.json_to_marc['693'][0]['e'])
+def test_title_translation(marcxml_to_json, json_to_marc):
+    """Test if title_translation is created correctly"""
+    assert (marcxml_to_json['title_translation']
+            [0]['title'],
+            json_to_marc['242'][0]['a'])
+    assert (marcxml_to_json['title_translation']
+            [0]['subtitle'],
+            json_to_marc['242'][0]['b'])
 
-    def test_thesaurus_terms(self):
-        """Test if thesaurus_terms is created correctly"""
-        self.assertEqual(self.marcxml_to_json['thesaurus_terms'][0]
-                         ['classification_scheme'],
-                         self.json_to_marc['695'][0]['2'])
-        self.assertEqual(self.marcxml_to_json['thesaurus_terms'][0]
-                         ['energy_range'],
-                         self.json_to_marc['695'][0]['e'])
-        self.assertEqual(self.marcxml_to_json['thesaurus_terms'][0]
-                         ['keyword'],
-                         self.json_to_marc['695'][0]['a'])
 
-    def test_thesis_supervisor(self):
-        """Test if thesis_supervisor is created correctly"""
-        self.assertEqual(self.marcxml_to_json['thesis_supervisor'][0]
-                         ['full_name'],
-                         self.json_to_marc['701'][0]['a'])
-        self.assertEqual(self.marcxml_to_json['thesis_supervisor'][0]
-                         ['INSPIRE_id'],
-                         self.json_to_marc['701'][0]['g'])
-        self.assertEqual(self.marcxml_to_json['thesis_supervisor'][0]
-                         ['external_id'],
-                         self.json_to_marc['701'][0]['j'])
-        self.assertEqual(self.marcxml_to_json['thesis_supervisor'][0]
-                         ['affiliation'],
-                         self.json_to_marc['701'][0]['u'])
+def test_title(marcxml_to_json, json_to_marc):
+    """Test if title is created correctly"""
+    assert (marcxml_to_json['titles'][1]['title'],
+            json_to_marc['245'][0]['a'])
 
-    def test_collaboration(self):
-        """Test if collaboration is created correctly"""
-        self.assertEqual(self.marcxml_to_json['collaboration'][0],
-                         self.json_to_marc['710'][0]['g'])
 
-    def test_publication_info(self):
-        """Test if publication info is created correctly"""
-        self.assertEqual(self.marcxml_to_json['publication_info']
-                         [0]['page_artid'],
-                         self.json_to_marc['773'][0]['c'])
-        self.assertEqual(self.marcxml_to_json['publication_info']
-                         [0]['journal_issue'],
-                         self.json_to_marc['773'][0]['n'])
-        self.assertEqual(self.marcxml_to_json['publication_info']
-                         [0]['journal_title'],
-                         self.json_to_marc['773'][0]['p'])
-        self.assertEqual(self.marcxml_to_json['publication_info']
-                         [0]['journal_volume'],
-                         self.json_to_marc['773'][0]['v'])
-        self.assertEqual(self.marcxml_to_json['publication_info']
-                         [0]['parent_recid'],
-                         self.json_to_marc['773'][0]['0'])
-        self.assertEqual(self.marcxml_to_json['publication_info']
-                         [0]['year'],
-                         self.json_to_marc['773'][0]['y'])
-        self.assertEqual(self.marcxml_to_json['publication_info']
-                         [0]['conf_acronym'],
-                         self.json_to_marc['773'][0]['o'])
-        self.assertEqual(self.marcxml_to_json['publication_info']
-                         [0]['reportnumber'],
-                         self.json_to_marc['773'][0]['r'])
-        self.assertEqual(self.marcxml_to_json['publication_info']
-                         [0]['confpaper_info'],
-                         self.json_to_marc['773'][0]['t'])
-        self.assertEqual(self.marcxml_to_json['publication_info']
-                         [0]['cnum'],
-                         self.json_to_marc['773'][0]['w'])
-        self.assertEqual(self.marcxml_to_json['publication_info']
-                         [0]['pubinfo_freetext'],
-                         self.json_to_marc['773'][0]['x'])
-        self.assertEqual(self.marcxml_to_json['publication_info']
-                         [0]['isbn'],
-                         self.json_to_marc['773'][0]['z'])
-        self.assertEqual(self.marcxml_to_json['publication_info']
-                         [0]['note'],
-                         self.json_to_marc['773'][0]['m'])
+def test_breadcrumb_title(marcxml_to_json, json_to_marc):
+    """Test if breadcrumb title is created correctly"""
+    titles = [d.get('a') for d in json_to_marc['245']]
+    assert (marcxml_to_json['breadcrumb_title'] in titles)
 
-    def test_succeeding_entry(self):
-        """Test if succeeding_entry is created correctly"""
-        self.assertEqual(self.marcxml_to_json['succeeding_entry']
-                         ['relationship_code'],
-                         self.json_to_marc['785']['r'])
-        self.assertEqual(self.marcxml_to_json['succeeding_entry']['recid'],
-                         self.json_to_marc['785']['w'])
-        self.assertEqual(self.marcxml_to_json['succeeding_entry']['isbn'],
-                         self.json_to_marc['785']['z'])
 
-    def test_url(self):
-        """Test if url is created correctly"""
-        self.assertEqual(self.marcxml_to_json['urls'][0]['url'],
-                         self.json_to_marc['8564'][0]['u'])
-        self.assertEqual(self.marcxml_to_json['urls'][0]['size'],
-                         self.json_to_marc['8564'][0]['s'])
-        self.assertEqual(self.marcxml_to_json['urls'][0]['doc_string'],
-                         self.json_to_marc['8564'][0]['w'])
-        self.assertEqual(self.marcxml_to_json['urls'][0]['description'],
-                         self.json_to_marc['8564'][0]['y'])
-        self.assertEqual(self.marcxml_to_json['urls'][0]['material_type'],
-                         self.json_to_marc['8564'][0]['3'])
-        self.assertEqual(self.marcxml_to_json['urls'][0]['comment'],
-                         self.json_to_marc['8564'][0]['z'])
-        self.assertEqual(self.marcxml_to_json['urls'][0]['name'],
-                         self.json_to_marc['8564'][0]['f'])
+def test_title_arxiv(marcxml_to_json, json_to_marc):
+    """Test if title arxiv is created correctly"""
+    def get(key):
+        return [d.get(key) for d in marcxml_to_json['titles']]
 
-    def test_oai_pmh(self):
-        """Test if oal_pmh is created correctly"""
-        self.assertEqual(self.marcxml_to_json['oai_pmh'][0]['id'],
-                         self.json_to_marc['909CO'][0]['o'])
-        self.assertEqual(self.marcxml_to_json['oai_pmh'][0]['set'],
-                         self.json_to_marc['909CO'][0]['p'])
+    assert (json_to_marc['246']['9'] in get('source'))
+    assert (json_to_marc['246']['b'] in get('subtitle'))
+    assert (json_to_marc['246']['a'] in get('title'))
 
-    def test_collections(self):
-        """Test if collections is created correctly"""
-        for index, val in enumerate(self.marcxml_to_json['collections']):
-            if 'primary' in val:
-                self.assertEqual(val['primary'],
-                                 self.json_to_marc['980'][index]['a'])
 
-    def test_references(self):
-        """Test if references are created correctly"""
-        for index, val in enumerate(self.marcxml_to_json['references']):
-            if 'recid' in val:
-                self.assertEqual(val['recid'],
-                                 self.json_to_marc['999C5'][index]['0'])
-            if 'texkey' in val:
-                self.assertEqual(val['texkey'],
-                                 self.json_to_marc['999C5'][index]['1'])
-            if 'doi' in val:
-                self.assertEqual(val['doi'],
-                                 self.json_to_marc['999C5'][index]['a'])
-            if 'collaboration' in val:
-                self.assertEqual(val['collaboration'],
-                                 self.json_to_marc['999C5'][index]['c'])
-            if 'editors' in val:
-                self.assertEqual(val['editors'],
-                                 self.json_to_marc['999C5'][index]['e'])
-            if 'authors' in val:
-                self.assertEqual(val['authors'],
-                                 self.json_to_marc['999C5'][index]['h'])
-            if 'misc' in val:
-                self.assertEqual(val['misc'],
-                                 self.json_to_marc['999C5'][index]['m'])
-            if 'number' in val:
-                self.assertEqual(val['number'],
-                                 self.json_to_marc['999C5'][index]['o'])
-            if 'isbn' in val:
-                self.assertEqual(val['isbn'],
-                                 self.json_to_marc['999C5'][index]['i'])
-            if 'publisher' in val:
-                self.assertEqual(val['publisher'],
-                                 self.json_to_marc['999C5'][index]['p'])
-            if 'maintitle' in val:
-                self.assertEqual(val['maintitle'],
-                                 self.json_to_marc['999C5'][index]['q'])
-            if 'report_number' in val:
-                self.assertEqual(val['report_number'],
-                                 self.json_to_marc['999C5'][index]['r'])
-            if 'title' in val:
-                self.assertEqual(val['title'],
-                                 self.json_to_marc['999C5'][index]['t'])
-            if 'url' in val:
-                self.assertEqual(val['url'],
-                                 self.json_to_marc['999C5'][index]['u'])
-            if 'journal_pubnote' in val:
-                self.assertEqual(val['journal_pubnote'],
-                                 self.json_to_marc['999C5'][index]['s'])
-            if 'raw_reference' in val:
-                self.assertEqual(val['raw_reference'],
-                                 self.json_to_marc['999C5'][index]['x'])
-            if 'year' in val:
-                self.assertEqual(val['year'],
-                                 self.json_to_marc['999C5'][index]['y'])
+def test_titles_old(marcxml_to_json, json_to_marc):
+    """Test if titles_old is created correctly"""
+    assert (marcxml_to_json['titles_old'][0]['source'],
+            json_to_marc['247'][0]['9'])
+    assert (marcxml_to_json['titles_old'][0]['subtitle'],
+            json_to_marc['247'][0]['b'])
+    assert (marcxml_to_json['titles_old'][0]['title'],
+            json_to_marc['247'][0]['a'])
 
-    def test_refextract(self):
-        """Test if refextract is created correctly"""
-        self.assertEqual(self.marcxml_to_json['refextract'][0]['time'],
-                         self.json_to_marc['999C6'][0]['t'])
-        self.assertEqual(self.marcxml_to_json['refextract'][0]['version'],
-                         self.json_to_marc['999C6'][0]['v'])
-        self.assertEqual(self.marcxml_to_json['refextract'][0]['comment'],
-                         self.json_to_marc['999C6'][0]['c'])
-        self.assertEqual(self.marcxml_to_json['refextract'][0]['source'],
-                         self.json_to_marc['999C6'][0]['s'])
 
-    def test_book_link(self):
-        """Test if the link to the book recid is generated correctly."""
-        self.assertEqual(self.marcxml_to_json_book['book']['recid'],
-                         1409249)
+def test_imprints(marcxml_to_json, json_to_marc):
+    """Test if imprints is created correctly"""
+    assert (marcxml_to_json['imprints'][0]['place'],
+            json_to_marc['260'][0]['a'])
+    assert (marcxml_to_json['imprints'][0]['publisher'],
+            json_to_marc['260'][0]['b'])
+    assert (marcxml_to_json['imprints'][0]['date'],
+            json_to_marc['260'][0]['c'])
 
-TEST_SUITE = make_test_suite(HepRecordsTests)
 
-if __name__ == "__main__":
-    run_test_suite(TEST_SUITE)
+def test_preprint_date(marcxml_to_json, json_to_marc):
+    """Test if preprint_date is created correctly"""
+    assert (marcxml_to_json['preprint_date'],
+            json_to_marc['269'][0]['c'])
+
+
+def test_page_nr(marcxml_to_json, json_to_marc):
+    """Test if page_nr is created correctly"""
+    assert (marcxml_to_json['page_nr'][0],
+            json_to_marc['300'][0]['a'])
+
+
+def test_book_series(marcxml_to_json, json_to_marc):
+    """Test if book_series is created correctly"""
+    assert (marcxml_to_json['book_series'][0]['value'],
+            json_to_marc['490'][0]['a'])
+    assert (marcxml_to_json['book_series'][0]['volume'],
+            json_to_marc['490'][0]['v'])
+
+
+def test_public_notes(marcxml_to_json, json_to_marc):
+    """Test if public_notes is created correctly"""
+    assert (marcxml_to_json['public_notes'][0]['value'],
+            json_to_marc['500'][0]['a'])
+    assert (marcxml_to_json['public_notes'][0]['source'],
+            json_to_marc['500'][0]['9'])
+
+
+def test_hidden_notes(marcxml_to_json, json_to_marc):
+    """Test if hidden_notes is created correctly"""
+    assert (marcxml_to_json['hidden_notes'][0]['value'],
+            json_to_marc['595'][0]['a'])
+    assert (marcxml_to_json['hidden_notes'][0]
+            ['cern_reference'],
+            json_to_marc['595'][0]['b'])
+    assert (marcxml_to_json['hidden_notes'][0]['cds'],
+            json_to_marc['595'][0]['c'])
+    assert (marcxml_to_json['hidden_notes'][0]['source'],
+            json_to_marc['595'][0]['9'])
+
+
+def test_thesis(marcxml_to_json, json_to_marc):
+    """Test if thesis is created correctly"""
+    assert (marcxml_to_json['thesis'][0]['degree_type'],
+            json_to_marc['502'][0]['b'])
+    assert (marcxml_to_json['thesis'][0]
+            ['university'],
+            json_to_marc['502'][0]['c'])
+    assert (marcxml_to_json['thesis'][0]['date'],
+            json_to_marc['502'][0]['d'])
+
+
+def test_abstract(marcxml_to_json, json_to_marc):
+    """Test if abstract is created correctly"""
+    assert (marcxml_to_json['abstracts'][0]['value'],
+            json_to_marc['520'][0]['a'])
+    assert (marcxml_to_json['abstracts'][0]
+            ['source'],
+            json_to_marc['520'][0]['9'])
+
+
+def test_funding_info(marcxml_to_json, json_to_marc):
+    """Test if funding_info is created correctly"""
+    assert (marcxml_to_json['funding_info'][0]['agency'],
+            json_to_marc['536'][0]['a'])
+    assert (marcxml_to_json['funding_info'][0]
+            ['grant_number'],
+            json_to_marc['536'][0]['c'])
+    assert (marcxml_to_json['funding_info'][0]
+            ['project_number'],
+            json_to_marc['536'][0]['f'])
+
+
+def test_licence(marcxml_to_json, json_to_marc):
+    """Test if license is created correctly"""
+    assert (marcxml_to_json['license'][0]['license'],
+            json_to_marc['540'][0]['a'])
+    assert (marcxml_to_json['license'][0]['imposing'],
+            json_to_marc['540'][0]['b'])
+    assert (marcxml_to_json['license'][0]['url'],
+            json_to_marc['540'][0]['u'])
+    assert (marcxml_to_json['license'][0]['material'],
+            json_to_marc['540'][0]['3'])
+
+
+def test_acquisition_source(marcxml_to_json, json_to_marc):
+    """Test if acquisition_source is created correctly"""
+    assert (marcxml_to_json['acquisition_source'][0]
+            ['source'],
+            json_to_marc['541'][0]['a'])
+    assert (marcxml_to_json['acquisition_source'][0]
+            ['email'],
+            json_to_marc['541'][0]['b'])
+    assert (marcxml_to_json['acquisition_source'][0]
+            ['method'],
+            json_to_marc['541'][0]['c'])
+    assert (marcxml_to_json['acquisition_source'][0]['date'],
+            json_to_marc['541'][0]['d'])
+    assert (marcxml_to_json['acquisition_source'][0]
+            ['submission_number'],
+            json_to_marc['541'][0]['e'])
+
+
+def test_copyright(marcxml_to_json, json_to_marc):
+    """Test if copyright is created correctly"""
+    assert (marcxml_to_json['copyright'][0]['material'],
+            json_to_marc['542'][0]['3'])
+    assert (marcxml_to_json['copyright'][0]['holder'],
+            json_to_marc['542'][0]['d'])
+    assert (marcxml_to_json['copyright'][0]['statement'],
+            json_to_marc['542'][0]['f'])
+    assert (marcxml_to_json['copyright'][0]['url'],
+            json_to_marc['542'][0]['u'])
+
+
+def test_subject_terms(marcxml_to_json, json_to_marc):
+    """Test if subject term is created correctly"""
+    assert (marcxml_to_json['subject_terms'][0]['scheme'],
+            json_to_marc['65017'][0]['2'])
+    assert (marcxml_to_json['subject_terms'][0]['term'],
+            json_to_marc['65017'][0]['a'])
+    assert (marcxml_to_json['subject_terms'][0]['source'],
+            json_to_marc['65017'][0]['9'])
+
+
+def test_free_keywords(marcxml_to_json, json_to_marc):
+    """Test if free_keywords is created correctly"""
+    assert (marcxml_to_json['free_keywords'][0]['value'],
+            json_to_marc['653'][0]['a'])
+    assert (marcxml_to_json['free_keywords'][0]['source'],
+            json_to_marc['653'][0]['9'])
+
+
+def test_accelerator_experiments(marcxml_to_json, json_to_marc):
+    """Test if accelerator_experiment is created correctly"""
+    assert (marcxml_to_json['accelerator_experiments'][0]
+            ['accelerator'],
+            json_to_marc['693'][0]['a'])
+    assert (marcxml_to_json['accelerator_experiments'][0]
+            ['experiment'],
+            json_to_marc['693'][0]['e'])
+
+
+def test_thesaurus_terms(marcxml_to_json, json_to_marc):
+    """Test if thesaurus_terms is created correctly"""
+    assert (marcxml_to_json['thesaurus_terms'][0]
+            ['classification_scheme'],
+            json_to_marc['695'][0]['2'])
+    assert (marcxml_to_json['thesaurus_terms'][0]
+            ['energy_range'],
+            json_to_marc['695'][0]['e'])
+    assert (marcxml_to_json['thesaurus_terms'][0]
+            ['keyword'],
+            json_to_marc['695'][0]['a'])
+
+
+def test_thesis_supervisor(marcxml_to_json, json_to_marc):
+    """Test if thesis_supervisor is created correctly"""
+    assert (marcxml_to_json['thesis_supervisor'][0]
+            ['full_name'],
+            json_to_marc['701'][0]['a'])
+    assert (marcxml_to_json['thesis_supervisor'][0]
+            ['INSPIRE_id'],
+            json_to_marc['701'][0]['g'])
+    assert (marcxml_to_json['thesis_supervisor'][0]
+            ['external_id'],
+            json_to_marc['701'][0]['j'])
+    assert (marcxml_to_json['thesis_supervisor'][0]
+            ['affiliation'],
+            json_to_marc['701'][0]['u'])
+
+
+def test_collaboration(marcxml_to_json, json_to_marc):
+    """Test if collaboration is created correctly"""
+    assert (marcxml_to_json['collaboration'][0],
+            json_to_marc['710'][0]['g'])
+
+
+def test_publication_info(marcxml_to_json, json_to_marc):
+    """Test if publication info is created correctly"""
+    assert (marcxml_to_json['publication_info']
+            [0]['page_artid'],
+            json_to_marc['773'][0]['c'])
+    assert (marcxml_to_json['publication_info']
+            [0]['journal_issue'],
+            json_to_marc['773'][0]['n'])
+    assert (marcxml_to_json['publication_info']
+            [0]['journal_title'],
+            json_to_marc['773'][0]['p'])
+    assert (marcxml_to_json['publication_info']
+            [0]['journal_volume'],
+            json_to_marc['773'][0]['v'])
+    assert (marcxml_to_json['publication_info']
+            [0]['parent_recid'],
+            json_to_marc['773'][0]['0'])
+    assert (marcxml_to_json['publication_info']
+            [0]['year'],
+            json_to_marc['773'][0]['y'])
+    assert (marcxml_to_json['publication_info']
+            [0]['conf_acronym'],
+            json_to_marc['773'][0]['o'])
+    assert (marcxml_to_json['publication_info']
+            [0]['reportnumber'],
+            json_to_marc['773'][0]['r'])
+    assert (marcxml_to_json['publication_info']
+            [0]['confpaper_info'],
+            json_to_marc['773'][0]['t'])
+    assert (marcxml_to_json['publication_info']
+            [0]['cnum'],
+            json_to_marc['773'][0]['w'])
+    assert (marcxml_to_json['publication_info']
+            [0]['pubinfo_freetext'],
+            json_to_marc['773'][0]['x'])
+    assert (marcxml_to_json['publication_info']
+            [0]['isbn'],
+            json_to_marc['773'][0]['z'])
+    assert (marcxml_to_json['publication_info']
+            [0]['note'],
+            json_to_marc['773'][0]['m'])
+
+
+def test_succeeding_entry(marcxml_to_json, json_to_marc):
+    """Test if succeeding_entry is created correctly"""
+    assert (marcxml_to_json['succeeding_entry']
+            ['relationship_code'],
+            json_to_marc['785']['r'])
+    assert (marcxml_to_json['succeeding_entry']['recid'],
+            json_to_marc['785']['w'])
+    assert (marcxml_to_json['succeeding_entry']['isbn'],
+            json_to_marc['785']['z'])
+
+
+def test_url(marcxml_to_json, json_to_marc):
+    """Test if url is created correctly"""
+    assert (marcxml_to_json['urls'][0]['url'],
+            json_to_marc['8564'][0]['u'])
+    assert (marcxml_to_json['urls'][0]['size'],
+            json_to_marc['8564'][0]['s'])
+    assert (marcxml_to_json['urls'][0]['doc_string'],
+            json_to_marc['8564'][0]['w'])
+    assert (marcxml_to_json['urls'][0]['description'],
+            json_to_marc['8564'][0]['y'])
+    assert (marcxml_to_json['urls'][0]['material_type'],
+            json_to_marc['8564'][0]['3'])
+    assert (marcxml_to_json['urls'][0]['comment'],
+            json_to_marc['8564'][0]['z'])
+    assert (marcxml_to_json['urls'][0]['name'],
+            json_to_marc['8564'][0]['f'])
+
+
+def test_oai_pmh(marcxml_to_json, json_to_marc):
+    """Test if oal_pmh is created correctly"""
+    assert (marcxml_to_json['oai_pmh'][0]['id'],
+            json_to_marc['909CO'][0]['o'])
+    assert (marcxml_to_json['oai_pmh'][0]['set'],
+            json_to_marc['909CO'][0]['p'])
+
+
+def test_collections(marcxml_to_json, json_to_marc):
+    """Test if collections is created correctly"""
+    for index, val in enumerate(marcxml_to_json['collections']):
+        if 'primary' in val:
+            assert (val['primary'],
+                    json_to_marc['980'][index]['a'])
+
+
+def test_references(marcxml_to_json, json_to_marc):
+    """Test if references are created correctly"""
+    for index, val in enumerate(marcxml_to_json['references']):
+        if 'recid' in val:
+            assert (val['recid'],
+                    json_to_marc['999C5'][index]['0'])
+        if 'texkey' in val:
+            assert (val['texkey'],
+                    json_to_marc['999C5'][index]['1'])
+        if 'doi' in val:
+            assert (val['doi'],
+                    json_to_marc['999C5'][index]['a'])
+        if 'collaboration' in val:
+            assert (val['collaboration'],
+                    json_to_marc['999C5'][index]['c'])
+        if 'editors' in val:
+            assert (val['editors'],
+                    json_to_marc['999C5'][index]['e'])
+        if 'authors' in val:
+            assert (val['authors'],
+                    json_to_marc['999C5'][index]['h'])
+        if 'misc' in val:
+            assert (val['misc'],
+                    json_to_marc['999C5'][index]['m'])
+        if 'number' in val:
+            assert (val['number'],
+                    json_to_marc['999C5'][index]['o'])
+        if 'isbn' in val:
+            assert (val['isbn'],
+                    json_to_marc['999C5'][index]['i'])
+        if 'publisher' in val:
+            assert (val['publisher'],
+                    json_to_marc['999C5'][index]['p'])
+        if 'maintitle' in val:
+            assert (val['maintitle'],
+                    json_to_marc['999C5'][index]['q'])
+        if 'report_number' in val:
+            assert (val['report_number'],
+                    json_to_marc['999C5'][index]['r'])
+        if 'title' in val:
+            assert (val['title'],
+                    json_to_marc['999C5'][index]['t'])
+        if 'url' in val:
+            assert (val['url'],
+                    json_to_marc['999C5'][index]['u'])
+        if 'journal_pubnote' in val:
+            assert (val['journal_pubnote'],
+                    json_to_marc['999C5'][index]['s'])
+        if 'raw_reference' in val:
+            assert (val['raw_reference'],
+                    json_to_marc['999C5'][index]['x'])
+        if 'year' in val:
+            assert (val['year'],
+                    json_to_marc['999C5'][index]['y'])
+
+
+def test_refextract(marcxml_to_json, json_to_marc):
+    """Test if refextract is created correctly"""
+    assert (marcxml_to_json['refextract'][0]['time'],
+            json_to_marc['999C6'][0]['t'])
+    assert (marcxml_to_json['refextract'][0]['version'],
+            json_to_marc['999C6'][0]['v'])
+    assert (marcxml_to_json['refextract'][0]['comment'],
+            json_to_marc['999C6'][0]['c'])
+    assert (marcxml_to_json['refextract'][0]['source'],
+            json_to_marc['999C6'][0]['s'])
+
+
+def test_book_link(marcxml_to_json_book):
+    """Test if the link to the book recid is generated correctly."""
+    assert (marcxml_to_json_book['book']['recid'],
+            1409249)


### PR DESCRIPTION
Adds missing handling + tests of 970__d and 981__a in dojson.

Significantly improves testing speed of `test_hep` from 23s to 2.3s by using pytest and fixtures. @kaplun @jacquerie @jmartinm 