### PR TITLE
search: type_code search

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -147,6 +147,7 @@ SEARCH_ELASTIC_KEYWORD_MAPPING = {
                     ],
     "abstract": ["abstracts.value"],
     "collaboration": ["collaboration.value", "collaboration.raw^2"],
+    "tc": ["collection"],
     "collection": ["collections.primary"],
     "doi": ["dois.value"],
     "doc_type": ["facet_inspire_doc_type"],

--- a/inspirehep/modules/records/mappings/records/hep.json
+++ b/inspirehep/modules/records/mappings/records/hep.json
@@ -20,7 +20,20 @@
                     "type": "pattern_replace",
                     "pattern": "[ \t]{2,}",
                     "replacement": " "
-                }
+                },
+                "tc_synonyms" : {
+                    "type" : "synonym",
+                    "synonyms" : [
+                        "b => book",
+                        "c => conferencepaper",
+                        "experimental note => note",
+                        "p => published",
+                        "t => thesis",
+                        "i => introductory",
+                        "l => lectures",
+                        "r => review"
+                      ]
+                    }
             },
             "analyzer": {
                 "basic_analyzer": {
@@ -42,6 +55,11 @@
                         "whitespace_remove",
                         "trim"
                     ]
+                },
+                "tc_synonyms_analyzer": {
+                  "type": "custom",
+                  "tokenizer": "keyword",
+                  "filter": ["tc_synonyms", "lowercase"]
                 }
             }
         },
@@ -232,7 +250,7 @@
                 },
                 "collection": {
                     "type": "string",
-                    "index": "not_analyzed"
+                    "analyzer": "tc_synonyms_analyzer"
                 },
                 "exactauthor": {
                     "type": "string",

--- a/tests/unit/search/test_search_query.py
+++ b/tests/unit/search/test_search_query.py
@@ -493,6 +493,15 @@ def test_topcite_colon():
     assert expected == result
 
 
+def test_type_code_colon():
+    query = InspireQuery('tc: l')
+
+    expected = {'query': {'multi_match': {'query': 'l', 'fields': ['collection']}}}
+    result = query.body
+
+    assert expected == result
+
+
 def test_find_journal():
     query = InspireQuery('find j "Phys.Rev.Lett.,105*"')
 
@@ -781,7 +790,7 @@ def test_find_country_code():
 def test_find_date():
     query = InspireQuery('fin date > today')
 
-    expected =  {}
+    expected = {}
     result = query.body
 
     assert expected == result
@@ -807,11 +816,10 @@ def test_find_report():
     assert expected == result
 
 
-@pytest.mark.xfail(reason='tracked in issue #817')
 def test_find_type_code():
     query = InspireQuery('find tc book')
 
-    expected = {}
+    expected = {'query': {'multi_match': {'query': 'book', 'fields': ['collection']}}}
     result = query.body
 
     assert expected == result


### PR DESCRIPTION
* Enables Searching by Type-Code (tc).

* Closes #970 .

* Need to be merged with inspirehep/invenio-query-parser#17 .

Signed-off-by: Panos Paparrigopoulos <panos.paparrigopoulos@cern.ch>