### PR TITLE
theme: ASSETS_DEBUG fix

### DIFF
--- a/inspirehep/modules/search/bundles.py
+++ b/inspirehep/modules/search/bundles.py
@@ -34,14 +34,10 @@ css = Bundle(
 )
 
 js = NpmBundle(
-    'node_modules/angular/angular.js',
     'js/search/app.js',
     filters='requirejs',
-    depends=('node_modules/invenio-search-js/dist/*.js', ),
     output='gen/search.%(version)s.js',
     npm={
-        "almond": "~0.3.1",
-        'angular': '~1.4.7',
         'invenio-search-js': '~0.1.0'
     },
 )

--- a/inspirehep/modules/search/static/js/search/app.js
+++ b/inspirehep/modules/search/static/js/search/app.js
@@ -22,10 +22,11 @@
  */
 
 require([
-    'node_modules/invenio-search-js/dist/invenio-search-js',
-    'js/search/inspire-search',
+    'angular',
+    'invenio-search',
+    'inspire-search',
     'js/inspire/module'
-  ], function(search) {
+  ], function() {
     // When the DOM is ready bootstrap the `invenio-serach-js`
     angular.element(document).ready(function() {
       angular.bootstrap(

--- a/inspirehep/modules/theme/bundles.py
+++ b/inspirehep/modules/theme/bundles.py
@@ -35,6 +35,20 @@ almondjs = NpmBundle(
     }
 )
 
+# require.js is only used when:
+#
+#  - ASSETS_DEBUG is True
+#  - REQUIREJS_RUN_IN_DEBUG is not False
+requirejs = NpmBundle(
+    "node_modules/requirejs/require.js",
+    "js/settings.js",
+    output="gen/require.%(version)s.js",
+    filters="uglifyjs",
+    npm={
+        "requirejs": "latest",
+    }
+)
+
 js = NpmBundle(
     'js/inspire_base_init.js',
     filters='requirejs',

--- a/inspirehep/modules/theme/static/js/settings.js
+++ b/inspirehep/modules/theme/static/js/settings.js
@@ -28,50 +28,18 @@ require.config({
     bootstrap: "node_modules/bootstrap-sass/assets/javascripts/bootstrap",
     angular: "node_modules/angular/angular",
     "angular-sanitize": "node_modules/angular-sanitize/angular-sanitize",
-    // "datatables.net": "vendors/datatables/media/js/jquery.dataTables",
-    // "datatables": "vendors/datatables/media/js/dataTables.bootstrap",
-    // jquery: "vendors/jquery/dist/jquery",
-    // "jquery.ui": "vendors/jquery-ui/jquery-ui",
-    // ui: "vendors/jquery-ui/ui",
-    // "jqueryui-timepicker": "vendors/jqueryui-timepicker-addon/dist",
-    // "jquery-form": "vendors/jquery-form/jquery.form",
+    "invenio-search": "node_modules/invenio-search-js/dist/invenio-search-js",
+    "inspire-search": "js/search/inspire-search",
     hgn: "node_modules/requirejs-hogan-plugin/hgn",
     hogan: "node_modules/hogan.js/web/builds/3.0.2/hogan-3.0.2.amd",
     text: "node_modules/requirejs-hogan-plugin/text",
     flight: "node_modules/flightjs/build/flight",
     typeahead: "node_modules/typeahead.js/dist/typeahead.bundle",
-    // "bootstrap-select": "js/bootstrap-select",
-    // "jquery-caret": "vendors/jquery.caret/dist/jquery.caret-1.5.2",
-    // "jquery-tokeninput": "vendors/jquery-tokeninput/src/jquery.tokeninput",
-    // "jquery-jeditable": "vendors/jquery.jeditable/index",
     "moment": "node_modules/moment/moment",
     "bootstrap-datetimepicker": "node_modules/eonasdan-bootstrap-datetimepicker/src/js/bootstrap-datetimepicker",
-    // "bootstrap-tagsinput": "vendors/bootstrap-tagsinput/src/bootstrap-tagsinput",
-    // bootstrap: "vendors/bootstrap/dist/js/bootstrap",
-    // prism: "vendors/prism/prism",
-    // d3: "vendors/d3/d3.js",
-    // "jasmine-jquery": "vendors/jasmine-jquery/lib/jasmine-jquery",
-    // "jasmine-core": "vendors/jasmine/lib/jasmine-core/jasmine",
-    // "jasmine-html": "vendors/jasmine/lib/jasmine-core/jasmine-html",
-    // "jasmine-ajax": "vendors/jasmine-ajax/lib/mock-ajax",
-    // "jasmine-flight": "vendors/jasmine-flight/lib/jasmine-flight",
-    // "jasmine-boot": "js/jasmine/boot",
-    // "jasmine-events": "js/jasmine/events_checker",
-    // "jasmine-initialization": "js/jasmine/initialization_checker",
-    // "select2": "vendor/select2/select2.min",
-    // "jsoneditor": "vendors/json-editor/dist/jsoneditor",
-    // "ckeditor-core": "vendors/ckeditor/ckeditor",
-    // "ckeditor-jquery": "vendors/ckeditor/adapters/jquery",
-    // // INSPIRE
     "bootstrap-multiselect": "node_modules/bootstrap-multiselect/dist/js/bootstrap-multiselect",
-    // "readmore": "vendors/readmore/readmore",
-    // "bucketsjs": "vendors/bucketsjs/dist/buckets",
     "feedback": "js/feedback/feedback",
     "toastr": "node_modules/toastr/toastr",
-    // "html2canvas": "vendors/html2canvas/build/html2canvas",
-    // "highcharts": "vendors/highcharts-release/highcharts",
-    // "jquery-menu-aim": "vendors/jQuery-menu-aim/jquery.menu-aim",
-    // "searchtypeahead-configuration": "js/search/invenio_with_spires_typeahead_configuration",
     "clipboard": "node_modules/clipboard/dist/clipboard"
   },
   shim: {
@@ -84,113 +52,23 @@ require.config({
     bootstrap: {
       deps: ["jquery"]
     },
-    // d3: {
-    //   exports: "d3"
-    // },
-    // "jqueryui-timepicker/jquery-ui-sliderAccess": {
-    //   deps: ["jquery"]
-    // },
-    // "jqueryui-timepicker/jquery-ui-timepicker-addon": {
-    //   deps: ["jquery",
-    //     "ui/slider"
-    //   ]
-    // },
-    // "jqueryui-timepicker/i18n/jquery-ui-timepicker-addon-i18n": {
-    //   deps: ["jqueryui-timepicker/jquery-ui-timepicker-addon"]
-    // },
     typeahead: {
       deps: ["jquery"],
       exports: "Bloodhound"
     },
-    // "bootstrap-select": {
-    //   deps: ["jquery"],
-    //   exports: "$.fn.buttonSelect"
-    // },
-    // "jquery-caret": {
-    //   deps: ["jquery"],
-    //   exports: "$.fn.caret"
-    // },
-    // "jquery-tokeninput": {
-    //   deps: ["jquery"],
-    //   exports: "$.fn.tokenInput"
-    // },
-    // "jquery-jeditable": {
-    //   deps: ["jquery"],
-    //   exports: "$.fn.editable"
-    // },
-    // "bootstrap-tagsinput": {
-    //   deps: ["jquery"],
-    //   exports: "$.fn.tagsinput"
-    // },
     "bootstrap-datetimepicker": {
       deps: ["jquery", "bootstrap", "moment"],
       exports: "$.fn.datetimepicker"
     },
-    // prism: {
-    //   exports: "Prism"
-    // },
-    // "jasmine-core": {
-    //   exports: "jasmineRequire"
-    // },
-    // "jasmine-boot": {
-    //   exports: "jasmine"
-    // },
-    // "jasmine-jquery": {
-    //   deps: ["jquery", "jasmine-boot"],
-    //   exports: "jasmine"
-    // },
-    // "jasmine-ajax": {
-    //   deps: ["jasmine-boot"],
-    //   exports: "jasmine"
-    // },
-    // "jasmine-html": {
-    //   deps: ["jasmine-core"],
-    //   exports: "jasmineRequire"
-    // },
-    // "jasmine-flight": {
-    //   deps: ["jasmine-boot", "jasmine-jquery"],
-    //   exports: "jasmine"
-    // },
-    // "vendors/jasmine/lib/jasmine-core/boot": {
-    //   deps: ["jasmine-html"],
-    //   exports: "window.onload"
-    // },
-    // "jasmine-events": {
-    //   deps: ["jasmine-jquery"],
-    //   exports: "jasmine.EventsChecker"
-    // },
-    // "jasmine-initialization": {
-    //   deps: ["jasmine-boot"]
-    // },
-    // select2: {
-    //   deps: ["jquery"],
-    //   exports: "select2"
-    // },
-    // jsoneditor: {
-    //   exports: "JSONEditor"
-    // },
-    // "ckeditor-jquery": {
-    //   deps: ["jquery", "ckeditor-core"]
-    // },
-    // // INSPIRE
     "bootstrap-multiselect": {
       deps: ["jquery"],
       exports: "$.fn.multiselect"
+    },
+    "invenio-search": {
+        deps: ["angular"]
+    },
+    "inspire-search": {
+        deps: ["angular"]
     }
-    // "readmore": {
-    //   deps: ["jquery"],
-    //   exports: "$.fn.readmore"
-    // }
-    // "html2canvas": {
-    //   deps: ["jquery"]
-    // },
-    // "highcharts": {
-    //   deps: ["jquery"],
-    //   exports: "Highcharts"
-    // },
-    // "jquery-menu-aim": {
-    //   deps: ["jquery"],
-    //   exports: "$.fn.menuAim"
-    // }
   }
 });

--- a/inspirehep/modules/theme/templates/inspirehep_theme/javascript.html
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/javascript.html
@@ -21,7 +21,18 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 -#}
-{% assets "almondjs" %}<script src="{{ ASSET_URL }}"></script>
-{% endassets %}
-{% assets "inspirehep_theme_js" %}<script src="{{ ASSET_URL }}"></script>
+{%- if config.get("ASSETS_DEBUG") -%}
+  {%- if not config.get("REQUIREJS_RUN_IN_DEBUG") -%}
+    {% assets "requirejs" %}
+    <script src="{{ ASSET_URL }}"></script>
+    {% endassets %}
+  {%- endif -%}
+{%- endif -%}
+{%- if not config.get("ASSETS_DEBUG") or config.get("REQUIREJS_RUN_IN_DEBUG") -%}
+  {% assets "almondjs" %}
+  <script src="{{ ASSET_URL }}"></script>
+  {% endassets %}
+{%- endif -%}
+{% assets "inspirehep_theme_js" %}
+<script src="{{ ASSET_URL }}"></script>
 {% endassets %}

--- a/setup.py
+++ b/setup.py
@@ -228,6 +228,7 @@ setup(
             'inspirehep_theme_css = inspirehep.modules.theme.bundles:css',
             'inspirehep_theme_js = inspirehep.modules.theme.bundles:js',
             'almondjs = inspirehep.modules.theme.bundles:almondjs',
+            'requirejs = inspirehep.modules.theme.bundles:requirejs',
             'inspirehep_forms_css = inspirehep.modules.forms.bundles:css',
             'inspirehep_forms_js = inspirehep.modules.forms.bundles:js',
             'inspirehep_author_update_css = inspirehep.modules.authors.bundles:css',


### PR DESCRIPTION
* Allows usage of ASSETS_DEBUG by including requirejs in the page when
  the setting is enabled.

* Bundle cleanup.

* NOTE: when switching to ASSETS_DEBUG=True the contents of the folder
  static/.webassets-cache/ should be removed to have full effect.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>