### PR TITLE
Fix for prod https:// SERVER_NAME in dojson and ref_loader

### DIFF
--- a/inspirehep/dojson/utils.py
+++ b/inspirehep/dojson/utils.py
@@ -19,8 +19,8 @@
 
 """DoJSON related utilities."""
 
-import pkg_resources
 import six
+import re
 
 try:
     from flask import current_app
@@ -153,12 +153,16 @@ def get_record_ref(recid, record_type='record'):
     """
     if recid is None:
         return None
-    default_server = 'inspirehep.net'
+    default_server = 'http://inspirehep.net'
     if current_app:
         server = current_app.config.get('SERVER_NAME', default_server)
     else:
         server = default_server
-    return {'$ref': 'http://{}/api/{}/{}'.format(server, record_type, recid)}
+    # This config might also be http://inspirehep.net or
+    # https://inspirehep.net.
+    if not re.match('^https?://', server):
+        server = 'http://{}'.format(server)
+    return {'$ref': '{}/api/{}/{}'.format(server, record_type, recid)}
 
 
 def get_recid_from_ref(ref_obj):

--- a/inspirehep/modules/records/json_ref_loader.py
+++ b/inspirehep/modules/records/json_ref_loader.py
@@ -22,6 +22,7 @@
 
 """Resource-aware json reference loaders to be used with jsonref."""
 
+import re
 from jsonref import JsonLoader, JsonRef
 from werkzeug.urls import url_parse
 
@@ -42,9 +43,9 @@ class AbstractRecordLoader(JsonLoader):
 
     def get_remote_json(self, uri, **kwargs):
         parsed_uri = url_parse(uri)
-        # Normalize optional 'http://' protocol in the config.
+        # Add http:// protocol so uri.netloc is correctly parsed.
         server_name = current_app.config.get('SERVER_NAME')
-        if not server_name.startswith('http://'):
+        if not re.match('^https?://', server_name):
             server_name = 'http://{}'.format(server_name)
         parsed_server = url_parse(server_name)
 

--- a/tests/unit/dojson/test_dojson_utils.py
+++ b/tests/unit/dojson/test_dojson_utils.py
@@ -17,14 +17,37 @@
 # along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
+import mock
+
 from inspirehep.dojson import utils
+
+
+@mock.patch('inspirehep.dojson.utils.current_app')
+def test_get_record_ref_server_name(current_app):
+    # Test empty SERVER_NAME.
+    current_app.config = {}
+    ref = utils.get_record_ref(123, 'record_type')
+    assert ref['$ref'].startswith('http://inspirehep.net')
+
+    # Test dev SERVER_NAME.
+    current_app.config = {'SERVER_NAME': 'localhost:5000'}
+    ref = utils.get_record_ref(123, 'record_type')
+    assert ref['$ref'].startswith('http://localhost:5000')
+
+    # Test http prod SERVER_NAME.
+    current_app.config = {'SERVER_NAME': 'http://inspirehep.net'}
+    ref = utils.get_record_ref(123, 'record_type')
+    assert ref['$ref'].startswith('http://inspirehep.net')
+
+    # Test https prod SERVER_NAME.
+    current_app.config = {'SERVER_NAME': 'https://inspirehep.net'}
+    ref = utils.get_record_ref(123, 'record_type')
+    assert ref['$ref'].startswith('https://inspirehep.net')
 
 
 def test_get_record_ref_with_record_type():
     ref = utils.get_record_ref(123, 'record_type')
-
     assert ref['$ref'].endswith('/api/record_type/123')
-    assert ref['$ref'].startswith('http://')
     assert utils.get_record_ref(None, 'record_type') == None
 
 

--- a/tests/unit/records/test_records_json_ref_loader.py
+++ b/tests/unit/records/test_records_json_ref_loader.py
@@ -82,13 +82,32 @@ def test_abstract_loader_url_fallbacks(get_record, super_get_r_j, current_app):
     current_app.config = {'SERVER_NAME': 'localhost:5000'}
     expect_actual = JsonRef({'$ref': 'http://localhost:5000/api/rt/1'},
                             loader=AbstractRecordLoader())
-
     assert expect_actual == with_actual
+
     expect_actual = JsonRef({'$ref': '/api/rt/1'},
                             loader=AbstractRecordLoader())
     assert expect_actual == with_actual
 
     expect_super = JsonRef({'$ref': 'http://inspirehep.net/api/rt/1'},
+                           loader=AbstractRecordLoader())
+    assert expect_super == with_super
+
+    # Check against prod https SERVER_NAME
+    current_app.config = {'SERVER_NAME': 'https://inspirehep.net'}
+    expect_actual = JsonRef({'$ref': 'https://inspirehep.net/api/rt/1'},
+                            loader=AbstractRecordLoader())
+    assert expect_actual == with_actual
+
+    expect_actual = JsonRef({'$ref': '/api/rt/1'},
+                            loader=AbstractRecordLoader())
+    assert expect_actual == with_actual
+
+    # https should be backwards compatible with resources indexed with http://.
+    expect_actual = JsonRef({'$ref': 'http://inspirehep.net/api/rt/1'},
+                            loader=AbstractRecordLoader())
+    assert expect_actual == with_actual
+
+    expect_super = JsonRef({'$ref': 'http://otherhost.net/api/rt/1'},
                            loader=AbstractRecordLoader())
     assert expect_super == with_super
 


### PR DESCRIPTION
* Fixes double http:// prepending when SERVERN_NAME is
  http://inspirehep.net

Signed-off-by: Mihai Bivol <mihai.bivol@cern.ch>

cc @kaplun Almost forgot to fix this :)