### PR TITLE
audit: initial Audit trail

### DIFF
--- a/inspirehep/modules/workflows/models.py
+++ b/inspirehep/modules/workflows/models.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2015, 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Extra models for workflows."""
+
+from __future__ import absolute_import, print_function
+
+from datetime import datetime
+
+from invenio_db import db
+
+
+class WorkflowsAudit(db.Model):
+
+    __tablename__ = "workflows_audit_logging"
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+
+    # Date that the action was taken
+    created = db.Column(db.DateTime, default=datetime.now, nullable=False)
+
+    user_id = db.Column(db.Integer, db.ForeignKey("accounts_user.id"), nullable=True)
+    object_id = db.Column(db.Integer, db.ForeignKey("workflows_object.id"), nullable=False)
+
+    # Score from model, action taken, recommendation from the model
+    score = db.Column(db.Float, default=0, nullable=False)
+    user_action = db.Column(db.Text, default="", nullable=False)
+    decision = db.Column(db.Text, default="", nullable=False)
+
+    source = db.Column(db.Text, default="", nullable=False)
+    action = db.Column(db.Text, default="", nullable=False)
+
+    def save(self):
+        """Save object to persistent storage."""
+        with db.session.begin_nested():
+            db.session.add(self)

--- a/inspirehep/modules/workflows/utils.py
+++ b/inspirehep/modules/workflows/utils.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2015, 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Model for WorkflowsAudit."""
+
+from __future__ import absolute_import, print_function
+
+from .models import WorkflowsAudit
+
+
+def log_workflows_action(action, prediction_results,
+                         object_id, user_id,
+                         source, user_action=""):
+    """Log the action taken by user compared to a prediction."""
+    if prediction_results:
+        score = prediction_results.get("max_score")  # returns 0.222113
+        decision = prediction_results.get("decision")  # returns "Rejected"
+
+        # Map actions to align with the prediction format
+        action_map = {
+            'accept': 'Non-CORE',
+            'accept_core': 'CORE',
+            'reject': 'Rejected'
+        }
+
+        logging_info = {
+            'object_id': object_id,
+            'user_id': user_id,
+            'score': score,
+            'user_action': action_map.get(user_action, ""),
+            'decision': decision,
+            'source': source,
+            'action': action
+        }
+        audit = WorkflowsAudit(**logging_info)
+        audit.save()

--- a/setup.py
+++ b/setup.py
@@ -265,6 +265,9 @@ setup(
         'invenio_workflows_ui.actions': [
             'author_approval = inspirehep.modules.authors.workflows.actions.author_approval:AuthorApproval',
         ],
+        'invenio_db.models': [
+            'inspire_workflows_audit = inspirehep.modules.workflows.models',
+        ],
     },
     tests_require=tests_require,
     cmdclass={'test': PyTest}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -32,7 +32,7 @@ from invenio_search import current_search_client as es
 from inspirehep.factory import create_app
 
 
-@pytest.yield_fixture(scope='session', autouse=True)
+@pytest.yield_fixture(scope='session')
 def app(request):
     """Flask application fixture."""
     app = create_app()
@@ -64,4 +64,21 @@ def app(request):
         add_citation_counts(request_timeout=20)
         es.indices.refresh('records-hep')  # Makes sure that all citation counts were added.
 
+        yield app
+
+
+@pytest.yield_fixture(scope='session')
+def db_only_app(request):
+    """Flask application fixture."""
+    app = create_app()
+
+    def teardown():
+        with app.app_context():
+            db.drop_all()
+
+    request.addfinalizer(teardown)
+
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
         yield app

--- a/tests/integration/workflows/test_audit.py
+++ b/tests/integration/workflows/test_audit.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Tests for WorkflowsAudit model."""
+
+from __future__ import absolute_import, print_function
+
+from invenio_db import db
+
+from invenio_accounts.models import User
+from invenio_workflows import WorkflowObject
+
+from inspirehep.modules.workflows.models import WorkflowsAudit
+from inspirehep.modules.workflows.utils import log_workflows_action
+
+
+def test_audit(db_only_app):
+    user_id = None
+    workflow_id = None
+    with db_only_app.app_context():
+        user = User(email="test@example.com", active=True)
+        user.password = "test"
+        db.session.add(user)
+
+        workflows_object = WorkflowObject.create_object()
+        workflows_object.save()
+
+        db.session.commit()
+        user_id = user.id
+        workflow_id = workflows_object.id
+
+    with db_only_app.app_context():
+        logging_info = {
+            'object_id': workflow_id,
+            'user_id': user_id,
+            'score': 0.222113,
+            'user_action': "Non-CORE",
+            'decision': "Rejected",
+            'source': "test",
+            'action': "accept"
+        }
+        audit = WorkflowsAudit(**logging_info)
+        audit.save()
+        db.session.commit()
+
+        assert WorkflowsAudit.query.count() == 1
+
+        audit_entry = WorkflowsAudit.query.filter(WorkflowsAudit.object_id == 1).one()
+        assert audit_entry
+        assert audit_entry.action == "accept"
+        assert audit_entry.score == 0.222113
+
+    prediction_results = dict(
+        max_score=0.222113, decision="Rejected"
+    )
+    with db_only_app.app_context():
+        log_workflows_action(
+            action="accept_core",
+            prediction_results=prediction_results,
+            object_id=workflow_id,
+            user_id=None,
+            source="test",
+            user_action="accept"
+        )
+        db.session.commit()
+
+        assert WorkflowsAudit.query.count() == 2
+
+        audit_entry = WorkflowsAudit.query.filter(
+            WorkflowsAudit.action == "accept_core"
+        ).one()
+        assert audit_entry
+        assert audit_entry.action == "accept_core"
+        assert audit_entry.score == 0.222113


### PR DESCRIPTION
* Adds back the Audit module for tracking actions in Holding Pen.

Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>