### PR TITLE
theme: hogan dependency fix

### DIFF
--- a/inspirehep/modules/theme/bundles.py
+++ b/inspirehep/modules/theme/bundles.py
@@ -31,12 +31,12 @@ js = Bundle(
         filters='uglifyjs',
         npm={
             "almond": "~0.3.1",
-            "hogan": "latest",
-            "requirejs-hogan-plugin": "latest",
+            "hogan.js": "~3.0.2",
+            "requirejs-hogan-plugin": "~0.3.1",
             "jquery": "~1.9.1",
-            "toastr": "latest",
+            "toastr": "~2.1.2",
             # "jQuery-menu-aim": "latest", # Not on npm :(
-            "clipboard": "latest",
+            "clipboard": "~1.5.8",
             "flightjs": "~1.5.0"
         }
     ),

--- a/inspirehep/modules/theme/ext.py
+++ b/inspirehep/modules/theme/ext.py
@@ -67,4 +67,7 @@ class INSPIRETheme(object):
 
     def init_config(self, config):
         """Initialize configuration."""
-        pass
+        from .bundles import js
+        # Set JS bundles to exclude for purpose of avoiding double jQuery etc.
+        # when other modules are building their JS bundles.
+        config.setdefault("THEME_BASE_BUNDLES_EXCLUDE_JS", js.contents)


### PR DESCRIPTION
* Fixes hogan npm dependency to `hogan.js` instead of `hogan`.

* Adds JS bundles to be excluded from other bundles to config
  variable `THEME_BASE_BUNDLES_EXCLUDE_JS`.

Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>