### PR TITLE
global: security loading workaround

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -104,7 +104,9 @@ SECURITY_RESET_SALT = "CHANGE_ME"
 
 # User profile
 # ============
-USERPROFILES_EXTEND_SECURITY_FORMS = True
+# FIXME Investigate why setting this to True sometimes forces using
+# the flask_security extension before being correctly initialized.
+USERPROFILES_EXTEND_SECURITY_FORMS = False
 USERPROFILES_SETTINGS_TEMPLATE = 'inspirehep_theme/accounts/settings/profile.html'
 
 # Search


### PR DESCRIPTION
* Changes config so that flask_security is not needed before being
  loaded.

Signed-off-by: Mihai Bivol <mihai.bivol@cern.ch>