### PR TITLE
js: load jquery-ui before bootstrap.js

### DIFF
--- a/inspirehep/modules/literaturesuggest/static/js/literaturesuggest/literature_submission_form.js
+++ b/inspirehep/modules/literaturesuggest/static/js/literaturesuggest/literature_submission_form.js
@@ -34,7 +34,7 @@ define(function(require, exports, module) {
   var SynchronizedField = require("js/literaturesuggest/synchronized_field");
   require("js/literaturesuggest/message_box");
   require("js/literaturesuggest/fields_group");
-  require('ui/jquery-ui');
+  require('jquery.ui');
   // require('ui/effect-blind');
   require("bootstrap-multiselect");
   require("bootstrap");
@@ -155,7 +155,6 @@ define(function(require, exports, module) {
         .fieldsGroup({
           onEmpty: function enableProceedingsBox() {
             that.$nonpublic_note.removeAttr('disabled');
-            $('.tooltip-wrapper').tooltip(); // trigger the tooltip
             $('.tooltip-wrapper').tooltip('destroy'); // destroy the tooltip
           },
           onNotEmpty: function disableProceedingsBox() {

--- a/inspirehep/modules/theme/static/js/settings.js
+++ b/inspirehep/modules/theme/static/js/settings.js
@@ -49,8 +49,7 @@ require.config({
     'inspirehep-search': 'node_modules/inspirehep-search-js/dist/inspirehep-search',
     'invenio-search': 'node_modules/invenio-search-js/dist/invenio-search-js',
     jquery: 'node_modules/jquery/jquery',
-    'jquery.ui': 'node_modules/jquery-ui',
-    ui: "node_modules/jquery-ui",
+    'jquery.ui': 'node_modules/jquery-ui/jquery-ui',
     moment: 'node_modules/moment/moment',
     'ngclipboard': 'node_modules/ngclipboard/src/ngclipboard',
     'profile': 'js/authors/profile',
@@ -76,7 +75,7 @@ require.config({
       deps: ['angular']
     },
     bootstrap: {
-      deps: ['jquery']
+      deps: ['jquery', 'jquery.ui']
     },
     'bootstrap-datetimepicker': {
       deps: ['jquery', 'bootstrap', 'moment'],
@@ -109,7 +108,7 @@ require.config({
       deps: ['jquery'],
       exports: 'Bloodhound'
     },
-    'ui': {
+    'jquery.ui': {
         deps: ['jquery']
     }
   }


### PR DESCRIPTION
* Conflicts can appear if jquery-ui is loaded after bootstrap.js as jQuery
  plugins can be shadowed (such as button or tooltip). This commit ensures
  that the correct order is used. (addresses #1119)

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>