### PR TITLE
fixtures: initial module

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -27,6 +27,7 @@
 from __future__ import absolute_import, print_function
 
 import os
+import sys
 
 from invenio_records_rest.facets import terms_filter
 
@@ -84,6 +85,10 @@ CACHE_REDIS_URL = os.environ.get(
     "redis://localhost:6379/0")
 CACHE_TYPE = "redis"
 ACCOUNTS_SESSION_REDIS_URL = "redis://localhost:6379/2"
+
+# Files
+# =====
+BASE_FILES_LOCATION = os.path.join(sys.prefix, 'var/data')
 
 # REST
 # ====
@@ -812,6 +817,9 @@ MAGPIE_API_URL = None   # e.g. "http://magpie.inspirehep.net/api"
 
 # Workflows
 # =========
+WORKFLOWS_DEFAULT_FILE_LOCATION_NAME = "holdingpen"
+"""Name of default workflow Location reference."""
+
 WORKFLOWS_UI_BASE_TEMPLATE = BASE_TEMPLATE
 WORKFLOWS_UI_LIST_TEMPLATE = "inspire_workflows/list.html"
 WORKFLOWS_UI_DETAILS_TEMPLATE = "inspire_workflows/details.html"

--- a/inspirehep/modules/fixtures/__init__.py
+++ b/inspirehep/modules/fixtures/__init__.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""INSPIRE fixtures - loading of configs and database content."""
+
+from __future__ import absolute_import, print_function
+
+from .ext import INSPIREFixtures
+
+__all__ = ('INSPIREFixtures')

--- a/inspirehep/modules/fixtures/cli.py
+++ b/inspirehep/modules/fixtures/cli.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Manage fixtures for INSPIRE site."""
+
+from __future__ import print_function
+
+import click
+
+from flask_cli import with_appcontext
+
+from .files import init_all_storage_paths
+
+
+@click.group()
+def fixtures():
+    """Command related to migrating INSPIRE data."""
+
+
+@fixtures.command()
+@with_appcontext
+def init():
+    """Init the system with fixtures."""
+    init_all_storage_paths()

--- a/inspirehep/modules/fixtures/ext.py
+++ b/inspirehep/modules/fixtures/ext.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""INSPIRE fixtures extension."""
+
+from __future__ import absolute_import, division, print_function
+
+from .cli import fixtures
+
+
+class INSPIREFixtures(object):
+    """INSPIRE fixtures extension."""
+
+    def __init__(self, app=None, **kwargs):
+        """Extension initialization."""
+        if app:
+            self.init_app(app, **kwargs)
+
+    def init_app(self, app, **kwargs):
+        """Initialize application object."""
+        app.cli.add_command(fixtures)
+
+        # Save reference to self on object
+        app.extensions['inspire-fixtures'] = self
+
+
+__all__ = ('INSPIREFixtures',)

--- a/inspirehep/modules/fixtures/files.py
+++ b/inspirehep/modules/fixtures/files.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Functions for searching ES and returning the results."""
+
+from __future__ import absolute_import, division, print_function
+
+import os
+
+from flask import current_app
+
+from invenio_db import db
+
+from invenio_files_rest.models import Location
+
+
+def init_default_storage_path():
+    """Init default file store location."""
+    try:
+        uri = current_app.config['BASE_FILES_LOCATION']
+        if uri.startswith('/') and not os.path.exists(uri):
+            os.makedirs(uri)
+        loc = Location(
+            name="default",
+            uri=uri,
+            default=True
+        )
+        db.session.add(loc)
+        db.session.commit()
+        return loc
+    except Exception:
+        db.session.rollback()
+        raise
+
+
+def init_workflows_storage_path(default=False):
+    """Init workflows file store location."""
+    try:
+        uri = current_app.config['WORKFLOWS_FILE_LOCATION']
+        if uri.startswith('/') and not os.path.exists(uri):
+            os.makedirs(uri)
+        loc = Location(
+            name=current_app.config["WORKFLOWS_DEFAULT_FILE_LOCATION_NAME"],
+            uri=uri,
+            default=False
+        )
+        db.session.add(loc)
+        db.session.commit()
+        return loc
+    except Exception:
+        db.session.rollback()
+        raise
+
+
+def init_all_storage_paths():
+    """Init all storage paths."""
+    init_default_storage_path()
+    init_workflows_storage_path()

--- a/inspirehep/modules/workflows/ext.py
+++ b/inspirehep/modules/workflows/ext.py
@@ -24,8 +24,6 @@
 import os
 import pkg_resources
 
-from flask_login import LoginManager
-
 from .views import blueprints
 
 
@@ -58,6 +56,10 @@ class INSPIREWorkflows(object):
         ))
         app.config["WORKFLOWS_STORAGEDIR"] = os.path.join(
             app.instance_path, "workflows", "storage"
+        )
+        app.config["WORKFLOWS_FILE_LOCATION"] = os.path.join(
+            app.config['BASE_FILES_LOCATION'],
+            "workflows", "files"
         )
         app.config['CLASSIFIER_WORKDIR'] = pkg_resources.resource_filename(
             'inspirehep', "taxonomies"

--- a/scripts/recreate_records
+++ b/scripts/recreate_records
@@ -63,7 +63,7 @@ inspirehep db drop --yes-i-know
 inspirehep db create
 inspirehep index destroy --force --yes-i-know
 inspirehep index init
+inspirehep fixtures init
 
 inspirehep migrator populate -f inspirehep/demosite/data/demo-records.xml.gz --wait=true
 inspirehep migrator count_citations
-

--- a/setup.py
+++ b/setup.py
@@ -166,6 +166,7 @@ setup(
             'inspire_workflows = inspirehep.modules.workflows:INSPIREWorkflows',
         ],
         'invenio_base.apps': [
+            'inspire_fixtures = inspirehep.modules.fixtures:INSPIREFixtures',
             'inspire_theme = inspirehep.modules.theme:INSPIRETheme',
             'inspire_migrator = inspirehep.modules.migrator:INSPIREMigrator',
             'inspire_search = inspirehep.modules.search:INSPIRESearch',

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -50,9 +50,11 @@ def app(request):
     with app.app_context():
         # Imports must be local, otherwise tasks default to pickle serializer.
         from inspirehep.modules.migrator.tasks import add_citation_counts, migrate
+        from inspirehep.modules.fixtures.files import init_all_storage_paths
 
         db.drop_all()
         db.create_all()
+        init_all_storage_paths()
 
         sleep(10)  # Makes sure that ES is up.
         _es = app.extensions['invenio-search']


### PR DESCRIPTION
* Adds new fixtures module used when setting up the INSPIRE instance
  to pre-load database tables with content and setting up folders etc.

* NOTE There is a new CLI command you need to run to setup the site properly:
  `inspirehep fixtures init`

E.g. we could potentially later hook up the collection loading here also from #1116 

@kaplun @jmartinm 