### PR TITLE
formulas: several fixes

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -246,6 +246,7 @@ to monitor the *Celery* tasks.
 
     (invenio)$ pip install honcho flower
     (invenio)$ cdvirtualenv src/inspire-next
+    (invenio)$ npm install
     (invenio)$ honcho start
 
 You can now proceed to initialize the database and create the related tables:

--- a/Procfile
+++ b/Procfile
@@ -2,5 +2,5 @@ web: inveniomanage runserver
 cache: redis-server
 worker: celery worker -E -A invenio_celery.celery --loglevel=INFO --workdir=$VIRTUAL_ENV
 workermon: flower --broker=amqp://guest:guest@localhost:5672//
-mathoid: nodejs node_modules/mathoid/server.js -c node_modules/mathoid/config.dev.yaml
+mathoid: node_modules/mathoid/server.js -c mathoid.config.yaml
 indexer: elasticsearch -Dcluster.name="inspire" -Ddiscovery.zen.ping.multicast.enabled=false -Dpath.data="$VIRTUAL_ENV/var/data/elasticsearch"  -Dpath.logs="$VIRTUAL_ENV/var/log/elasticsearch"

--- a/inspirehep/base/templates/search/facets/hep.html
+++ b/inspirehep/base/templates/search/facets/hep.html
@@ -40,26 +40,6 @@
     <hr />
   </div>
   {% endif %}
-  {% if 'formulas' in aggs and aggs['formulas']['buckets'] %}
-    <h4 id="filter-by-formulas" class="pointer"><i class="fa fa-chevron-down facet-slider"></i> Filter by Formulas</h4>
-    <div class="facet-container" id="facet-doc_type">
-    {% for formulas in aggs['formulas']['buckets'] %}
-    <div class="checkbox checkbox-facets">
-      <label>
-        {%- set is_checked = 'checked' if 'formulas' in filtered_facets
-            and formulas['key'] in filtered_facets['formulas']['inc'] -%}
-        <input class="include-facet"
-              type="checkbox"
-              {{is_checked}}
-              name="formulas" value="{{ formulas['key'] }}">
-        <span class="facet-title-truncate">{{ formulas['key'] }}</span>
-        <span class="facet-label label label-default {{ 'label-primary' if is_checked}} pull-right">{{ formulas['doc_count'] }}</span>
-      </label>
-    </div>
-    {% endfor %}
-    <hr />
-  </div>
-  {% endif %}
   {% if 'subject' in aggs and aggs['subject']['buckets'] %}
     <h4 id="filter-by-subject" class="pointer"><i class="fa fa-chevron-down facet-slider"></i> Filter by Subject</h4>
     <div class="facet-container" id="facet-subject">
@@ -79,6 +59,26 @@
       {% endfor %}
       <hr />
     </div>
+  {% endif %}
+  {% if 'formulas' in aggs and aggs['formulas']['buckets'] %}
+    <h4 id="filter-by-formulas" class="pointer"><i class="fa fa-chevron-down facet-slider"></i> Filter by Formulas</h4>
+    <div class="facet-container" id="facet-formulas">
+    {% for formulas in aggs['formulas']['buckets'] %}
+    <div class="checkbox checkbox-facets">
+      <label>
+        {%- set is_checked = 'checked' if 'formulas' in filtered_facets
+            and formulas['key'] in filtered_facets['formulas']['inc'] -%}
+        <input class="include-facet"
+              type="checkbox"
+              {{is_checked}}
+              name="formulas" value="{{ formulas['key'] }}">
+        <span class="facet-title-truncate">{{ formulas['key'] }}</span>
+        <span class="facet-label label label-default {{ 'label-primary' if is_checked}} pull-right">{{ formulas['doc_count'] }}</span>
+      </label>
+    </div>
+    {% endfor %}
+    <hr />
+  </div>
   {% endif %}
   {% if 'author' in aggs and aggs['author']['buckets'] %}
     <h4 id="filter-by-author" class="pointer"><i class="fa fa-chevron-down facet-slider"></i> Filter by Author</h4>

--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -213,7 +213,7 @@ ORCID_APP_CREDENTIALS = dict(
     consumer_secret="changeme",
 )
 
-MATHOID_SERVER = "http://localhost:10044"
+MATHOID_SERVER = ""  # "http://localhost:10044"
 
 CFG_WEBSEARCH_SYNONYM_KBRS = {
     'journal': ['JOURNALS', 'leading_to_comma'],

--- a/inspirehep/modules/records/receivers.py
+++ b/inspirehep/modules/records/receivers.py
@@ -19,6 +19,7 @@
 
 from invenio_records.signals import before_record_index
 from inspirehep.utils.formulas import get_all_unicode_formula_tokens_from_text
+from invenio_base.globals import cfg
 
 
 @before_record_index.connect
@@ -27,6 +28,8 @@ def populate_formulas(recid, json, *args, **kwargs):
     Extract all useful LaTeX/MathML formulas from title/abstract and add it
     to the facet_formulas facet.
     """
+    if not cfg.get("MATHOID_SERVER"):
+        return
     formulas = set()
     for title in json.get('titles', []):
         if 'title' in title:

--- a/inspirehep/utils/formulas.py
+++ b/inspirehep/utils/formulas.py
@@ -96,7 +96,7 @@ def splitter(formula):
         return [formula] + [splitter(component) for component in formula.split(u'→')]
     if u'/' in formula:
         return [formula] + [splitter(component) for component in formula.split(u'/')]
-    return [formula]
+    return [formula] if formula else []
 
 
 def parenthesizer(formula):

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 # Install mathoid
-npm install -g mathoid
+npm install mathoid
 
 # Run mathoid
-/usr/lib/node_modules/mathoid/server.js -c /usr/lib/node_modules/mathoid/config.dev.yaml &
+node_modules/mathoid/server.js -c mathoid.config.yaml &
 
 # Run services
 service mysql start
@@ -26,6 +26,8 @@ inveniomanage config set PACKAGES_EXCLUDE []  # test all packages
 inveniomanage config set CFG_TMPDIR /tmp
 inveniomanage config set CFG_SITE_URL http://localhost
 inveniomanage config set CFG_SITE_SECURE_URL http://localhost
+inveniomanage config set MATHOID_SERVER http://localhost:10044
+
 inveniomanage config set ASSETS_DEBUG True  # ignore assets issues
 inveniomanage config set LESS_RUN_IN_DEBUG False
 inveniomanage config set REQUIREJS_RUN_IN_DEBUG False

--- a/mathoid.config.yaml
+++ b/mathoid.config.yaml
@@ -1,0 +1,67 @@
+# Number of worker processes to spawn.
+# Set to 0 to run everything in a single process without clustering.
+# Use 'ncpu' to run as many workers as there are CPU units
+num_workers: ncpu
+
+# Log error messages and gracefully restart a worker if v8 reports that it
+# uses more heap (note: not RSS) than this many mb.
+worker_heap_limit_mb: 250
+
+# Logger info
+logging:
+  level: warn
+#  streams:
+#  # Use gelf-stream -> logstash
+#  - type: gelf
+#    host: logstash1003.eqiad.wmnet
+#    port: 12201
+
+# Statsd metrics reporter
+metrics:
+  #type: log
+  #host: localhost
+  #port: 8125
+
+services:
+  - name: mathoid
+    # a relative path or the name of an npm package, if different from name
+    module: ./node_modules/mathoid/app.js
+    # optionally, a version constraint of the npm package
+    # version: ^0.4.0
+    # per-service config
+    conf:
+      port: 10044
+      interface: localhost # uncomment to only listen on localhost
+      # more per-service config settings
+      # the location of the spec, defaults to spec.yaml if not specified
+      # spec: ./spec.template.yaml
+      # allow cross-domain requests to the API (default '*')
+      cors: '*'
+      # to disable use:
+      # cors: false
+      # to restrict to a particular domain, use:
+      # cors: restricted.domain.org
+      # URL of the outbound proxy to use (complete with protocol)
+      # proxy: http://my.proxy.org:8080
+      # the list of domains for which not to use the proxy defined above
+      # no_proxy_list:
+      #   - domain1.com
+      #   - domain2.org
+      # the list of incoming request headers that can be logged; if left empty,
+      # the following headers are allowed: cache-control, content-length,
+      # content-type, if-match, user-agent, x-request-id
+      # log_header_whitelist:
+      #   - cache-control
+      #   - content-length
+      #   - content-type
+      #   - if-match
+      #   - user-agent
+      #   - x-request-id
+      # list of enabled renders
+      svg: false
+      img: false
+      png: false #new feature
+      speakText: false #new feature
+      texvcinfo: false
+      sppechOn: false
+      speech: false

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,7 +23,8 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 [pytest]
-addopts = --pep8 --ignore=docs --cov=inspirehep --cov-report=term-missing
+addopts = --pep8 --ignore=docs --ignore=node_modules --cov=inspirehep --cov-report=term-missing
 pep8ignore =
     tests/* ALL
     *.py E501
+    node_modules/* ALL


### PR DESCRIPTION
* Fixes deployment of Mathoid to be compatible with Docker, Linux and
  Mac OS.

* Provides default Mathoid configuration suitable to be run on
  production. (closes #864)

* Fixes positioning of formulas facet and its correct ID, so that
  closing it actually works. (closes #862 )

* Skips empty formulas. (closes #863 )

* Documents installation steps for Mathoid.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>