### PR TITLE
JSON Reference Resolver that bypasses HTTP requests for known resources.

### DIFF
--- a/inspirehep/modules/records/json_ref_loader.py
+++ b/inspirehep/modules/records/json_ref_loader.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Resource-aware json reference loaders to be used with jsonref."""
+
+from jsonref import JsonLoader, JsonRef
+from werkzeug.urls import url_parse
+
+from flask import current_app
+
+from inspirehep.utils import record_getter
+
+
+class AbstractRecordLoader(JsonLoader):
+    """Base for resource-aware record loaders.
+
+    Resolves the refered resource by the given uri by first checking against
+    local resources.
+    """
+
+    def get_record(self, record_type, recid):
+        raise NotImplementedError()
+
+    def get_remote_json(self, uri, **kwargs):
+        parsed_uri = url_parse(uri)
+        # Normalize optional 'http://' protocol in the config.
+        server_name = current_app.config.get('SERVER_NAME')
+        if not server_name.startswith('http://'):
+            server_name = 'http://{}'.format(server_name)
+        parsed_server = url_parse(server_name)
+
+        if parsed_uri.netloc and parsed_uri.netloc != parsed_server.netloc:
+            return super(AbstractRecordLoader, self).get_remote_json(uri,
+                                                                     **kwargs)
+        path_parts = parsed_uri.path.strip('/').split('/')
+        if len(path_parts) < 2:
+            current_app.logger.error('Bad JSONref URI: {0}'.format(uri))
+            return None
+
+        record_type = path_parts[-2]
+        recid = path_parts[-1]
+        res = self.get_record(record_type, recid)
+        return res
+
+
+class ESJsonLoader(AbstractRecordLoader):
+    """Resolve resources by retrieving them from Elasticsearch."""
+
+    def get_record(self, record_type, recid):
+        try:
+            return record_getter.get_es_record(record_type, recid)
+        except record_getter.RecordGetterError:
+            return None
+
+
+class DatabaseJsonLoader(AbstractRecordLoader):
+
+    def get_record(self, record_type, recid):
+        try:
+            return record_getter.get_db_record(record_type, recid)
+        except record_getter.RecordGetterError:
+            return None
+
+
+es_record_loader = ESJsonLoader()
+db_record_loader = DatabaseJsonLoader()
+
+
+def replace_refs(obj, source='db'):
+    """Replaces record refs in obj by bypassing HTTP requests.
+
+    Any reference URI that comes from the same server and references a resource
+    will be resolved directly either from the database or from Elasticsearch.
+
+    :param obj:
+        Dict-like object for which '$ref' fields are recursively replaced.
+    :param source:
+        List of sources from which to resolve the references. It can be any of:
+            * 'db' - resolve from Database
+            * 'es' - resolve from Elasticsearch
+            * 'http' - force using HTTP
+
+    :returns:
+        The same obj structure with the '$ref' fields replaced with the object
+        available at the given URI.
+    """
+    loaders = {
+        'db': db_record_loader,
+        'es': es_record_loader,
+        'http': None
+    }
+    if source not in loaders:
+        raise ValueError('source must be one of {}'.format(loaders.keys()))
+
+    loader = loaders[source]
+    return JsonRef.replace_refs(obj, loader=loader)

--- a/inspirehep/utils/record_getter.py
+++ b/inspirehep/utils/record_getter.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Resource-aware json reference loaders to be used with jsonref."""
+
+from functools import wraps
+
+from flask import current_app
+
+from invenio_records.api import Record
+from invenio_pidstore.models import PersistentIdentifier
+from invenio_search import current_search_client as es
+
+
+class RecordGetterError(Exception):
+
+    def __init__(self, message, cause):
+        super(RecordGetterError, self).__init__(message)
+        self.cause = cause
+
+    def __repr__(self):
+        return '{} caused by {}'.format(
+            super(RecordGetterError, self).__repr__(),
+            repr(self.cause)
+        )
+
+    def __str__(self):
+        return repr(self)
+
+
+def raise_record_getter_error_and_log(f):
+    @wraps(f)
+    def wrapper(record_type, recid):
+        try:
+            return f(record_type, recid)
+        except Exception as e:
+            current_app.logger.error('Error in retrieving record [{0}:{1}] '
+                                     'caused by {2}'.format(record_type, recid,
+                                                            repr(e)))
+            raise RecordGetterError(e.message, e)
+
+    return wrapper
+
+
+@raise_record_getter_error_and_log
+def get_es_record(record_type, recid):
+    pid = PersistentIdentifier.get(record_type, recid)
+    search_conf = current_app.config['RECORDS_REST_ENDPOINTS'][record_type]
+
+    return es.get_source(
+        index=search_conf['search_index'],
+        id=str(pid.object_uuid),
+        doc_type=search_conf['search_type'])
+
+
+@raise_record_getter_error_and_log
+def get_db_record(record_type, recid):
+    pid = PersistentIdentifier.get(record_type, recid)
+    return Record.get_record(pid.object_uuid)

--- a/tests/unit/records/test_records_json_ref_loader.py
+++ b/tests/unit/records/test_records_json_ref_loader.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+import mock
+
+from jsonref import JsonRef
+
+from inspirehep.modules.records.json_ref_loader import (
+    AbstractRecordLoader, DatabaseJsonLoader, ESJsonLoader, replace_refs)
+from inspirehep.utils.record_getter import RecordGetterError
+
+
+def _build_url(app, record_type='literature', recid='42'):
+    server = app.config['SERVER_NAME']
+    if not server.startswith('http://'):
+        server = 'http://{}'.format(server)
+    return '{}/api/{}/{}'.format(server, record_type, recid)
+
+
+@mock.patch('inspirehep.modules.records.json_ref_loader.record_getter.get_es_record')
+@mock.patch('inspirehep.modules.records.json_ref_loader.record_getter.get_db_record')
+def test_replace_refs_correct_sources(get_db_rec, get_es_rec, app):
+    with_es_record = {'ES': 'ES'}
+    with_db_record = {'DB': 'DB'}
+
+    get_es_rec.return_value = with_es_record
+    get_db_rec.return_value = with_db_record
+
+    with app.app_context():
+        db_rec = replace_refs({'$ref': _build_url(app)}, 'db')
+        es_rec = replace_refs({'$ref': _build_url(app)}, 'es')
+
+        # Lazy objects need to be evaluated in app_context.
+        assert db_rec == with_db_record
+        assert es_rec == with_es_record
+
+
+@mock.patch('inspirehep.modules.records.json_ref_loader.current_app')
+@mock.patch('inspirehep.modules.records.json_ref_loader.JsonLoader.get_remote_json')
+@mock.patch('inspirehep.modules.records.json_ref_loader.AbstractRecordLoader.get_record')
+def test_abstract_loader_url_fallbacks(get_record, super_get_r_j, current_app):
+    with_super = {'SUPER': 'SUPER'}
+    with_actual = {'ACTUAL': 'ACTUAL'}
+    super_get_r_j.return_value = with_super
+    get_record.return_value = with_actual
+
+    # Check against prod SERVER_NAME
+    current_app.config = {'SERVER_NAME': 'http://inspirehep.net'}
+
+    expect_actual = JsonRef({'$ref': 'http://inspirehep.net/api/rt/1'},
+                            loader=AbstractRecordLoader())
+    assert expect_actual == with_actual
+
+    expect_actual = JsonRef({'$ref': '/api/rt/1'},
+                            loader=AbstractRecordLoader())
+    assert expect_actual == with_actual
+
+    expect_super = JsonRef({'$ref': 'http://otherhost.net/api/rt/1'},
+                           loader=AbstractRecordLoader())
+    assert expect_super == with_super
+
+    # Check against dev SERVER_NAME
+    current_app.config = {'SERVER_NAME': 'localhost:5000'}
+    expect_actual = JsonRef({'$ref': 'http://localhost:5000/api/rt/1'},
+                            loader=AbstractRecordLoader())
+
+    assert expect_actual == with_actual
+    expect_actual = JsonRef({'$ref': '/api/rt/1'},
+                            loader=AbstractRecordLoader())
+    assert expect_actual == with_actual
+
+    expect_super = JsonRef({'$ref': 'http://inspirehep.net/api/rt/1'},
+                           loader=AbstractRecordLoader())
+    assert expect_super == with_super
+
+
+@mock.patch('inspirehep.modules.records.json_ref_loader.current_app')
+@mock.patch('inspirehep.modules.records.json_ref_loader.AbstractRecordLoader.get_record')
+def test_abstract_loader_recid_parsing(get_record, current_app):
+    current_app.config = {'SERVER_NAME': 'http://inspirehep.net'}
+    with_actual = {'ACTUAL': 'ACTUAL'}
+    get_record.return_value = with_actual
+
+    expect_actual = JsonRef({'$ref': 'http://inspirehep.net/api/rt1/1'},
+                            loader=AbstractRecordLoader())
+    # Force evaluation of get_record by this assertion.
+    assert expect_actual == with_actual
+    get_record.assert_called_with('rt1', '1')
+
+    expect_actual = JsonRef({'$ref': '/api/rt2/2'},
+                            loader=AbstractRecordLoader())
+    assert expect_actual == with_actual
+    get_record.assert_called_with('rt2', '2')
+
+    expect_actual = JsonRef({'$ref': '/rt3/3/'},
+                            loader=AbstractRecordLoader())
+    assert expect_actual == with_actual
+    get_record.assert_called_with('rt3', '3')
+
+
+@mock.patch('inspirehep.modules.records.json_ref_loader.current_app')
+@mock.patch('inspirehep.modules.records.json_ref_loader.AbstractRecordLoader.get_record')
+def test_abstract_loader_return_none(get_record, current_app):
+    current_app.config = {'SERVER_NAME': 'http://inspirehep.net'}
+
+    expect_none = JsonRef({'$ref': 'http://inspirehep.net'},
+                          loader=AbstractRecordLoader())
+    assert expect_none == None
+    expect_none = JsonRef({'$ref': 'http://inspirehep.net/'},
+                          loader=AbstractRecordLoader())
+    assert expect_none == None
+    expect_none = JsonRef({'$ref': 'http://inspirehep.net/bad'},
+                          loader=AbstractRecordLoader())
+    assert expect_none == None
+    assert get_record.call_count == 0
+
+
+@mock.patch('inspirehep.modules.records.json_ref_loader.current_app')
+@mock.patch('inspirehep.modules.records.json_ref_loader.record_getter.get_es_record')
+@mock.patch('inspirehep.modules.records.json_ref_loader.record_getter.get_db_record')
+def test_specific_loaders_return_none(get_db_rec, get_es_rec, current_app):
+    current_app.config = {'SERVER_NAME': 'http://inspirehep.net'}
+    get_es_rec.side_effect = RecordGetterError('err', None)
+    get_db_rec.side_effect = RecordGetterError('err', None)
+
+    expect_none = JsonRef({'$ref': 'http://inspirehep.net/api/rt/1'},
+                          loader=DatabaseJsonLoader())
+    assert expect_none == None
+    expect_none = JsonRef({'$ref': 'http://inspirehep.net/api/rt/2'},
+                          loader=ESJsonLoader())
+    assert expect_none == None
+    assert get_db_rec.call_count == 1
+    assert get_es_rec.call_count == 1

--- a/tests/unit/utils/test_utils_record_getter.py
+++ b/tests/unit/utils/test_utils_record_getter.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+import pytest
+
+from inspirehep.utils import record_getter
+
+
+def test_error_decorator():
+    @record_getter.raise_record_getter_error_and_log
+    def goodfn(record_type, recid):
+        return 42
+
+    assert goodfn(None, None) == 42
+
+    @record_getter.raise_record_getter_error_and_log
+    def badfn(record_type, recid):
+        raise Exception('message')
+
+    with pytest.raises(record_getter.RecordGetterError):
+        badfn(None, None)


### PR DESCRIPTION
* Adds JSON reference loaders that first try to resolve recird URIS
  against the database or Elasticsearch before making HTTP requests.

usage example
```python
>>> from inspirehep.modules.records import json_ref_loader
>>> json_ref_loader.replace_refs({'$ref': 'http://localhost:5000/api/literature/1385669'})
{'samething': 'from db'}
>>> json_ref_loader.replace_refs({'$ref': 'http://localhost:5000/api/literature/1385669'}, 'es')
{'samething': 'from elastic'}
>>> json_ref_loader.replace_refs({'$ref': 'http://localhost:5000/api/literature/1385669'}, 'http')
{'samething': 'using GET'}
```

Signed-off-by: Mihai Bivol <mihai.bivol@cern.ch>