### PR TITLE
theme: add MathJax

### DIFF
--- a/inspirehep/modules/search/templates/search/search.html
+++ b/inspirehep/modules/search/templates/search/search.html
@@ -21,6 +21,8 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 #}
 
+{% from "inspirehep_theme/format/record/Inspire_Default_HTML_general_macros.tpl" import mathjax %}
+
 {% extends config.SEARCH_UI_BASE_TEMPLATE %}
 
 {%- block css %}
@@ -30,6 +32,7 @@
 
 {%- block javascript %}
   {{ super() }}
+  {{ mathjax() | safe }}
   {% assets "invenio_search_ui_search_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
 {%- endblock javascript %}
 

--- a/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Inspire_Default_HTML_detailed.tpl
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Inspire_Default_HTML_detailed.tpl
@@ -104,6 +104,7 @@
 
 {% block javascript %}
   {{ super() }}
+  {{ mathjax() | safe }}
   {%- assets "inspirehep_detailed_js" %}
     <script src="{{ ASSET_URL }}"></script>
   {%- endassets %}

--- a/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Inspire_Default_HTML_general_macros.tpl
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Inspire_Default_HTML_general_macros.tpl
@@ -267,22 +267,21 @@
 {% endmacro %}
 
 {% macro mathjax() %}
-{% set version = '2.5.3' %}
-<script src="//cdnjs.cloudflare.com/ajax/libs/mathjax/{{version}}/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 <script type="text/javascript">
-    require([
-      "jquery",
-      ], function ($) {
-          $(document).ready(function () {
-            MathJax.Hub.Config({
-                tex2jax: {inlineMath: [['$', '$'], ['\\(', '\\)']],
-                processEscapes: true},
-                showProcessingMessages: false,
-                messageStyle: "none"
-            });
-            MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
-          })
-      }
-    );
+  require([
+    "jquery",
+    ], function ($) {
+      $(document).ready(function () {
+        MathJax.Hub.Config({
+          tex2jax: {inlineMath: [['$', '$'], ['\\(', '\\)']],
+          processEscapes: true},
+          showProcessingMessages: false,
+          messageStyle: "none"
+        });
+        MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
+      })
+    }
+  );
 </script>
 {% endmacro %}


### PR DESCRIPTION
* Extends JS dependencies in order to render mathematical notation
  using MathJax. ~~NOTE: works only in ASSETS_DEBUG = True.~~

Signed-off-by: Grzegorz Jacenków <grzegorz.jacenkow@cern.ch>