### PR TITLE
authors: ORCID duplicate validation

### DIFF
--- a/inspirehep/modules/authors/forms.py
+++ b/inspirehep/modules/authors/forms.py
@@ -38,9 +38,11 @@ from invenio_deposit.field_widgets import ColumnInput, \
 from invenio_deposit.form import WebDepositForm
 from invenio_deposit import fields
 from inspirehep.modules.deposit.filters import clean_empty_list
+from inspirehep.modules.deposit.validators.simple_fields import duplicated_orcid_validator
 
 from inspirehep.modules.forms.validators import ORCIDValidator, \
     RegexpStopValidator
+
 
 
 def currentCheckboxWidget(field, **kwargs):
@@ -326,7 +328,8 @@ class AuthorUpdateForm(WebDepositForm):
                         "\d{4}-\d{4}-\d{4}-\d{3}[\dX]",
                         message="A valid ORCID iD consists of 16 digits separated by dashes.",
         ),
-            ORCIDValidator]
+            ORCIDValidator,
+            duplicated_orcid_validator]
     )
 
     status_options = [("active", _("Active")),
@@ -500,6 +503,10 @@ class AuthorUpdateForm(WebDepositForm):
     def __init__(self, is_review=False, *args, **kwargs):
         """Constructor."""
         super(AuthorUpdateForm, self).__init__(*args, **kwargs)
+        is_update = kwargs.pop('is_update', False)
+        if is_update:
+            self.orcid.widget = HiddenInput()
+            self.orcid.validators = []
         if is_review:
             self.bai.widget = TextInput()
             self.bai.widget_classes = "form-control"

--- a/inspirehep/modules/authors/templates/authors/forms/update_form.html
+++ b/inspirehep/modules/authors/templates/authors/forms/update_form.html
@@ -18,6 +18,7 @@
 #}
 {%- extends "forms/form.html" -%}
 {% set title = "New author information - INSPIRE Labs" if new else "Update author information - INSPIRE Labs" %}
+{% set is_update = False if new else True %}
 
 {% block global_bundles %}
   {{ super() }}
@@ -52,9 +53,9 @@ require(
 
     var config = {
       form: {
-        save_url: '{{ url_for("inspire_authors.validate") }}',
-        save_all_url: '{{ url_for("inspire_authors.validate", all='1') }}',
-        complete_url: '{{ url_for("inspire_authors.validate", submit='1') }}',
+        save_url: '{{ url_for("inspire_authors.validate", is_update=is_update) }}',
+        save_all_url: '{{ url_for("inspire_authors.validate", all='1', is_update=is_update) }}',
+        complete_url: '{{ url_for("inspire_authors.validate", submit='1', is_update=is_update) }}',
         autocomplete_url: '{{ url_for("inspire_authors.autocomplete", field_name="__FIELDNAME__") }}',
         datepicker_element: '.datepicker',
         datepicker_options: {

--- a/inspirehep/modules/authors/views.py
+++ b/inspirehep/modules/authors/views.py
@@ -67,7 +67,8 @@ def convert_for_form(data):
     if "name" in data:
         data["full_name"] = data["name"].get("value")
         try:
-            data["given_names"] = data["name"].get("value").split(",")[1].strip()
+            data["given_names"] = data["name"].get(
+                "value").split(",")[1].strip()
         except IndexError:
             data["given_names"] = ""
         data["family_name"] = data["name"].get("value").split(",")[0].strip()
@@ -146,9 +147,11 @@ def validate():
     """Validate form and return validation errors."""
     if request.method != 'POST':
         abort(400)
+
+    is_update = True if request.args.get('is_update') == 'True' else False
     data = request.json or MultiDict({})
     formdata = MultiDict(data or {})
-    form = AuthorUpdateForm(formdata=formdata)
+    form = AuthorUpdateForm(formdata=formdata, is_update=is_update)
     form.validate()
 
     result = {}
@@ -186,7 +189,7 @@ def update(recid):
         data["recid"] = recid
     else:
         return redirect(url_for("inspire_authors.new"))
-    form = AuthorUpdateForm(data=data)
+    form = AuthorUpdateForm(data=data, is_update=True)
     ctx = {
         "action": url_for('.submitupdate'),
         "name": "authorUpdateForm",
@@ -299,7 +302,7 @@ def submitupdate():
     from inspirehep.modules.forms.utils import DataExporter
     from invenio_workflows.models import BibWorkflowObject
     from flask.ext.login import current_user
-    form = AuthorUpdateForm(formdata=request.form)
+    form = AuthorUpdateForm(formdata=request.form, is_update=True)
     visitor = DataExporter()
     visitor.visit(form)
     myobj = BibWorkflowObject.create_object(id_user=current_user.get_id())

--- a/inspirehep/modules/deposit/validators/simple_fields.py
+++ b/inspirehep/modules/deposit/validators/simple_fields.py
@@ -87,18 +87,30 @@ def does_exist_in_inspirehep(query, collection=None):
     return False
 
 
-def inspirehep_duplicated_validator(inspire_query, property_name):
+def inspirehep_duplicated_validator(inspire_query, property_name, collection=None):
     """Check if a record with the same doi already exists.
 
     Needs to be wrapped in a function with proper validator signature.
     """
-    if does_exist_in_inspirehep(inspire_query):
+    if does_exist_in_inspirehep(inspire_query, collection):
         url = "http://inspirehep.net/search?" + urlencode({'p': inspire_query})
+        if collection:
+            url += '&' + urlencode({'cc': collection})
         raise ValidationError(
             'There exists already an item with the same %s. '
             '<a target="_blank" href="%s">See the record.</a>'
             % (property_name, url)
         )
+
+
+def duplicated_orcid_validator(form, field):
+    """Check if a record with the same ORCID already exists."""
+    orcid = field.data
+    # TODO: local check for duplicates
+    if not orcid:
+        return
+    if cfg.get('PRODUCTION_MODE'):
+        inspirehep_duplicated_validator('035__a:' + orcid, 'ORCID', 'HepNames')
 
 
 def duplicated_doi_validator(form, field):


### PR DESCRIPTION
* Checks for ORCID duplicates in order to not allow new author information
  to be submitted if an ORCID already exists in inspirehep.net.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>