### PR TITLE
authors: ORCID duplicate validation

### DIFF
--- a/inspirehep/modules/authors/forms.py
+++ b/inspirehep/modules/authors/forms.py
@@ -38,6 +38,7 @@ from inspirehep.modules.forms.field_widgets import ColumnInput, \
 from inspirehep.modules.forms.form import INSPIREForm
 from inspirehep.modules.forms import fields
 from inspirehep.modules.forms.filter_utils import clean_empty_list
+from inspirehep.modules.forms.validators.simple_fields import duplicated_orcid_validator
 
 from inspirehep.modules.forms.validation_utils import ORCIDValidator, \
     RegexpStopValidator
@@ -337,7 +338,8 @@ class AuthorUpdateForm(INSPIREForm):
                         "\d{4}-\d{4}-\d{4}-\d{3}[\dX]",
                         message="A valid ORCID iD consists of 16 digits separated by dashes.",
         ),
-            ORCIDValidator]
+            ORCIDValidator,
+            duplicated_orcid_validator]
     )
 
     status_options = [("active", _("Active")),
@@ -511,6 +513,10 @@ class AuthorUpdateForm(INSPIREForm):
     def __init__(self, is_review=False, *args, **kwargs):
         """Constructor."""
         super(AuthorUpdateForm, self).__init__(*args, **kwargs)
+        is_update = kwargs.pop('is_update', False)
+        if is_update:
+            self.orcid.widget = HiddenInput()
+            self.orcid.validators = []
         if is_review:
             self.bai.widget = TextInput()
             self.bai.widget_classes = "form-control"

--- a/inspirehep/modules/authors/templates/authors/forms/update_form.html
+++ b/inspirehep/modules/authors/templates/authors/forms/update_form.html
@@ -18,6 +18,7 @@
 #}
 {%- extends "forms/form.html" -%}
 {% set title = "New author information - INSPIRE Labs" if new else "Update author information - INSPIRE Labs" %}
+{% set is_update = False if new else True %}
 
 
 {% block form_title scoped %}
@@ -49,9 +50,9 @@ require(
 
     var config = {
       form: {
-        save_url: '{{ url_for("inspirehep_authors_holdingpen.validate") }}',
-        save_all_url: '{{ url_for("inspirehep_authors_holdingpen.validate", all='1') }}',
-        complete_url: '{{ url_for("inspirehep_authors_holdingpen.validate", submit='1') }}',
+        save_url: '{{ url_for("inspirehep_authors_holdingpen.validate", is_update=is_update) }}',
+        save_all_url: '{{ url_for("inspirehep_authors_holdingpen.validate", all='1', is_update=is_update) }}',
+        complete_url: '{{ url_for("inspirehep_authors_holdingpen.validate", submit='1', is_update=is_update) }}',
         datepicker_element: '.datepicker',
         datepicker_options: {
             useCurrent: false,

--- a/inspirehep/modules/forms/validators/simple_fields.py
+++ b/inspirehep/modules/forms/validators/simple_fields.py
@@ -85,18 +85,30 @@ def does_exist_in_inspirehep(query, collection=None):
     return False
 
 
-def inspirehep_duplicated_validator(inspire_query, property_name):
+def inspirehep_duplicated_validator(inspire_query, property_name, collection=None):
     """Check if a record with the same doi already exists.
 
     Needs to be wrapped in a function with proper validator signature.
     """
-    if does_exist_in_inspirehep(inspire_query):
+    if does_exist_in_inspirehep(inspire_query, collection):
         url = "http://inspirehep.net/search?" + urlencode({'p': inspire_query})
+        if collection:
+            url += '&' + urlencode({'cc': collection})
         raise ValidationError(
             'There exists already an item with the same %s. '
             '<a target="_blank" href="%s">See the record.</a>'
             % (property_name, url)
         )
+
+
+def duplicated_orcid_validator(form, field):
+    """Check if a record with the same ORCID already exists."""
+    orcid = field.data
+    # TODO: local check for duplicates
+    if not orcid:
+        return
+    if current_app.config.get('PRODUCTION_MODE'):
+        inspirehep_duplicated_validator('035__a:' + orcid, 'ORCID', 'HepNames')
 
 
 def duplicated_doi_validator(form, field):


### PR DESCRIPTION
* Checks for ORCID duplicates in order to not allow new author information
  to be submitted if an ORCID already exists in inspirehep.net.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>