### PR TITLE
records: impact graph API addition

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -267,7 +267,11 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/x-cvformathtml': ('inspirehep.modules.records.serializers'
                                            ':cvformathtml_v1_response'),
             'application/x-cvformattext': ('inspirehep.modules.records.serializers'
-                                           ':cvformattext_v1_response')
+                                           ':cvformattext_v1_response'),
+            'application/x-impact.graph+json': (
+                'inspirehep.modules.records.serializers'
+                ':impactgraph_v1_response'
+            ),
         },
         search_serializers={
             'application/json': ('invenio_records_rest.serializers'

--- a/inspirehep/modules/records/serializers/__init__.py
+++ b/inspirehep/modules/records/serializers/__init__.py
@@ -26,9 +26,12 @@
 
 from __future__ import absolute_import, print_function
 
-from invenio_records_rest.serializers.response import record_responsify, \
+from invenio_records_rest.serializers.response import (
+    record_responsify,
     search_responsify
+)
 
+from .impactgraph_serializer import ImpactGraphSerializer
 from .json import JSONBriefSerializer
 from .bibtex_serializer import BIBTEXSerializer
 from .latexeu_serializer import LATEXEUSerializer
@@ -69,3 +72,6 @@ cvformathtml_v1_search = search_responsify(cvformathtml_v1,
                                            'application/x-cvformathtml')
 cvformattext_v1_search = search_responsify(cvformattext_v1,
                                            'application/x-cvformattext')
+impactgraph_v1 = ImpactGraphSerializer()
+impactgraph_v1_response = record_responsify(impactgraph_v1,
+                                            'application/x-impact.graph+json')

--- a/inspirehep/modules/records/serializers/impactgraph_serializer.py
+++ b/inspirehep/modules/records/serializers/impactgraph_serializer.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Impact Graph serializer for records."""
+
+from __future__ import absolute_import, print_function
+
+import json
+
+from invenio_search import current_search_client
+from invenio_search.api import Query
+
+from inspirehep.utils.record import get_title
+
+
+class ImpactGraphSerializer(object):
+
+    """Impact Graph serializer for records."""
+
+    def serialize(self, pid, record, links_factory=None):
+        """
+        Serialize a single impact graph from a record.
+
+        :param pid: Persistent identifier instance.
+        :param record: Record instance.
+        :param links_factory: Factory function for the link generation,
+                              which are added to the response.
+        """
+        out = {}
+
+        # Add information about current record
+        out['inspire_id'] = record['control_number']
+        out['title'] = get_title(record)
+        out['year'] = record['earliest_date'].split('-')[0]
+
+        # Get citations
+        citations = []
+
+        es_query = Query('refersto:' + record['control_number'])
+        es_query.body.update(
+            {
+                'size': 9999
+            }
+        )
+        record_citations = current_search_client.search(
+            index='records-hep',
+            doc_type='hep',
+            body=es_query.body,
+            _source=[
+                'control_number',
+                'citation_count',
+                'titles',
+                'earliest_date'
+            ]
+        )['hits']['hits']
+        for citation in record_citations:
+            citation = citation['_source']
+            citations.append({
+                "inspire_id": citation['control_number'],
+                "citation_count": citation.get('citation_count', 0),
+                "title": get_title(citation),
+                "year": citation['earliest_date'].split('-')[0]
+            })
+
+        out['citations'] = citations
+
+        # Get references
+        record_references = record.get('references', [])
+        references = []
+
+        reference_recids = [
+            ref['recid'] for ref in record_references if ref.get('recid')
+        ]
+
+        if reference_recids:
+            mget_body = {
+                "ids": reference_recids
+            }
+
+            record_references = current_search_client.mget(
+                index='records-hep',
+                doc_type='hep',
+                body=mget_body,
+                _source=[
+                    'control_number',
+                    'citation_count',
+                    'titles',
+                    'earliest_date'
+                ]
+            )
+
+            for reference in record_references["docs"]:
+                ref_info = reference["_source"]
+
+                references.append({
+                    "inspire_id": ref_info['control_number'],
+                    "citation_count": ref_info.get('citation_count', 0),
+                    "title": get_title(ref_info),
+                    "year": ref_info['earliest_date'].split('-')[0]
+                })
+
+        out['references'] = references
+
+        return json.dumps(out)

--- a/inspirehep/utils/record.py
+++ b/inspirehep/utils/record.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Helpers for handling records."""
+
+
+def get_title(record):
+    """Get preferred title from record."""
+    title = ""
+    for title in record.get('titles', []):
+        if title.get('title'):
+            return title['title']
+
+    return title

--- a/tests/integration/test_impact_graphs.py
+++ b/tests/integration/test_impact_graphs.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Tests for Impact Graph API."""
+
+import json
+
+
+def test_impact_graphs_api(app):
+    """Test response of impact graph API."""
+    with app.test_client() as client:
+        result = client.get(
+            "/api/literature/613135",
+            headers={"Accept": "application/x-impact.graph+json"}
+        )
+
+        result = json.loads(result.data)
+        assert result['title'] == u'First year Wilkinson Microwave Anisotropy Probe (WMAP) observations: Determination of cosmological parameters'
+        assert result['year'] == u'2003'
+        assert len(result['citations']) == 14

--- a/tests/unit/utils/test_utils_record.py
+++ b/tests/unit/utils/test_utils_record.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Tests for record-related utilities."""
+
+from inspirehep.utils.record import get_title
+
+
+def test_get_title():
+    """Test get title utility."""
+    double_title = {
+        "titles": [
+            {
+                "source": "arXiv",
+                "title": "Parton distributions with LHC data"
+            },
+            {
+                "title": "Parton distributions with LHC data"
+            }
+        ]
+    }
+
+    assert get_title(double_title) == "Parton distributions with LHC data"
+
+    single_title = {
+        "titles": [
+            {
+                "subtitle": "Harvest of Run 1",
+                "title": "The Large Hadron Collider"
+            }
+        ]
+    }
+
+    assert get_title(single_title) == "The Large Hadron Collider"
+
+    empty_title = {
+        "titles": []
+    }
+
+    assert get_title(empty_title) == ""
+
+    no_title_key = {
+        "not_titles": []
+    }
+
+    assert get_title(no_title_key) == ""


### PR DESCRIPTION
* Adds API to retrieve information regarding references and citations
  for a given record. Needed by impact graph visualization. (closes #1044)

* Adds new record utils for record-related utilities.

* Adds get_title util.

* Adds appropriate tests for the added functionality.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>