### PR TITLE
references: template fix

### DIFF
--- a/inspirehep/base/templates/references.html
+++ b/inspirehep/base/templates/references.html
@@ -30,7 +30,7 @@
           [{{ reference['number'] }}]
         {% endif %}
         {% call cache_if_not_debug('record_oneline', record['control_number']) %}
-        <a href="/record/{{record.recid}}">{{ render_record_title() }}</a>
+        <a href="/record/{{record['control_number']}}">{{ render_record_title() }}</a>
       </div>
       <div class="reference-authors">{{ render_record_authors(is_brief=true, show_affiliations=false) | safe }}</div>
       <div class="reference-journal">{{ record_publication_info() | safe }}</div>

--- a/inspirehep/utils/references.py
+++ b/inspirehep/utils/references.py
@@ -17,6 +17,8 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 #
 
+from invenio_records.api import Record
+
 from invenio_ext.es import es
 
 from invenio_ext.template import render_template_to_string
@@ -46,7 +48,6 @@ def render_references(record):
         refs_from_es = {
             ref['_id']: ref['_source'] for ref in records_from_es
         }
-
         for reference in references:
             row = []
             recid = reference.get('recid')
@@ -54,7 +55,7 @@ def render_references(record):
 
             if recid and ref_record:
                 recid = reference['recid']
-                ref_record = refs_from_es.get(str(recid))
+                ref_record = Record(refs_from_es.get(str(recid)))
                 if ref_record:
                     row.append(render_template_to_string(
                         "references.html",


### PR DESCRIPTION
* Wraps record JSON passed to reference template in invenio_records
  Record object to allow for 'smart' access of keys in the template.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>