### PR TITLE
dojson: hep `license` field regex fix

### DIFF
--- a/inspirehep/dojson/hep/fields/bd5xx.py
+++ b/inspirehep/dojson/hep/fields/bd5xx.py
@@ -185,7 +185,7 @@ def license(self, key, value):
     }
 
 
-@hep2marc.over('540', 'license')
+@hep2marc.over('540', '^license$')
 @utils.for_each_value
 @utils.filter_values
 def license2marc(self, key, value):


### PR DESCRIPTION
Fix discovered while working with literature suggest and workflows.

cc @tomaszgy @bittirousku @jmartinm 