### PR TITLE
Porting schemas to use JSONref

### DIFF
--- a/inspirehep/dojson/bibfield/fields/bibfield.py
+++ b/inspirehep/dojson/bibfield/fields/bibfield.py
@@ -29,6 +29,8 @@ import six
 
 from dojson import utils
 
+from inspirehep.dojson import utils as inspire_dojson_utils
+
 from ..model import bibfield
 
 
@@ -285,7 +287,8 @@ def thesis_supervisor(self, key, value):
     for val in value:
         out.append({
             "full_name": val.get('full_name'),
-            "recid": val.get('external_id'),
+            "record": inspire_dojson_utils.get_record_ref(
+                val.get('external_id'), 'literature'),
             "affiliation": {
                 "value": val.get('affiliation')
             },

--- a/inspirehep/dojson/common/base.py
+++ b/inspirehep/dojson/common/base.py
@@ -173,12 +173,14 @@ def spires_sysnos(self, key, value):
         elif 'd' in val:
             new_recid = val.get('d')
     if new_recid is not None:
-        self['new_recid'] = new_recid
+        # FIXME we are currently using the default /record API. Which might
+        # resolve to a 404 response.
+        self['new_record'] = inspire_dojson_utils.get_record_ref(new_recid)
     return sysnos or None
 
 
-@hep2marc.over('970', '(spires_sysnos|new_recid)')
-@hepnames2marc.over('970', '(spires_sysnos|new_recid)')
+@hep2marc.over('970', '(spires_sysnos|new_record)')
+@hepnames2marc.over('970', '(spires_sysnos|new_record)')
 def spires_sysnos2marc(self, key, value):
     """970 SPIRES number and new recid."""
     value = utils.force_list(value)
@@ -188,9 +190,11 @@ def spires_sysnos2marc(self, key, value):
         existing_values.extend(
             [{'a': val} for val in value if val]
         )
-    elif key == 'new_recid':
+    elif key == 'new_record':
+        val_recids = [inspire_dojson_utils.get_recid_from_ref(val)
+                      for val in value]
         existing_values.extend(
-            [{'d': val} for val in value if val]
+            [{'d': val} for val in val_recids if val]
         )
     return existing_values
 
@@ -249,18 +253,20 @@ def collections2marc(self, key, value):
     }
 
 
-@hep.over('deleted_recids', '^981..')
-@conferences.over('deleted_recids', '^981..')
-@institutions.over('deleted_recids', '^981..')
-@experiments.over('deleted_recids', '^981..')
-@journals.over('deleted_recids', '^981..')
-@hepnames.over('deleted_recids', '^981..')
-@jobs.over('deleted_recids', '^981..')
+@hep.over('deleted_records', '^981..')
+@conferences.over('deleted_records', '^981..')
+@institutions.over('deleted_records', '^981..')
+@experiments.over('deleted_records', '^981..')
+@journals.over('deleted_records', '^981..')
+@hepnames.over('deleted_records', '^981..')
+@jobs.over('deleted_records', '^981..')
 @utils.for_each_value
 @utils.ignore_value
-def deleted_recids(self, key, value):
+def deleted_records(self, key, value):
     """Recid of deleted record this record is master for."""
-    return value.get('a')
+    # FIXME we are currently using the default /record API. Which might
+    # resolve to a 404 response.
+    return inspire_dojson_utils.get_record_ref(value.get('a'))
 
 
 @hep.over('fft', '^FFT..')
@@ -299,12 +305,12 @@ def fft2marc(self, key, value):
     }
 
 
-@hep2marc.over('981', 'deleted_recids')
-@hepnames2marc.over('981', 'deleted_recids')
+@hep2marc.over('981', 'deleted_records')
+@hepnames2marc.over('981', 'deleted_records')
 @utils.for_each_value
 @utils.filter_values
-def deleted_recids2marc(self, key, value):
+def deleted_records2marc(self, key, value):
     """Deleted recids."""
     return {
-        'a': value
+        'a': inspire_dojson_utils.get_recid_from_ref(value)
     }

--- a/inspirehep/dojson/experiments/fields/bd1xx.py
+++ b/inspirehep/dojson/experiments/fields/bd1xx.py
@@ -24,6 +24,8 @@
 
 from dojson import utils
 
+from inspirehep.dojson import utils as inspire_dojson_utils
+
 from ..model import experiments
 
 
@@ -107,7 +109,7 @@ def related_experiments(self, key, value):
         recid = None
     return {
         'name': value.get('a'),
-        'recid': recid
+        'record': inspire_dojson_utils.get_record_ref(recid, 'experiments')
     }
 
 

--- a/inspirehep/dojson/hep/fields/bd1xx.py
+++ b/inspirehep/dojson/hep/fields/bd1xx.py
@@ -37,16 +37,17 @@ def authors(self, key, value):
     def get_value(value):
         affiliations = []
         if value.get('u'):
-            recid = ''
+            recid = None
             try:
                 recid = int(value.get('z'))
             except:
                 pass
             affiliations = inspire_dojson_utils.remove_duplicates_from_list(
                 utils.force_list(value.get('u')))
-            affiliations = [{'value': aff, 'recid': recid} for
+            record = inspire_dojson_utils.get_record_ref(recid, 'institutions')
+            affiliations = [{'value': aff, 'record': record} for
                             aff in affiliations]
-        person_recid = ''
+        person_recid = None
         if value.get('x'):
             try:
                 person_recid = int(value.get('x'))
@@ -55,13 +56,15 @@ def authors(self, key, value):
         inspire_id = ''
         if value.get('i'):
             inspire_id = utils.force_list(value.get('i'))[0]
+        person_record = inspire_dojson_utils.get_record_ref(person_recid,
+                                                            'authors')
         ret = {
             'full_name': value.get('a'),
             'role': value.get('e'),
             'alternative_name': value.get('q'),
             'inspire_id': inspire_id,
             'orcid': value.get('j'),
-            'recid': person_recid,
+            'record': person_record,
             'email': value.get('m'),
             'affiliations': affiliations,
             'profile': {"__url__": inspire_dojson_utils.create_profile_url(
@@ -108,7 +111,7 @@ def authors2marc(self, key, value):
             'j': value.get('orcid'),
             'm': value.get('email'),
             'u': affiliations,
-            'x': value.get('recid'),
+            'x': inspire_dojson_utils.get_recid_from_ref(value.get('record')),
             'y': value.get('curated_relation')
         }
 

--- a/inspirehep/dojson/hep/fields/bd5xx.py
+++ b/inspirehep/dojson/hep/fields/bd5xx.py
@@ -24,6 +24,8 @@
 
 from dojson import utils
 
+from inspirehep.dojson import utils as inspire_dojson_utils
+
 from ..model import hep, hep2marc
 
 
@@ -99,7 +101,8 @@ def thesis(self, key, value):
         'degree_type': value.get('b'),
         'university': value.get('c'),
         'date': value.get('d'),
-        'recid': value.get('z'),
+        'record': inspire_dojson_utils.get_record_ref(value.get('z'),
+                                                      'institutions'),
         'curated_relation': curated_relation,
     }
 

--- a/inspirehep/dojson/hep/fields/bd6xx.py
+++ b/inspirehep/dojson/hep/fields/bd6xx.py
@@ -96,7 +96,7 @@ def free_keywords2marc(self, key, value):
 @utils.filter_values
 def accelerator_experiments(self, key, value):
     """The accelerator/experiment related to this record."""
-    recid = ''
+    recid = None
     curated_relation = False
     if '0' in value:
         try:
@@ -106,7 +106,7 @@ def accelerator_experiments(self, key, value):
     if recid:
         curated_relation = True
     return {
-        'recid': recid,
+        'record': inspire_dojson_utils.get_record_ref(recid, 'experiments'),
         'accelerator': value.get('a'),
         'experiment': value.get('e'),
         'curated_relation': curated_relation

--- a/inspirehep/dojson/hep/fields/bd70x75x.py
+++ b/inspirehep/dojson/hep/fields/bd70x75x.py
@@ -61,7 +61,7 @@ def collaboration(self, key, value):
     value = utils.force_list(value)
 
     def get_value(value):
-        recid = ''
+        recid = None
         if '0' in value:
             try:
                 recid = int(value.get('0'))
@@ -69,7 +69,7 @@ def collaboration(self, key, value):
                 pass
         return {
             'value': value.get('g'),
-            'recid': recid
+            'record': inspire_dojson_utils.get_record_ref(recid, 'experiments')
         }
     collaboration = self.get('collaboration', [])
 

--- a/inspirehep/dojson/hep/fields/bd76x78x.py
+++ b/inspirehep/dojson/hep/fields/bd76x78x.py
@@ -24,6 +24,8 @@
 
 from dojson import utils
 
+from inspirehep.dojson import utils as inspire_dojson_utils
+
 from ..model import hep, hep2marc
 
 
@@ -44,11 +46,16 @@ def publication_info(self, key, value):
     parent_recid = get_int_value(value.get('0'))
     journal_recid = get_int_value(value.get('1'))
     conference_recid = get_int_value(value.get('2'))
-
-    return {
-        'parent_recid': parent_recid,
-        'journal_recid': journal_recid,
-        'conference_recid': conference_recid,
+    parent_record = inspire_dojson_utils.get_record_ref(parent_recid,
+                                                        'literature')
+    conference_record = inspire_dojson_utils.get_record_ref(conference_recid,
+                                                            'conferences')
+    journal_record = inspire_dojson_utils.get_record_ref(journal_recid,
+                                                         'journals')
+    res = {
+        'parent_record': parent_record,
+        'conference_record': conference_record,
+        'journal_record': journal_record,
         'page_artid': value.get('c'),
         'journal_issue': value.get('n'),
         'conf_acronym': value.get('o'),
@@ -63,6 +70,8 @@ def publication_info(self, key, value):
         'note': value.get('m'),
     }
 
+    return res
+
 
 @hep2marc.over('773', 'publication_info')
 @utils.for_each_value
@@ -70,7 +79,8 @@ def publication_info(self, key, value):
 def publication_info2marc(self, key, value):
     """Publication info about record."""
     return {
-        '0': value.get('parent_recid'),
+        '0': inspire_dojson_utils.get_recid_from_ref(
+            value.get('parent_record')),
         'c': value.get('page_artid'),
         'n': value.get('journal_issue'),
         'o': value.get('conf_acronym'),
@@ -95,7 +105,8 @@ def succeeding_entry(self, key, value):
 
     return {
         'relationship_code': value.get('r'),
-        'recid': value.get('w'),
+        'record': inspire_dojson_utils.get_record_ref(
+            value.get('w'), 'literature'),
         'isbn': value.get('z'),
     }
 
@@ -105,6 +116,6 @@ def succeeding_entry2marc(self, key, value):
     """Succeeding Entry."""
     return {
         'r': value.get('relationship_code'),
-        'w': value.get('recid'),
+        'w': inspire_dojson_utils.get_recid_from_ref(value.get('record')),
         'z': value.get('isbn'),
     }

--- a/inspirehep/dojson/hep/fields/bd90x99x.py
+++ b/inspirehep/dojson/hep/fields/bd90x99x.py
@@ -36,7 +36,7 @@ def references(self, key, value):
     value = utils.force_list(value)
 
     def get_value(value):
-        recid = ''
+        recid = None
         number = ''
         year = ''
         if '0' in value:
@@ -55,7 +55,7 @@ def references(self, key, value):
             except:
                 pass
         return {
-            'recid': recid,
+            'record': inspire_dojson_utils.get_record_ref(recid, 'literature'),
             'texkey': value.get('1'),
             'doi': value.get('a'),
             'collaboration': utils.force_list(value.get('c')),
@@ -88,7 +88,7 @@ def references(self, key, value):
 def references2marc(self, key, value):
     """Produce list of references."""
     return {
-        '0': value.get('recid'),
+        '0': inspire_dojson_utils.get_recid_from_ref(value.get('record')),
         '1': value.get('texkey'),
         'a': value.get('doi'),
         'c': value.get('collaboration'),

--- a/inspirehep/dojson/hep/model.py
+++ b/inspirehep/dojson/hep/model.py
@@ -25,6 +25,8 @@
 from dojson import Overdo
 from dojson.utils import force_list
 
+from inspirehep.dojson import utils as inspire_dojson_utils
+
 from ..schema import SchemaOverdo
 
 
@@ -40,7 +42,8 @@ def add_book_info(record, blob):
             for pubinfo in pubinfos:
                 if pubinfo.get('0'):
                     record['book'] = {
-                        'recid': int(force_list(pubinfo.get('0'))[0])
+                        'record': inspire_dojson_utils.get_record_ref(
+                            int(force_list(pubinfo.get('0'))[0]), 'literature')
                     }
 
 

--- a/inspirehep/dojson/hepnames/fields/bd1xx.py
+++ b/inspirehep/dojson/hepnames/fields/bd1xx.py
@@ -235,7 +235,7 @@ def positions(self, key, value):
     have to follow the convention `mth-year`. For example: `10-2012`.
     """
     curated_relation = False
-    recid = ''
+    recid = None
     status = ''
     recid_status = utils.force_list(value.get('z'))
     if recid_status:
@@ -246,9 +246,11 @@ def positions(self, key, value):
                 recid = val
                 curated_relation = True
 
+    inst = {'name': value.get('a'),
+            'record': inspire_dojson_utils.get_record_ref(recid,
+                                                          'institutions')}
     return {
-        'institution': {'name': value.get('a'), 'recid': recid} if
-        value.get('a') else None,
+        'institution': inst if inst['name'] else None,
         'rank': value.get('r'),
         'start_date': value.get('s'),
         'end_date': value.get('t'),

--- a/inspirehep/dojson/jobs/fields/bd1xx.py
+++ b/inspirehep/dojson/jobs/fields/bd1xx.py
@@ -24,6 +24,8 @@
 
 from dojson import utils
 
+from inspirehep.dojson import utils as inspire_dojson_utils
+
 from ..model import jobs
 
 
@@ -107,7 +109,7 @@ def institution(self, key, value):
         recid = int(value.get('z'))
     return {
         'curated_relation': curated_relation,
-        'recid': recid,
+        'record': inspire_dojson_utils.get_record_ref(recid, 'isntitutions'),
         'name': value.get('a'),
     }
 

--- a/inspirehep/dojson/utils.py
+++ b/inspirehep/dojson/utils.py
@@ -19,7 +19,13 @@
 
 """DoJSON related utilities."""
 
+import pkg_resources
 import six
+
+try:
+    from flask import current_app
+except ImportError:
+    current_app = None
 
 
 def legacy_export_as_marc(json, tabsize=4):
@@ -136,3 +142,33 @@ def remove_duplicates_from_list_of_dicts(ld):
             seen.add(t)
 
     return result
+
+
+def get_record_ref(recid, record_type='record'):
+    """Create record jsonref reference object from recid.
+
+    None recids will return a None object.
+    Valid recids will return an object in the form of:
+        {'$ref': url_for_record}
+    """
+    if recid is None:
+        return None
+    default_server = 'inspirehep.net'
+    if current_app:
+        server = current_app.config.get('SERVER_NAME', default_server)
+    else:
+        server = default_server
+    return {'$ref': 'http://{}/api/{}/{}'.format(server, record_type, recid)}
+
+
+def get_recid_from_ref(ref_obj):
+    """Retrieve recid from jsonref reference object.
+
+    If no recid can be parsed, return None.
+    """
+    url = ref_obj.get('$ref', '')
+    try:
+        res = int(url.split('/')[-1])
+    except ValueError:
+        res = None
+    return res

--- a/inspirehep/dojson/utils.py
+++ b/inspirehep/dojson/utils.py
@@ -166,6 +166,8 @@ def get_recid_from_ref(ref_obj):
 
     If no recid can be parsed, return None.
     """
+    if not isinstance(ref_obj, dict):
+        return None
     url = ref_obj.get('$ref', '')
     try:
         res = int(url.split('/')[-1])

--- a/inspirehep/modules/records/jsonschemas/records/acquisition_source.json
+++ b/inspirehep/modules/records/jsonschemas/records/acquisition_source.json
@@ -1,6 +1,5 @@
 {
     "$schema": "http://json-schema.org/schema#",
-    "id": "http://labs.inspirehep.net/schemas/acquisition_source-0.0.1.json",
     "properties": {
         "acquisition_source": {
             "id": "#acquisition_source",

--- a/inspirehep/modules/records/jsonschemas/records/authors.json
+++ b/inspirehep/modules/records/jsonschemas/records/authors.json
@@ -10,9 +10,6 @@
             "items": {
                 "type": "object",
                 "properties": {
-                    "recid": {
-                        "type": "integer"
-                    },
                     "degree_type": {
                         "enum": [
                             "PhD",
@@ -26,6 +23,9 @@
                     },
                     "curated_relation": {
                         "type": "boolean"
+                    },
+                    "record": {
+                        "$ref": "json_reference.json"
                     }
                 }
             },
@@ -62,10 +62,10 @@
         "conferences": {
             "uniqueItems": true,
             "items": {
-                "type": "integer"
+                "$ref": "json_reference.json"
             },
             "type": "array",
-            "description": "Contains information about attended conferences. (their recids)"
+            "description": "Contains information about attended conferences. (their record URIs)"
         },
         "positions": {
             "uniqueItems": true,
@@ -95,7 +95,6 @@
                             "Diploma",
                             "Bachelor",
                             "smirnov@ictp.it"
-
                         ],
                         "type": "string"
                     },
@@ -105,13 +104,13 @@
                             "curated_relation": {
                                 "type": "boolean"
                             },
-                            "recid": {
-                                "type": "integer",
-                                "description": "Corresponding record ID in the institution database"
-                            },
                             "name": {
                                 "type": "string",
                                 "description": "The raw institution name"
+                            },
+                            "record": {
+                                "description": "Corresponding URI for the institution record",
+                                "$ref": "json_reference.json"
                             }
                         }
                     },
@@ -299,9 +298,9 @@
                     "curated_relation": {
                         "type": "boolean"
                     },
-                    "recid": {
-                        "type": "integer",
-                        "description": "Record ID of the experiment record"
+                    "record": {
+                        "description": "URI for the experiment record",
+                        "$ref": "json_reference.json"
                     }
                 }
             },

--- a/inspirehep/modules/records/jsonschemas/records/conferences.json
+++ b/inspirehep/modules/records/jsonschemas/records/conferences.json
@@ -1,6 +1,5 @@
 {
     "$schema": "http://json-schema.org/schema#",
-    "id": "http://labs.inspirehep.net/schemas/conferences-0.0.1.json",
     "properties": {
         "acronym": {
             "title": "Conference acronym",

--- a/inspirehep/modules/records/jsonschemas/records/experiments.json
+++ b/inspirehep/modules/records/jsonschemas/records/experiments.json
@@ -1,6 +1,5 @@
 {
     "$schema": "http://json-schema.org/schema#",
-    "id": "http://labs.inspirehep.net/schemas/experiments-0.0.1.json",
     "properties": {
         "accelerator": {
             "enum": [
@@ -14,9 +13,9 @@
             "title": "Affiliation",
             "type": "array"
         },
-        "affiliation_recid": {
-            "title": "Record ID of institution",
-            "type": "integer"
+        "affiliation_record": {
+            "title": "Institution record URI",
+            "$ref": "json_reference.json"
         },
         "collaboration": {
             "title": "Collaboration",
@@ -130,10 +129,6 @@
                         "title": "Name of related experiment",
                         "type": "string"
                     },
-                    "recid": {
-                        "title": "Record ID of related experiment",
-                        "type": "integer"
-                    },
                     "relation": {
                         "description": "FIXME: shall we simply store preceeding experiment and generate the symmetric relation automatically?",
                         "enum": [
@@ -142,6 +137,10 @@
                         ],
                         "title": "Type of relation",
                         "type": "string"
+                    },
+                    "record": {
+                        "title": "URI for the related experiment record",
+                        "$ref": "json_reference.json"
                     }
                 },
                 "type": "object"
@@ -170,14 +169,14 @@
                         "title": "Name",
                         "type": "string"
                     },
-                    "recid": {
-                        "title": "Record ID of the person",
-                        "type": "integer"
-                    },
                     "start_date": {
                         "format": "date",
                         "title": "Start date",
                         "type": "string"
+                    },
+                    "record": {
+                        "title": "URI for the person record",
+                        "$ref": "json_reference.json"
                     }
                 },
                 "required": [

--- a/inspirehep/modules/records/jsonschemas/records/hep.json
+++ b/inspirehep/modules/records/jsonschemas/records/hep.json
@@ -1,7 +1,6 @@
 {
     "description": "An article or thesis or book or...",
     "title": "Publication",
-    "id": "http://labs.inspirehep.net/schemas/hep-0.0.1.json",
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
@@ -267,14 +266,14 @@
                     "affiliation": {
                         "type": "string"
                     },
-                    "recid": {
-                        "type": "integer"
-                    },
                     "full_name": {
                         "type": "string"
                     },
                     "curated_relation": {
                         "type": "boolean"
+                    },
+                    "record": {
+                        "$ref": "json_reference.json"
                     }
                 }
             },
@@ -300,10 +299,6 @@
                         "type": "string",
                         "description": "FIXME: shall we match these with the insitution database? I guess so."
                     },
-                    "recid": {
-                        "type": "integer",
-                        "description": "Record ID of the matched insitution."
-                    },
                     "degree_type": {
                         "enum": [
                             "PhD",
@@ -316,6 +311,10 @@
                         ],
                         "type": "string",
                         "description": "FIXME: this enum must be reviewed"
+                    },
+                    "record": {
+                        "description": "URI of the matched insitution record.",
+                        "$ref": "json_reference.json"
                     }
                 }
             },
@@ -370,17 +369,17 @@
                     "note": {
                         "type": "string"
                     },
-                    "parent_recid": {
-                        "type": "integer",
-                        "description": "Record ID of the parent this record is part of"
+                    "parent_record": {
+                        "$ref": "json_reference.json",
+                        "description": "URI for the parent this record is part of"
                     },
-                    "journal_recid": {
-                        "type": "integer",
-                        "description": "Record ID of corresponding Journal"
+                    "journal_record": {
+                        "$ref": "json_reference.json",
+                        "description": "URI for corresponding Journal"
                     },
-                    "conference_recid": {
-                        "type": "integer",
-                        "description": "Record ID of corresponding Conference"
+                    "conference_record": {
+                        "$ref": "json_reference.json",
+                        "description": "URI for corresponding Conference"
                     },
                     "reportnumber": {
                         "type": "string"
@@ -461,9 +460,6 @@
                     "maintitle": {
                         "type": "string"
                     },
-                    "recid": {
-                        "type": "integer"
-                    },
                     "raw_reference": {
                         "type": "array"
                     },
@@ -476,6 +472,9 @@
                     "journal_pubnote": {
                         "pattern": ".*,.*,.*",
                         "type": "array"
+                    },
+                    "record": {
+                        "$ref": "json_reference.json"
                     }
                 }
             },
@@ -576,10 +575,6 @@
                         "type": "boolean",
                         "description": "Was the experiment actually proofchecked by a cataloguer?"
                     },
-                    "recid": {
-                        "type": "integer",
-                        "description": "Record ID of the corresponding experiment."
-                    },
                     "experiment": {
                         "type": "string"
                     },
@@ -592,6 +587,10 @@
                     },
                     "institution": {
                         "type": "string"
+                    },
+                    "record": {
+                        "description": "URI for the corresponding experiment record.",
+                        "$ref": "json_reference.json"
                     }
                 }
             },
@@ -698,11 +697,11 @@
                     "relationship_code": {
                         "type": "string"
                     },
-                    "recid": {
-                        "type": "string"
-                    },
                     "isbn": {
                         "type": "string"
+                    },
+                    "record": {
+                        "$ref": "json_reference.json"
                     }
                 },
                 "description": "Reference to previously merged records."
@@ -742,8 +741,8 @@
                     "value": {
                         "type": "string"
                     },
-                    "recid": {
-                        "type": "integer"
+                    "record": {
+                        "$ref": "json_reference.json"
                     }
                 }
             },
@@ -806,15 +805,15 @@
                                     "description": "Did a cataloguer proof-checked the recid?",
                                     "title": "The affiliation is curated?"
                                 },
-                                "recid": {
-                                    "type": "integer",
-                                    "description": "Record ID in the Institution collection",
-                                    "title": "Record ID of institution"
-                                },
                                 "value": {
                                     "type": "string",
                                     "description": "The affiliation as it appears on the paper",
                                     "title": "Name of institution"
+                                },
+                                "record": {
+                                    "description": "URI for the Institution collection record",
+                                    "title": "URI for the Institution collection record",
+                                    "$ref": "json_reference.json"
                                 }
                             },
                             "title": "Affiliation"
@@ -839,11 +838,6 @@
                         "type": "boolean",
                         "description": "Was this signature actually claimed or proof-checked by cataloguer?",
                         "title": "The relation is curated?"
-                    },
-                    "recid": {
-                        "type": "integer",
-                        "description": "Record ID of the person in HepNames",
-                        "title": "Record ID of the person"
                     },
                     "orcid": {
                         "pattern": "\\d{4}-\\d{4}-\\d{4}-\\d{4}",
@@ -882,6 +876,11 @@
                         "title": "Phonetic name",
                         "description": "Phonetic notation of the author's name.",
                         "type": "string"
+                    },
+                    "record": {
+                        "description": "URI for the person record",
+                        "title": "URI for the person record",
+                        "$ref": "json_reference.json"
                     }
                 },
                 "title": "Author"
@@ -982,18 +981,18 @@
             "description": "Whether this document can be cited. FIXME: can this be derived from other properties?",
             "title": "Citeable?"
         },
-        "deleted_recids": {
+        "deleted_records": {
             "type": "array",
             "items": {
-                "type": "string"
+                "$ref": "json_reference.json"
             },
-            "description": "List of deleted recids referring to this record",
+            "description": "List of deleted records referring to this record",
             "title": "Deleted Records"
         },
-        "new_recid": {
-            "type": "string",
+        "new_record": {
+            "$ref": "json_reference.json",
             "description": "Master record that replaces this record",
-            "title": "New recid"
+            "title": "New record"
         },
         "license": {
             "uniqueItems": true,

--- a/inspirehep/modules/records/jsonschemas/records/institutions.json
+++ b/inspirehep/modules/records/jsonschemas/records/institutions.json
@@ -1,6 +1,5 @@
 {
     "$schema": "http://json-schema.org/schema#",
-    "id": "http://labs.inspirehep.net/schemas/institutions-0.0.1.json",
     "properties": {
         "ICN": {
             "description": "HEP affiliation following new standards",
@@ -159,10 +158,10 @@
             "title": "Obsolete ICN",
             "type": "string"
         },
-        "obsolete_recid": {
-            "description": "record ID of obsolete inst for which this inst should be used instead",
-            "title": "Obsolete record ID",
-            "type": "integer"
+        "obsolete_record": {
+            "description": "record URI of obsolete inst for which this inst should be used instead",
+            "title": "Obsolete record URI",
+            "$ref": "json_reference.json"
         },
         "old_ICN": {
             "description": "HEP affiliation (spires name)",
@@ -199,10 +198,6 @@
                         "title": "Name of related institute",
                         "type": "string"
                     },
-                    "recid": {
-                        "title": "Record ID of related institute",
-                        "type": "integer"
-                    },
                     "relation_type": {
                         "description": "FIXME: do we actually need 'successor' at all? Can't we derive it from predecessor?",
                         "enum": [
@@ -212,6 +207,10 @@
                         ],
                         "title": "Relation type",
                         "type": "string"
+                    },
+                    "record": {
+                        "title": "URI for the related institute record",
+                        "$ref": "json_reference.json"
                     }
                 },
                 "title": "Related institute",

--- a/inspirehep/modules/records/jsonschemas/records/jobs.json
+++ b/inspirehep/modules/records/jsonschemas/records/jobs.json
@@ -1,6 +1,5 @@
 {
     "$schema": "http://json-schema.org/schema#",
-    "id": "http://labs.inspirehep.net/schemas/jobs-0.0.1.json",
     "properties": {
         "closed_date": {
             "format": "date",
@@ -65,9 +64,9 @@
                         "title": "Institution name",
                         "type": "string"
                     },
-                    "recid": {
-                        "title": "Institution Record ID",
-                        "type": "integer"
+                    "record": {
+                        "title": "Institution Record URI",
+                        "$ref": "json_reference.json"
                     }
                 },
                 "title": "Institution",

--- a/inspirehep/modules/records/jsonschemas/records/journals.json
+++ b/inspirehep/modules/records/jsonschemas/records/journals.json
@@ -1,6 +1,5 @@
 {
     "$schema": "http://json-schema.org/schema#",
-    "id": "http://labs.inspirehep.net/schemas/journals-0.0.1.json",
     "properties": {
         "coden": {
             "items": {
@@ -111,10 +110,6 @@
                     "title": "ISSN of the related record",
                     "type": "string"
                 },
-                "recid": {
-                    "title": "Record ID of the related record",
-                    "type": "integer"
-                },
                 "relation": {
                     "description": "FIXME: as usual, shall we capture only superseeded records and derive the symmetric relation automatically?",
                     "enum": [
@@ -123,6 +118,10 @@
                     ],
                     "title": "Type of relation",
                     "type": "string"
+                },
+                "record": {
+                    "title": "URI for the related record",
+                    "$ref": "json_reference.json"
                 }
             },
             "required": [

--- a/inspirehep/modules/records/jsonschemas/records/json_reference.json
+++ b/inspirehep/modules/records/jsonschemas/records/json_reference.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "$ref": {
+            "description": "URL to the referenced resource",
+            "type": "string",
+            "format": "url"
+        }
+    },
+    "required": ["$ref"],
+    "type": "object"
+}

--- a/inspirehep/modules/theme/jinja2filters.py
+++ b/inspirehep/modules/theme/jinja2filters.py
@@ -33,6 +33,11 @@ import time
 from flask import session, current_app
 from jinja2.filters import evalcontextfilter
 
+from inspirehep.utils.date import (
+    create_datestruct,
+    convert_datestruct_to_dategui,
+)
+
 from invenio_search.api import Query
 
 from .views import blueprint
@@ -318,7 +323,8 @@ def format_cnum_with_slash(value):
     cnum = value[:3] + '/' + value[3:5] + '/'
     if "-" in value:
         return value.replace("-", "/")
-    else:
+    else:  # pragma: nocover
+        # XXX(jacquerie): never happens.
         if len(value) == 8:
             day = value[5:7]
             nr = value[7]
@@ -328,13 +334,15 @@ def format_cnum_with_slash(value):
             return cnum + day
 
 
+# XXX(jacquerie): hyphEns.
 @blueprint.app_template_filter()
 def format_cnum_with_hyphons(value):
     value = str(value)
     cnum = value[:3] + '-' + value[3:5] + '-'
     if "-" in value:
         return value
-    else:
+    else:  # pragma: nocover
+        # XXX(jacquerie): never happens.
         if len(value) == 8:
             day = value[5:7]
             nr = value[7]
@@ -471,6 +479,7 @@ def ads_links(record):
             (ADSURL, lastname, initial, lastname, firstnames)
     else:
         if 'name' in record:
+            # XXX(jacquerie): should escape whitespace?
             link = "%sauthor=%s" % (ADSURL, record['name']['preferred_name'])
     return link
 
@@ -561,6 +570,7 @@ def publication_info(record):
         for pub_info in record['publication_info']:
             if 'conference_recid' in pub_info \
                     and 'parent_recid' in pub_info:
+                # XXX(jacquerie): should be abstracted in a method.
                 pid = PersistentIdentifier.get(
                     'conferences', str(pub_info['conference_recid']))
                 conference_rec = es.get_source(
@@ -595,6 +605,7 @@ def publication_info(record):
                     pass
             elif 'conference_recid' in pub_info \
                     and 'parent_recid' not in pub_info:
+                # XXX(jacquerie): should be abstracted in a method.
                 pid = PersistentIdentifier.get(
                     'conferences', str(pub_info['conference_recid']))
                 conference_rec = es.get_source(
@@ -617,6 +628,7 @@ def publication_info(record):
                     pass
             elif 'parent_recid' in pub_info and \
                     'conference_recid' not in pub_info:
+                # XXX(jacquerie): should be abstracted in a method.
                 pid = PersistentIdentifier.get(
                     'conferences', str(pub_info['parent_recid']))
                 parent_rec = es.get_source(
@@ -645,11 +657,6 @@ def publication_info(record):
 @blueprint.app_template_filter()
 def format_date(datetext):
     """Display date in human readable form from available metadata."""
-    from inspirehep.utils.date import (
-        create_datestruct,
-        convert_datestruct_to_dategui,
-    )
-
     datestruct = create_datestruct(datetext)
 
     if datestruct:

--- a/tests/test_hep.py
+++ b/tests/test_hep.py
@@ -26,6 +26,7 @@ import pytest
 from dojson.contrib.marc21.utils import create_record
 
 from inspirehep.dojson.hep import hep, hep2marc
+from inspirehep.dojson.utils import get_recid_from_ref
 
 
 @pytest.fixture
@@ -155,7 +156,7 @@ def test_authors(marcxml_to_json, json_to_marc):
             json_to_marc['100']['m'])
     assert (marcxml_to_json['authors'][0]['affiliations'][0]['value'] ==
             json_to_marc['100']['u'][0])
-    assert (marcxml_to_json['authors'][0]['recid'] ==
+    assert (get_recid_from_ref(marcxml_to_json['authors'][0]['record']) ==
             json_to_marc['100']['x'])
     assert (marcxml_to_json['authors'][0]['curated_relation'] ==
             json_to_marc['100']['y'])
@@ -393,7 +394,8 @@ def test_publication_info(marcxml_to_json, json_to_marc):
             json_to_marc['773'][0]['p'])
     assert (marcxml_to_json['publication_info'][0]['journal_volume'] ==
             json_to_marc['773'][0]['v'])
-    assert (marcxml_to_json['publication_info'][0]['parent_recid'] ==
+    assert (get_recid_from_ref(marcxml_to_json['publication_info']
+            [0]['parent_record']) ==
             json_to_marc['773'][0]['0'])
     assert (marcxml_to_json['publication_info'][0]['year'] ==
             json_to_marc['773'][0]['y'])
@@ -418,7 +420,8 @@ def test_succeeding_entry(marcxml_to_json, json_to_marc):
     assert (marcxml_to_json['succeeding_entry']
             ['relationship_code'] ==
             json_to_marc['785']['r'])
-    assert (marcxml_to_json['succeeding_entry']['recid'] ==
+    assert (get_recid_from_ref(
+                marcxml_to_json['succeeding_entry']['record']) ==
             json_to_marc['785']['w'])
     assert (marcxml_to_json['succeeding_entry']['isbn'] ==
             json_to_marc['785']['z'])
@@ -461,8 +464,8 @@ def test_collections(marcxml_to_json, json_to_marc):
 def test_references(marcxml_to_json, json_to_marc):
     """Test if references are created correctly."""
     for index, val in enumerate(marcxml_to_json['references']):
-        if 'recid' in val:
-            assert (val['recid'] ==
+        if 'record' in val:
+            assert (get_recid_from_ref(val['record']) ==
                     json_to_marc['999C5'][index]['0'])
         if 'texkey' in val:
             assert (val['texkey'] ==

--- a/tests/test_hep.py
+++ b/tests/test_hep.py
@@ -531,5 +531,5 @@ def test_refextract(marcxml_to_json, json_to_marc):
 
 def test_book_link(marcxml_to_json_book):
     """Test if the link to the book recid is generated correctly."""
-    assert (marcxml_to_json_book['book']['recid'] ==
+    assert (get_recid_from_ref(marcxml_to_json_book['book']['record']) ==
             1409249)

--- a/tests/test_hep.py
+++ b/tests/test_hep.py
@@ -79,15 +79,15 @@ def test_spires_sysnos(marcxml_to_json, json_to_marc):
             [p.get('a') for p in json_to_marc['970'] if 'a' in p])
 
 
-def test_deleted_recids(marcxml_to_json, json_to_marc):
+def test_deleted_records(marcxml_to_json, json_to_marc):
     """Test if deleted_recids is created correctly."""
-    assert (marcxml_to_json['deleted_recids'][0] in
+    assert (get_recid_from_ref(marcxml_to_json['deleted_records'][0]) in
             [p.get('a') for p in json_to_marc['981'] if 'a' in p])
 
 
-def test_new_recid(marcxml_to_json, json_to_marc):
-    """Test if deleted_recids is created correctly."""
-    assert (marcxml_to_json['new_recid'] in
+def test_new_record(marcxml_to_json, json_to_marc):
+    """Test if new_record is created correctly."""
+    assert (get_recid_from_ref(marcxml_to_json['new_record']) in
             [p.get('d') for p in json_to_marc['970'] if 'd' in p])
 
 

--- a/tests/unit/dojson/test_dojson_utils.py
+++ b/tests/unit/dojson/test_dojson_utils.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+from inspirehep.dojson import utils
+
+
+def test_get_record_ref_with_record_type():
+    ref = utils.get_record_ref(123, 'record_type')
+
+    assert ref['$ref'].endswith('/api/record_type/123')
+    assert ref['$ref'].startswith('http://')
+    assert utils.get_record_ref(None, 'record_type') == None
+
+
+
+def test_get_record_ref_default():
+    ref = utils.get_record_ref(123)
+
+    assert ref['$ref'].endswith('/api/record/123')
+
+
+def test_get_recid_from_ref():
+    assert utils.get_recid_from_ref(None) == None
+    assert utils.get_recid_from_ref('a_string') == None
+    assert utils.get_recid_from_ref({}) == None
+    assert utils.get_recid_from_ref({'bad_key': 'some_val'}) == None
+    assert utils.get_recid_from_ref({'$ref': 'a_string'}) == None
+    assert utils.get_recid_from_ref({'$ref': 'http://bad_url'}) == None
+    assert utils.get_recid_from_ref({'$ref': 'http://good_url/123'}) == 123

--- a/tests/unit/records/test_records_receivers.py
+++ b/tests/unit/records/test_records_receivers.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+from inspirehep.modules.records import receivers
+
+
+def test_populate_recid_from_ref_naming():
+    json_dict = {
+        'simple_key': {'$ref': 'http://x/y/1'},
+        'key_with_record': {'$ref': 'http://x/y/2'},
+        'record': {'$ref': 'http://x/y/3'},
+        'embedded_list': [{'record': {'$ref': 'http://x/y/4'}}],
+        'embedded_record': {'record': {'$ref': 'http://x/y/5'}}
+    }
+
+    receivers.populate_recid_from_ref(None, json_dict)
+
+    assert json_dict['simple_key_recid'] == 1
+    assert json_dict['key_with_recid'] == 2
+    assert json_dict['recid'] == 3
+    assert json_dict['embedded_list'][0]['recid'] == 4
+    assert json_dict['embedded_record']['recid'] == 5
+
+
+def test_populate_recid_from_ref_deleted_records():
+    json_dict = {
+        'deleted_records': [{'$ref': 'http://x/y/1'},
+                            {'$ref': 'http://x/y/2'}]
+    }
+
+    receivers.populate_recid_from_ref(None, json_dict)
+
+    assert json_dict['deleted_recids'] == [1, 2]
+

--- a/tests/unit/theme/test_theme_jinja2filters.py
+++ b/tests/unit/theme/test_theme_jinja2filters.py
@@ -1,0 +1,994 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+import datetime
+
+import jinja2
+import mock
+import pytest
+
+from inspirehep.modules.theme.jinja2filters import *
+
+from invenio_records.api import Record
+
+
+@pytest.fixture
+def jinja_env():
+    return jinja2.Environment()
+
+
+@pytest.fixture
+def jinja_mock_env():
+    class JinjaMockEnv(object):
+        @property
+        def autoescape(self):
+            return True
+
+    return JinjaMockEnv()
+
+
+@mock.patch('inspirehep.modules.theme.jinja2filters.current_app.jinja_env.get_template')
+def test_apply_template_on_array_returns_empty_list_on_empty_list(g_t, jinja_env):
+    g_t.return_value = jinja_env.from_string('{{ content }}')
+
+    expected = []
+    result = apply_template_on_array([], 'banana')
+
+    assert expected == result
+
+
+@mock.patch('inspirehep.modules.theme.jinja2filters.current_app.jinja_env.get_template')
+def test_apply_template_on_array_applies_template(g_t, jinja_env):
+    g_t.return_value = jinja_env.from_string('{{ content }}')
+
+    expected = ['foo']
+    result = apply_template_on_array(['foo'], 'banana')
+
+    assert expected == result
+
+
+@mock.patch('inspirehep.modules.theme.jinja2filters.current_app.jinja_env.get_template')
+def test_apply_template_on_array_accepts_strings_as_a_list_of_one_element(g_t, jinja_env):
+    g_t.return_value = jinja_env.from_string('{{ content }}')
+
+    expected = ['foo']
+    result = apply_template_on_array('foo', 'banana')
+
+    assert expected == result
+
+
+def test_apply_template_on_array_returns_empty_list_on_non_iterable():
+    expected = []
+    result = apply_template_on_array(0, 'banana')
+
+    assert expected == result
+
+
+def test_join_array_returns_empty_string_on_empty_list(jinja_mock_env):
+    expected = ''
+    result = join_array(jinja_mock_env, [], ':')
+
+    assert expected == result
+
+
+def test_join_array_adds_no_separator_on_a_list_of_one_element(jinja_mock_env):
+    expected = 'foo'
+    result = join_array(jinja_mock_env, ['foo'], '|')
+
+    assert expected == result
+
+
+def test_join_array_accepts_strings_as_a_list_of_one_element(jinja_mock_env):
+    expected = 'foo'
+    result = join_array(jinja_mock_env, 'foo', ' ')
+
+    assert expected == result
+
+
+def test_join_array_joins_with_a_separator(jinja_mock_env):
+    expected = 'foo,bar'
+    result = join_array(jinja_mock_env, ['foo', 'bar'], ',')
+
+    assert expected == result
+
+
+def test_new_line_after_adds_a_break():
+    expected = 'foo<br>'
+    result = new_line_after('foo')
+
+    assert expected == result
+
+
+def test_new_line_after_adds_no_break_after_empty_string():
+    expected = ''
+    result = new_line_after('')
+
+    assert expected == result
+
+
+def test_email_links_returns_email_link_on_list_of_one_element():
+    expected = ['\n\n<a href="mailto:foo@example.com">foo@example.com</a>']
+    result = email_links(['foo@example.com'])
+
+    assert expected == result
+
+
+def test_url_links_returns_url_link_on_list_of_one_element():
+    record_with_urls = Record({'urls': [{'value': 'http://www.example.com'}]})
+
+    expected = ['\n\n<a href="http://www.example.com">http://www.example.com</a>']
+    result = url_links(record_with_urls)
+
+    assert expected == result
+
+
+def test_institutes_links():
+    record_with_institute = Record({'institute': ['foo']})
+
+    expected = ['\n\n<a href="search/?cc=Institutions&p=110_u%3Afoo&of=hd">foo</a>']
+    result = institutes_links(record_with_institute)
+
+    assert expected == result
+
+
+def test_author_profile():
+    record_with_profile = Record({'profile': ['foo']})
+
+    expected = ['\n\n<a href="/author/search?q=foo">foo</a>']
+    result = author_profile(record_with_profile)
+
+    assert expected == result
+
+
+def test_words():
+    expected = 'foo bar'
+    result = words('foo bar baz', 2)
+
+    assert expected == result
+
+
+def test_end_words():
+    expected = 'bar baz'
+    result = words_to_end('foo bar baz', 1)
+
+    assert expected == result
+
+
+def test_is_list_returns_true_for_a_list():
+    assert is_list([])
+
+
+def test_is_list_returns_none_for_something_not_a_list():
+    assert is_list('foo') is None
+
+
+def test_remove_duplicates_returns_empty_list_on_empty_list():
+    expected = []
+    result = remove_duplicates([])
+
+    assert expected == result
+
+
+def test_remove_duplicates_removes_duplicates_from_list_with_elements():
+    expected = ['foo', 'bar']
+    result = remove_duplicates(['foo', 'bar', 'foo', 'foo', 'bar'])
+
+    assert expected == result
+
+
+def test_has_space_returns_true_if_space():
+    assert has_space('foo bar')
+
+
+def test_has_space_returns_none_if_no_space():
+    assert has_space('foo') is None
+
+
+def test_count_words():
+    expected = 3
+    result = count_words('foo, bar baz')
+
+    assert expected == result
+
+
+@pytest.mark.xfail(reason='intbitset not installed')
+def test_is_intbit_set_converts_to_list_if_true():
+    an_intbit_set = intbitset([1, 2, 3])
+
+    expected = [1, 2, 3]
+    result = is_intbit_set(an_intbit_set)
+
+    assert expected == result
+
+
+@pytest.mark.xfail(reason='intbitset not installed')
+def test_is_intbit_set_leaves_untouched_if_false():
+    not_an_intbit_set = intbitset([1, 2, 3])
+
+    expected = [1, 2, 3]
+    result = is_intbit_set(not_an_intbit_set)
+
+    assert expected == result
+
+
+@pytest.mark.xfail(reason='does not preserve order')
+def test_remove_duplicates_from_dict_removes_duplicates():
+    list_of_dicts_with_duplicates = [
+        {'a': 123, 'b': 1234},
+        {'a': 3222, 'b': 1234},
+        {'a': 123, 'b': 1234}
+    ]
+
+    expected = [{'a': 123, 'b': 1234}, {'a': 3222, 'b': 1234}]
+    result = remove_duplicates_from_dict(list_of_dicts_with_duplicates)
+
+    assert expected == result
+
+
+def test_conference_date_returns_date_when_record_has_a_date():
+    with_a_date = Record({'date': '26-30 Mar 2012'})
+
+    expected = '26-30 Mar 2012'
+    result = conference_date(with_a_date)
+
+    assert expected == result
+
+
+def test_conference_date_returns_empty_string_when_no_opening_date():
+    no_opening_date = Record({'closing_date': '2015-03-21'})
+
+    expected = ''
+    result = conference_date(no_opening_date)
+
+    assert expected == result
+
+
+def test_conference_date_returns_empty_string_when_no_closing_date():
+    no_closing_date = Record({'opening_date': '2015-03-14'})
+
+    expected = ''
+    result = conference_date(no_closing_date)
+
+    assert expected == result
+
+
+def test_conference_date_formats_date_when_same_year_same_month():
+    same_year_same_month = Record({
+        'opening_date': '2015-03-14',
+        'closing_date': '2015-03-21'
+    })
+
+    expected = '14-21 Mar 2015'
+    result = conference_date(same_year_same_month)
+
+    assert expected == result
+
+
+def test_conference_date_formats_date_when_same_year_different_month():
+    same_year_different_month = Record({
+        'opening_date': '2012-05-28',
+        'closing_date': '2012-06-01'
+    })
+
+    expected = '28 May - 01 Jun 2012'
+    result = conference_date(same_year_different_month)
+
+    assert expected == result
+
+
+def test_conference_date_formats_date_when_different_year():
+    different_year = Record({
+        'opening_date': '2012-12-31',
+        'closing_date': '2013-01-01'
+    })
+
+    expected = '31 Dec 2012 - 01 Jan 2013'
+    result = conference_date(different_year)
+
+    assert expected == result
+
+
+def test_search_for_experiments_returns_empty_string_on_empty_list():
+    expected = ''
+    result = search_for_experiments([])
+
+    assert expected == result
+
+
+def test_search_for_experiments_returns_a_link_on_a_list_of_one_element():
+    expected = '<a href="/search?p=experiment_name:foo&cc=Experiments">foo</a>'
+    result = search_for_experiments(['foo'])
+
+    assert expected == result
+
+
+def test_search_for_experiments_joins_with_a_comma_and_a_space():
+    expected = (
+        '<a href="/search?p=experiment_name:foo&cc=Experiments">foo</a>, '
+        '<a href="/search?p=experiment_name:bar&cc=Experiments">bar</a>'
+    )
+    result = search_for_experiments(['foo', 'bar'])
+
+    assert expected == result
+
+
+def test_experiment_date_returns_none_with_no_dates():
+    with_no_dates = Record({})
+
+    assert experiment_date(with_no_dates) is None
+
+
+def test_experiment_date_returns_started_with_date_started():
+    with_date_started = Record({'date_started': '1993'})
+
+    expected = 'Started: 1993'
+    result = experiment_date(with_date_started)
+
+    assert expected == result
+
+
+def test_experiment_date_returns_still_running_with_date_completed_9999():
+    with_date_completed_9999 = Record({'date_completed': '9999'})
+
+    expected = 'Still Running'
+    result = experiment_date(with_date_completed_9999)
+
+    assert expected == result
+
+
+def test_experiment_date_returns_completed_with_date_completed():
+    with_date_completed = Record({'date_completed': '1993'})
+
+    expected = 'Completed: 1993'
+    result = experiment_date(with_date_completed)
+
+    assert expected == result
+
+
+def test_proceedings_link_returns_empty_string_without_cnum():
+    without_cnum = Record({})
+
+    expected = ''
+    result = proceedings_link(without_cnum)
+
+    assert expected == result
+
+
+@pytest.mark.xfail(reason='invenio_search.api.Query has no search method')
+def test_proceedings_link_returns_empty_string_with_zero_search_results():
+    with_cnum = Record({'cnum': 'banana'})
+
+    expected = ''
+    result = proceedings_link(with_cnum)
+
+    assert expected == result
+
+
+@pytest.mark.xfail(reason='invenio_search.api.Query has no search method')
+def test_proceedings_link_returns_a_link_with_one_search_result():
+    with_cnum = Record({'cnum': 'banana'})
+
+    expected = '<a href="/record/foo">Proceedings</a>'
+    result = proceedings_link(with_cnum)
+
+    assert expected == result
+
+
+@pytest.mark.xfail(reason='invenio_search.api.Query has no search method')
+def test_proceedings_link_joins_with_a_comma_and_a_space():
+    """Also depends on removed invenio.legacy.bibrecord."""
+    with_cnum = Record({'cnum': 'banana'})
+
+    expected = 'TODO'
+    result = proceedings_link(with_cnum)
+
+    assert expected == result
+
+
+@pytest.mark.xfail(reason='KeyError accessing related_experiments')
+def test_experiment_link_returns_empty_list_without_related_experiments():
+    without_related_experiment = Record({})
+
+    expected = []
+    result = experiment_link(without_related_experiment)
+
+    assert expected == result
+
+
+def test_experiment_link_returns_link_for_a_list_of_one_element():
+    related_experiments_a_list_of_one_element = Record({
+        'related_experiments': [
+            {'name': 'foo'}
+        ]
+    })
+
+    expected = ['<a href=/search?cc=Experiments&p=experiment_name:foo>foo</a>']
+    result = experiment_link(related_experiments_a_list_of_one_element)
+
+    assert expected == result
+
+
+def test_format_cnum_with_slash_replaces_dash_with_slash():
+    expected = 'C12/03/26.1'
+    result = format_cnum_with_slash('C12-03-26.1')
+
+    assert expected == result
+
+
+def test_format_cnum_with_hyphons():
+    expected = 'C12-03-26.1'
+    result = format_cnum_with_hyphons('C12-03-26.1')
+
+    assert expected == result
+
+
+@pytest.mark.xfail(reason='invenio_search.api.Query has no search method')
+def test_link_to_hep_affiliation_returns_link_when_record_has_ICN():
+    with_ICN = Record({'ICN': 'foo'})
+
+    expected = 'TODO'
+    result = link_to_hep_affiliation(with_ICN)
+
+    assert expected == result
+
+
+def test_join_nested_lists():
+    expected = 'foo bar baz'
+    result = join_nested_lists([['foo', 'bar'], ['baz']], ' ')
+
+    assert expected == result
+
+
+def test_sanitize_collection_name_returns_none_on_empty_string():
+    assert sanitize_collection_name('') is None
+
+
+def test_sanitize_collection_name_replaces_hepnames_with_authors():
+    expected = 'authors'
+    result = sanitize_collection_name('hepnames')
+
+    assert expected == result
+
+
+def test_sanitize_collection_name_replaces_hep_with_literature():
+    expected = 'literature'
+    result = sanitize_collection_name('hep')
+
+    assert expected == result
+
+
+def test_collection_select_current_returns_active_if_equal():
+    expected = 'active'
+    result = collection_select_current('foo', 'FOO')
+
+    assert expected == result
+
+
+def test_collection_select_current_returns_empty_string_if_different():
+    expected = ''
+    result = collection_select_current('foo', 'bar')
+
+    assert expected == result
+
+
+@pytest.mark.xfail(reason='to be implemented')
+def test_number_of_records():
+    expected = -1
+    result = number_of_records('foo')
+
+    assert expected == result
+
+
+def test_sanitize_arxiv_pdf_removes_arxiv_prefix():
+    expected = '0808.1819.pdf'
+    result = sanitize_arxiv_pdf('arXiv:0808.1819')
+
+    assert expected == result
+
+
+def test_sort_list_by_dict_val():
+    expected = [
+        {'doc_count': 2},
+        {'doc_count': 1},
+        {'doc_count': 0}
+    ]
+    result = sort_list_by_dict_val([
+        {'doc_count': 1},
+        {'doc_count': 0},
+        {'doc_count': 2}
+    ])
+
+    assert expected == result
+
+
+def test_epoch_to_year_format():
+    expected = '1993'
+    result = epoch_to_year_format('728632800000')
+
+    assert expected == result
+
+
+def test_construct_date_format():
+    expected = '1993-02-02->1993-12-31'
+    result = construct_date_format('728632800000')
+
+    assert expected == result
+
+
+@mock.patch('inspirehep.modules.theme.jinja2filters.current_app.config', {'FACETS_SIZE_LIMIT': 2})
+def test_limit_facet_elements():
+    expected = ['foo', 'bar']
+    result = limit_facet_elements(['foo', 'bar', 'baz'])
+
+    assert expected == result
+
+
+def test_author_urls_returns_empty_string_on_empty_list():
+    expected = ''
+    result = author_urls([], ',')
+
+    assert expected == result
+
+
+def test_author_urls_builds_url_on_list_of_one_element():
+    expected = '<a href="/search?ln=en&amp;cc=HepNames&amp;p=name:foo&amp;of=hd">foo</a>'
+    result = author_urls([{'name': 'foo'}], '|')
+
+    assert expected == result
+
+
+def test_author_urls_joins_with_the_separator():
+    expected = '<a href="/search?ln=en&amp;cc=HepNames&amp;p=name:foo&amp;of=hd">foo</a>, <a href="/search?ln=en&amp;cc=HepNames&amp;p=name:bar&amp;of=hd">bar</a>'
+    result = author_urls([{'name': 'foo'}, {'name': 'bar'}], ', ')
+
+    assert expected == result
+
+
+def test_ads_links_returns_empty_string_when_record_has_no_name():
+    without_name = Record({})
+
+    expected = ''
+    result = ads_links(without_name)
+
+    assert expected == result
+
+
+def test_ads_links_builds_link_from_full_name():
+    with_full_name = Record({
+        'name': {'value': 'Ellis, John R.'}
+    })
+
+    expected = 'http://adsabs.harvard.edu/cgi-bin/author_form?author=Ellis,+J&fullauthor=Ellis,+John+R.'
+    result = ads_links(with_full_name)
+
+    assert expected == result
+
+
+def test_ads_links_uses_preferred_name_when_name_has_no_lastname():
+    without_last_name = Record({
+        'name': {
+            'value': ', John R.',
+            'preferred_name': 'Ellis, John R.'
+        }
+    })
+
+    expected = 'http://adsabs.harvard.edu/cgi-bin/author_form?author=Ellis, John R.'
+    result = ads_links(without_last_name)
+
+    assert expected == result
+
+
+def test_citation_phrase_singular_with_one_citation():
+    expected = 'Cited 1 time'
+    result = citation_phrase(1)
+
+    assert expected == result
+
+
+def test_citation_phrase_plural_with_zero_citations():
+    expected = 'Cited 0 times'
+    result = citation_phrase(0)
+
+    assert expected == result
+
+
+def test_citation_phrase_plural_with_more_citations():
+    expected = 'Cited 2 times'
+    result = citation_phrase(2)
+
+    assert expected == result
+
+
+@mock.patch(
+    'inspirehep.modules.theme.jinja2filters.session',
+    {
+        'last-queryfoobar': {
+            'number_of_hits': 1337,
+            'timestamp': datetime.datetime(
+                1993, 2, 2, 5, 57, 0, 0)}})
+@mock.patch('inspirehep.modules.theme.jinja2filters.datetime')
+def test_number_of_search_results_fetches_from_session(mock_datetime):
+    mock_datetime.datetime.utcnow.return_value = datetime.datetime(1993, 2, 2, 6, 0, 0, 0)
+
+    expected = 1337
+    result = number_of_search_results('foo', 'bar')
+
+    assert expected == result
+
+@pytest.mark.xfail(reason='should pass keyword arguments, not a dict')
+@mock.patch('inspirehep.modules.theme.jinja2filters.session', {})
+@mock.patch('inspirehep.modules.theme.jinja2filters.Query')
+def test_number_of_search_results_falls_back_to_query(Query):
+    number_of_search_results('foo', 'bar')
+
+    Query.assert_called_once_with('foo AND collection:"bar"')
+
+
+def test_is_upper_returns_true_when_all_uppercase():
+    assert is_upper('FOO')
+
+
+@pytest.mark.xfail(reason='function is returned instead')
+def test_is_upper_returns_false_when_not_all_uppercase():
+    assert not is_upper('foo')
+
+
+def test_split_author_name():
+    expected = 'baz bar foo'
+    result = split_author_name('foo,bar,baz')
+
+    assert expected == result
+
+
+def test_strip_leading_number_plot_caption():
+    expected = 'foo'
+    result = strip_leading_number_plot_caption('00000 foo')
+
+    assert expected == result
+
+
+def test_publication_info_returns_empty_dict_when_no_publication_info():
+    without_publication_info = Record({})
+
+    expected = {}
+    result = publication_info(without_publication_info)
+
+    assert expected == result
+
+
+def test_publication_info_an_empty_list():
+    an_empty_list = Record({'publication_info': []})
+
+    expected = {}
+    result = publication_info(an_empty_list)
+
+    assert expected == result
+
+
+def test_publication_info_a_list_of_one_element():
+    a_list_of_one_element = Record({
+        'publication_info': [
+            {'journal_title': 'Int.J.Mod.Phys.'}
+        ]
+    })
+
+    expected = {'pub_info': ['<i>Int.J.Mod.Phys.</i>']}
+    result = publication_info(a_list_of_one_element)
+
+    assert expected == result
+
+
+def test_publication_info_a_list_of_two_elements():
+    a_list_of_two_elements = Record({
+        'publication_info': [
+            {
+                'journal_volume': '8',
+                'journal_title': 'JINST',
+                'page_artid': 'P09009',
+                'year': 2013
+            },
+            {
+                'journal_volume': '8',
+                'journal_title': 'JINST',
+                'page_artid': '9009',
+                'year': 2013
+            }
+        ]
+    })
+
+    expected = {
+        'pub_info': [
+            '<i>JINST</i> 8 (2013) P09009',
+            '<i>JINST</i> 8 (2013) 9009'
+        ]
+    }
+    result = publication_info(a_list_of_two_elements)
+
+    assert expected == result
+
+
+def test_publication_info_from_journal_title_and_journal_volume():
+    with_journal_title_and_journal_volume = Record({
+        'publication_info': [
+            {
+                'journal_title': 'JHEP',
+                'journal_volume': '1508'
+            }
+        ]
+    })
+
+    expected = {
+        'pub_info': [
+            '<i>JHEP</i> 1508'
+        ]
+    }
+    result = publication_info(with_journal_title_and_journal_volume)
+
+    assert expected == result
+
+
+def test_publication_info_from_journal_title_and_year():
+    with_journal_title_and_year = Record({
+        'publication_info': [
+            {
+                'journal_title': 'Eur.Phys.J.',
+                'year': 2015
+            }
+        ]
+    })
+
+    expected = {
+        'pub_info': [
+            '<i>Eur.Phys.J.</i> (2015)'
+        ]
+    }
+    result = publication_info(with_journal_title_and_year)
+
+    assert expected == result
+
+
+def test_publication_info_from_journal_title_and_journal_issue():
+    with_journal_title_and_journal_issue = Record({
+        'publication_info': [
+            {
+                'journal_title': 'JINST',
+                'journal_issue': '02'
+            }
+        ]
+    })
+
+    expected = {
+        'pub_info': [
+            '<i>JINST</i> 02, '
+        ]
+    }
+    result = publication_info(with_journal_title_and_journal_issue)
+
+    assert expected == result
+
+
+def test_publication_info_from_journal_title_and_pages_artid():
+    with_journal_title_and_pages_artid = Record({
+        'publication_info': [
+            {
+                'journal_title': 'Astrophys.J.',
+                'page_artid': '525'
+            }
+        ]
+    })
+
+    expected = {
+        'pub_info': [
+            '<i>Astrophys.J.</i> 525'
+        ]
+    }
+    result = publication_info(with_journal_title_and_pages_artid)
+
+    assert expected == result
+
+
+def test_publication_info_from_pubinfo_freetext():
+    with_pubinfo_freetext = Record({
+        'publication_info': [
+            {'pubinfo_freetext': 'Phys. Rev. 127 (1962) 965-970'}
+        ]
+    })
+
+    expected = {
+        'pub_info': [
+            'Phys. Rev. 127 (1962) 965-970'
+        ]
+    }
+    result = publication_info(with_pubinfo_freetext)
+
+    assert expected == result
+
+
+@mock.patch('inspirehep.modules.theme.jinja2filters.PersistentIdentifier.get')
+@mock.patch('inspirehep.modules.theme.jinja2filters.es.get_source')
+def test_publication_info_from_conference_recid_and_parent_recid(g_s, g):
+    with_title = Record({'title': '2005 International Linear Collider Workshop (LCWS 2005)'})
+
+    g_s.return_value = with_title
+
+    with_conference_recid_and_parent_recid = Record({
+        'publication_info': [
+            {
+                'conference_record': {'$ref': 'http://x/y/976391'},
+                'parent_record': {'$ref': 'http://x/y/1402672'}
+            }
+        ]
+    })
+
+    expected = {
+        'conf_info': 'Published in <a href="/record/1402672">proceedings</a> '
+                     'of <a href="/record/976391">2005 International Linear '
+                     'Collider Workshop (LCWS 2005)</a>'
+    }
+    result = publication_info(with_conference_recid_and_parent_recid)
+
+    assert expected == result
+
+
+@mock.patch('inspirehep.modules.theme.jinja2filters.PersistentIdentifier.get')
+@mock.patch('inspirehep.modules.theme.jinja2filters.es.get_source')
+def test_publication_info_from_conference_recid_and_parent_recid_with_pages(g_s, g):
+    with_title = Record({'title': '50th Rencontres de Moriond on EW Interactions and Unified Theories'})
+
+    g_s.return_value = with_title
+
+    with_conference_recid_and_parent_recid_and_pages = Record({
+        'publication_info': [
+            {
+                'conference_record': {'$ref': 'http://x/y/1331207'},
+                'parent_record': {'$ref': 'http://x/y/1402672'},
+                'page_artid': '515-518'
+            }
+        ]
+    })
+
+    expected = {
+        'conf_info': 'Published in <a href="/record/1402672">proceedings</a> '
+                     'of <a href="/record/1331207">50th Rencontres de Moriond '
+                     'on EW Interactions and Unified Theories</a>, pages  \n  '
+                     '515-518'
+    }
+    result = publication_info(with_conference_recid_and_parent_recid_and_pages)
+
+    assert expected == result
+
+
+@mock.patch('inspirehep.modules.theme.jinja2filters.PersistentIdentifier.get')
+@mock.patch('inspirehep.modules.theme.jinja2filters.es.get_source')
+def test_publication_info_with_pub_info_and_conf_info(g_s, g):
+    with_title = Record({
+        'title': '2005 International Linear Collider Workshop (LCWS 2005)'
+    })
+
+    g_s.return_value = with_title
+
+    with_pub_info_and_conf_info = Record({
+        'publication_info': [
+            {
+                'journal_title': 'eConf',
+                'journal_volume': 'C050318'
+            },
+            {
+                'conference_record': {'$ref': 'http://x/y/976391'},
+                'parent_record': {'$ref': 'http://x/y/706120'}
+            }
+        ]
+    })
+
+    expected = {
+        'conf_info': '(<a href="/record/706120">Proceedings</a> of <a '
+                     'href="/record/976391">\n  2005 International Linear '
+                     'Collider Workshop (LCWS 2005)</a>)',
+        'pub_info': ['<i>eConf</i> C050318']
+    }
+    result = publication_info(with_pub_info_and_conf_info)
+
+    assert expected == result
+
+
+@mock.patch('inspirehep.modules.theme.jinja2filters.PersistentIdentifier.get')
+@mock.patch('inspirehep.modules.theme.jinja2filters.es.get_source')
+def test_publication_info_from_conference_recid_and_not_parent_recid(g_s, g):
+    with_title = Record({
+        'title': '20th International Workshop on Deep-Inelastic Scattering and Related Subjects'
+    })
+
+    g_s.return_value = with_title
+
+    with_conference_recid_without_parent_recid = Record({
+        'publication_info': [
+            {'conference_record': {'$ref': 'http://x/y/1086512'}}
+        ]
+    })
+
+    expected = {
+        'conf_info': 'Contribution to <a href="/record/1086512">20th '
+                     'International Workshop on Deep-Inelastic Scattering '
+                     'and Related Subjects</a>'
+    }
+    result = publication_info(with_conference_recid_without_parent_recid)
+
+    assert expected == result
+
+
+@pytest.mark.xfail(reason='pid searched in the wrong collection')
+def test_publication_info_from_not_conference_recid_and_parent_recid():
+    without_conference_recid_with_parent_recid = Record({
+        'publication_info': [
+            {'parent_record': {'$ref': 'http://x/y/720114'}}
+        ]
+    })
+
+    expected = {
+        'conf_info': 'Published in <a href="/record/720114">proceedings</a> '
+                     'of 2005 International Linear Collider Physics and '
+                     'Detector Workshop and 2nd ILC Accelerator Workshop '
+                     '(Snowmass 2005)'
+    }
+    result = publication_info(without_conference_recid_with_parent_recid)
+
+    assert expected == result
+
+
+@mock.patch('inspirehep.modules.theme.jinja2filters.create_datestruct')
+def test_format_date_returns_none_when_datestruct_is_none(c_d):
+    c_d.return_value = None
+
+    assert format_date('banana') is None
+
+
+@pytest.mark.xfail(reason='outputs an integer')
+@mock.patch('inspirehep.modules.theme.jinja2filters.create_datestruct')
+def test_format_date_returns_none_when_datestruct_has_one_element(c_d):
+    c_d.return_value = (1993,)
+
+    expected = '1993'
+    result = format_date('banana')
+
+    assert expected == result
+
+
+@pytest.mark.xfail(reason='doesn\'t format the date')
+@mock.patch('inspirehep.modules.theme.jinja2filters.create_datestruct')
+def test_format_date_returns_none_when_no_datestruct(c_d):
+    c_d.return_value = (1993, 2)
+
+    expected = 'February 1, 1993'
+    result = format_date('banana')
+
+    assert expected == result
+
+
+@pytest.mark.xfail(reason='doesn\'t format the date')
+@mock.patch('inspirehep.modules.theme.jinja2filters.create_datestruct')
+def test_format_date_returns_none_when_no_datestruct(c_d):
+    c_d.return_value = (1993, 2, 2)
+
+    expected = 'February 2, 1993'
+    result = format_date('banana')
+
+    assert expected == result


### PR DESCRIPTION
* [x] In order to reduce boilerplate in other schema definitions add `json_reference.json` schema as defined above to be served.

* [x] Amend jsoschemas to use `smth_record: {"$ref": "json_reference.json"}`

* [x] Amend ES Mappings (If actually needed)

* [x] Amend Dojson
  * [x] Add forward and backward $ref generation
  * [x] + Unit test
  * [x] Change __all__ fields that use recids
  * [x] + Test against __existing__ fixtures

* [x] Amend Receivers to put back the recid to be indexed in ES
  * [x] Unit Test (Integration tests not needed)

* [x] Fix broken views
* [x] Test thanks @jacquerie :+1: 

* [x] ~~Integration test the process~~ Wait for better framework to do this
LE: Actually the base of any integration test will be reindexing everything and asserting that all the marc records were indexed as json correctly. So any integration testing framework will always use this code.

* Closes #958