### PR TITLE
search: enables refersto:recid:xxx search

### DIFF
--- a/inspirehep/modules/search/walkers/elasticsearch.py
+++ b/inspirehep/modules/search/walkers/elasticsearch.py
@@ -90,6 +90,11 @@ class ElasticSearchDSL(object):
     @visitor(Value)
     def visit(self, node):
         def query(keyword):
+            # FIXME: This is a temporary hack that should be removed when
+            # nested keywords search is implemented.
+            if str(node.value).startswith('recid:'):
+                node.value = node.value[len('recid:'):]
+
             fields = self.get_fields_for_keyword(keyword, mode='a')
             if fields == ['authors.full_name', 'authors.alternative_name']:
                 return {"bool":

--- a/tests/unit/search/test_search_query.py
+++ b/tests/unit/search/test_search_query.py
@@ -465,7 +465,6 @@ def test_journal_colon():
     assert expected == result
 
 
-@pytest.mark.xfail(reason='extra "recid:" added to the ES query')
 def test_refersto_colon_recid_colon():
     query = InspireQuery('refersto:recid:1286113')
 


### PR DESCRIPTION
* When `refersto` is followed by `recid` the search will work as intended.

Signed-off-by: Panos Paparrigopoulos <panos.paparrigopoulos@cern.ch>