### PR TITLE
theme: footer style fix in error pages

### DIFF
--- a/inspirehep/modules/theme/static/scss/base/footer.scss
+++ b/inspirehep/modules/theme/static/scss/base/footer.scss
@@ -46,8 +46,10 @@ section.custom-footer {
     border-width: 1px 0 0 0;
 }
 
-.footer-heading {
+.custom-footer .footer-heading {
     color: lighten($navbar-inverse-bg, 40%);
+    font-size: 18px;
+    text-align: start;
 }
 
 .custom-footer .row .col-xs-4 {

--- a/inspirehep/modules/theme/templates/inspirehep_theme/footer.html
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/footer.html
@@ -49,9 +49,9 @@
     </div>
 
     <div class="col-xs-4">
-      <ul class="list-unstyled">
-        <h4 class="footer-heading">Technology</h4>
+      <h4 class="footer-heading">Technology</h4>
       <hr class="footer-divider">
+      <ul class="list-unstyled">
         <li><a class="footer" href="{{ url_for('inspirehep_theme.index') }}">INSPIRE Labs</a></li>
         <li>{{ _("Powered by") }} <a class="footer" href="http://invenio-software.org/" target="_blank">Invenio</a></li>
       </ul>

--- a/inspirehep/modules/theme/templates/inspirehep_theme/header.html
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/header.html
@@ -178,7 +178,6 @@
             </ul>
           </li>
           {%- endif %}
-          </li>
         </ul>
       </div>
       {% if request.endpoint in ['inspirehep_search.search', 'invenio_records_ui.literature'] %}


### PR DESCRIPTION
The CSS rule for `.error-pages h4` was leaking in the footer. I fixed it by making the footer CSS more specific and specifying the default values.

Also contains a commit to fix two HTML validity issues I found while investigating this tiny bug.

WDYT about tests that check the validity of HTML pages we generate? Spoiler alert: we fail.