### PR TITLE
records: impact graph API addition

### DIFF
--- a/inspirehep/modules/records/views.py
+++ b/inspirehep/modules/records/views.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from flask import Blueprint, jsonify
+
+from invenio_base.decorators import wash_arguments
+from invenio_ext.es import es
+from invenio_search.api import Query
+
+from inspirehep.utils.record import get_title
+
+
+blueprint = Blueprint(
+    'inspire_records',
+    __name__,
+    url_prefix='/record',
+    template_folder='templates',
+    static_folder="static",
+)
+
+
+@blueprint.route('/api/impactgraph', methods=['GET'])
+@wash_arguments({'recid': (unicode, "")})
+def impactgraph(recid):
+    """Handler for impact graph information retrieval."""
+    record = es.get_source(index='hep', id=recid, doc_type='record')
+
+    out = {}
+
+    # Add information about current record
+    out['inspire_id'] = record['control_number']
+    out['title'] = get_title(record)
+    out['year'] = record['earliest_date'].split('-')[0]
+
+    # Get citations
+    citations = []
+
+    es_query = Query('refersto:' + recid).search()
+    es_query.body.update(
+        {
+            'size': 9999
+        }
+    )
+    record_citations = es_query.records()
+    for citation in record_citations:
+        citations.append({
+            "inspire_id": citation['control_number'],
+            "citation_count": citation['citation_count'],
+            "title": get_title(citation),
+            "year": citation['earliest_date'].split('-')[0]
+        })
+
+    out['citations'] = citations
+
+    # Get references
+    record_references = record.get('references')
+    references = []
+
+    reference_recids = [
+        ref['recid'] for ref in record_references if ref.get('recid')
+    ]
+
+    if reference_recids:
+        mget_body = {
+            "ids": reference_recids
+        }
+
+        record_references = es.mget(
+            index='hep',
+            doc_type='record',
+            body=mget_body
+        )
+
+        for reference in record_references["docs"]:
+            ref_info = reference["_source"]
+
+            references.append({
+                "inspire_id": ref_info['control_number'],
+                "citation_count": ref_info['citation_count'],
+                "title": get_title(ref_info),
+                "year": ref_info['earliest_date'].split('-')[0]
+            })
+
+    out['references'] = references
+
+    return jsonify(out)

--- a/inspirehep/utils/record.py
+++ b/inspirehep/utils/record.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Helpers for handling records."""
+
+
+def get_title(record):
+    """Get preferred title from record."""
+    title = ""
+    for title in record.get('titles', []):
+        if title.get('title'):
+            return title['title']
+
+    return title

--- a/tests/fixtures/test_impact_graph_output.json
+++ b/tests/fixtures/test_impact_graph_output.json
@@ -1,0 +1,165 @@
+{
+  "inspire_id": "613135",
+  "year": "2003",
+  "citations": [
+    {
+      "inspire_id": "1406546",
+      "year": "2015",
+      "citation_count": 0,
+      "title": "Dynamical Systems Analysis of Various Dark Energy Models"
+    },
+    {
+      "inspire_id": "710976",
+      "year": "2006",
+      "citation_count": 1,
+      "title": "Les Houches 'Physics at TeV colliders 2005' Beyond the standard model working group: Summary report."
+    },
+    {
+      "inspire_id": "1407029",
+      "year": "2015",
+      "citation_count": 0,
+      "title": "Generalized Ghost Pilgrim Scalar Field Models of Dark Energy"
+    },
+    {
+      "inspire_id": "1208271",
+      "year": "2012",
+      "citation_count": 6,
+      "title": "Nine-Year Wilkinson Microwave Anisotropy Probe (WMAP) Observations: Final Maps and Results"
+    },
+    {
+      "inspire_id": "1407939",
+      "year": "2015",
+      "citation_count": 0,
+      "title": "A search for neutrino signal from dark matter annihilation in the center of the Milky Way with Baikal NT200"
+    },
+    {
+      "inspire_id": "1404775",
+      "year": "2015",
+      "citation_count": 0,
+      "title": "Analysis of dark energy models in DGP braneworld"
+    },
+    {
+      "inspire_id": "1404052",
+      "year": "2007",
+      "citation_count": 0,
+      "title": "Baryon Asymmetry of the Universe and Neutrino Physics"
+    },
+    {
+      "inspire_id": "1286727",
+      "year": "2014",
+      "citation_count": 2,
+      "title": "Natural Inflation: Consistency with Cosmic Microwave Background Observations of Planck and BICEP2"
+    },
+    {
+      "inspire_id": "1343079",
+      "year": "2015",
+      "citation_count": 4,
+      "title": "Planck 2015 results. XIII. Cosmological parameters"
+    },
+    {
+      "inspire_id": "1407807",
+      "year": "2015",
+      "citation_count": 0,
+      "title": "Relativistic Stars in dRGT Massive Gravity"
+    },
+    {
+      "inspire_id": "1408252",
+      "year": "2016",
+      "citation_count": 0,
+      "title": "Beyond Standard Model Physics under the ground and in the sky"
+    },
+    {
+      "inspire_id": "1402716",
+      "year": "2007",
+      "citation_count": 0,
+      "title": "Signatures of new physics from the primordial universe"
+    },
+    {
+      "inspire_id": "1403701",
+      "year": "2015",
+      "citation_count": 0,
+      "title": "Holographic dark energy in a vector field cosmology"
+    },
+    {
+      "inspire_id": "1405627",
+      "year": "2014",
+      "citation_count": 0,
+      "title": "Anisotropic inflationary scenarios and observational signatures"
+    }
+  ],
+  "references": [
+    {
+      "inspire_id": "604625",
+      "year": "2002",
+      "citation_count": 2,
+      "title": "Does the sun shine by p p or CNO fusion reactions?"
+    },
+    {
+      "inspire_id": "482987",
+      "year": "1998",
+      "citation_count": 1,
+      "title": "The Age of the Universe"
+    },
+    {
+      "inspire_id": "611633",
+      "year": "2003",
+      "citation_count": 1,
+      "title": "Effects of the sound speed of quintessence on the microwave background and large scale structure."
+    },
+    {
+      "inspire_id": "556264",
+      "year": "2001",
+      "citation_count": 2,
+      "title": "Accelerated universe from gravity leaking to extra dimensions."
+    },
+    {
+      "inspire_id": "553744",
+      "year": "2001",
+      "citation_count": 2,
+      "title": "Constraints on inflation from CMB and Lyman-alpha forest."
+    },
+    {
+      "inspire_id": "524480",
+      "year": "2000",
+      "citation_count": 1,
+      "title": "CMB anisotropies: A Decadal survey"
+    },
+    {
+      "inspire_id": "452092",
+      "year": "1997",
+      "citation_count": 3,
+      "title": "Weighing neutrinos with galaxy surveys."
+    },
+    {
+      "inspire_id": "598954",
+      "year": "2002",
+      "citation_count": 1,
+      "title": "Atmospheric neutrinos in 2002."
+    },
+    {
+      "inspire_id": "484837",
+      "year": "1998",
+      "citation_count": 16,
+      "title": "Measurements of Omega and Lambda from 42 High-Redshift Supernovae"
+    },
+    {
+      "inspire_id": "470671",
+      "year": "1998",
+      "citation_count": 20,
+      "title": "Observational Evidence from Supernovae for an Accelerating Universe and a Cosmological Constant"
+    },
+    {
+      "inspire_id": "507635",
+      "year": "1999",
+      "citation_count": 3,
+      "title": "Observational evidence for self-interacting cold dark matter."
+    },
+    {
+      "inspire_id": "586817",
+      "year": "2002",
+      "citation_count": 2,
+      "title": "Inflation, CDM, and the central density problem."
+    }
+  ],
+  "title": "First Year Wilkinson Microwave Anisotropy Probe (WMAP) Observations: Determination of Cosmological Parameters"
+}

--- a/tests/test_impactgraph_api.py
+++ b/tests/test_impactgraph_api.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Tests for Impact Graph API."""
+
+import json
+import os
+import pkg_resources
+
+from invenio.testsuite import InvenioTestCase
+
+
+class ImpactGraphTests(InvenioTestCase):
+
+    """Tests Impact Graph views"""
+
+    impact_output = json.loads(pkg_resources.resource_string(
+        'tests',
+        os.path.join(
+            'fixtures',
+            'test_impact_graph_output.json')
+         )
+    )
+
+    def test_impact_graph_api(self):
+        """Test response of impact graph API."""
+        result = self.client.get("/record/api/impactgraph?recid=613135")
+        assert result.json == self.impact_output

--- a/tests/test_record_utils.py
+++ b/tests/test_record_utils.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Tests for record-related utilities."""
+
+from inspirehep.utils.record import get_title
+
+
+def test_get_title():
+    """Test get title utility."""
+    double_title = {
+        "titles": [
+            {
+                "source": "arXiv",
+                "title": "Parton distributions with LHC data"
+            },
+            {
+                "title": "Parton distributions with LHC data"
+            }
+        ]
+    }
+
+    assert get_title(double_title) == "Parton distributions with LHC data"
+
+    single_title = {
+        "titles": [
+            {
+                "subtitle": "Harvest of Run 1",
+                "title": "The Large Hadron Collider"
+            }
+        ]
+    }
+
+    assert get_title(single_title) == "The Large Hadron Collider"
+
+    empty_title = {
+        "titles": []
+    }
+
+    assert get_title(empty_title) == ""
+
+    no_title_key = {
+        "not_titles": []
+    }
+
+    assert get_title(no_title_key) == ""


### PR DESCRIPTION
* Adds API to retrieve information regarding references and citations
  for a given record. Needed by impact graph visualization.

* Adds new record utils for record-related utilities.

* Adds get_title util.

* Adds appropriate tests for the added functionality.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>