### PR TITLE
Make scripts/recreate_records work with honcho start

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,6 +1,6 @@
 web: inspirehep --debug run
 cache: redis-server
-worker: celery worker -E -A inspirehep.celery --loglevel=INFO --workdir=$VIRTUAL_ENV --purge
+worker: celery worker -E -A inspirehep.celery --loglevel=INFO --workdir="${VIRTUAL_ENV}" --autoreload --pidfile="${VIRTUAL_ENV}/worker.pid" --purge
 workermon: flower --broker=amqp://guest:guest@localhost:5672//
 # mathoid: node_modules/mathoid/server.js -c mathoid.config.yaml
 indexer: elasticsearch -Dcluster.name="inspire" -Ddiscovery.zen.ping.multicast.enabled=false -Dpath.data="$VIRTUAL_ENV/var/data/elasticsearch"  -Dpath.logs="$VIRTUAL_ENV/var/log/elasticsearch"

--- a/scripts/recreate_records
+++ b/scripts/recreate_records
@@ -36,14 +36,30 @@ if [ ! -x "$(command -v celery)" ]; then
   exit 1
 fi
 
+CELERY_LOGLEVEL=$1
+if [ -z $1 ]; then
+	CELERY_LOGLEVEL="ERROR"
+fi
+
+cleanup() {
+	echo "----> Killing Celery Worker ${CELERY_PID}"
+	kill "${CELERY_PID}"
+}
+
+CELERY_PIDFILE="${VIRTUAL_ENV}/worker.pid"
+if [ -f "${CELERY_PIDFILE}" ]; then
+	echo "----> Purging all pending messages"
+	celery purge -f -A inspirehep.celery --workdir="${VIRTUAL_ENV}"
+else
+	celery worker -E -A inspirehep.celery --loglevel=${CELERY_LOGLEVEL} --workdir="${VIRTUAL_ENV}" --autoreload --pidfile="${CELERY_PIDFILE}" --purge &
+	CELERY_PID=$!
+	trap 'cleanup' 0 1 2 3 6
+fi
+
 inspirehep db drop --yes-i-know
 inspirehep db create
 inspirehep index destroy --force --yes-i-know
 inspirehep index init
 
-celery 2>/dev/null worker -E -A inspirehep.celery --workdir="${VIRTUALENV}" --purge &
-CELERY_PID=$!
-
 inspirehep migrator populate -f inspirehep/demosite/data/demo-records.xml.gz --wait=true
 
-kill "${CELERY_PID}"


### PR DESCRIPTION
* `scripts/recreate_records` did not cleanup any workers upon cancellation -> fix that using trap
* `scripts/recreate_records` started new workers even if others were started via `honcho start` -> fix using a common pidfile
* the first argument is the celery loglevel. Makes things easy to debug when breaking `recreate_records`

TODO
* ~~test `--autoreload` (having the server started with `honcho start` would not autoreload on code changes before, but the webapp did)~~ Does not work
* ~~make everything work with ES started as a service (`service elasticsearch start`)~~

LE:
`scripts/recreate_records` doesn't care about how ES is started so it might be left like this for now. On the other hand I am not sure on how `honcho start` works with ES installed as a service.
LE2:
Managing ES will remain the dev's responsibility
LE3:
Autoreload doesn't work :(

cc @kaplun, @jacquerie