### PR TITLE
WIP records/search/theme: suggestion messages

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -33,6 +33,7 @@ services:
       - BROKER_URL=amqp://guest:guest@rabbitmq:5672//
       - CELERY_RESULT_BACKEND=amqp://guest:guest@rabbitmq:5672//
       - CACHE_REDIS_URL=redis://redis:6379/0
+      - ACCOUNTS_SESSION_REDIS_URL=redis://redis:6379/2
       - SEARCH_ELASTIC_HOSTS=indexer
 
   unit:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - BROKER_URL=amqp://guest:guest@rabbitmq:5672//
       - CELERY_RESULT_BACKEND=amqp://guest:guest@rabbitmq:5672//
       - CACHE_REDIS_URL=redis://redis:6379/0
+      - ACCOUNTS_SESSION_REDIS_URL=redis://redis:6379/2
       - SEARCH_ELASTIC_HOSTS=indexer
 
   # Services using the inspirehep code.

--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -83,7 +83,9 @@ CACHE_REDIS_URL = os.environ.get(
     "CACHE_REDIS_URL",
     "redis://localhost:6379/0")
 CACHE_TYPE = "redis"
-ACCOUNTS_SESSION_REDIS_URL = "redis://localhost:6379/2"
+ACCOUNTS_SESSION_REDIS_URL = os.environ.get(
+    "ACCOUNTS_SESSION_REDIS_URL",
+    "redis://localhost:6379/2")
 
 # Files
 # =====

--- a/inspirehep/modules/search/walkers/elasticsearch.py
+++ b/inspirehep/modules/search/walkers/elasticsearch.py
@@ -29,8 +29,8 @@ from elasticsearch_dsl import Q
 
 from invenio_query_parser.ast import (AndOp, DoubleQuotedValue, EmptyQuery,
                                       GreaterEqualOp, GreaterOp, Keyword,
-                                      KeywordOp, LowerEqualOp, LowerOp, NotOp,
-                                      OrOp, RangeOp, RegexValue,
+                                      KeywordOp, LowerEqualOp, LowerOp, MalformedQuery,
+                                      NotOp, OrOp, RangeOp, RegexValue,
                                       SingleQuotedValue, Value,
                                       ValueQuery, WildcardQuery)
 from invenio_query_parser.visitor import make_visitor
@@ -58,6 +58,10 @@ class ElasticSearchDSL(object):
         return [field]
 
     # pylint: disable=W0613,E0102
+
+    @visitor(MalformedQuery)
+    def visit(self, op):
+        return Q('match_all')
 
     @visitor(FilterOp)
     def visit(self, node, left, right):

--- a/inspirehep/modules/theme/static/scss/base/header.scss
+++ b/inspirehep/modules/theme/static/scss/base/header.scss
@@ -662,6 +662,53 @@ a.external-link::after {
     }
 }
 
+/* Suggestion messages
+-------------------------------------------------- */
+.input-group-btn{
+    width: 1px !important;
+}
+
+.input-group-btn.landing_page{
+    width: 1% !important;
+}
+
+.suggestion_tooltip {
+  width: 250px;
+  opacity: 1 !important;
+}
+
+.suggestion_icon {
+    position: absolute;
+    right: 100px;
+    bottom: 4px;
+    z-index: 3;
+}
+
+.suggestion_icon#literature {
+    color: $literature-collection;
+}
+.suggestion_icon#authors {
+    color: $authors-collection;
+}
+.suggestion_icon#data {
+    color: $data-collection;
+}
+.suggestion_icon#conferences {
+    color: $conferences-collection;
+}
+.suggestion_icon#jobs {
+    color: $jobs-collection;
+}
+.suggestion_icon#institutions {
+    color: $institutions-collection;
+}
+.suggestion_icon#experiments {
+    color: $experiments-collection;
+}
+.suggestion_icon#journals {
+    color: $journals-collection;
+}
+
 /* Mobile styles
 -------------------------------------------------- */
 @media only screen and (max-width : $screen-md-min) {

--- a/inspirehep/modules/theme/templates/inspirehep_theme/search/collection_basic.html
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/search/collection_basic.html
@@ -26,6 +26,7 @@
 {% block body %}
   {% block search_bar %}
     <div id="search-bar" class="{{collection_name}}">
+      {% set landing_page = 'landing_page' %}
       {% include 'inspirehep_theme/search/form/index.html' %}
     </div>
   {% endblock %}

--- a/inspirehep/modules/theme/templates/inspirehep_theme/search/form/controls.html
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/search/form/controls.html
@@ -34,7 +34,10 @@
   placeholder="Search {{ collection_name }}"
   autofocus
 >
-<span class="input-group-btn">
+<inspire-search-suggestions
+template="{{ url_for('static', filename='node_modules/inspirehep-search-js/dist/templates/suggestions.html') }}">
+</inspire-search-suggestions>
+<span class="{{ landing_page }} input-group-btn">
   <button tabindex="2" type="submit" class="btn btn-primary btn-inline-icon-hide-sm {{ collection_name }}-search-button" id="search-form-button">
     <i class="glyphicon glyphicon-search"></i>
   </button>

--- a/tests/integration/test_api_literature.py
+++ b/tests/integration/test_api_literature.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import json
+
+
+def test_api_literature_search_no_warnings_when_query_is_well_formed(app):
+    with app.test_client() as client:
+        response = client.get(
+            '/api/literature/?cc=literature&q=author:+Panos',
+            headers = {
+                'Accept': 'application/vnd+inspire.brief+json',
+            },
+        )
+
+        expected = []
+        result = json.loads(response.data)
+
+        assert expected == result['warnings']
+
+
+def test_api_literature_search_has_warnings_when_query_is_malformed(app):
+    with app.test_client() as client:
+        response = client.get(
+            '/api/literature/?cc=literature&q=author:+Panos+(',
+            headers = {
+                'Accept': 'application/vnd+inspire.brief+json',
+            },
+        )
+
+        result = json.loads(response.data)
+
+        assert {u'query_suggestion': u'MalformedQuery'} in result['warnings']
+
+
+def test_api_literature_search_has_warnings_when_query_has_unssuported_keywords(app):
+    with app.test_client() as client:
+        response = client.get(
+            '/api/literature/?cc=literature&q=refersto:+123',
+            headers = {
+                'Accept': 'application/vnd+inspire.brief+json',
+            },
+        )
+
+        result = json.loads(response.data)
+
+        assert {u'query_suggestion': u'keyword refersto is currently unsupported'} in result['warnings']
+
+
+def test_api_literature_search_has_warnings_when_query_has_extra_keywords(app):
+    with app.test_client() as client:
+        response = client.get(
+            '/api/literature/?cc=literature&q=author:+John+Ellis',
+            headers = {
+                'Accept': 'application/vnd+inspire.brief+json',
+            },
+        )
+
+        result = json.loads(response.data)
+
+        assert {u'query_suggestion': u'Extra Keyword'} in result['warnings']

--- a/tests/unit/search/test_search_query.py
+++ b/tests/unit/search/test_search_query.py
@@ -20,9 +20,11 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-import pytest
-
 from inspirehep.modules.search import IQ
+
+from flask import current_app
+
+import pytest
 
 
 def test_empty():
@@ -393,7 +395,8 @@ def test_author_colon_bai_with_double_quotes_and_collection_colon():
             ]
         }
     }
-    result = query.to_dict()
+    with current_app.test_request_context():
+        result = query.to_dict()
 
     assert expected == result
 
@@ -495,7 +498,8 @@ def test_author_colon_bai_with_double_quotes_and_collection_colon_and_cited_colo
             ]
         }
     }
-    result = query.to_dict()
+    with current_app.test_request_context():
+        result = query.to_dict()
 
     assert expected == result
 
@@ -779,7 +783,7 @@ def test_find_author_with_hash_wildcard():
                     'default_field': 'authors.alternative_name',
                     'query': 'chkv*'}}
             ]}
-        }
+    }
     result = query.to_dict()
 
     assert expected == result


### PR DESCRIPTION
- Adds suggestion messages on search.
- Succeeds #939 and #991.

Preview Screenshots:

![prev1](https://cloud.githubusercontent.com/assets/8779550/15928127/66571fd6-2e45-11e6-87cd-69cffe454469.png)

![prev2](https://cloud.githubusercontent.com/assets/8779550/15928128/66605754-2e45-11e6-9343-ae13c47df8ed.png)

![prev3](https://cloud.githubusercontent.com/assets/8779550/15928129/666188e0-2e45-11e6-8650-b8a661185eae.png)

Currently we have 3 types of messages (as shown on the above screenshot):
- Malformed queries (queries with unclosed parentheses etc).
- Unsupported keywords (queries containing currently unsupported keywords that require nested searches such as refersto).
- Extra keyword queries (queries such as `author: foo bar` in which only `foo` is searched in authors while `bar` is searched in the `full_text`).

TODO:
- [ ] Pass tests.
- [x] Write tests.
- [ ] Decide on final form of messages (and, why not, add more messages).

Signed-off-by: Panos Paparrigopoulos panos.paparrigopoulos@cern.ch
