### PR TITLE
theme: add postfeedback handler

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -139,6 +139,10 @@ OAUTHCLIENT_ORCID_CREDENTIALS = dict(
     consumer_secret="CHANGE_ME",
 )
 
+# Feedback
+CFG_SITE_SUPPORT_EMAIL = "admin@inspirehep.net"
+INSPIRELABS_FEEDBACK_EMAIL = "labsfeedback@inspirehep.net"
+
 
 # from invenio_records_rest.facets import terms_filter
 # SEARCH_UI_SEARCH_API='/api/records/'

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 -e git+https://github.com/inveniosoftware/invenio-formatter.git#egg=invenio-formatter
+-e git+https://github.com/inveniosoftware/invenio-mail.git#egg=invenio-mail
 -e git+https://github.com/inspirehep/invenio-query-parser.git@invenio3#egg=invenio-query-parser==0.4.2.dev20160221
 -e git+https://github.com/inspirehep/invenio-records.git@invenio3#egg=invenio-records
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+import pytest
+import six
+
+from flask_celeryext import FlaskCeleryExt
+from invenio_mail import InvenioMail
+from inspirehep.factory import create_app
+
+
+if six.PY2:
+    from StringIO import StringIO
+else:
+    from io import StringIO
+
+
+@pytest.yield_fixture(scope='session', autouse=True)
+def email_app(request):
+    """Email-aware Flask application fixture."""
+    app = create_app(
+        CFG_SITE_SUPPORT_EMAIL='admin@inspirehep.net',
+        INSPIRELABS_FEEDBACK_EMAIL='labsfeedback@inspirehep.net',
+        CELERY_ALWAYS_EAGER=True,
+        CELERY_RESULT_BACKEND='cache',
+        CELERY_CACHE_BACKEND='memory',
+        CELERY_EAGER_PROPAGATES_EXCEPTIONS=True,
+        MAIL_SUPPRESS_SEND=True,
+    )
+    FlaskCeleryExt(app)
+
+    InvenioMail(app, StringIO())
+
+    with app.app_context():
+        yield app

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+import mock
+import pytest
+
+
+def test_postfeedback_provided_email(email_app):
+    """Accepts feedback when providing en email."""
+    with email_app.test_client() as client:
+        response = client.post('/postfeedback', data=dict(
+            feedback='foo bar', replytoaddr='foo@bar.com'))
+
+        assert response.status_code == 200
+
+
+@mock.patch('inspirehep.modules.theme.views.current_user')
+def test_postfeedback_logged_in_user(current_user, email_app):
+    """Falls back to the email of the logged in user."""
+    current_user.is_anonymous = False
+    current_user.get.return_value = 'foo@bar.com'
+
+    with email_app.test_client() as client:
+        response = client.post('/postfeedback', data=dict(feedback='foo bar'))
+
+        assert response.status_code == 200
+
+
+def test_postfeedback_anonymous_user(email_app):
+    """Rejects feedback without an email."""
+    with email_app.test_client() as client:
+        response = client.post('/postfeedback', data=dict(feedback='foo bar'))
+
+        assert response.status_code == 403
+
+
+def test_postfeedback_empty_feedback(email_app):
+    """Rejects empty feedback."""
+    with email_app.test_client() as client:
+        response = client.post('/postfeedback', data=dict(feedback=''))
+
+        assert response.status_code == 400
+
+@mock.patch('inspirehep.modules.theme.views.send_email.delay')
+def test_postfeedback_send_email_failure(delay, email_app):
+    """Informs the user when a server error occurred."""
+    class FalseResult():
+        def result(self):
+            return False
+
+    delay.return_value = FalseResult()
+
+    with email_app.test_client() as client:
+        response = client.post('/postfeedback', data=dict(
+            feedback='foo bar', replytoaddr='foo@bar.com'))
+
+        assert response.status_code == 500


### PR DESCRIPTION
Also adds the `app` fixture, which can be injected in the tests that need access to the application context.

Similar fixtures for DB, ES... will be ported from Zenodo (https://github.com/zenodo/zenodo/blob/ca7f630c45ff01ccf0cb84587407e23a060a7879/tests/unit/conftest.py) as soon as they are needed.