### PR TITLE
search: case insensitive keywords

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -170,7 +170,7 @@ SEARCH_ELASTIC_KEYWORD_MAPPING = {
     "695__a": ["thesaurus_terms.keyword"],
     "773__y": ["publication_info.year"],
     "authorcount": ["authors.full_name"],
-    "arXiv": ["arxiv_eprints.value"],
+    "arxiv": ["arxiv_eprints.value"],
     "caption": ["urls.description"],
     "country": ["authors.affiliations.value"],
     "firstauthor": ["authors.full_name", "authors.alternative_name"],

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@
 -e git+https://github.com/inveniosoftware/invenio-formatter.git#egg=invenio-formatter
 -e git+https://github.com/inveniosoftware/invenio-mail.git#egg=invenio-mail
 -e git+https://github.com/inveniosoftware/invenio-records-rest.git#egg=invenio-records-rest
--e git+https://github.com/inspirehep/invenio-query-parser.git@invenio3#egg=invenio-query-parser==0.4.2.dev20160221
+-e git+https://github.com/inspirehep/invenio-query-parser.git@invenio3#egg=invenio-query-parser==0.4.2.dev20160310
 -e git+https://github.com/inspirehep/invenio-records.git@invenio3#egg=invenio-records
 -e git+https://github.com/inspirehep/invenio-pidstore.git#egg=invenio-pidstore
 


### PR DESCRIPTION
* Allows invenio-query-parser to accept case insesitive keywords.

* Should be merged with inspirehep/invenio-query-parser#16.

Signed-off-by: Panos Paparrigopoulos <panos.paparrigopoulos@cern.ch>