### PR TITLE
search: enables wildcards

### DIFF
--- a/inspirehep/modules/search/walkers/elasticsearch_no_keywords.py
+++ b/inspirehep/modules/search/walkers/elasticsearch_no_keywords.py
@@ -24,7 +24,7 @@ from invenio_query_parser.ast import (
     GreaterEqualOp, GreaterOp, Keyword,
     KeywordOp, LowerEqualOp, LowerOp,
     MalformedQuery, NotOp, OrOp, RangeOp, RegexValue,
-    SingleQuotedValue, Value, ValueQuery
+    SingleQuotedValue, Value, ValueQuery, WildcardQuery
 
 )
 from invenio_query_parser.visitor import make_visitor
@@ -95,6 +95,10 @@ class ElasticSearchNoKeywordsDSL(object):
 
     @visitor(GreaterOp)
     def visit(self, node, value_fn):
+        pass
+
+    @visitor(WildcardQuery)
+    def visit(self, node):
         pass
 
     @visitor(LowerOp)

--- a/tests/unit/search/test_search_query.py
+++ b/tests/unit/search/test_search_query.py
@@ -171,6 +171,23 @@ def test_exactauthor():
     assert expected == result
 
 
+def test_abstract_colon_with_star_wildcard():
+    query = InspireQuery('abstract: part*')
+
+    expected = {
+        'query': {
+            'query_string': {
+                'analyze_wildcard': 'true',
+                'default_field': 'abstracts.value',
+                'query': 'part*'
+            }
+        }
+    }
+    result = query.body
+
+    assert expected == result
+
+
 def test_author_colon():
     query = InspireQuery('author: vagenas')
 
@@ -511,6 +528,29 @@ def test_type_code_colon():
     assert expected == result
 
 
+def test_find_author_with_hash_wildcard():
+    query = InspireQuery('find a chkv#')
+
+    expected = {
+        'query': {
+            'bool': {
+                'should': [{
+                    'query_string': {
+                        'analyze_wildcard': 'true',
+                        'default_field': 'authors.full_name',
+                        'query': 'chkv*'}}, {
+                    'query_string': {
+                        'analyze_wildcard': 'true',
+                        'default_field': 'authors.alternative_name',
+                        'query': 'chkv*'}}
+                ]}
+            }
+        }
+    result = query.body
+
+    assert expected == result
+
+    
 def test_find_journal():
     query = InspireQuery('find j "Phys.Rev.Lett.,105*"')
 


### PR DESCRIPTION
* Enables searching with wildcards (only used in the end of a word).

* Should be merged with inspirehep/invenio-query-parser#14.

* Should be merged with  inspirehep/invenio-query-parser#18.

* Closes box no.10 of #817.

* Closes #831.

Signed-off-by: Panos Paparrigopoulos <panos.paparrigopoulos@cern.ch>