### PR TITLE
theme: detailed record references fix

### DIFF
--- a/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Inspire_Default_HTML_detailed.tpl
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Inspire_Default_HTML_detailed.tpl
@@ -107,6 +107,9 @@
 
 {% block javascript %}
   {{ super() }}
+  {%- assets "inspirehep_detailed_js" %}
+    <script src="{{ ASSET_URL }}"></script>
+  {%- endassets %}
   {{ mathjax() | safe }}
   <script type="text/javascript">
     require(
@@ -122,9 +125,6 @@
         });
       });
   </script>
-  {%- assets "inspirehep_detailed_js" %}
-    <script src="{{ ASSET_URL }}"></script>
-  {%- endassets %}
   <script>
   require(
     [

--- a/inspirehep/modules/theme/templates/inspirehep_theme/references.html
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/references.html
@@ -27,10 +27,10 @@
         {% if reference['number'] %}
           [{{ reference['number'] }}]
         {% endif %}
-        <a href="/record/{{record['control_number']}}">{{ render_record_title() }}</a>
+        <a href="/literature/{{record['control_number']}}">{{ render_record_title(record) }}</a>
       </div>
-      <div class="reference-authors">{{ render_record_authors(is_brief=true, show_affiliations=false) | safe }}</div>
-      <div class="reference-journal">{{ record_publication_info() | safe }}</div>
+      <div class="reference-authors">{{ render_record_authors(record, is_brief=true, show_affiliations=false, number_of_displayed_authors=1) | safe }}</div>
+      <div class="reference-journal">{{ record_publication_info(record) | safe }}</div>
   {% else %}
     <div class="reference-title">
       {% if reference['number'] %}


### PR DESCRIPTION
* Fixes references endpoint to correctly retrieve references via search call
  instead of mget.

* Changes bundle addition in detailed page template to make sure datatables
  js gets loaded before it is needed.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>