### PR TITLE
templates: strip plot caption

### DIFF
--- a/inspirehep/base/templates/format/record/Inspire_HTML_detailed_macros.tpl
+++ b/inspirehep/base/templates/format/record/Inspire_HTML_detailed_macros.tpl
@@ -333,7 +333,7 @@
               {% if url.get('url') %}
                 {% if url.get('url').endswith(".png") or url.get('url').endswith(".jpg") %}
                 <div id="slide-content-{{ loop.index0 }}">
-                  <span>{{ url.get('description') }}</span>
+                  <span>{{ url.get('description')|strip_leading_number_plot_caption }}</span>
                 </div>
                 {% endif %}
               {% endif %}

--- a/inspirehep/ext/jinja_filters/record.py
+++ b/inspirehep/ext/jinja_filters/record.py
@@ -424,6 +424,10 @@ def setup_app(app):
         return 5184000  # 60 days
 
     @app.template_filter()
+    def strip_leading_number_plot_caption(text):
+        return re.sub(r'^\d{5}\s+', '', text)
+
+    @app.template_filter()
     def publication_info(record):
         """Displays inline publication and conference information"""
         result = {}


### PR DESCRIPTION
* Removes leading internal number in plot captions. (closes #870)

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>