### PR TITLE
theme: inspire AngularJS module and filters

### DIFF
--- a/inspirehep/modules/search/static/js/search/app.js
+++ b/inspirehep/modules/search/static/js/search/app.js
@@ -24,11 +24,14 @@
 require([
     'node_modules/invenio-search-js/dist/invenio-search-js',
     'js/search/inspire-search',
+    'js/inspire/module'
   ], function(search) {
     // When the DOM is ready bootstrap the `invenio-serach-js`
     angular.element(document).ready(function() {
       angular.bootstrap(
-        document.getElementById("invenio-search"), ['invenioSearch', 'inspireSearch']
+        document.getElementById("invenio-search"), ['invenioSearch',
+                                                    'inspireSearch',
+                                                    'inspire']
       );
     });
 });

--- a/inspirehep/modules/search/static/templates/search/literature/briefresults.html
+++ b/inspirehep/modules/search/static/templates/search/literature/briefresults.html
@@ -27,6 +27,8 @@
                     <div class="col-md-12 ">
                       Journal info goes here
                     </div>
+                    <div ng-bind-html='record.metadata.dois | doi' class="col-md-12 ">
+                    </div>
                     <div>
                       Arxiv info
                     </div>

--- a/inspirehep/modules/theme/bundles.py
+++ b/inspirehep/modules/theme/bundles.py
@@ -38,12 +38,20 @@ almondjs = NpmBundle(
 js = NpmBundle(
     'js/inspire_base_init.js',
     filters='requirejs',
+    depends=(
+        'js/*.js',
+        'js/inspire/*.js',
+        'js/inspire/filters/*.js',
+        'node_modules/invenio-search-js/dist/*.js',
+    ),
     output="gen/inspirehep.%(version)s.js",
     npm={
         "jquery": "~1.9.1",
         "toastr": "~2.1.2",
         "clipboard": "~1.5.8",
-        "flightjs": "~1.5.0"
+        "flightjs": "~1.5.0",
+        "angular": "~1.4.9",
+        "angular-sanitize": "~1.4.9"
     }
 )
 

--- a/inspirehep/modules/theme/static/js/inspire/filters/doi.js
+++ b/inspirehep/modules/theme/static/js/inspire/filters/doi.js
@@ -1,0 +1,45 @@
+/*
+ * This file is part of INSPIRE.
+ * Copyright (C) 2016 CERN.
+ *
+ * INSPIRE is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * INSPIRE is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+* In applying this license, CERN does not
+* waive the privileges and immunities granted to it by virtue of its status
+* as an Intergovernmental Organization or submit itself to any jurisdiction.
+*/
+
+define([], function() {
+  /**
+  * AngularJS filter to display DOI information
+  *
+  * FIXME: missing proper logic to remove duplicates, trim DOI and so on
+  */
+  function doiFilter() {
+    return function(input) {
+      if (!input) {
+        return '';
+      }
+
+      for (var i=0; i < input.length; i++) {
+        if (input[i].value) {
+          return '<a href="http://dx.doi.org/' + input[i].value + '" title="DOI" >' + input[i].value + '</a>'
+        }
+      }
+
+      return input;
+    }
+  }
+  return doiFilter;
+});

--- a/inspirehep/modules/theme/static/js/inspire/filters/module.js
+++ b/inspirehep/modules/theme/static/js/inspire/filters/module.js
@@ -1,0 +1,28 @@
+/*
+ * This file is part of INSPIRE.
+ * Copyright (C) 2016 CERN.
+ *
+ * INSPIRE is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * INSPIRE is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+* In applying this license, CERN does not
+* waive the privileges and immunities granted to it by virtue of its status
+* as an Intergovernmental Organization or submit itself to any jurisdiction.
+*/
+
+define(['js/inspire/filters/doi', 'angular-sanitize'], function(doiFilter){
+  var app = angular.module('inspire.filters', ['ngSanitize'])
+    .filter('doi', doiFilter);
+  // return the module
+  return app;
+});

--- a/inspirehep/modules/theme/static/js/inspire/module.js
+++ b/inspirehep/modules/theme/static/js/inspire/module.js
@@ -1,0 +1,28 @@
+
+/*
+ * This file is part of INSPIRE.
+ * Copyright (C) 2016 CERN.
+ *
+ * INSPIRE is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * INSPIRE is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+* In applying this license, CERN does not
+* waive the privileges and immunities granted to it by virtue of its status
+* as an Intergovernmental Organization or submit itself to any jurisdiction.
+*/
+
+define(['js/inspire/filters/module'], function(filters){
+  var app = angular.module('inspire', ['inspire.filters']);
+  // return the app
+  return app;
+});

--- a/inspirehep/modules/theme/static/js/settings.js
+++ b/inspirehep/modules/theme/static/js/settings.js
@@ -26,6 +26,8 @@ require.config({
   paths: {
     jquery: "node_modules/jquery/jquery",
     bootstrap: "node_modules/bootstrap-sass/assets/javascripts/bootstrap",
+    angular: "node_modules/angular/angular",
+    "angular-sanitize": "node_modules/angular-sanitize/angular-sanitize",
     // "datatables.net": "vendors/datatables/media/js/jquery.dataTables",
     // "datatables": "vendors/datatables/media/js/dataTables.bootstrap",
     // jquery: "vendors/jquery/dist/jquery",
@@ -73,6 +75,9 @@ require.config({
     "clipboard": "node_modules/clipboard/dist/clipboard"
   },
   shim: {
+    angular: {
+      exports: 'angular'
+    },
     jquery: {
       exports: "$"
     },


### PR DESCRIPTION
* Creates inspire AngularJS module that can be reused across the site.

* Includes inspire AngularJS filters in search results page.

* Adds angular and angular-sanitize as dependencies.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>