### PR TITLE
dojson: guarantee order when removing duplicates

### DIFF
--- a/inspirehep/dojson/hep/fields/bd01x09x.py
+++ b/inspirehep/dojson/hep/fields/bd01x09x.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # INSPIRE is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -23,6 +23,8 @@
 """MARC 21 model definition."""
 
 from dojson import utils
+
+from inspirehep.dojson import utils as inspire_dojson_utils
 
 from ..model import hep, hep2marc
 
@@ -82,7 +84,7 @@ def dois(self, key, value):
                             'value': val.get('a'),
                             'source': val.get('9')
                         })
-    return [dict(t) for t in set([tuple(d.items()) for d in out])]
+    return inspire_dojson_utils.remove_duplicates_from_list_of_dicts(out)
 
 
 @hep.over('persistent_identifiers', '^024[1032478_][10_]')
@@ -173,7 +175,7 @@ def report_numbers(self, key, value):
     for element in report_number:
         if isinstance(element['value'], list):
             return report_number
-    return [dict(t) for t in set([tuple(d.items()) for d in report_number])]
+    return inspire_dojson_utils.remove_duplicates_from_list_of_dicts(report_number)
 
 
 @hep2marc.over('037', 'report_numbers')

--- a/inspirehep/dojson/hep/fields/bd1xx.py
+++ b/inspirehep/dojson/hep/fields/bd1xx.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # INSPIRE is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -43,8 +43,8 @@ def authors(self, key, value):
                 recid = int(value.get('z'))
             except:
                 pass
-            affiliations = list(set(utils.force_list(
-                value.get('u'))))
+            affiliations = inspire_dojson_utils.remove_duplicates_from_list(
+                utils.force_list(value.get('u')))
             affiliations = [{'value': aff, 'recid': recid} for
                             aff in affiliations]
         if value.get('y'):

--- a/inspirehep/dojson/hep/fields/bd20x24x.py
+++ b/inspirehep/dojson/hep/fields/bd20x24x.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # INSPIRE is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -24,6 +24,8 @@
 
 from dojson import utils
 
+from inspirehep.dojson import utils as inspire_dojson_utils
+
 from ..model import hep, hep2marc
 
 
@@ -41,13 +43,7 @@ def title_variation(self, key, value):
     else:
         title_variation_list.append(get_value(value))
 
-    seen = set()
-    title_variation = []
-    for element in title_variation_list:
-        if element not in seen:
-            title_variation.append(element)
-            seen.add(element)
-    return title_variation
+    return inspire_dojson_utils.remove_duplicates_from_list(title_variation_list)
 
 
 @hep2marc.over('210', '^title_variation$')

--- a/inspirehep/dojson/hep/fields/bd6xx.py
+++ b/inspirehep/dojson/hep/fields/bd6xx.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # INSPIRE is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -23,6 +23,8 @@
 """MARC 21 model definition."""
 
 from dojson import utils
+
+from inspirehep.dojson import utils as inspire_dojson_utils
 
 from ..model import hep, hep2marc
 
@@ -129,7 +131,7 @@ def thesaurus_terms(self, key, value):
     for element in thesaurus_terms:
         if isinstance(element['keyword'], list):
             return thesaurus_terms
-    return [dict(t) for t in set([tuple(d.items()) for d in thesaurus_terms])]
+    return inspire_dojson_utils.remove_duplicates_from_list_of_dicts(thesaurus_terms)
 
 
 @hep2marc.over('695', 'thesaurus_terms')

--- a/inspirehep/dojson/hep/fields/bd70x75x.py
+++ b/inspirehep/dojson/hep/fields/bd70x75x.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # INSPIRE is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -23,6 +23,8 @@
 """MARC 21 model definition."""
 
 from dojson import utils
+
+from inspirehep.dojson import utils as inspire_dojson_utils
 
 from ..model import hep, hep2marc
 
@@ -69,8 +71,7 @@ def collaboration(self, key, value):
         }
     collaboration = self.get('collaboration', [])
     if isinstance(value, list):
-        filtered_value = [dict(t) for t in
-                          set([tuple(d.items()) for d in value])]
+        filtered_value = inspire_dojson_utils.remove_duplicates_from_list_of_dicts(value)
         for element in filtered_value:
             collaboration.append(get_value(element))
     else:

--- a/inspirehep/dojson/utils.py
+++ b/inspirehep/dojson/utils.py
@@ -104,3 +104,35 @@ def strip_empty_values(obj):
         return type(obj)(new_obj)
     else:
         return obj
+
+
+def remove_duplicates_from_list(l):
+    """Remove duplicates from a list preserving the order.
+
+    We might be tempted to use the list(set(l)) idiom,
+    but it doesn't preserve the order, which hinders
+    testability."""
+    result = []
+
+    for el in l:
+        if el not in result:
+            result.append(el)
+
+    return result
+
+
+def remove_duplicates_from_list_of_dicts(ld):
+    """Remove duplicates from a list of dictionaries preserving the order.
+
+    We can't use the generic list helper because a dictionary isn't
+    hashable. Taken from http://stackoverflow.com/a/9427216/374865."""
+    result = []
+    seen = set()
+
+    for d in ld:
+        t = tuple(d.items())
+        if t not in seen:
+            result.append(d)
+            seen.add(t)
+
+    return result

--- a/tests/dojson/test_utils.py
+++ b/tests/dojson/test_utils.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+from inspirehep.dojson.utils import (
+    remove_duplicates_from_list,
+    remove_duplicates_from_list_of_dicts
+)
+
+
+def test_remove_duplicates_from_list_preserving_order():
+    """Remove duplicates from a list preserving the order."""
+    list_with_duplicates = ['foo', 'bar', 'foo']
+
+    expected = ['foo', 'bar']
+    result = remove_duplicates_from_list(list_with_duplicates)
+
+    assert expected == result
+
+def test_remove_duplicates_from_list_of_dicts_preserving_order():
+    """Remove duplicates from a list of dictionaries preserving the order."""
+    list_of_dicts_with_duplicates = [
+        {'a': 123, 'b': 1234},
+        {'a': 3222, 'b': 1234},
+        {'a': 123, 'b': 1234}
+    ]
+
+    expected = [{'a': 123, 'b': 1234}, {'a': 3222, 'b': 1234}]
+    result = remove_duplicates_from_list_of_dicts(list_of_dicts_with_duplicates)
+
+    assert expected == result

--- a/tests/test_bibtex.py
+++ b/tests/test_bibtex.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # INSPIRE is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -53,7 +53,7 @@ class BibtexTests(InvenioTestCase):
             'year': 2015,
             'number': '7',
             'pages': '318',
-            'doi': '10.1140/epjc/s10052-015-3518-2, 10.1140/epjc/s10052-015-3661-9',
+            'doi': '10.1140/epjc/s10052-015-3661-9, 10.1140/epjc/s10052-015-3518-2',
             'note': '[Erratum: Eur. Phys. J.C75,no.10,463(2015)]',
             'eprint': '1503.03290',
             'archivePrefix': 'arXiv',

--- a/tests/test_cvlatex_html_text.py
+++ b/tests/test_cvlatex_html_text.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # INSPIRE is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -58,7 +58,7 @@ class CvLatexHtmlTextTests(InvenioTestCase):
             'title': '\nSearch for supersymmetry in events containing a same-flavour opposite-sign dilepton pair, jets, and large missing transverse momentum in $\sqrt{s}=8$ TeV $pp$ collisions with the ATLAS detector\n',
             'author': 'Georges Aad',
             'arxiv': 'arXiv:1503.03290 [hep-ex]',
-            'doi': '10.1140/epjc/s10052-015-3518-2, 10.1140/epjc/s10052-015-3661-9',
+            'doi': '10.1140/epjc/s10052-015-3661-9, 10.1140/epjc/s10052-015-3518-2',
             'publi_info': ['Eur.Phys.J. C75 (2015) 7, 318', 'Eur.Phys.J. C75 (2015) 10, 463']
 
         }
@@ -67,7 +67,7 @@ class CvLatexHtmlTextTests(InvenioTestCase):
             'title': '\nSearch for supersymmetry in events containing a same-flavour opposite-sign dilepton pair, jets, and large missing transverse momentum in $\sqrt{s}=8$ TeV $pp$ collisions with the ATLAS detector\n',
             'author': 'Georges Aad',
             'arxiv': 'arXiv:1503.03290 [hep-ex]',
-            'doi': '10.1140/epjc/s10052-015-3518-2, 10.1140/epjc/s10052-015-3661-9',
+            'doi': '10.1140/epjc/s10052-015-3661-9, 10.1140/epjc/s10052-015-3518-2',
             'publi_info': ['Eur.Phys.J. C75 (2015) 7, 318', 'Eur.Phys.J. C75 (2015) 10, 463']
 
         }

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # INSPIRE is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -56,7 +56,7 @@ class ExportTests(InvenioTestCase):
 
         self.sample_export_good = {
             'citation_key': 'Aad:2015wqa',
-            'doi': '10.1140/epjc/s10052-015-3518-2, 10.1140/epjc/s10052-015-3661-9',
+            'doi': '10.1140/epjc/s10052-015-3661-9, 10.1140/epjc/s10052-015-3518-2',
             'arxiv_field': {u'categories': [u'hep-ex'], u'value': u'arXiv:1503.03290'},
             'arxiv': 'arXiv:1503.03290 [hep-ex]',
             'reportNumber': 'CERN-PH-EP-2015-038',


### PR DESCRIPTION
Introduces two new utils, `remove_duplicates_from_list` and `remove_duplicates_from_list_of_dicts`. They do as it says on the tin, except they also preserve the original ordering, something which is useful to have during testing.

Not having that was causing failures such as https://travis-ci.org/inspirehep/inspire-next/jobs/108116178#L1952. Testing that this bug won't occur again is outside of the scope of this PR; maybe in a future PR?