### PR TITLE
global: dummy sleep removal in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,9 +56,6 @@ install:
   - "travis_retry pip install -r requirements.txt --pre"
   - "scripts/clean_assets"
 
-before_script:
-  - "sleep 10"  # Allow ES to start.
-
 script:
   - "python setup.py test"
 


### PR DESCRIPTION
* Removes not needed sleep command in testing.

Signed-off-by: Mihai Bivol <mihai.bivol@cern.ch>