### PR TITLE
less: make modal headers consistent

### DIFF
--- a/inspirehep/base/static/less/base/modals.less
+++ b/inspirehep/base/static/less/base/modals.less
@@ -1,8 +1,6 @@
 /**
- * -*- mode: text; coding: utf-8; -*-
- *
  * This file is part of INSPIRE.
- * Copyright (C) 2014, 2016 CERN.
+ * Copyright (C) 2016 CERN.
 
  * INSPIRE is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -19,24 +17,25 @@
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
  */
 
-@charset "utf-8";
+//
+// Modals
+// --------------------------------------------------
 
-@import "../vendors/bootstrap/less/bootstrap.less";
-@import "../vendors/font-awesome/less/font-awesome.less";
-
-// Setting the path to fonts files.
-@icon-font-path: "/vendors/bootstrap/fonts/";
-@fa-font-path: "/vendors/font-awesome/fonts";
+@import (reference) "../inspire.less";
 
 
-// LESS files according to the templates
-@import "accounts/settings/account-settings.less";
-@import "base/variables.less";
-@import "base/core.less";
-@import "base/header.less";
-@import "base/footer.less";
-@import "base/helpers.less";
-@import "base/panels.less";
-@import "base/sticky-footer.less";
-@import "base/list-group.less";
-@import "base/modals.less";
+.modal-header {
+    background-color: @brand-primary;
+
+    .modal-title {
+        color: white;
+    }
+
+    .close {
+        color: whitesmoke;
+
+        &:hover {
+            color: white;
+        }
+    }
+}

--- a/inspirehep/base/static/less/format/detailed-record.less
+++ b/inspirehep/base/static/less/format/detailed-record.less
@@ -126,10 +126,6 @@
     font-weight: normal;
     text-align: left;
 
-    #citeModalLabel {
-        margin-bottom: 10px;
-    }
-
     .pointer {
         cursor:pointer;
     }


### PR DESCRIPTION
As mentioned in https://github.com/inspirehep/inspire-next/pull/599#issuecomment-183371344, here's a PR to make all modal headers consistently blue.

BTW, @nikpap, can I remove this `10px` margin? https://github.com/inspirehep/inspire-next/blob/287381506bdd46bc0809c701b2a194be1ccff697/inspirehep/base/static/less/format/detailed-record.less#L129-L131 It's the only inconsistency I found in the headers I checked.