### PR TITLE
config: REMEMBER_COOKIE_HTTPONLY set

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -108,6 +108,11 @@ SECURITY_PASSWORD_SALT = "CHANGE_ME"
 SECURITY_REMEMBER_SALT = "CHANGE_ME"
 SECURITY_RESET_SALT = "CHANGE_ME"
 
+REMEMBER_COOKIE_HTTPONLY = True
+"""
+Prevents the "Remember Me" cookie from being accessed by client-side
+scripts
+"""
 # User profile
 # ============
 # FIXME Investigate why setting this to True sometimes forces using


### PR DESCRIPTION
* Prevents the "Remember Me" cookie from being accessed by client-side scripts.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>