### PR TITLE
dojson: repeatable statistics

### DIFF
--- a/inspirehep/dojson/current_marcxml_usage/README.rst
+++ b/inspirehep/dojson/current_marcxml_usage/README.rst
@@ -1,0 +1,11 @@
+=====================
+Current MARCXML usage
+=====================
+
+This directory contains 2 types of files:
+ * The repeatable ones contain information about which field (and subfields
+   within fields) are repeated for a given collection. The number in parenthesis
+   can be used as a hint to know which entries are actually outliers that need
+   to be corrected.
+ * The other type of files list for every MARC field/subfield some statistics
+   and example of values (and in case, outliers).

--- a/inspirehep/dojson/current_marcxml_usage/closed-jobs-repeatable.txt
+++ b/inspirehep/dojson/current_marcxml_usage/closed-jobs-repeatable.txt
@@ -1,0 +1,22 @@
+8564  -> (122) http://inspirehep.net/record/1403652, http://inspirehep.net/record/1405022, http://inspirehep.net/record/1408448
+970   -> (1) http://inspirehep.net/record/962894
+110   -> (206) http://inspirehep.net/record/1418583, http://inspirehep.net/record/1419942, http://inspirehep.net/record/1421493
+037   -> (3) http://inspirehep.net/record/1235473, http://inspirehep.net/record/1391062, http://inspirehep.net/record/1402512
+981   -> (1) http://inspirehep.net/record/1402512
+656   -> (932) http://inspirehep.net/record/1418583, http://inspirehep.net/record/1420224, http://inspirehep.net/record/1424904
+046   -> (4622) http://inspirehep.net/record/1081089, http://inspirehep.net/record/1089493, http://inspirehep.net/record/1089529
+043   -> (3) http://inspirehep.net/record/1244575, http://inspirehep.net/record/1375854, http://inspirehep.net/record/1419940
+961   -> (8228) http://inspirehep.net/record/1115232, http://inspirehep.net/record/1219665, http://inspirehep.net/record/1319813
+270   -> (4397) http://inspirehep.net/record/1397774, http://inspirehep.net/record/1397918, http://inspirehep.net/record/1399245
+693   -> (327) http://inspirehep.net/record/1416420, http://inspirehep.net/record/1416679, http://inspirehep.net/record/1421462
+65017 -> (5734) http://inspirehep.net/record/1426863, http://inspirehep.net/record/1426922, http://inspirehep.net/record/1427094
+040   -> (1) http://inspirehep.net/record/962894
+
+656  a -> (4) http://inspirehep.net/record/1255134, http://inspirehep.net/record/1255887, http://inspirehep.net/record/1255967
+270  o -> (48) http://inspirehep.net/record/1384981, http://inspirehep.net/record/1397580, http://inspirehep.net/record/1411981
+270  m -> (116) http://inspirehep.net/record/1409664, http://inspirehep.net/record/1409865, http://inspirehep.net/record/1414235
+037  a -> (1) http://inspirehep.net/record/1209976
+693  e -> (3) http://inspirehep.net/record/1255967, http://inspirehep.net/record/1281989, http://inspirehep.net/record/1283256
+270  p -> (129) http://inspirehep.net/record/1409865, http://inspirehep.net/record/1414235, http://inspirehep.net/record/1416417
+8564 u -> (3) http://inspirehep.net/record/1080228, http://inspirehep.net/record/1216569, http://inspirehep.net/record/1222760
+110  a -> (43) http://inspirehep.net/record/1328347, http://inspirehep.net/record/1334592, http://inspirehep.net/record/1394079

--- a/inspirehep/dojson/current_marcxml_usage/conferences-repeatable.txt
+++ b/inspirehep/dojson/current_marcxml_usage/conferences-repeatable.txt
@@ -1,0 +1,38 @@
+500   -> (394) http://inspirehep.net/record/1436321, http://inspirehep.net/record/1439816, http://inspirehep.net/record/1445071
+8564  -> (984) http://inspirehep.net/record/1403315, http://inspirehep.net/record/1403852, http://inspirehep.net/record/1421099
+111   -> (9) http://inspirehep.net/record/973675, http://inspirehep.net/record/978993, http://inspirehep.net/record/1220831
+411   -> (298) http://inspirehep.net/record/1404073, http://inspirehep.net/record/1404074, http://inspirehep.net/record/1425611
+667   -> (1) http://inspirehep.net/record/968711
+695   -> (15) http://inspirehep.net/record/1320615, http://inspirehep.net/record/1320679, http://inspirehep.net/record/1328291
+773   -> (3) http://inspirehep.net/record/967218, http://inspirehep.net/record/969989, http://inspirehep.net/record/973815
+520   -> (7) http://inspirehep.net/record/1288023, http://inspirehep.net/record/1389784, http://inspirehep.net/record/1408811
+981   -> (2) http://inspirehep.net/record/979804, http://inspirehep.net/record/1203896
+270   -> (224) http://inspirehep.net/record/1436422, http://inspirehep.net/record/1436447, http://inspirehep.net/record/1449856
+711   -> (359) http://inspirehep.net/record/1436452, http://inspirehep.net/record/1436454, http://inspirehep.net/record/1441257
+970   -> (17) http://inspirehep.net/record/977895, http://inspirehep.net/record/978204, http://inspirehep.net/record/980521
+980   -> (1139) http://inspirehep.net/record/1449766, http://inspirehep.net/record/1449856, http://inspirehep.net/record/1449858
+65017 -> (1124) http://inspirehep.net/record/1449856, http://inspirehep.net/record/1449858, http://inspirehep.net/record/1449859
+035   -> (4) http://inspirehep.net/record/964507, http://inspirehep.net/record/978445, http://inspirehep.net/record/978448
+909CO -> (14) http://inspirehep.net/record/1298092, http://inspirehep.net/record/1299763, http://inspirehep.net/record/1321581
+6531  -> (3032) http://inspirehep.net/record/1446711, http://inspirehep.net/record/1446793, http://inspirehep.net/record/1449859
+505   -> (2) http://inspirehep.net/record/1211445, http://inspirehep.net/record/1244702
+595 D -> (10) http://inspirehep.net/record/1223906, http://inspirehep.net/record/1320615, http://inspirehep.net/record/1320679
+
+999C6v -> (3) http://inspirehep.net/record/964571, http://inspirehep.net/record/978822, http://inspirehep.net/record/1388546
+111  d -> (1) http://inspirehep.net/record/1084037
+111  c -> (10) http://inspirehep.net/record/1085463, http://inspirehep.net/record/1126173, http://inspirehep.net/record/1299602
+111  b -> (1) http://inspirehep.net/record/963611
+270  m -> (13) http://inspirehep.net/record/1414293, http://inspirehep.net/record/1436421, http://inspirehep.net/record/1439825
+970  a -> (3) http://inspirehep.net/record/973072, http://inspirehep.net/record/978993, http://inspirehep.net/record/981005
+111  e -> (27) http://inspirehep.net/record/1308774, http://inspirehep.net/record/1311394, http://inspirehep.net/record/1315730
+520  a -> (1) http://inspirehep.net/record/1127630
+8564 y -> (133) http://inspirehep.net/record/1402433, http://inspirehep.net/record/1402435, http://inspirehep.net/record/1403314
+500  a -> (2) http://inspirehep.net/record/981555, http://inspirehep.net/record/1117750
+909COo -> (1) http://inspirehep.net/record/1357523
+980  a -> (1) http://inspirehep.net/record/1119924
+411  a -> (8) http://inspirehep.net/record/969879, http://inspirehep.net/record/973987, http://inspirehep.net/record/979566
+270  p -> (1) http://inspirehep.net/record/1323026
+595  a -> (1) http://inspirehep.net/record/1299602
+711  b -> (12) http://inspirehep.net/record/1388117, http://inspirehep.net/record/1388235, http://inspirehep.net/record/1388249
+8564 u -> (1) http://inspirehep.net/record/1123950
+111  a -> (11) http://inspirehep.net/record/1192090, http://inspirehep.net/record/1206144, http://inspirehep.net/record/1217781

--- a/inspirehep/dojson/current_marcxml_usage/experiments-repeatable.txt
+++ b/inspirehep/dojson/current_marcxml_usage/experiments-repeatable.txt
@@ -1,0 +1,24 @@
+8564  -> (62) http://inspirehep.net/record/1337943, http://inspirehep.net/record/1346343, http://inspirehep.net/record/1399306
+695   -> (2) http://inspirehep.net/record/1275752, http://inspirehep.net/record/1287309
+700   -> (2064) http://inspirehep.net/record/1110672, http://inspirehep.net/record/1317971, http://inspirehep.net/record/1387676
+970   -> (3) http://inspirehep.net/record/1108203, http://inspirehep.net/record/1108227, http://inspirehep.net/record/1108237
+710   -> (18) http://inspirehep.net/record/1110641, http://inspirehep.net/record/1110662, http://inspirehep.net/record/1249670
+520   -> (14) http://inspirehep.net/record/1110249, http://inspirehep.net/record/1110568, http://inspirehep.net/record/1110625
+419   -> (213) http://inspirehep.net/record/1275752, http://inspirehep.net/record/1337948, http://inspirehep.net/record/1402888
+981   -> (3) http://inspirehep.net/record/1108506, http://inspirehep.net/record/1298909, http://inspirehep.net/record/1357671
+270   -> (250) http://inspirehep.net/record/1239433, http://inspirehep.net/record/1239434, http://inspirehep.net/record/1239436
+510   -> (217) http://inspirehep.net/record/1386519, http://inspirehep.net/record/1386527, http://inspirehep.net/record/1401120
+702   -> (615) http://inspirehep.net/record/1402897, http://inspirehep.net/record/1402899, http://inspirehep.net/record/1409204
+119   -> (10) http://inspirehep.net/record/1108219, http://inspirehep.net/record/1109177, http://inspirehep.net/record/1110516
+980   -> (138) http://inspirehep.net/record/1411559, http://inspirehep.net/record/1416761, http://inspirehep.net/record/1420092
+65017 -> (17) http://inspirehep.net/record/1373185, http://inspirehep.net/record/1374162, http://inspirehep.net/record/1409205
+046   -> (2329) http://inspirehep.net/record/1318099, http://inspirehep.net/record/1318100, http://inspirehep.net/record/1318106
+6531  -> (107) http://inspirehep.net/record/1110637, http://inspirehep.net/record/1299097, http://inspirehep.net/record/1401303
+372   -> (9) http://inspirehep.net/record/1109017, http://inspirehep.net/record/1109089, http://inspirehep.net/record/1109388
+
+700  v -> (1) http://inspirehep.net/record/1108243
+700  u -> (327) http://inspirehep.net/record/1110644, http://inspirehep.net/record/1110667, http://inspirehep.net/record/1110671
+046  r -> (1) http://inspirehep.net/record/1317974
+700  a -> (2147) http://inspirehep.net/record/1110670, http://inspirehep.net/record/1110671, http://inspirehep.net/record/1110672
+119  u -> (2) http://inspirehep.net/record/1110488, http://inspirehep.net/record/1228417
+510  a -> (3) http://inspirehep.net/record/1110515, http://inspirehep.net/record/1299096, http://inspirehep.net/record/1299097

--- a/inspirehep/dojson/current_marcxml_usage/hep-repeatable.txt
+++ b/inspirehep/dojson/current_marcxml_usage/hep-repeatable.txt
@@ -1,0 +1,163 @@
+041   -> (3) http://inspirehep.net/record/1114353, http://inspirehep.net/record/1231408, http://inspirehep.net/record/1370573
+700   -> (477230) http://inspirehep.net/record/1450082, http://inspirehep.net/record/1450083, http://inspirehep.net/record/1450084
+110   -> (141) http://inspirehep.net/record/1279518, http://inspirehep.net/record/1280969, http://inspirehep.net/record/1380642
+690C  -> (65617) http://inspirehep.net/record/1353000, http://inspirehep.net/record/1359986, http://inspirehep.net/record/1415012
+970   -> (1161) http://inspirehep.net/record/1216662, http://inspirehep.net/record/1216894, http://inspirehep.net/record/1217110
+78708 -> (1) http://inspirehep.net/record/1192107
+65071 -> (1) http://inspirehep.net/record/1120806
+981   -> (38) http://inspirehep.net/record/1286960, http://inspirehep.net/record/1291275, http://inspirehep.net/record/1307769
+542   -> (98) http://inspirehep.net/record/1321023, http://inspirehep.net/record/1329945, http://inspirehep.net/record/1416909
+961   -> (977225) http://inspirehep.net/record/1424760, http://inspirehep.net/record/1424761, http://inspirehep.net/record/1424762
+980   -> (1097304) http://inspirehep.net/record/1450082, http://inspirehep.net/record/1450083, http://inspirehep.net/record/1450084
+650   -> (8) http://inspirehep.net/record/1223711, http://inspirehep.net/record/1223712, http://inspirehep.net/record/1223714
+6507  -> (214) http://inspirehep.net/record/1222522, http://inspirehep.net/record/1222542, http://inspirehep.net/record/1227106
+8564  -> (336337) http://inspirehep.net/record/1450043, http://inspirehep.net/record/1450045, http://inspirehep.net/record/1450046
+653   -> (146) http://inspirehep.net/record/1275304, http://inspirehep.net/record/1276360, http://inspirehep.net/record/1276696
+269   -> (766) http://inspirehep.net/record/1447967, http://inspirehep.net/record/1447968, http://inspirehep.net/record/1449928
+0247  -> (51338) http://inspirehep.net/record/1447916, http://inspirehep.net/record/1447922, http://inspirehep.net/record/1448227
+242   -> (2) http://inspirehep.net/record/195800, http://inspirehep.net/record/1210369
+210   -> (28272) http://inspirehep.net/record/1416929, http://inspirehep.net/record/1416940, http://inspirehep.net/record/1419875
+520   -> (63796) http://inspirehep.net/record/1447916, http://inspirehep.net/record/1447922, http://inspirehep.net/record/1448227
+245   -> (38) http://inspirehep.net/record/1423108, http://inspirehep.net/record/1426628, http://inspirehep.net/record/1430493
+022   -> (1) http://inspirehep.net/record/1387710
+541   -> (264) http://inspirehep.net/record/1426432, http://inspirehep.net/record/1439262, http://inspirehep.net/record/1448241
+78002 -> (4) http://inspirehep.net/record/1120733, http://inspirehep.net/record/1278199, http://inspirehep.net/record/1395503
+595   -> (649698) http://inspirehep.net/record/1437902, http://inspirehep.net/record/1446800, http://inspirehep.net/record/1449932
+701   -> (2135) http://inspirehep.net/record/1448146, http://inspirehep.net/record/1448151, http://inspirehep.net/record/1449931
+540   -> (1952) http://inspirehep.net/record/1445090, http://inspirehep.net/record/1446927, http://inspirehep.net/record/1446959
+505   -> (46) http://inspirehep.net/record/1365369, http://inspirehep.net/record/1375103, http://inspirehep.net/record/1376202
+902   -> (18092) http://inspirehep.net/record/1328344, http://inspirehep.net/record/1357665, http://inspirehep.net/record/1357669
+65027 -> (10) http://inspirehep.net/record/816484, http://inspirehep.net/record/839996, http://inspirehep.net/record/900977
+695   -> (647207) http://inspirehep.net/record/1450060, http://inspirehep.net/record/1450061, http://inspirehep.net/record/1450067
+020   -> (710) http://inspirehep.net/record/1444601, http://inspirehep.net/record/1444929, http://inspirehep.net/record/1449925
+694   -> (1) http://inspirehep.net/record/898809
+037   -> (190308) http://inspirehep.net/record/1450013, http://inspirehep.net/record/1450022, http://inspirehep.net/record/1450025
+0248  -> (3) http://inspirehep.net/record/1260884, http://inspirehep.net/record/1286960, http://inspirehep.net/record/1429571
+721   -> (2) http://inspirehep.net/record/169763, http://inspirehep.net/record/458126
+490   -> (2) http://inspirehep.net/record/158963, http://inspirehep.net/record/161705
+246   -> (24354) http://inspirehep.net/record/1442357, http://inspirehep.net/record/1444862, http://inspirehep.net/record/1446773
+999C6 -> (517) http://inspirehep.net/record/1434119, http://inspirehep.net/record/1434369, http://inspirehep.net/record/1434371
+100   -> (284) http://inspirehep.net/record/1449177, http://inspirehep.net/record/1449180, http://inspirehep.net/record/1449182
+999c5 -> (1) http://inspirehep.net/record/711422
+6531  -> (148119) http://inspirehep.net/record/1450079, http://inspirehep.net/record/1450080, http://inspirehep.net/record/1450082
+595 D -> (99543) http://inspirehep.net/record/1444923, http://inspirehep.net/record/1445134, http://inspirehep.net/record/1446693
+500   -> (64672) http://inspirehep.net/record/1450044, http://inspirehep.net/record/1450045, http://inspirehep.net/record/1450046
+710   -> (4106) http://inspirehep.net/record/1447163, http://inspirehep.net/record/1447805, http://inspirehep.net/record/1447824
+300   -> (47) http://inspirehep.net/record/1240528, http://inspirehep.net/record/1266243, http://inspirehep.net/record/1376608
+773   -> (296217) http://inspirehep.net/record/1447871, http://inspirehep.net/record/1447875, http://inspirehep.net/record/1447876
+084   -> (127357) http://inspirehep.net/record/1447869, http://inspirehep.net/record/1447908, http://inspirehep.net/record/1447909
+270   -> (1) http://inspirehep.net/record/1127460
+78502 -> (1) http://inspirehep.net/record/1230253
+9995C -> (8) http://inspirehep.net/record/857446, http://inspirehep.net/record/867126, http://inspirehep.net/record/886766
+693   -> (5682) http://inspirehep.net/record/1447799, http://inspirehep.net/record/1447805, http://inspirehep.net/record/1447824
+65017 -> (217390) http://inspirehep.net/record/1450058, http://inspirehep.net/record/1450063, http://inspirehep.net/record/1450082
+035   -> (902611) http://inspirehep.net/record/1450035, http://inspirehep.net/record/1450036, http://inspirehep.net/record/1450037
+999C5 -> (822257) http://inspirehep.net/record/1450080, http://inspirehep.net/record/1450083, http://inspirehep.net/record/1450084
+909CO -> (167) http://inspirehep.net/record/1429459, http://inspirehep.net/record/1433269, http://inspirehep.net/record/1433485
+260   -> (145) http://inspirehep.net/record/1419618, http://inspirehep.net/record/1425745, http://inspirehep.net/record/1429151
+
+999C6v -> (88593) http://inspirehep.net/record/1450035, http://inspirehep.net/record/1450036, http://inspirehep.net/record/1450037
+500  a -> (3) http://inspirehep.net/record/808572, http://inspirehep.net/record/925049, http://inspirehep.net/record/1432039
+020  u -> (1) http://inspirehep.net/record/1418892
+0248 p -> (1755) http://inspirehep.net/record/1447968, http://inspirehep.net/record/1449928, http://inspirehep.net/record/1449929
+0248 q -> (2) http://inspirehep.net/record/1429310, http://inspirehep.net/record/1429369
+970  a -> (28) http://inspirehep.net/record/1209611, http://inspirehep.net/record/1210573, http://inspirehep.net/record/1217763
+693  a -> (1) http://inspirehep.net/record/1283402
+693  e -> (5) http://inspirehep.net/record/1297909, http://inspirehep.net/record/1307834, http://inspirehep.net/record/1432768
+595 Da -> (11343) http://inspirehep.net/record/1444540, http://inspirehep.net/record/1444845, http://inspirehep.net/record/1444900
+502  c -> (25) http://inspirehep.net/record/1385648, http://inspirehep.net/record/1429559, http://inspirehep.net/record/1429933
+502  d -> (1) http://inspirehep.net/record/1296504
+540  a -> (17) http://inspirehep.net/record/1414669, http://inspirehep.net/record/1414670, http://inspirehep.net/record/1414671
+505  a -> (2) http://inspirehep.net/record/1408599, http://inspirehep.net/record/1444601
+505  t -> (6) http://inspirehep.net/record/1399463, http://inspirehep.net/record/1422656, http://inspirehep.net/record/1422851
+505  r -> (4) http://inspirehep.net/record/1237174, http://inspirehep.net/record/1249419, http://inspirehep.net/record/1293063
+999C5 -> (1) http://inspirehep.net/record/1279134
+650172 -> (10) http://inspirehep.net/record/460369, http://inspirehep.net/record/587812, http://inspirehep.net/record/612048
+035  z -> (3) http://inspirehep.net/record/73278, http://inspirehep.net/record/663001, http://inspirehep.net/record/674498
+300  a -> (1) http://inspirehep.net/record/1222489
+035  a -> (2) http://inspirehep.net/record/629557, http://inspirehep.net/record/1264800
+260  b -> (3) http://inspirehep.net/record/273300, http://inspirehep.net/record/580146, http://inspirehep.net/record/1389075
+260  c -> (2) http://inspirehep.net/record/202165, http://inspirehep.net/record/670467
+260  a -> (1) http://inspirehep.net/record/1263141
+595  a -> (16) http://inspirehep.net/record/1422920, http://inspirehep.net/record/1448175, http://inspirehep.net/record/1448350
+700  q -> (11) http://inspirehep.net/record/1420658, http://inspirehep.net/record/1422910, http://inspirehep.net/record/1448393
+084  a -> (8) http://inspirehep.net/record/1376406, http://inspirehep.net/record/1376407, http://inspirehep.net/record/1406874
+700  v -> (17205) http://inspirehep.net/record/1450077, http://inspirehep.net/record/1450078, http://inspirehep.net/record/1450082
+700  u -> (128968) http://inspirehep.net/record/1450048, http://inspirehep.net/record/1450049, http://inspirehep.net/record/1450059
+961  c -> (2) http://inspirehep.net/record/737285, http://inspirehep.net/record/756157
+700  a -> (72) http://inspirehep.net/record/1421135, http://inspirehep.net/record/1429700, http://inspirehep.net/record/1449094
+700  e -> (4) http://inspirehep.net/record/616871, http://inspirehep.net/record/730416, http://inspirehep.net/record/853449
+700  j -> (60) http://inspirehep.net/record/1418701, http://inspirehep.net/record/1418702, http://inspirehep.net/record/1421607
+700  i -> (7) http://inspirehep.net/record/1304657, http://inspirehep.net/record/1368899, http://inspirehep.net/record/1413104
+961  x -> (2) http://inspirehep.net/record/371884, http://inspirehep.net/record/737285
+700  m -> (52) http://inspirehep.net/record/1408756, http://inspirehep.net/record/1410925, http://inspirehep.net/record/1448164
+999C5N -> (1) http://inspirehep.net/record/1382050
+701  u -> (139) http://inspirehep.net/record/1429582, http://inspirehep.net/record/1429584, http://inspirehep.net/record/1429607
+701  a -> (48) http://inspirehep.net/record/1351645, http://inspirehep.net/record/1351646, http://inspirehep.net/record/1385655
+541  a -> (1632) http://inspirehep.net/record/1427667, http://inspirehep.net/record/1427668, http://inspirehep.net/record/1429161
+999C59 -> (474) http://inspirehep.net/record/1447858, http://inspirehep.net/record/1447870, http://inspirehep.net/record/1447959
+999C50 -> (116) http://inspirehep.net/record/1386346, http://inspirehep.net/record/1392540, http://inspirehep.net/record/1409385
+909COp -> (64998) http://inspirehep.net/record/1449929, http://inspirehep.net/record/1449991, http://inspirehep.net/record/1449993
+909COq -> (365) http://inspirehep.net/record/1411220, http://inspirehep.net/record/1411702, http://inspirehep.net/record/1428663
+909COo -> (3) http://inspirehep.net/record/378656, http://inspirehep.net/record/1245515, http://inspirehep.net/record/1286304
+0247 9 -> (7) http://inspirehep.net/record/775359, http://inspirehep.net/record/1081350, http://inspirehep.net/record/1117362
+999C5  -> (1) http://inspirehep.net/record/1279196
+0247 2 -> (1) http://inspirehep.net/record/1292531
+490  a -> (1) http://inspirehep.net/record/670467
+020  a -> (3) http://inspirehep.net/record/787461, http://inspirehep.net/record/1226366, http://inspirehep.net/record/1340406
+100  e -> (3) http://inspirehep.net/record/876830, http://inspirehep.net/record/1396604, http://inspirehep.net/record/1409583
+999C5y -> (295) http://inspirehep.net/record/1424761, http://inspirehep.net/record/1430886, http://inspirehep.net/record/1435121
+100  a -> (18) http://inspirehep.net/record/1341911, http://inspirehep.net/record/1376754, http://inspirehep.net/record/1377023
+100  m -> (90) http://inspirehep.net/record/1424695, http://inspirehep.net/record/1429933, http://inspirehep.net/record/1432775
+999C5r -> (5599) http://inspirehep.net/record/1449987, http://inspirehep.net/record/1449990, http://inspirehep.net/record/1450016
+999C5p -> (9724) http://inspirehep.net/record/1450031, http://inspirehep.net/record/1450037, http://inspirehep.net/record/1450053
+100  i -> (1) http://inspirehep.net/record/1184548
+100  h -> (43) http://inspirehep.net/record/1429475, http://inspirehep.net/record/1429476, http://inspirehep.net/record/1429479
+999C5u -> (1876) http://inspirehep.net/record/1449082, http://inspirehep.net/record/1449931, http://inspirehep.net/record/1450049
+100  j -> (23) http://inspirehep.net/record/1417898, http://inspirehep.net/record/1418655, http://inspirehep.net/record/1418656
+100  u -> (130728) http://inspirehep.net/record/1449938, http://inspirehep.net/record/1450052, http://inspirehep.net/record/1450060
+999C5i -> (211) http://inspirehep.net/record/1426370, http://inspirehep.net/record/1436348, http://inspirehep.net/record/1450026
+100  v -> (12761) http://inspirehep.net/record/1450075, http://inspirehep.net/record/1450077, http://inspirehep.net/record/1450082
+999C5o -> (99) http://inspirehep.net/record/1439039, http://inspirehep.net/record/1441658, http://inspirehep.net/record/1448543
+8564 | -> (1) http://inspirehep.net/record/931278
+999C5m -> (1328) http://inspirehep.net/record/1446858, http://inspirehep.net/record/1447935, http://inspirehep.net/record/1447939
+999C5c -> (2033) http://inspirehep.net/record/1449905, http://inspirehep.net/record/1449999, http://inspirehep.net/record/1450000
+999C5a -> (25) http://inspirehep.net/record/1416003, http://inspirehep.net/record/1424282, http://inspirehep.net/record/1426682
+999C5g -> (1) http://inspirehep.net/record/1279196
+999C5e -> (4544) http://inspirehep.net/record/1449843, http://inspirehep.net/record/1449844, http://inspirehep.net/record/1449852
+773  c -> (35) http://inspirehep.net/record/1262147, http://inspirehep.net/record/1338092, http://inspirehep.net/record/1371762
+8564 J -> (1) http://inspirehep.net/record/1369357
+999C5S -> (1) http://inspirehep.net/record/1382050
+773  m -> (24) http://inspirehep.net/record/1445261, http://inspirehep.net/record/1447540, http://inspirehep.net/record/1449342
+773  n -> (4) http://inspirehep.net/record/324293, http://inspirehep.net/record/324323, http://inspirehep.net/record/324385
+773  q -> (2) http://inspirehep.net/record/93420, http://inspirehep.net/record/93421
+773  p -> (59) http://inspirehep.net/record/1341560, http://inspirehep.net/record/1341563, http://inspirehep.net/record/1386767
+999C5I -> (1) http://inspirehep.net/record/1117209
+773  r -> (2) http://inspirehep.net/record/406165, http://inspirehep.net/record/873214
+8564 \ -> (6) http://inspirehep.net/record/1266764, http://inspirehep.net/record/1280712, http://inspirehep.net/record/1339405
+773  w -> (189) http://inspirehep.net/record/1405352, http://inspirehep.net/record/1420854, http://inspirehep.net/record/1424721
+773  v -> (72) http://inspirehep.net/record/1345095, http://inspirehep.net/record/1386767, http://inspirehep.net/record/1392569
+773  y -> (83) http://inspirehep.net/record/1373163, http://inspirehep.net/record/1375273, http://inspirehep.net/record/1386767
+773  x -> (9) http://inspirehep.net/record/448056, http://inspirehep.net/record/688558, http://inspirehep.net/record/1194126
+999C5{ -> (1) http://inspirehep.net/record/1279134
+6531 G -> (1) http://inspirehep.net/record/1401509
+037  a -> (5) http://inspirehep.net/record/1127460, http://inspirehep.net/record/1347160, http://inspirehep.net/record/1352751
+037  c -> (10) http://inspirehep.net/record/1447016, http://inspirehep.net/record/1447947, http://inspirehep.net/record/1449944
+980  a -> (7) http://inspirehep.net/record/1247377, http://inspirehep.net/record/1276767, http://inspirehep.net/record/1331863
+8564 u -> (112) http://inspirehep.net/record/1280712, http://inspirehep.net/record/1305268, http://inspirehep.net/record/1340442
+245  b -> (3) http://inspirehep.net/record/1123251, http://inspirehep.net/record/1224368, http://inspirehep.net/record/1417166
+520  a -> (76) http://inspirehep.net/record/1297699, http://inspirehep.net/record/1319174, http://inspirehep.net/record/1370576
+999C5s -> (32181) http://inspirehep.net/record/1450030, http://inspirehep.net/record/1450031, http://inspirehep.net/record/1450039
+269  c -> (1) http://inspirehep.net/record/1384006
+269  b -> (1) http://inspirehep.net/record/1384006
+8564 g -> (1) http://inspirehep.net/record/1346254
+999C5t -> (8180) http://inspirehep.net/record/1450021, http://inspirehep.net/record/1450023, http://inspirehep.net/record/1450025
+8564 y -> (14) http://inspirehep.net/record/1312672, http://inspirehep.net/record/1403548, http://inspirehep.net/record/1421100
+690C a -> (1) http://inspirehep.net/record/351779
+8564 { -> (2) http://inspirehep.net/record/1288042, http://inspirehep.net/record/1339405
+999C5h -> (42150) http://inspirehep.net/record/1449854, http://inspirehep.net/record/1450050, http://inspirehep.net/record/1450051
+6531 9 -> (28) http://inspirehep.net/record/1425625, http://inspirehep.net/record/1426746, http://inspirehep.net/record/1432547
+694  a -> (1) http://inspirehep.net/record/893472
+100  q -> (11) http://inspirehep.net/record/1444428, http://inspirehep.net/record/1445054, http://inspirehep.net/record/1446945
+520  1 -> (1) http://inspirehep.net/record/1220490
+245  9 -> (1) http://inspirehep.net/record/1283862

--- a/inspirehep/dojson/current_marcxml_usage/hepnames-repeatable.txt
+++ b/inspirehep/dojson/current_marcxml_usage/hepnames-repeatable.txt
@@ -1,0 +1,45 @@
+8564  -> (821) http://inspirehep.net/record/1426446, http://inspirehep.net/record/1445067, http://inspirehep.net/record/1449135
+970   -> (34) http://inspirehep.net/record/1074905, http://inspirehep.net/record/1078991, http://inspirehep.net/record/1257900
+670   -> (21413) http://inspirehep.net/record/1409400, http://inspirehep.net/record/1409679, http://inspirehep.net/record/1419881
+909CO -> (2) http://inspirehep.net/record/1340974, http://inspirehep.net/record/1346435
+100   -> (43) http://inspirehep.net/record/1271309, http://inspirehep.net/record/1271312, http://inspirehep.net/record/1271316
+880   -> (1) http://inspirehep.net/record/982820
+667   -> (67) http://inspirehep.net/record/1069059, http://inspirehep.net/record/1080253, http://inspirehep.net/record/1210935
+680   -> (1) http://inspirehep.net/record/1114396
+981   -> (33) http://inspirehep.net/record/1274136, http://inspirehep.net/record/1279168, http://inspirehep.net/record/1336659
+711   -> (384) http://inspirehep.net/record/1070223, http://inspirehep.net/record/1074282, http://inspirehep.net/record/1076749
+400   -> (1689) http://inspirehep.net/record/1437888, http://inspirehep.net/record/1437894, http://inspirehep.net/record/1438446
+961   -> (97803) http://inspirehep.net/record/1389808, http://inspirehep.net/record/1400626, http://inspirehep.net/record/1403408
+980   -> (82404) http://inspirehep.net/record/1449869, http://inspirehep.net/record/1449926, http://inspirehep.net/record/1449948
+541   -> (3) http://inspirehep.net/record/1006981, http://inspirehep.net/record/1125509, http://inspirehep.net/record/1389072
+371   -> (51486) http://inspirehep.net/record/1449135, http://inspirehep.net/record/1449136, http://inspirehep.net/record/1450086
+693   -> (6989) http://inspirehep.net/record/1436463, http://inspirehep.net/record/1437900, http://inspirehep.net/record/1444559
+65017 -> (10906) http://inspirehep.net/record/1448251, http://inspirehep.net/record/1448252, http://inspirehep.net/record/1449134
+035   -> (46211) http://inspirehep.net/record/1449869, http://inspirehep.net/record/1449926, http://inspirehep.net/record/1449948
+595   -> (16457) http://inspirehep.net/record/1383817, http://inspirehep.net/record/1408679, http://inspirehep.net/record/1444293
+701   -> (3624) http://inspirehep.net/record/1448250, http://inspirehep.net/record/1448251, http://inspirehep.net/record/1449136
+678   -> (27) http://inspirehep.net/record/1050651, http://inspirehep.net/record/1051695, http://inspirehep.net/record/1075570
+
+650172 -> (1) http://inspirehep.net/record/1055341
+909COo -> (134) http://inspirehep.net/record/1403407, http://inspirehep.net/record/1415236, http://inspirehep.net/record/1416404
+400  a -> (19) http://inspirehep.net/record/1292425, http://inspirehep.net/record/1292426, http://inspirehep.net/record/1292431
+961  c -> (7) http://inspirehep.net/record/1013883, http://inspirehep.net/record/1029683, http://inspirehep.net/record/1037794
+970  a -> (36) http://inspirehep.net/record/1074025, http://inspirehep.net/record/1078703, http://inspirehep.net/record/1250053
+693  e -> (4) http://inspirehep.net/record/1032368, http://inspirehep.net/record/1058096, http://inspirehep.net/record/1074927
+961  x -> (10) http://inspirehep.net/record/1041210, http://inspirehep.net/record/1060811, http://inspirehep.net/record/1064639
+100  a -> (1) http://inspirehep.net/record/1272247
+371  z -> (3) http://inspirehep.net/record/1032642, http://inspirehep.net/record/1040069, http://inspirehep.net/record/1050475
+371  t -> (1) http://inspirehep.net/record/1028796
+371  s -> (2) http://inspirehep.net/record/1010082, http://inspirehep.net/record/1029281
+371  r -> (7) http://inspirehep.net/record/1046266, http://inspirehep.net/record/1219369, http://inspirehep.net/record/1224674
+8564 g -> (1) http://inspirehep.net/record/1008846
+371  o -> (43) http://inspirehep.net/record/1260522, http://inspirehep.net/record/1269378, http://inspirehep.net/record/1369939
+371  m -> (215) http://inspirehep.net/record/1408378, http://inspirehep.net/record/1410701, http://inspirehep.net/record/1411773
+100  q -> (3) http://inspirehep.net/record/1256722, http://inspirehep.net/record/1272247, http://inspirehep.net/record/1274155
+701  i -> (7) http://inspirehep.net/record/1029254, http://inspirehep.net/record/1029266, http://inspirehep.net/record/1060326
+701  g -> (1) http://inspirehep.net/record/1076348
+8564 u -> (1) http://inspirehep.net/record/1015217
+701  a -> (2) http://inspirehep.net/record/1035369, http://inspirehep.net/record/1059108
+371  a -> (41) http://inspirehep.net/record/1403464, http://inspirehep.net/record/1403469, http://inspirehep.net/record/1403470
+670  a -> (1) http://inspirehep.net/record/1005647
+035  a -> (2) http://inspirehep.net/record/1013883, http://inspirehep.net/record/1024159

--- a/inspirehep/dojson/current_marcxml_usage/institutions-repeatable.txt
+++ b/inspirehep/dojson/current_marcxml_usage/institutions-repeatable.txt
@@ -1,0 +1,40 @@
+8564  -> (36) http://inspirehep.net/record/1281006, http://inspirehep.net/record/1293658, http://inspirehep.net/record/1295115
+970   -> (23) http://inspirehep.net/record/912417, http://inspirehep.net/record/1241037, http://inspirehep.net/record/1241099
+110   -> (16) http://inspirehep.net/record/911486, http://inspirehep.net/record/1225384, http://inspirehep.net/record/1240986
+667   -> (12) http://inspirehep.net/record/911216, http://inspirehep.net/record/911270, http://inspirehep.net/record/911565
+6781  -> (4) http://inspirehep.net/record/905391, http://inspirehep.net/record/909164, http://inspirehep.net/record/910530
+410   -> (5960) http://inspirehep.net/record/1430108, http://inspirehep.net/record/1442294, http://inspirehep.net/record/1442295
+680   -> (1) http://inspirehep.net/record/909023
+981   -> (7) http://inspirehep.net/record/922207, http://inspirehep.net/record/940108, http://inspirehep.net/record/946374
+510   -> (201) http://inspirehep.net/record/1430106, http://inspirehep.net/record/1437897, http://inspirehep.net/record/1446792
+043   -> (16) http://inspirehep.net/record/912243, http://inspirehep.net/record/912256, http://inspirehep.net/record/912287
+961   -> (9605) http://inspirehep.net/record/1241290, http://inspirehep.net/record/1241291, http://inspirehep.net/record/1388773
+980   -> (9780) http://inspirehep.net/record/1441259, http://inspirehep.net/record/1444399, http://inspirehep.net/record/1445046
+371   -> (26) http://inspirehep.net/record/1119936, http://inspirehep.net/record/1279690, http://inspirehep.net/record/1389987
+65017 -> (7) http://inspirehep.net/record/1125505, http://inspirehep.net/record/1182113, http://inspirehep.net/record/1424710
+595   -> (9) http://inspirehep.net/record/907231, http://inspirehep.net/record/907275, http://inspirehep.net/record/907691
+372   -> (2) http://inspirehep.net/record/903421, http://inspirehep.net/record/911565
+
+6781 a -> (1) http://inspirehep.net/record/902725
+410  g -> (5954) http://inspirehep.net/record/1412141, http://inspirehep.net/record/1430099, http://inspirehep.net/record/1430956
+980  a -> (172) http://inspirehep.net/record/1241287, http://inspirehep.net/record/1241289, http://inspirehep.net/record/1241291
+980  b -> (5100) http://inspirehep.net/record/1345384, http://inspirehep.net/record/1351710, http://inspirehep.net/record/1388773
+8564 u -> (1) http://inspirehep.net/record/909904
+510  w -> (1) http://inspirehep.net/record/911145
+510  a -> (1) http://inspirehep.net/record/911145
+667  a -> (2) http://inspirehep.net/record/910767, http://inspirehep.net/record/919235
+371  g -> (105) http://inspirehep.net/record/1241283, http://inspirehep.net/record/1241285, http://inspirehep.net/record/1241287
+371  f -> (6856) http://inspirehep.net/record/914934, http://inspirehep.net/record/914935, http://inspirehep.net/record/915906
+371  e -> (21) http://inspirehep.net/record/1389989, http://inspirehep.net/record/1389990, http://inspirehep.net/record/1406039
+371  d -> (105) http://inspirehep.net/record/1241270, http://inspirehep.net/record/1241287, http://inspirehep.net/record/1267144
+371  c -> (21) http://inspirehep.net/record/909803, http://inspirehep.net/record/909853, http://inspirehep.net/record/1241145
+371  b -> (18) http://inspirehep.net/record/943602, http://inspirehep.net/record/963424, http://inspirehep.net/record/1111526
+371  a -> (9839) http://inspirehep.net/record/1448142, http://inspirehep.net/record/1448222, http://inspirehep.net/record/1448400
+110  t -> (1) http://inspirehep.net/record/902672
+110  u -> (1) http://inspirehep.net/record/904695
+510  0 -> (1) http://inspirehep.net/record/911145
+410  a -> (31) http://inspirehep.net/record/1209215, http://inspirehep.net/record/1246977, http://inspirehep.net/record/1430099
+110  x -> (22) http://inspirehep.net/record/1238200, http://inspirehep.net/record/1272948, http://inspirehep.net/record/1272953
+034  d -> (107) http://inspirehep.net/record/1442294, http://inspirehep.net/record/1442295, http://inspirehep.net/record/1444399
+110  a -> (2) http://inspirehep.net/record/905390, http://inspirehep.net/record/917349
+110  b -> (8) http://inspirehep.net/record/909904, http://inspirehep.net/record/910192, http://inspirehep.net/record/1220418

--- a/inspirehep/dojson/current_marcxml_usage/jobs-repeatable.txt
+++ b/inspirehep/dojson/current_marcxml_usage/jobs-repeatable.txt
@@ -1,0 +1,12 @@
+8564  -> (7) http://inspirehep.net/record/1416935, http://inspirehep.net/record/1416936, http://inspirehep.net/record/1424919
+110   -> (17) http://inspirehep.net/record/1427342, http://inspirehep.net/record/1432032, http://inspirehep.net/record/1446799
+037   -> (2) http://inspirehep.net/record/1332454, http://inspirehep.net/record/1444470
+656   -> (43) http://inspirehep.net/record/1436416, http://inspirehep.net/record/1437992, http://inspirehep.net/record/1447878
+961   -> (5) http://inspirehep.net/record/961145, http://inspirehep.net/record/962775, http://inspirehep.net/record/1083758
+270   -> (4) http://inspirehep.net/record/1385206, http://inspirehep.net/record/1386760, http://inspirehep.net/record/1397923
+693   -> (45) http://inspirehep.net/record/1447878, http://inspirehep.net/record/1447943, http://inspirehep.net/record/1448391
+65017 -> (273) http://inspirehep.net/record/1448397, http://inspirehep.net/record/1449868, http://inspirehep.net/record/1449936
+270  o -> (9) http://inspirehep.net/record/1437992, http://inspirehep.net/record/1437993, http://inspirehep.net/record/1444586
+270  m -> (19) http://inspirehep.net/record/1432640, http://inspirehep.net/record/1437992, http://inspirehep.net/record/1437993
+110  a -> (1) http://inspirehep.net/record/1328021
+270  p -> (17) http://inspirehep.net/record/1426377, http://inspirehep.net/record/1437992, http://inspirehep.net/record/1437993

--- a/inspirehep/dojson/current_marcxml_usage/journals-repeatable.txt
+++ b/inspirehep/dojson/current_marcxml_usage/journals-repeatable.txt
@@ -1,0 +1,12 @@
+8564  -> (24) http://inspirehep.net/record/1342165, http://inspirehep.net/record/1388906, http://inspirehep.net/record/1389229
+030   -> (12) http://inspirehep.net/record/1213834, http://inspirehep.net/record/1213970, http://inspirehep.net/record/1305561
+667   -> (31) http://inspirehep.net/record/1357927, http://inspirehep.net/record/1385705, http://inspirehep.net/record/1388334
+530   -> (2) http://inspirehep.net/record/1212966, http://inspirehep.net/record/1389746
+730   -> (2482) http://inspirehep.net/record/1418291, http://inspirehep.net/record/1418292, http://inspirehep.net/record/1441133
+677   -> (26) http://inspirehep.net/record/1214806, http://inspirehep.net/record/1214849, http://inspirehep.net/record/1214881
+022   -> (26) http://inspirehep.net/record/1416938, http://inspirehep.net/record/1416942, http://inspirehep.net/record/1418291
+980   -> (1) http://inspirehep.net/record/1311535
+640   -> (10) http://inspirehep.net/record/1214629, http://inspirehep.net/record/1214731, http://inspirehep.net/record/1214771
+643   -> (1) http://inspirehep.net/record/1212635
+711  b -> (1) http://inspirehep.net/record/1212848
+540  a -> (1) http://inspirehep.net/record/1267572


### PR DESCRIPTION
* Adds statistics files for every collection, to describe the current
  usage on legacy for MARC fields and subfields.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>