### PR TITLE
authors: add uuid generator

### DIFF
--- a/inspirehep/modules/authors/receivers.py
+++ b/inspirehep/modules/authors/receivers.py
@@ -22,10 +22,30 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
+import uuid
 
 from invenio_indexer.signals import before_record_index
+from invenio_records.signals import (
+    before_record_insert,
+    before_record_update)
 
 from .utils import author_tokenize
+
+
+@before_record_insert.connect
+@before_record_update.connect
+def assign_uuid(sender, *args, **kwargs):
+    """Assign uuid to each signature.
+    The method assigns to each signature a universally unique
+    identifier based on Python's built-in uuid4. The identifier
+    is allocated during the insertion of a new record.
+    """
+    authors = sender.get('authors', [])
+
+    for author in authors:
+        # Skip if the author was already populated with a UUID.
+        if 'uuid' not in author:
+            author['uuid'] = str(uuid.uuid4())
 
 
 @before_record_index.connect

--- a/tests/unit/authors/test_authors_receivers.py
+++ b/tests/unit/authors/test_authors_receivers.py
@@ -61,3 +61,22 @@ def test_name_variations():
             'John Richard Ellis',
             'R Ellis',
             'Richard Ellis'])
+
+
+def test_uuid_generation():
+    json_dict = {
+        "authors": [{
+            "full_name": "John Doe",
+            "uuid": "I am unique"
+        }, {
+            "full_name": "John Richard Ellis"
+        }]
+    }
+
+    receivers.assign_uuid(json_dict)
+
+    # Check if the author with existing UUID has still the same UUID.
+    assert(json_dict['authors'][0]['uuid'] == "I am unique")
+
+    # Check if the author with no UUID got one.
+    assert(json_dict['authors'][1]['uuid'] is not None)


### PR DESCRIPTION
* Adds uuid to each signature on before_record_insert signal.

* Adds test to check if uuid field is not empty.

Signed-off-by: Grzegorz Jacenków <grzegorz.jacenkow@cern.ch>