### PR TITLE
WIP authors: split blueprints

### DIFF
--- a/inspirehep/modules/authors/ext.py
+++ b/inspirehep/modules/authors/ext.py
@@ -24,9 +24,13 @@
 
 """INSPIRE module to manage authors."""
 
-from __future__ import absolute_import, print_function
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals)
 
-from .views import blueprint
+from .views import blueprints
 
 from . import config
 
@@ -42,7 +46,8 @@ class INSPIREAuthors(object):
     def init_app(self, app, assets=None, **kwargs):
         """Initialize application object."""
         self.init_config(app)
-        app.register_blueprint(blueprint)
+        for blueprint in blueprints:
+            app.register_blueprint(blueprint)
         app.extensions['inspire-authors'] = self
 
     def init_config(self, app):

--- a/inspirehep/modules/authors/views/__init__.py
+++ b/inspirehep/modules/authors/views/__init__.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 331, Boston, MA 02111-1307, USA.
+
+"""View blueprints for Author module."""
+
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals)
+
+from .holdingpen import blueprint as holdingpen_blueprint
+from .publications import blueprint as publications_blueprint
+
+blueprints = [
+    holdingpen_blueprint,
+    publications_blueprint,
+]

--- a/inspirehep/modules/authors/views/publications.py
+++ b/inspirehep/modules/authors/views/publications.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""INSPIRE authors publications views."""
+
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals)
+
+from elasticsearch.helpers import scan
+from flask import (
+    Blueprint,
+    jsonify,
+    request)
+
+from invenio_search import current_search_client
+
+from inspirehep.utils.record import get_title
+
+
+blueprint = Blueprint('inspirehep_authors_blueprints',
+                      __name__,
+                      url_prefix='/author',
+                      template_folder='../templates',
+                      static_folder='../static')
+
+
+@blueprint.route('/publications', methods=['GET'])
+def get_publications():
+    recid = request.values.get('recid', 0, type=int)
+
+    publications = []
+    collaborations = set()
+    keywords = set()
+
+    for result in scan(
+            current_search_client,
+            query={
+                '_source': ['accelerator_experiments',
+                            'control_number',
+                            'earliest_date',
+                            'facet_inspire_doc_type',
+                            'publication_info',
+                            'titles',
+                            'thesaurus_terms'
+                            ],
+                'query': {"match": {"authors.recid": recid}}
+            },
+            index='records-hep',
+            doc_type='hep'):
+
+        try:
+            result_source = result['_source']
+            publication = {}
+
+            # Get publication title (required).
+            publication['title'] = get_title(result_source)
+
+            # Get publication recid (required).
+            publication['recid'] = result_source['control_number']
+        except (IndexError, KeyError):
+            continue
+
+        # Get publication type.
+        try:
+            publication['type'] = result_source.get(
+                'facet_inspire_doc_type', [])[0]
+        except IndexError:
+            publication['type'] = "Not defined"
+
+        # Get journal title.
+        try:
+            publication['journal_title'] = result_source.get(
+                'publication_info', [])[0]['journal_title']
+
+            # Get journal recid.
+            try:
+                publication['journal_recid'] = result_source.get(
+                    'publication_info', [])[0]['journal_recid']
+            except KeyError:
+                pass
+        except (IndexError, KeyError):
+            pass
+
+        # Get publication year.
+        try:
+            publication['year'] = result_source.get(
+                'publication_info', [])[0]['year']
+        except (IndexError, KeyError):
+            pass
+
+        # Get keywords.
+        for keyword in result_source.get('thesaurus_terms', []):
+            if keyword.get('keyword') is not "* Automatic Keywords *" \
+                    and keyword.get('keyword'):
+                keywords.add(keyword.get('keyword'))
+
+        # Get collaborations.
+        for experiment in result_source.get(
+                'accelerator_experiments', []):
+            collaborations.add(experiment.get('experiment'))
+
+        # Append to the list.
+        publications.append(publication)
+
+    response = {}
+    response['publications'] = publications
+    response['keywords'] = list(keywords)
+    response['collaborations'] = list(collaborations)
+
+    return jsonify(response)

--- a/inspirehep/modules/theme/jinja2filters.py
+++ b/inspirehep/modules/theme/jinja2filters.py
@@ -24,7 +24,11 @@
 
 """Jinja utilities for INSPIRE."""
 
-from __future__ import absolute_import, print_function
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals)
 
 import json
 import re
@@ -297,7 +301,8 @@ def proceedings_link(record):
     if not cnum:
         return out
 
-    records = perform_es_search("cnum:%s and 980__a:proceedings" % (cnum,))
+    records = perform_es_search(
+        'cnum:%s and 980__a:proceedings' % cnum, 'records-conferences')
 
     if len(records):
         if len(records) > 1:
@@ -386,7 +391,7 @@ def link_to_hep_affiliation(record):
     except KeyError:
         return ''
 
-    records = perform_es_search("affiliation:%s" % icn)
+    records = perform_es_search('affiliation:%s' % icn, 'records-institutions')
     results = records.hits.total
 
     if results:

--- a/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Inspire_Default_HTML_detailed.tpl
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Inspire_Default_HTML_detailed.tpl
@@ -21,13 +21,6 @@
 {% from "inspirehep_theme/format/record/Inspire_HTML_detailed_macros.tpl" import record_buttons, record_collection_heading, record_collections, record_publication_info, record_doi, record_links, detailed_record_abstract, record_keywords, record_references, record_citations, record_plots, record_doi with context %}
 {% from "inspirehep_theme/format/record/Inspire_Default_HTML_general_macros.tpl" import mathjax, render_record_title, render_record_authors, record_cite_modal, record_arxiv, record_report_numbers with context %}
 
-{%- block css %}
-  {{ super() }}
-  {%- assets "inspirehep_detailed_css" %}
-  <link href="{{ ASSET_URL }}" rel="stylesheet">
-  {%- endassets %}
-{%- endblock css %}
-
 {% block body %}
 <div id="record_content">
 <div class="record-detailed">
@@ -106,7 +99,6 @@
   </div>
 </div>
 </div>
-
 {% endblock body %}
 
 {% block javascript %}
@@ -116,6 +108,3 @@
     <script src="{{ ASSET_URL }}"></script>
   {%- endassets %}
 {% endblock javascript %}
-
-
-

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -43,7 +43,7 @@ def app(request):
 
             sleep(10)  # Makes sure that ES is up.
             _es = app.extensions['invenio-search']
-            list(_es.delete(ignore=[400]))
+            list(_es.delete(ignore=[404]))
 
     request.addfinalizer(teardown)
 
@@ -56,6 +56,7 @@ def app(request):
 
         sleep(10)  # Makes sure that ES is up.
         _es = app.extensions['invenio-search']
+        list(_es.delete(ignore=[404]))
         list(_es.create(ignore=[400]))
 
         migrate('./inspirehep/demosite/data/demo-records.xml.gz', wait_for_results=True)

--- a/tests/integration/test_author_views.py
+++ b/tests/integration/test_author_views.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals)
+
+import json
+
+
+def test_author_publications_is_there(app):
+    with app.test_client() as client:
+        assert client.get(
+            '/author/publications?recid=984519').status_code == 200
+
+
+def test_author_publications_returns_the_right_data(app):
+    with app.test_client() as client:
+        response = json.loads(
+            client.get('/author/publications?recid=984519').data)
+
+        # FIXME: Asserts should be more specific.
+        assert len(response['collaborations']) == 4
+        assert len(response['keywords']) == 218
+        assert len(response['publications']) == 30

--- a/tests/unit/authors/test_authors_views.py
+++ b/tests/unit/authors/test_authors_views.py
@@ -20,11 +20,17 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals)
 
 from invenio_records.api import Record
 
-from inspirehep.modules.authors.views import convert_for_form, get_inspire_url
+from inspirehep.modules.authors.views.holdingpen import (
+    convert_for_form,
+    get_inspire_url)
 
 
 def test_convert_for_form_without_name_urls_fc_positions_advisors_and_ids():


### PR DESCRIPTION
* Split author module view into holdingpen and publications views.

* Adds basic test to prevent regression.

Co-authored-by: Jacopo Notarstefano <jacopo.notarstefano@cern.ch>
Signed-off-by: Grzegorz Jacenków <grzegorz.jacenkow@cern.ch>