### PR TITLE
utils: dotted record key lookup

### DIFF
--- a/inspirehep/utils/record.py
+++ b/inspirehep/utils/record.py
@@ -22,6 +22,10 @@
 
 """Helpers for handling records."""
 
+import re
+
+SPLIT_KEY_PATTERN = re.compile('\.|\[')
+
 
 def get_title(record):
     """Get preferred title from record."""
@@ -31,3 +35,53 @@ def get_title(record):
             return title['title']
 
     return title
+
+
+def get_value(record, key, default=None):
+    """Return item as `dict.__getitem__` but using 'smart queries'.
+    .. note::
+        Accessing one value in a normal way, meaning d['a'], is almost as
+        fast as accessing a regular dictionary. But using the special
+        name convention is a bit slower than using the regular access:
+        .. code-block:: python
+            >>> %timeit x = dd['a[0].b']
+            100000 loops, best of 3: 3.94 us per loop
+            >>> %timeit x = dd['a'][0]['b']
+            1000000 loops, best of 3: 598 ns per loop
+    """
+    def getitem(k, v):
+        if isinstance(v, dict):
+            return v[k]
+        elif ']' in k:
+            k = k[:-1].replace('n', '-1')
+            # Work around for list indexes and slices
+            try:
+                return v[int(k)]
+            except ValueError:
+                return v[slice(*map(
+                    lambda x: int(x.strip()) if x.strip() else None,
+                    k.split(':')
+                ))]
+        else:
+            tmp = []
+            for inner_v in v:
+                try:
+                    tmp.append(getitem(k, inner_v))
+                except KeyError:
+                    continue
+            return tmp
+
+    # Check if we are using python regular keys
+    try:
+        return record[key]
+    except KeyError:
+        pass
+
+    keys = SPLIT_KEY_PATTERN.split(key)
+    value = record
+    for k in keys:
+        try:
+            value = getitem(k, value)
+        except KeyError:
+            return default
+    return value

--- a/inspirehep/utils/record_getter.py
+++ b/inspirehep/utils/record_getter.py
@@ -22,6 +22,8 @@
 
 """Resource-aware json reference loaders to be used with jsonref."""
 
+from __future__ import absolute_import, print_function
+
 from functools import wraps
 
 from flask import current_app

--- a/tests/unit/utils/test_utils_record.py
+++ b/tests/unit/utils/test_utils_record.py
@@ -19,12 +19,14 @@
 
 """Tests for record-related utilities."""
 
-from inspirehep.utils.record import get_title
+import pytest
+
+from inspirehep.utils.record import get_title, get_value
 
 
-def test_get_title():
-    """Test get title utility."""
-    double_title = {
+@pytest.fixture
+def double_title():
+    return {
         "titles": [
             {
                 "source": "arXiv",
@@ -36,9 +38,10 @@ def test_get_title():
         ]
     }
 
-    assert get_title(double_title) == "Parton distributions with LHC data"
 
-    single_title = {
+@pytest.fixture
+def single_title():
+    return {
         "titles": [
             {
                 "subtitle": "Harvest of Run 1",
@@ -47,16 +50,30 @@ def test_get_title():
         ]
     }
 
-    assert get_title(single_title) == "The Large Hadron Collider"
 
-    empty_title = {
+@pytest.fixture
+def empty_title():
+    return {
         "titles": []
     }
 
+
+def test_get_title(double_title, single_title, empty_title):
+    """Test get title utility."""
+    assert get_title(double_title) == "Parton distributions with LHC data"
+    assert get_title(single_title) == "The Large Hadron Collider"
     assert get_title(empty_title) == ""
 
     no_title_key = {
         "not_titles": []
     }
-
     assert get_title(no_title_key) == ""
+
+
+def test_get_value(double_title, single_title, empty_title):
+    """Test get_value utility"""
+    assert len(get_value(double_title, "titles.title")) == 2
+    assert get_value(double_title, "titles.title[0]") == "Parton distributions with LHC data"
+    assert get_value(single_title, "titles.title") == ["The Large Hadron Collider"]
+    assert get_value(empty_title, "titles.title") == []
+    assert get_value(empty_title, "foo", {}) == {}


### PR DESCRIPTION
* Adds a utility function `get_smart_value` to allow for dotted
  record key lookup. E.g. `get_smart_value(rec, "titles.title")`.

* Migrated from legacy `invenio_utils.datastructures` package.

Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>