### PR TITLE
utils: legacy date formatting port

### DIFF
--- a/base.requirements.txt
+++ b/base.requirements.txt
@@ -17,5 +17,5 @@ git+https://github.com/inspirehep/invenio-oaiharvester@master#egg=invenio-oaihar
 git+https://github.com/inspirehep/invenio-oauthclient@master#egg=invenio-oauthclient==0.1.1.dev20151215
 git+https://github.com/inspirehep/invenio-records@master#egg=invenio-records==0.3.5.dev20160122
 git+https://github.com/inspirehep/invenio-search@master#egg=invenio-search==0.1.6.dev20160205
-git+https://github.com/inspirehep/invenio-utils@master#egg=invenio-utils==0.2.1.dev20160116
+git+https://github.com/inspirehep/invenio-utils@master#egg=invenio-utils==0.2.1.dev20160210
 git+https://github.com/inspirehep/invenio-workflows@master#egg=invenio-workflows==0.1.3.dev20160210

--- a/inspirehep/base/templates/format/record/Inspire_Default_HTML_brief.tpl
+++ b/inspirehep/base/templates/format/record/Inspire_Default_HTML_brief.tpl
@@ -47,11 +47,9 @@
                 <div class="brief-record-details">
                 <div class="authors">
                   {{ render_record_authors(is_brief=true, show_affiliations=false) }}
-                  {% if record.get('earliest_date') %}
-                    <span id="record-date">
-                      - {{ record.get('earliest_date').split('-')[0] }}
-                    </span>
-                  {% endif %}
+                  <span id="record-date">
+                    - {{ record.get('earliest_date')|format_date }}
+                  </span>
                 </div>
                 <div class="row">
                   {% if pub_info['pub_info'] and record.get('dois') %}

--- a/inspirehep/base/templates/format/record/Inspire_Default_HTML_detailed.tpl
+++ b/inspirehep/base/templates/format/record/Inspire_Default_HTML_detailed.tpl
@@ -32,11 +32,9 @@
         </div>
         <div id="record-authors">
           {{ render_record_authors(is_brief=false, number_of_displayed_authors=25) }}
-          {% if record.get('earliest_date') %}
-            <span id="record-date">
-              - {{ record.get('earliest_date').split('-')[0] }}
-            </span>
-          {% endif %}
+          <span id="record-date">
+            - {{ record.get('earliest_date')|format_date }}
+          </span>
         </div>
         <div id="record-journal">
           {% if record|publication_info %}

--- a/inspirehep/dojson/hep/receivers.py
+++ b/inspirehep/dojson/hep/receivers.py
@@ -48,6 +48,16 @@ def earliest_date(sender, *args, **kwargs):
             if 'year' in publication_info_key:
                 dates.append(publication_info_key['year'])
 
+    if 'creation_modification_date' in sender:
+        for date in sender['creation_modification_date']:
+            if 'creation_date' in date:
+                dates.append(date['creation_date'])
+
+    if 'imprints' in sender:
+        for imprint in sender['imprints']:
+            if 'date' in imprint:
+                dates.append(imprint['date'])
+
     earliest_date = create_earliest_date(dates)
     if earliest_date:
         sender['earliest_date'] = earliest_date

--- a/inspirehep/ext/jinja_filters/record.py
+++ b/inspirehep/ext/jinja_filters/record.py
@@ -518,3 +518,28 @@ def setup_app(app):
                         template="format/record/Conference_info_macros.tpl",
                         ctx=ctx)
         return result
+
+    @app.template_filter()
+    def format_date(datetext):
+        """Display date in human readable form from available metadata."""
+        from inspirehep.utils.date import create_datestruct
+        from invenio_utils.date import convert_datestruct_to_dategui
+
+        datestruct = create_datestruct(datetext)
+
+        if datestruct:
+            dummy_time = (0, 0, 44, 2, 320, 0)
+            if len(datestruct) == 3:
+                datestruct = datestruct + dummy_time
+                date = convert_datestruct_to_dategui(
+                    datestruct, output_format="MMM d, Y"
+                )
+                return date
+            elif len(datestruct) == 2:
+                datestruct = datestruct + (1,) + dummy_time
+                date = convert_datestruct_to_dategui(
+                    datestruct, output_format="MMM Y"
+                )
+                return date
+            elif len(datestruct) == 1:
+                return datestruct[0]

--- a/inspirehep/utils/date.py
+++ b/inspirehep/utils/date.py
@@ -87,3 +87,19 @@ def create_valid_date(date, date_format_full="%Y-%m-%d",
                 except ValueError:
                     pass
     return valid_date
+
+
+def create_datestruct(datetext):
+    """
+    Create a datestruct out of a date text in format YYYY-MM-dd
+    :param datetext: date from record
+    :type datetext: str
+    :returns: tuple of 1 or more integers, up to max (year, month, day).
+        Otherwise None.
+    """
+    if isinstance(datetext, int):
+        datetext = unicode(datetext)
+    if not datetext or not isinstance(datetext, six.string_types):
+        return None
+    datetext = datetext.strip()
+    return tuple([int(component) for component in datetext.split('-')])

--- a/tests/test_date_utils.py
+++ b/tests/test_date_utils.py
@@ -19,7 +19,9 @@
 
 """Tests for DoJSON utilities."""
 
-from inspirehep.utils.date import create_valid_date, create_earliest_date
+from inspirehep.utils.date import (create_valid_date,
+                                   create_earliest_date,
+                                   create_datestruct)
 
 
 def test_create_valid_date():
@@ -39,3 +41,10 @@ def test_create_earliest_date():
     """Test the date validator that excepts list."""
     assert create_earliest_date([1877, '2002-01-05']) == '1877'
     assert create_earliest_date(['1877-02-03', '1877']) == '1877-02-03'
+
+
+def test_create_datestruct():
+    """Test the datestruct creation."""
+    assert create_datestruct('2002-01-05') == (2002, 1, 5)
+    assert create_datestruct('1877-02') == (1877, 2)
+    assert create_datestruct('1900') == (1900, )

--- a/tests/test_dojson_receivers.py
+++ b/tests/test_dojson_receivers.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Tests for HEP DoJSON receivers."""
+
+import pytest
+
+from inspirehep.dojson.hep.receivers import earliest_date
+
+
+@pytest.fixture
+def full_record():
+    """."""
+    return {
+        "preprint_date": "2014-05-29",
+        "arxiv_eprints": [
+            {
+                "categories": ["hep-ex"],
+                "value": "arXiv:1405.7570"
+            }
+        ],
+        "publication_info": [
+            {
+                "journal_issue": "9",
+                "journal_recid": 1212905,
+                "journal_title": "Eur.Phys.J.",
+                "journal_volume": "C74",
+                "page_artid": "3036",
+                "year": 2014
+            }
+        ],
+        "creation_modification_date": [
+            {
+                "creation_date": "2015-11-04",
+                "modification_date": "2014-05-30"
+            }
+        ],
+        "imprints": [{"date": "2014-09-26"}],
+        "thesis": [
+            {
+                "curated_relation": "false",
+                "date": "2008",
+                "degree_type":
+                "PhD"
+            }
+        ]
+
+    }
+
+
+@pytest.fixture
+def pub_info(full_record):
+    """."""
+    return {
+        "publication_info": full_record["publication_info"]
+    }
+
+
+@pytest.fixture
+def creation_modification_date(full_record):
+    """."""
+    return {
+        "creation_modification_date": full_record["creation_modification_date"]
+    }
+
+
+@pytest.fixture
+def imprints(full_record):
+    """."""
+    return {
+        "imprints": full_record["imprints"]
+    }
+
+
+@pytest.fixture
+def thesis(full_record):
+    """."""
+    return {
+        "thesis": full_record["thesis"]
+    }
+
+
+def test_earliest_date(full_record, pub_info, creation_modification_date,
+                       imprints, thesis):
+    """Test earliest_date record enhancer."""
+    earliest_date(full_record)
+    earliest_date(pub_info)
+    earliest_date(creation_modification_date)
+    earliest_date(imprints)
+    earliest_date(thesis)
+    assert full_record['earliest_date'] == '2008'
+    assert pub_info['earliest_date'] == '2014'
+    assert creation_modification_date['earliest_date'] == '2015-11-04'
+    assert imprints['earliest_date'] == '2014-09-26'
+    assert thesis['earliest_date'] == '2008'


### PR DESCRIPTION
* Displays dates in the same format as current production.

* Improves earliest_date recognition.

* Adds test for earliest_date and new utilities.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>