### PR TITLE
schemas: fix hep collections bug

### DIFF
--- a/inspirehep/modules/records/jsonschemas/records/hep.json
+++ b/inspirehep/modules/records/jsonschemas/records/hep.json
@@ -977,8 +977,7 @@
                     "primary": {
                         "type": "string"
                     }
-                },
-                "type": "string"
+                }
             },
             "uniqueItems": true,
             "type": "array",


### PR DESCRIPTION
* Removes string type of items in collections field.

Signed-off-by: Grzegorz Jacenków <grzegorz.jacenkow@cern.ch>