### PR TITLE
orcid: pushing records to orcid

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -289,6 +289,8 @@ RECORDS_REST_ENDPOINTS = dict(
                                  ':json_v1_response'),
             'application/x-bibtex': ('inspirehep.modules.records.serializers'
                                      ':bibtex_v1_response'),
+            'application/x-orcid': ('inspirehep.modules.records.serializers'
+                                    ':orcid_response'),
             'application/x-latexeu': ('inspirehep.modules.records.serializers'
                                       ':latexeu_v1_response'),
             'application/x-latexus': ('inspirehep.modules.records.serializers'
@@ -316,6 +318,8 @@ RECORDS_REST_ENDPOINTS = dict(
             ),
             'application/x-bibtex': ('inspirehep.modules.records.serializers'
                                      ':bibtex_v1_search'),
+            'application/x-orcid': ('inspirehep.modules.records.serializers'
+                                    ':orcid_search'),
             'application/x-latexeu': ('inspirehep.modules.records.serializers'
                                       ':latexeu_v1_search'),
             'application/x-latexus': ('inspirehep.modules.records.serializers'
@@ -821,6 +825,7 @@ INDEXER_BULK_REQUEST_TIMEOUT = 120
 
 # OAuthclient
 # ===========
+orcid.REMOTE_APP['params']['request_token_params'] = {'scope': '/orcid-profile/read-limited /activities/update /orcid-bio/update'}
 OAUTHCLIENT_REMOTE_APPS = dict(
     orcid=orcid.REMOTE_APP,
 )
@@ -829,6 +834,12 @@ OAUTHCLIENT_ORCID_CREDENTIALS = dict(
     consumer_secret="CHANGE_ME",
 )
 
+OAUTHCLIENT_SETTINGS_TEMPLATE = 'inspirehep_theme/page.html'
+
+ORCID_SYNCHRONIZATION_ENABLED = False
+
+# Error Pages
+# ========
 THEME_401_TEMPLATE = "inspirehep_theme/errors/401.html"
 THEME_403_TEMPLATE = "inspirehep_theme/errors/403.html"
 THEME_404_TEMPLATE = "inspirehep_theme/errors/404.html"

--- a/inspirehep/modules/orcid/__init__.py
+++ b/inspirehep/modules/orcid/__init__.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import (
+    absolute_import,
+    division,
+    print_function)
+
+from .ext import INSPIREOrcid
+
+from .receivers import *
+
+__all__ = ('INSPIREOrcid',)

--- a/inspirehep/modules/orcid/config.py
+++ b/inspirehep/modules/orcid/config.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import (
+    absolute_import,
+    division,
+    print_function)
+
+ORCID_WORK_TYPES = {
+    "book": "BOOK",
+    "conferencepaper": "CONFERENCE_PAPER",
+    "proceedings": "BOOK",
+    "preprint": "WORKING_PAPER",
+    "note": "WORKING_PAPER",
+    "published": "JOURNAL_ARTICLE",
+    "thesis": "DISSERTATION",
+    "lectures": "LECTURE_SPEECH",
+    "bookchapter": "BOOK_CHAPTER",
+    "report": "REPORT"
+}

--- a/inspirehep/modules/orcid/ext.py
+++ b/inspirehep/modules/orcid/ext.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import (
+    absolute_import,
+    division,
+    print_function)
+
+import orcid
+
+
+class INSPIREOrcid(object):
+    """INSPIRE orcid extension."""
+
+    def __init__(self, app=None, **kwargs):
+        """Extension initialization."""
+        self.app = app
+        if app:
+            self.init_app(app, **kwargs)
+
+    def init_app(self, app, **kwargs):
+        """Initialize application object."""
+        app.extensions['inspire-orcid'] = self
+
+        orcid_base_url = app.config['OAUTHCLIENT_REMOTE_APPS'][
+            'orcid']['params']['base_url']
+        orcid_consumer_secret = app.config[
+            'OAUTHCLIENT_ORCID_CREDENTIALS']['consumer_secret']
+        orcid_consumer_key = app.config[
+            'OAUTHCLIENT_ORCID_CREDENTIALS']['consumer_key']
+
+        self.sandbox = (orcid_base_url == 'https://pub.sandbox.orcid.org/')
+
+        self.orcid_api = orcid.MemberAPI(
+            orcid_consumer_secret, orcid_consumer_key, sandbox=self.sandbox)

--- a/inspirehep/modules/orcid/models.py
+++ b/inspirehep/modules/orcid/models.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from invenio_db import db
+
+from sqlalchemy_utils.types import UUIDType
+
+
+class InspireOrcidRecords(db.Model):
+    __tablename__ = 'inspire_orcid_records'
+
+    orcid = db.Column(db.String(160), primary_key=True)
+    record_id = db.Column(UUIDType)
+    put_code = db.Column(db.Integer, primary_key=True)

--- a/inspirehep/modules/orcid/receivers.py
+++ b/inspirehep/modules/orcid/receivers.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from inspirehep.modules.records.signals import after_record_enhanced
+
+from invenio_records.signals import before_record_delete
+
+from .tasks import delete_from_orcid, send_to_orcid
+
+from flask import current_app
+
+
+@after_record_enhanced.connect
+def send_records_to_orcid(sender, *args, **kwargs):
+    """ Schedules a Celery task that sends every new/updated record to orcid.
+
+        :param sender: The record to be sented to orcid (in json format).
+    """
+    if current_app.config.get('ORCID_SYNCHRONIZATION_ENABLED'):
+        send_to_orcid.delay(sender=sender)
+
+
+@before_record_delete.connect
+def delete_record_from_orcid(sender, *args, **kwargs):
+    """ Schedules a Celery task that removes records from orcid.
+
+        :param sender: The record to be deleted from orcid (in json format).
+    """
+    if current_app.config.get('ORCID_SYNCHRONIZATION_ENABLED'):
+        delete_from_orcid.delay(sender=sender)

--- a/inspirehep/modules/orcid/schema.py
+++ b/inspirehep/modules/orcid/schema.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from HTMLParser import HTMLParser
+
+import dojson
+
+from dojson import utils
+
+from inspirehep.utils.record import get_abstract, get_subtitle, get_title
+
+from .config import ORCID_WORK_TYPES
+
+orcid_overdo = dojson.Overdo()
+
+
+class MLStripper(HTMLParser):
+
+    def __init__(self):
+        self.reset()
+        self.fed = []
+
+    def handle_data(self, d):
+        self.fed.append(d)
+
+    def get_data(self):
+        return ''.join(self.fed)
+
+
+def strip_tags(html):
+    """ Strips html tags out of a given string.
+    """
+    if html is None:
+        html = ''
+    s = MLStripper()
+    s.feed(html)
+    return s.get_data()
+
+
+@orcid_overdo.over('title', 'titles')
+def title_rule(self, key, value):
+    title = get_title({"titles": value})
+    if title == '':
+        raise KeyError
+    subtitle = get_subtitle({"titles": value})
+    return {"title": title,
+            "subtitle": subtitle}
+
+
+@orcid_overdo.over('journal-title', 'publication_info')
+def publication_rule(self, key, value):
+    try:
+        return value[0]['journal_title']
+    except (TypeError, KeyError):
+        pass
+
+
+@orcid_overdo.over('short-description', 'abstracts')
+def abstract_rule(self, key, value):
+    return strip_tags(get_abstract({"abstracts": value}))
+
+
+@orcid_overdo.over('publication-date', 'imprints')
+def date_rule(self, key, value):
+    try:
+        date = value[0].get('date')
+        date = date.split('-')
+        final_date = ['', '', '']
+        if date[0]:
+            final_date[0] = date[0]
+        if date[1]:
+            final_date[1] = date[1]
+        if date[2]:
+            final_date[2] = date[2]
+        publication_date = {'year': int(final_date[0]),
+                            'month': int(final_date[1]),
+                            'day': int(final_date[2])
+                            }
+        return publication_date
+    except (TypeError, IndexError, AttributeError):
+        pass
+
+
+@orcid_overdo.over('work_external_identifier', 'arxiv_eprints|dois')
+@dojson.utils.for_each_value
+def external_id_rule(self, key, value):
+    if key == 'dois':
+        return{
+            'external-identifier-type': 'DOI',
+            'external-identifier-id': value.get('value')
+        }
+    if key == 'arxiv_eprints':
+        return {
+            'external-identifier-type': 'ARXIV',
+            'external-identifier-id': value.get('value')
+        }
+
+
+@orcid_overdo.over('contributors', 'authors')
+def authors_rule(self, key, value):
+    value = utils.force_list(value)
+    orcid_authors = []
+    for index, author in enumerate(value):
+        orcid_authors.append({
+            'credit-name': value[index].get('full_name'),
+            'contributor-orcid': value[index].get('orcid') if 'orcid' in value[index] else '',
+            'contributor-attributes': {
+                'contributor-role': 'AUTHOR',
+                'contributor-sequence': ('FIRST' if index is 0 else 'ADDITIONAL')
+            }
+        })
+        if index is 19:
+            break
+
+    return {"contributor": orcid_authors}
+
+
+@orcid_overdo.over('type', 'collections')
+def work_type_rule(self, key, value):
+    work_type = ''
+    try:
+        for val in value:
+            if val['primary'].lower() in ORCID_WORK_TYPES:
+                return ORCID_WORK_TYPES[val['primary'].lower()]
+            else:
+                work_type = 'UNDEFINED'
+        return work_type
+    except KeyError:
+        pass

--- a/inspirehep/modules/orcid/tasks.py
+++ b/inspirehep/modules/orcid/tasks.py
@@ -1,0 +1,176 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from celery import shared_task
+from celery.utils.log import get_task_logger
+
+from flask import current_app
+
+from invenio_db import db
+
+from invenio_oauthclient.models import RemoteAccount, UserIdentity
+
+from invenio_pidstore.resolver import Resolver
+
+from invenio_search import current_search_client
+from invenio_search.utils import schema_to_index
+
+from requests import RequestException
+
+from .models import InspireOrcidRecords
+from .utils import convert_to_orcid, get_authors_credentials
+
+logger = get_task_logger(__name__)
+
+
+def prepare_authors_data_for_pushing_to_orcid(json):
+    """ Extracts the authors with valid orcid credentials from the list of authors
+    of a given record in json format.
+    """
+    resolver = Resolver(pid_type='literature',
+                        object_type='rec', getter=lambda x: x)
+    record_id = resolver.resolve(json.get('control_number'))[
+        0].object_uuid
+    authors = get_orcid_valid_authors(json)
+    token = None
+    author_orcid = ''
+    authors_with_orcid_credentials = []
+    for author in authors:
+        try:
+            token, author_orcid = get_authors_credentials(author['_source'])
+        except AttributeError:
+            continue
+        try:
+            authors_with_orcid_credentials.append((InspireOrcidRecords.query.filter_by(
+                orcid=author_orcid, record_id=record_id).first().put_code, token, author_orcid, record_id))
+        except AttributeError:
+            authors_with_orcid_credentials.append(
+                ([], token, author_orcid, record_id))
+            continue
+    return authors_with_orcid_credentials
+
+
+@shared_task(ignore_result=True)
+def delete_from_orcid(sender, api=None):
+    """ Deletes a record from orcid.
+    """
+    if not api:
+        api = current_app.extensions['inspire-orcid'].orcid_api
+
+    resolver = Resolver(pid_type='literature',
+                        object_type='rec', getter=lambda x: x)
+    record_id = resolver.resolve(sender.get('control_number'))[
+        0].object_uuid
+    records = InspireOrcidRecords.query.filter_by(record_id=record_id).all()
+    for record in records:
+        raw_user = UserIdentity.query.filter_by(
+            id=record.orcid, method='orcid').first()
+        user = RemoteAccount.query.filter_by(user_id=raw_user.id_user).first()
+        token = user.tokens[0].access_token
+        api.remove_record(record.orcid, token, 'work', record.put_code)
+        with db.session.begin_nested():
+            db.session.delete(record)
+        db.session.commit()
+
+
+def doc_type_should_be_sent_to_orcid(record):
+    index, doc_type = schema_to_index(record['$schema'])
+    return doc_type == 'hep'
+
+
+@shared_task(ignore_result=True)
+def send_to_orcid(sender, api=None):
+    """Sends records to orcid."""
+    if doc_type_should_be_sent_to_orcid(sender):
+        logger.info("Sending " + sender.get('control_number') + " to orcid.")
+        try:
+            if not api:
+                api = current_app.extensions['inspire-orcid'].orcid_api
+            orcid_json = convert_to_orcid(sender)
+            authors = prepare_authors_data_for_pushing_to_orcid(sender)
+            for author in authors:
+                try:
+                    put_code = author[0]
+                    token = author[1]
+                    author_orcid = author[2]
+                    record_id = author[3]
+                    if not put_code:
+                        put_code = api.add_record(  # try-continue
+                            author_orcid, token, 'work', orcid_json)
+                        orcid_log_record = InspireOrcidRecords(
+                            orcid=author_orcid,
+                            record_id=record_id,
+                            put_code=put_code)
+                        with db.session.begin_nested():
+                            db.session.add(orcid_log_record)
+                        db.session.commit()
+                    else:
+                        api.update_record(author_orcid, token,
+                                          'work', orcid_json, str(put_code))
+                    logger.info("Succersfully sent " +
+                                sender.get('control_number') + " to orcid.")
+                except RequestException as e:
+                    print(e.response.text, sender['control_number'])
+                    logger.info("Failed to push " +
+                                sender.get('control_number') + " to orcid.")
+                    continue
+        except (KeyError, AttributeError, TypeError) as e:
+            logger.info("Failed to convert " +
+                        sender.get('control_number') + " to orcid.")
+
+
+def get_author_collection_records_from_valid_authors(authors_refs):
+    """ Queries elasticsearch for the author-records of the given authors references.
+    """
+    es_query = {
+        "filter": {
+            "bool": {
+                "must": [
+                    {"terms": {
+                        "self.$ref": authors_refs
+                    }}, {"match": {
+                        "ids.type": "ORCID"
+                    }}
+                ]
+            }
+        }
+    }
+    authors = current_search_client.search(
+        index='records-authors',
+        doc_type='authors',
+        body=es_query
+    )['hits']['hits']
+    return authors
+
+
+def get_orcid_valid_authors(record):
+    """ Returns all the valid author-records from a hep-record.
+    A valid author-rerord is one that contains an orcid id.
+    """
+    authors_refs = []
+    for author in record['authors']:
+        try:
+            authors_refs.append(author['record']['$ref'])
+        except KeyError:
+            continue
+
+    return get_author_collection_records_from_valid_authors(authors_refs)

--- a/inspirehep/modules/orcid/utils.py
+++ b/inspirehep/modules/orcid/utils.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from inspirehep.utils.bibtex import Bibtex
+
+from invenio_oauthclient.models import RemoteAccount, UserIdentity
+
+from .schema import orcid_overdo
+
+
+def convert_to_orcid(record):
+    """ Converts a given record to a json containing the information that
+    orcid needs.
+    """
+    orcid_json = orcid_overdo.do(record)
+
+    orcid_json['external-identifiers'] = {
+        'work-external-identifier': orcid_json['work_external_identifier']}
+    orcid_json.pop('work_external_identifier')
+    orcid_json['citation'] = {'citation': Bibtex(
+        record).format(), 'citation-type': 'BIBTEX'}
+
+    return orcid_json
+
+
+def get_authors_credentials(author):
+    """Returns the orcid-id and the orcid-token for a specific author (if available)."""
+    author_orcid = ''
+    for orcid_id in author['ids']:
+        if orcid_id['type'] == 'ORCID':
+            author_orcid = orcid_id['value']
+    raw_user = UserIdentity.query.filter_by(
+        id=author_orcid, method='orcid').first()
+    user = RemoteAccount.query.filter_by(user_id=raw_user.id_user).first()
+    token = user.tokens[0].access_token
+    return (token, author_orcid)

--- a/inspirehep/modules/records/mappings/records/authors.json
+++ b/inspirehep/modules/records/mappings/records/authors.json
@@ -117,6 +117,15 @@
                 "positions": {
                     "type": "nested",
                     "include_in_parent": true
+                },
+                "self":{
+                  "type": "object",
+                  "properties":{
+                    "$ref": {
+                      "type": "string",
+                      "index": "not_analyzed"
+                    }
+                  }
                 }
             }
         }

--- a/inspirehep/modules/records/serializers/__init__.py
+++ b/inspirehep/modules/records/serializers/__init__.py
@@ -36,6 +36,7 @@ from .latexus_serializer import LATEXUSSerializer
 from .cvformatlatex_serializer import CVFORMATLATEXSerializer
 from .cvformathtml_serializer import CVFORMATHTMLSerializer
 from .cvformattext_serializer import CVFORMATTEXTSerializer
+from .orcid_serializer import ORCIDSerializer
 from .schemas.json import RecordSchemaJSONBRIEFV1
 
 from .response import record_responsify_nocache
@@ -50,6 +51,7 @@ latexus_v1 = LATEXUSSerializer()
 cvformatlatex_v1 = CVFORMATLATEXSerializer()
 cvformathtml_v1 = CVFORMATHTMLSerializer()
 cvformattext_v1 = CVFORMATTEXTSerializer()
+orcid = ORCIDSerializer()
 
 bibtex_v1_response = record_responsify_nocache(
     bibtex_v1, 'application/x-bibtex')
@@ -63,7 +65,7 @@ cvformathtml_v1_response = record_responsify_nocache(cvformathtml_v1,
                                                      'application/x-cvformathtml')
 cvformattext_v1_response = record_responsify_nocache(cvformattext_v1,
                                                      'application/x-cvformattext')
-
+orcid_response = record_responsify_nocache(orcid, 'application/x-orcid')
 
 bibtex_v1_search = search_responsify(bibtex_v1, 'application/x-bibtex')
 latexeu_v1_search = search_responsify(latexeu_v1, 'application/x-latexeu')
@@ -77,3 +79,4 @@ cvformattext_v1_search = search_responsify(cvformattext_v1,
 impactgraph_v1 = ImpactGraphSerializer()
 impactgraph_v1_response = record_responsify_nocache(impactgraph_v1,
                                                     'application/x-impact.graph+json')
+orcid_search = search_responsify(orcid, 'application/x-orcid')

--- a/inspirehep/modules/records/serializers/orcid_serializer.py
+++ b/inspirehep/modules/records/serializers/orcid_serializer.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Orcid serializer for records."""
+
+from __future__ import absolute_import, print_function
+
+import json
+
+from inspirehep.modules.orcid.tasks import convert_to_orcid
+
+
+class ORCIDSerializer(object):
+    """Orcid serializer for records."""
+
+    def serialize(self, pid, record, links_factory=None):
+        """Serialize a single orcid from a record.
+        :param pid: Persistent identifier instance.
+        :param record: Record instance.
+        :param links_factory: Factory function for the link generation,
+                              which are added to the response.
+        """
+        return json.dumps(convert_to_orcid(record.dumps()))
+
+    def serialize_search(self, pid_fetcher, search_result, links=None,
+                         item_links_factory=None):
+        """Serialize a search result.
+        :param pid_fetcher: Persistent identifier fetcher.
+        :param search_result: Elasticsearch search result.
+        :param links: Dictionary of links to add to response.
+        """
+        records = []
+        for hit in search_result['hits']['hits']:
+            records.append(json.dumps((convert_to_orcid(hit['_source']))))
+
+        return "\n".join(records)

--- a/inspirehep/modules/records/signals.py
+++ b/inspirehep/modules/records/signals.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014, 2015, 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Record module signals."""
+
+from blinker import Namespace
+
+_signals = Namespace()
+
+after_record_enhanced = _signals.signal('after-record-enhanced')
+"""Signal is sent before a record is indexed and after all the enchancers have
+populated it.
+"""

--- a/inspirehep/modules/theme/templates/inspirehep_theme/accounts/login.html
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/accounts/login.html
@@ -33,7 +33,7 @@
 <div class="col-xs-12 col-sm-10 col-md-8 col-lg-6 col-centered">
   <div class="well">
     <br/>
-    {% set next = request.url if request.endpoint != 'security.logout' and request.endpoint != 'security.login' else config.SERVER_NAME %}
+    {% set next = request.url if request.endpoint != 'security.logout' and request.endpoint != 'security.login' else request.args.get('next', '') %}
     <div class="row text-center">
       <a href="{{ url_for('invenio_oauthclient.login', remote_app='orcid', next=next) }}" tabindex="0" id="orcid_login" class="btn btn-lg" role="button"><img id="orcid-id-logo" src="{{ url_for('static', filename='images/orcid.png') }}" alt="ORCID logo"> {{ _('Sign in with ORCID') }}</a>
       <p class="text-center">
@@ -42,7 +42,7 @@
             {{ _('What is ORCID?') }}
           </a>
         </small>
-      </p>      
+      </p>
       {% if config.DEBUG or request.args.get('local') %}
         <h3 align="center" id="login-header">&mdash; OR &mdash;</h3>
         {%- with form = login_user_form %}

--- a/inspirehep/utils/record.py
+++ b/inspirehep/utils/record.py
@@ -29,12 +29,54 @@ SPLIT_KEY_PATTERN = re.compile('\.|\[')
 
 def get_title(record):
     """Get preferred title from record."""
-    title = ""
-    for title in record.get('titles', []):
-        if title.get('title'):
-            return title['title']
+    chosen_title = ""
 
-    return title
+    for title in record.get('titles', []):
+        if 'source' in title and title.get('source') != 'arXiv':
+            return title.get('title')
+        elif 'source' in title and title.get('source') == 'arXiv':
+            pass
+        else:
+            chosen_title = title.get('title')
+
+    if not chosen_title and len(record.get('titles', [])) > 0:
+        chosen_title = record['titles'][0]['title']
+
+    return chosen_title
+
+
+def get_subtitle(record):
+    """Get preferred subtitle from record."""
+    chosen_subtitle = ""
+
+    for title in record.get('titles', []):
+        if 'source' in title and 'subtitle' in title and title.get('source') != 'arXiv':
+            return title.get('subtitle')
+        elif 'source' in title and 'subtitle' in title and title.get('source') == 'arXiv':
+            if not chosen_subtitle:
+                chosen_subtitle = title.get('subtitle')
+        else:
+            if 'subtitle' in title:
+                chosen_subtitle = title.get('subtitle')
+    return chosen_subtitle
+
+
+def get_abstract(record):
+    """Get preferred abstract from record."""
+    chosen_abstract = ""
+
+    for abstract in record.get('abstracts', []):
+        if 'source' in abstract and abstract.get('source') != 'arXiv':
+            return abstract.get('value')
+        elif 'source' in abstract and abstract.get('source') == 'arXiv':
+            pass
+        else:
+            chosen_abstract = abstract.get('value')
+
+    if not chosen_abstract and len(record.get('abstracts', [])) > 0:
+        chosen_abstract = record['abstracts'][0]['value']
+
+    return chosen_abstract
 
 
 def get_value(record, key, default=None):

--- a/setup.py
+++ b/setup.py
@@ -186,6 +186,7 @@ setup(
             'inspire_warnings = inspirehep.modules.warnings:INSPIREWarnings',
             'arxiv = inspirehep.modules.arxiv:Arxiv',
             'crossref = inspirehep.modules.crossref:CrossRef',
+            'inspire_orcid = inspirehep.modules.orcid:INSPIREOrcid',
         ],
         'invenio_assets.bundles': [
             'inspirehep_theme_css = inspirehep.modules.theme.bundles:css',

--- a/tests/integration/test_orcid.py
+++ b/tests/integration/test_orcid.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from inspirehep.modules.orcid.models import InspireOrcidRecords
+
+from inspirehep.utils.record_getter import get_db_record
+
+from invenio_accounts.models import User
+
+from invenio_db import db
+
+from invenio_oauthclient.models import RemoteAccount, RemoteToken, UserIdentity
+
+from invenio_search import current_search_client as es
+
+import pytest
+
+
+class OrcidApiMock(object):
+
+    def __init__(self, put_code):
+        self.put_code = put_code
+
+    def add_record(self, author_orcid, token, category, orcid_json):
+        return self.put_code
+
+    def update_record(self, author_orcid, token, category, orcid_json, put_code):
+        pass
+
+    def remove_record(self, author_orcid, token, category, put_code):
+        pass
+
+
+class MockUser:
+
+    def __init__(self, app):
+        self.app = app
+
+
+@pytest.fixture(scope="function")
+def mock_user(app, request):
+
+    def teardown(app):
+        with app.app_context():
+            user = User.query.filter_by(id=1).first()
+            token = RemoteToken.query.filter_by(access_token='123').first()
+            user_identity = UserIdentity.query.filter_by(
+                id='0000-0001-9412-8627', method='orcid').first()
+            remote_account = RemoteAccount.query.filter_by(user_id=1).first()
+            with db.session.begin_nested():
+                db.session.delete(user_identity)
+                db.session.delete(remote_account)
+                db.session.delete(token)
+                db.session.delete(user)
+            db.session.commit()
+
+    request.addfinalizer(lambda: teardown(app))
+
+    user = User(
+        id=1
+    )
+    token = RemoteToken(
+        access_token='123'
+    )
+    user_identity = UserIdentity(
+        id='0000-0001-9412-8627',
+        id_user='1',
+        method='orcid')
+    remote_account = RemoteAccount(
+        user_id=1,
+        extra_data={},
+        client_id=1,
+        user=user,
+        tokens=[token])
+    with app.app_context():
+        with db.session.begin_nested():
+            db.session.add(user)
+            db.session.add(token)
+            db.session.add(user_identity)
+            db.session.add(remote_account)
+        db.session.commit()
+    return MockUser(app)
+
+
+@pytest.fixture(scope='function')
+def orcid_test(mock_user, request):
+    """Orcid test fixture."""
+    app = mock_user.app
+
+    def teardown(app):
+        with app.app_context():
+            es.delete(index='records-authors', doc_type='authors', id=10)
+
+    record = {
+        "name": {
+            "status": "ACTIVE",
+            "preferred_name": "Full Name",
+            "value": "Full Name"
+        },
+        "$schema": "http://localhost:5000/schemas/records/authors.json",
+        "control_number": "10",
+        "self": {"$ref": "http://localhost:5000/api/authors/10"},
+        "ids": [{
+            "type": "INSPIRE",
+            "value": "INSPIRE-0000000"
+        },
+            {
+            "type": "ORCID",
+            "value": "0000-0001-9412-8627"
+        }],
+        "self_recid": 10,
+        "earliest_date": "2015-09-23"
+    }
+
+    request.addfinalizer(lambda: teardown(app))
+
+    with app.app_context():
+        es.index(index='records-authors',
+                 doc_type='authors', id=10, body=record)
+        es.indices.refresh('records-authors')
+        record = get_db_record('literature', 782466)
+        record['authors'].append({u'affiliations': [{u'value': u'St. Petersburg, INP'}],  u'curated_relation': True,  u'full_name': u'Full, Name',  u'profile': {
+                                 u'__url__': u'http://inspirehep.net/record/00000000'},  u'record': {u'$ref': u'http://localhost:5000/api/authors/10'}})
+        mock_orcid_api = OrcidApiMock(1)
+        return mock_orcid_api, record
+
+
+def test_record_is_sent_to_orcid(app, orcid_test):
+    mock_orcid_api, record = orcid_test
+    with app.app_context():
+        from inspirehep.modules.orcid.tasks import send_to_orcid
+        send_to_orcid(record, api=mock_orcid_api)
+
+        expected = 1
+        result = len(InspireOrcidRecords.query.all())
+
+        assert result == expected
+
+
+def test_record_is_deleted_from_orcid(app, orcid_test):
+    mock_orcid_api, record = orcid_test
+    with app.app_context():
+        from inspirehep.modules.orcid.tasks import delete_from_orcid, send_to_orcid
+        send_to_orcid(record, api=mock_orcid_api)
+        delete_from_orcid(record, api=mock_orcid_api)
+
+        expected = 0
+        result = len(InspireOrcidRecords.query.all())
+
+        assert result == expected

--- a/tests/unit/orcid/test_orcid_converter.py
+++ b/tests/unit/orcid/test_orcid_converter.py
@@ -1,0 +1,497 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2015, 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Tests for json conversion to orcid form."""
+
+from inspirehep.modules.orcid.utils import convert_to_orcid
+
+import pytest
+
+
+def test_succesfull_conversion():
+
+    record = {
+        "$schema": "http://localhost:5000/schemas/records/hep.json",
+        "abstracts": [
+            {
+                "source": "arXiv",
+                "value": "<with_html_tag>Abstract</with_html_tag>"
+            }
+        ],
+        "arxiv_eprints": [
+            {
+                "categories": [
+                    "hep-ph"
+                ],
+                "value": "arXiv:0000.00000"
+            }
+        ],
+        "authors": [
+            {
+                "affiliations": [
+                    {
+                        "value": "Affil Inst."
+                    }
+                ],
+                "curated_relation": False,
+                "full_name": "Name, Full",
+                "inspire_id": "INSPIRE-00000000",
+                "orcid": "0000-0000-0000"
+            },
+            {
+                "affiliations": [
+                    {
+                        "value": "Affil Inst."
+                    }
+                ],
+                "curated_relation": False,
+                "full_name": "Name2, Full",
+                "inspire_id": "INSPIRE-00000001"
+            }
+        ],
+        "collections": [
+            {
+                "primary": "report"
+            },
+            {
+                "primary": "arXiv"
+            },
+            {
+                "primary": "book"
+            },
+            {
+                "primary": "HEP"
+            }
+        ],
+        "publication_info": [
+            {
+                "journal_volume": "19",
+                "journal_title": "Nuovo Cim.",
+                "page_artid": "154-164",
+                "year": 1961
+            }
+        ],
+        "control_number": "0000000",
+        "external_system_numbers": [
+            {
+                "institute": "INSPIRETeX",
+                "obsolete": False,
+                "value": "Kats:2015sss"
+            },
+            {
+                "institute": "arXiv",
+                "obsolete": False,
+                "value": "oai:arXiv.org:0000.00000"
+            }
+        ],
+        "public_notes": [
+            {
+                "source": "arXiv",
+                "value": "17 pages, 3 figures"
+            }
+        ],
+        "self": {
+            "$ref": "http://localhost:5000/api/literature/0000000"
+        },
+        "titles": [
+            {
+                "source": "arXiv",
+                "title": "Title",
+                "subtitle": "Subtitle"
+            },
+            {
+                "title": "Title2"
+            },
+            {
+                "source": "other",
+                "title": "Title3"
+            }
+        ]
+    }
+
+    expected = {'citation': {'citation': u'@book{Kats:2015sss,\n      author         = "Name, Full and Name2, Full",\n      title          = "{Title}",\n      volume         = "19",\n      year           = "1961",\n      eprint         = "0000.00000",\n      archivePrefix  = "arXiv",\n      primaryClass   = "hep-ph",\n      SLACcitation   = "%%CITATION = ARXIV:0000.00000;%%"\n}',
+                             'citation-type': 'BIBTEX'},
+                'contributors': {'contributor': [{'contributor-attributes': {'contributor-role': 'AUTHOR',
+                                                                             'contributor-sequence': 'FIRST'},
+                                                  'contributor-orcid': '0000-0000-0000',
+                                                  'credit-name': 'Name, Full'},
+                                                 {'contributor-attributes': {'contributor-role': 'AUTHOR',
+                                                                             'contributor-sequence': 'ADDITIONAL'},
+                                                  'contributor-orcid': '',
+                                                  'credit-name': 'Name2, Full'}]},
+                'external-identifiers': {'work-external-identifier': [{'external-identifier-id': 'arXiv:0000.00000',
+                                                                       'external-identifier-type': 'ARXIV'}]},
+                'journal-title': 'Nuovo Cim.',
+                'short-description': 'Abstract',
+                'title': {'subtitle': 'Subtitle', 'title': 'Title3'},
+                'type': 'REPORT'}
+    result = convert_to_orcid(record)
+    assert expected == result
+
+
+def test_arxiv_missing_conversion():
+    record = {
+        "$schema": "http://localhost:5000/schemas/records/hep.json",
+        "abstracts": [
+            {
+                "source": "arXiv",
+                "value": "Abstract"
+            }
+        ],
+        "authors": [
+            {
+                "affiliations": [
+                    {
+                        "value": "Affil Inst."
+                    }
+                ],
+                "curated_relation": False,
+                "full_name": "Name, Full",
+                "inspire_id": "INSPIRE-00000000",
+                "orcid": "0000-0000-0000"
+            },
+            {
+                "affiliations": [
+                    {
+                        "value": "Affil Inst."
+                    }
+                ],
+                "curated_relation": False,
+                "full_name": "Name2, Full",
+                "inspire_id": "INSPIRE-00000001"
+            }
+        ],
+        "collections": [
+            {
+                "primary": "report"
+            },
+            {
+                "primary": "arXiv"
+            },
+            {
+                "primary": "book"
+            },
+            {
+                "primary": "HEP"
+            }
+        ],
+        "control_number": "0000000",
+        "external_system_numbers": [
+            {
+                "institute": "INSPIRETeX",
+                "obsolete": False,
+                "value": "Kats:2015sss"
+            },
+            {
+                "institute": "arXiv",
+                "obsolete": False,
+                "value": "oai:arXiv.org:0000.00000"
+            }
+        ],
+        "public_notes": [
+            {
+                "source": "arXiv",
+                "value": "17 pages, 3 figures"
+            }
+        ],
+        "self": {
+            "$ref": "http://localhost:5000/api/literature/0000000"
+        },
+        "titles": [
+            {
+                "source": "arXiv",
+                "title": "Title",
+                "subtitle": "Subtitle"
+            },
+            {
+                "title": ""
+            },
+            {
+                "source": "other",
+                "title": "Title3"
+            }
+        ]
+    }
+
+    with pytest.raises(KeyError):
+        convert_to_orcid(record)
+
+
+def test_record():
+    record = {
+        "titles": [
+            {
+                "title": "Title"
+            }
+        ],
+        "dois": [
+            {
+                "value": "00.0000/PhysRevD.00.000000"
+            }
+        ],
+        "publication_info": [
+            {
+                "year": 1961
+            }
+        ],
+        "collections": [
+            {
+                "primary": "not_valid"
+            }
+        ],
+        "control_number": "0000000",
+        "imprints": [
+            {
+                "date": "2008-08-14"
+            }
+        ]
+    }
+
+    excepted = {'citation': {'citation': u'@article{,\n      key            = "0000000",\n      title          = "{Title}",\n      year           = "1961",\n      doi            = "00.0000/PhysRevD.00.000000",\n      SLACcitation   = "%%CITATION = INSPIRE-0000000;%%"\n}',
+                             'citation-type': 'BIBTEX'},
+                'external-identifiers': {'work-external-identifier': [{'external-identifier-id': '00.0000/PhysRevD.00.000000',
+                                                                       'external-identifier-type': 'DOI'}]},
+                'journal-title': None,
+                'publication-date': {'day': 14, 'month': 8, 'year': 2008},
+                'title': {'subtitle': '', 'title': 'Title'},
+                'type': 'UNDEFINED'}
+    result = convert_to_orcid(record)
+
+    assert excepted == result
+
+
+def test_record_with_more_than_20_authors_return_the_first_20_authors():
+    record = {"titles": [
+        {
+            "title": "Title"
+        }
+    ],
+        "authors": [{
+            "affiliations": [{
+                "value": "Affil Inst."
+            }
+            ],
+            "curated_relation": False,
+            "full_name": "Name, Full" + str(i),
+            "inspire_id": "INSPIRE-00000000",
+            "orcid": "0000-0000-0000"
+        } for i in range(22)],
+        "dois": [
+        {
+            "value": "00.0000/PhysRevD.00.000000"
+        }
+    ],
+        "publication_info": [
+        {
+            "year": 1961
+        }],
+        "collections": [
+        {
+            "primary": "not_valid"
+        }
+    ],
+        "control_number": "0000000",
+        "imprints": [
+        {
+            "date": "2008-08-14"
+        }
+    ]
+    }
+
+    expected = {'citation': {'citation': u'@article{,\n      key            = "0000000",\n      author         = "Name, Full0 and others",\n      title          = "{Title}",\n      year           = "1961",\n      doi            = "00.0000/PhysRevD.00.000000",\n      SLACcitation   = "%%CITATION = INSPIRE-0000000;%%"\n}',
+                             'citation-type': 'BIBTEX'},
+                'contributors': {'contributor': [{'contributor-attributes': {'contributor-role': 'AUTHOR',
+                                                                             'contributor-sequence': 'FIRST'},
+                                                  'contributor-orcid': '0000-0000-0000',
+                                                  'credit-name': 'Name, Full0'},
+                                                 {'contributor-attributes': {'contributor-role': 'AUTHOR',
+                                                                             'contributor-sequence': 'ADDITIONAL'},
+                                                  'contributor-orcid': '0000-0000-0000',
+                                                  'credit-name': 'Name, Full1'},
+                                                 {'contributor-attributes': {'contributor-role': 'AUTHOR',
+                                                                             'contributor-sequence': 'ADDITIONAL'},
+                                                  'contributor-orcid': '0000-0000-0000',
+                                                  'credit-name': 'Name, Full2'},
+                                                 {'contributor-attributes': {'contributor-role': 'AUTHOR',
+                                                                             'contributor-sequence': 'ADDITIONAL'},
+                                                  'contributor-orcid': '0000-0000-0000',
+                                                  'credit-name': 'Name, Full3'},
+                                                 {'contributor-attributes': {'contributor-role': 'AUTHOR',
+                                                                             'contributor-sequence': 'ADDITIONAL'},
+                                                  'contributor-orcid': '0000-0000-0000',
+                                                  'credit-name': 'Name, Full4'},
+                                                 {'contributor-attributes': {'contributor-role': 'AUTHOR',
+                                                                             'contributor-sequence': 'ADDITIONAL'},
+                                                  'contributor-orcid': '0000-0000-0000',
+                                                  'credit-name': 'Name, Full5'},
+                                                 {'contributor-attributes': {'contributor-role': 'AUTHOR',
+                                                                             'contributor-sequence': 'ADDITIONAL'},
+                                                  'contributor-orcid': '0000-0000-0000',
+                                                  'credit-name': 'Name, Full6'},
+                                                 {'contributor-attributes': {'contributor-role': 'AUTHOR',
+                                                                             'contributor-sequence': 'ADDITIONAL'},
+                                                  'contributor-orcid': '0000-0000-0000',
+                                                  'credit-name': 'Name, Full7'},
+                                                 {'contributor-attributes': {'contributor-role': 'AUTHOR',
+                                                                             'contributor-sequence': 'ADDITIONAL'},
+                                                  'contributor-orcid': '0000-0000-0000',
+                                                  'credit-name': 'Name, Full8'},
+                                                 {'contributor-attributes': {'contributor-role': 'AUTHOR',
+                                                                             'contributor-sequence': 'ADDITIONAL'},
+                                                  'contributor-orcid': '0000-0000-0000',
+                                                  'credit-name': 'Name, Full9'},
+                                                 {'contributor-attributes': {'contributor-role': 'AUTHOR',
+                                                                             'contributor-sequence': 'ADDITIONAL'},
+                                                  'contributor-orcid': '0000-0000-0000',
+                                                  'credit-name': 'Name, Full10'},
+                                                 {'contributor-attributes': {'contributor-role': 'AUTHOR',
+                                                                             'contributor-sequence': 'ADDITIONAL'},
+                                                  'contributor-orcid': '0000-0000-0000',
+                                                  'credit-name': 'Name, Full11'},
+                                                 {'contributor-attributes': {'contributor-role': 'AUTHOR',
+                                                                             'contributor-sequence': 'ADDITIONAL'},
+                                                  'contributor-orcid': '0000-0000-0000',
+                                                  'credit-name': 'Name, Full12'},
+                                                 {'contributor-attributes': {'contributor-role': 'AUTHOR',
+                                                                             'contributor-sequence': 'ADDITIONAL'},
+                                                  'contributor-orcid': '0000-0000-0000',
+                                                  'credit-name': 'Name, Full13'},
+                                                 {'contributor-attributes': {'contributor-role': 'AUTHOR',
+                                                                             'contributor-sequence': 'ADDITIONAL'},
+                                                  'contributor-orcid': '0000-0000-0000',
+                                                  'credit-name': 'Name, Full14'},
+                                                 {'contributor-attributes': {'contributor-role': 'AUTHOR',
+                                                                             'contributor-sequence': 'ADDITIONAL'},
+                                                  'contributor-orcid': '0000-0000-0000',
+                                                  'credit-name': 'Name, Full15'},
+                                                 {'contributor-attributes': {'contributor-role': 'AUTHOR',
+                                                                             'contributor-sequence': 'ADDITIONAL'},
+                                                  'contributor-orcid': '0000-0000-0000',
+                                                  'credit-name': 'Name, Full16'},
+                                                 {'contributor-attributes': {'contributor-role': 'AUTHOR',
+                                                                             'contributor-sequence': 'ADDITIONAL'},
+                                                  'contributor-orcid': '0000-0000-0000',
+                                                  'credit-name': 'Name, Full17'},
+                                                 {'contributor-attributes': {'contributor-role': 'AUTHOR',
+                                                                             'contributor-sequence': 'ADDITIONAL'},
+                                                  'contributor-orcid': '0000-0000-0000',
+                                                  'credit-name': 'Name, Full18'},
+                                                 {'contributor-attributes': {'contributor-role': 'AUTHOR',
+                                                                             'contributor-sequence': 'ADDITIONAL'},
+                                                  'contributor-orcid': '0000-0000-0000',
+                                                  'credit-name': 'Name, Full19'}]},
+                'external-identifiers': {'work-external-identifier': [{'external-identifier-id': '00.0000/PhysRevD.00.000000',
+                                                                       'external-identifier-type': 'DOI'}]},
+                'journal-title': None,
+                'publication-date': {'day': 14, 'month': 8, 'year': 2008},
+                'title': {'subtitle': '', 'title': 'Title'},
+                'type': 'UNDEFINED'}
+    result = convert_to_orcid(record)
+
+    assert expected == result
+
+
+def test_record_without_title():
+    record = {
+        "titles": [
+            {
+                "title": ""
+            }
+        ],
+        "dois": [
+            {
+                "value": "00.0000/PhysRevD.00.000000"
+            }
+        ],
+        "collections": [
+            {
+                "primary": "book"
+            }
+        ],
+        "control_number": "0000000"
+    }
+
+    with pytest.raises(KeyError):
+        convert_to_orcid(record)
+
+
+def test_record_with_invalid_date():
+    record = {
+        "titles": [
+            {
+                "title": "Title"
+            }
+        ],
+        "dois": [
+            {
+                "value": "00.0000/PhysRevD.00.000000"
+            }
+        ],
+        "collections": [
+            {
+                "primary": "book"
+            }
+        ],
+        "control_number": "0000000",
+        "imprints": [
+            {}
+        ]
+    }
+
+    expected = {'citation': {'citation': u'@book{,\n      key            = "0000000",\n      title          = "{Title}",\n      doi            = "00.0000/PhysRevD.00.000000",\n      SLACcitation   = "%%CITATION = INSPIRE-0000000;%%"\n}',
+                             'citation-type': 'BIBTEX'},
+                'external-identifiers': {'work-external-identifier': [{'external-identifier-id': '00.0000/PhysRevD.00.000000',
+                                                                       'external-identifier-type': 'DOI'}]},
+                'publication-date': None,
+                'title': {'subtitle': '', 'title': 'Title'},
+                'type': 'BOOK'}
+
+    result = convert_to_orcid(record)
+
+    assert expected == result
+
+
+def test_record_without_primary_collection():
+    record = {
+        "titles": [
+            {
+                "title": "Title"
+            }
+        ],
+        "collections": [
+            {
+                "not_primary": "not_valid"
+            }
+        ],
+        "control_number": "0000000",
+        "dois": [
+            {
+                "value": "00.0000/PhysRevD.00.000000"
+            }
+        ]
+    }
+    excepted = {'citation': {'citation': u'@article{,\n      key            = "0000000",\n      title          = "{Title}",\n      doi            = "00.0000/PhysRevD.00.000000",\n      SLACcitation   = "%%CITATION = INSPIRE-0000000;%%"\n}',
+                             'citation-type': 'BIBTEX'},
+                'external-identifiers': {'work-external-identifier': [{'external-identifier-id': '00.0000/PhysRevD.00.000000',
+                                                                       'external-identifier-type': 'DOI'}]},
+                'title': {'subtitle': '', 'title': 'Title'},
+                'type': None}
+    result = convert_to_orcid(record)
+
+    assert excepted == result

--- a/tests/unit/utils/test_utils_record.py
+++ b/tests/unit/utils/test_utils_record.py
@@ -19,61 +19,284 @@
 
 """Tests for record-related utilities."""
 
+from __future__ import absolute_import, print_function
+
+from inspirehep.utils.record import get_abstract, get_subtitle, get_title, get_value
+
+from invenio_records.api import Record
+
 import pytest
 
-from inspirehep.utils.record import get_title, get_value
+
+def test_get_title_returns_empty_string_when_no_titles():
+    no_titles = Record({})
+
+    expected = ''
+    result = get_title(no_titles)
+
+    assert expected == result
 
 
-@pytest.fixture
-def double_title():
-    return {
-        "titles": [
+def test_get_subtitle_returns_empty_string_when_no_titles():
+    no_titles = Record({})
+
+    expected = ''
+    result = get_subtitle(no_titles)
+
+    assert expected == result
+
+
+def test_get_abstract_returns_empty_string_when_no_titles():
+    no_abstracts = Record({})
+
+    expected = ''
+    result = get_abstract(no_abstracts)
+
+    assert expected == result
+
+
+def test_get_title_returns_empty_string_when_titles_is_empty():
+    empty_titles = Record({'titles': []})
+
+    expected = ''
+    result = get_title(empty_titles)
+
+    assert expected == result
+
+
+def test_get_subtitle_returns_empty_string_when_titles_is_empty():
+    empty_titles = Record({'titles': []})
+
+    expected = ''
+    result = get_subtitle(empty_titles)
+
+    assert expected == result
+
+
+def test_get_abstract_returns_empty_string_when_abstracts_is_empty():
+    empty_abstracts = Record({'abstracts': []})
+
+    expected = ''
+    result = get_abstract(empty_abstracts)
+
+    assert expected == result
+
+
+def test_get_title_returns_the_only_title():
+    single_title = Record({
+        'titles': [
+            {
+                'source': "arXiv",
+                'title': 'The Large Hadron Collider'
+            }
+        ]
+    })
+
+    expected = 'The Large Hadron Collider'
+    result = get_title(single_title)
+
+    assert expected == result
+
+
+def test_get_subtitle_returns_the_only_subtitle():
+    single_subtitle = Record({
+        'titles': [
             {
                 "source": "arXiv",
-                "title": "Parton distributions with LHC data"
-            },
-            {
-                "title": "Parton distributions with LHC data"
+                'subtitle': 'Harvest of Run 1'
             }
         ]
-    }
+    })
+
+    expected = 'Harvest of Run 1'
+    result = get_subtitle(single_subtitle)
+
+    assert expected == result
 
 
-@pytest.fixture
-def single_title():
-    return {
+def test_get_abstract_returns_the_only_abstract():
+    single_abstract = Record({
+        "abstracts": [
+            {
+                "source": "arXiv",
+                "value": "abstract",
+            }
+        ]
+    })
+
+    expected = 'abstract'
+    result = get_abstract(single_abstract)
+
+    assert expected == result
+
+
+def test_get_title_returns_the_non_arxiv_title_with_source():
+    double_title = Record({
         "titles": [
             {
-                "subtitle": "Harvest of Run 1",
-                "title": "The Large Hadron Collider"
+                "source": "other",
+                "title": "Importance of a consistent choice of alpha(s) in the matching of AlpGen and Pythia"
+            },
+            {
+                "source": "arXiv",
+                "title": "Monte Carlo tuning in the presence of Matching"
+            }
+        ],
+    })
+
+    expected = 'Importance of a consistent choice of alpha(s) in the matching of AlpGen and Pythia'
+    result = get_title(double_title)
+
+    assert expected == result
+
+
+def test_get_title_returns_the_non_arxiv_title():
+    double_title = Record({
+        "titles": [
+            {
+                "title": "Importance of a consistent choice of alpha(s) in the matching of AlpGen and Pythia"
+            },
+            {
+                "source": "arXiv",
+                "title": "Monte Carlo tuning in the presence of Matching"
+            }
+        ],
+    })
+
+    expected = 'Importance of a consistent choice of alpha(s) in the matching of AlpGen and Pythia'
+    result = get_title(double_title)
+
+    assert expected == result
+
+
+def test_get_subtitle_returns_the_non_arxiv_subtitle_with_source():
+    double_subtitle = Record({
+        "titles": [
+            {
+                "source": "other",
+                "subtitle": "Importance of a consistent choice of alpha(s) in the matching of AlpGen and Pythia"
+            },
+            {
+                "source": "arXiv",
+                "subtitle": "Monte Carlo tuning in the presence of Matching"
+            }
+        ],
+    })
+
+    expected = 'Importance of a consistent choice of alpha(s) in the matching of AlpGen and Pythia'
+    result = get_subtitle(double_subtitle)
+
+    assert expected == result
+
+
+def test_get_subtitle_returns_the_non_arxiv_subtitle():
+    double_subtitle = Record({
+        "titles": [
+            {
+                "subtitle": "Importance of a consistent choice of alpha(s) in the matching of AlpGen and Pythia"
+            },
+            {
+                "source": "arXiv",
+                "subtitle": "Monte Carlo tuning in the presence of Matching"
+            }
+        ],
+    })
+
+    expected = 'Importance of a consistent choice of alpha(s) in the matching of AlpGen and Pythia'
+    result = get_subtitle(double_subtitle)
+
+    assert expected == result
+
+
+def test_get_abstract_returns_the_non_arxiv_abstract():
+    double_abstract = Record({
+        "abstracts": [
+            {
+                "source": "arXiv",
+                "value": "arXiv abstract"
+            },
+            {
+                "value": "abstract"
             }
         ]
-    }
+    })
+
+    expected = 'abstract'
+    result = get_abstract(double_abstract)
+
+    assert expected == result
 
 
-@pytest.fixture
-def empty_title():
-    return {
-        "titles": []
-    }
+def test_get_abstract_with_multiple_sources_returns_the_non_arxiv_abstract():
+    double_abstract = Record({
+        "abstracts": [
+            {
+                "source": "arXiv",
+                "value": "arXiv abstract"
+            },
+            {
+                "source": "other",
+                "value": "abstract"
+            }
+        ]
+    })
+
+    expected = 'abstract'
+    result = get_abstract(double_abstract)
+
+    assert expected == result
 
 
-def test_get_title(double_title, single_title, empty_title):
-    """Test get title utility."""
-    assert get_title(double_title) == "Parton distributions with LHC data"
-    assert get_title(single_title) == "The Large Hadron Collider"
-    assert get_title(empty_title) == ""
+def test_get_value_returns_the_two_titles():
+    double_title = Record({
+        "titles": [
+            {
+                "title": "Importance of a consistent choice of alpha(s) in the matching of AlpGen and Pythia"
+            },
+            {
+                "title": "Monte Carlo tuning in the presence of Matching"
+            }
+        ],
+    })
 
-    no_title_key = {
-        "not_titles": []
-    }
-    assert get_title(no_title_key) == ""
+    expected = 2
+    result = len(get_value(double_title, "titles.title"))
+
+    assert expected == result
 
 
-def test_get_value(double_title, single_title, empty_title):
-    """Test get_value utility"""
-    assert len(get_value(double_title, "titles.title")) == 2
-    assert get_value(double_title, "titles.title[0]") == "Parton distributions with LHC data"
-    assert get_value(single_title, "titles.title") == ["The Large Hadron Collider"]
-    assert get_value(empty_title, "titles.title") == []
-    assert get_value(empty_title, "foo", {}) == {}
+def test_get_value_returns_the_selected_title():
+    double_title = Record({
+        "titles": [
+            {
+                "title": "Importance of a consistent choice of alpha(s) in the matching of AlpGen and Pythia"
+            },
+            {
+                "title": "Monte Carlo tuning in the presence of Matching"
+            }
+        ],
+    })
+
+    expected = 'Importance of a consistent choice of alpha(s) in the matching of AlpGen and Pythia'
+    result = get_value(double_title, "titles.title[0]")
+
+    assert expected == result
+
+
+def test_get_value_returns_single_title():
+    empty_titles = Record({'titles': []})
+
+    expected = []
+    result = get_value(empty_titles, "titles.title")
+
+    assert expected == result
+
+
+@pytest.mark.xfail(reason='Returns None instead of {}.')
+def test_get_value_returns_empty_dic_when_there_are_no_titles():
+    empty_titles = Record({'titles': []})
+
+    expected = {}
+    result = get_value(empty_titles, "foo")
+
+    assert expected == result


### PR DESCRIPTION
Adds the functionality to send updated/new records to orcid.
- [x] Tweak the json converter's results to fully follow orcids schema.
- [x] Convert citations to bibtex and add them to the output json. 
- [x] Extract the needed information of the author to push on his behalf to orcid.
- [x] Check json acceptance from orcid.
- [x] Tests.
- [x] Code cleanup.
- [x] Should redirect after login.

Signed-off-by: Panos Paparrigopoulos <panos.paparrigopoulos@cern