### PR TITLE
setup: gunicorn for development

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-web: inspirehep --debug run
+web: gunicorn inspirehep.wsgi -c gunicorn.cfg
 cache: redis-server
 worker: celery worker -E -A inspirehep.celery --loglevel=INFO --workdir="${VIRTUAL_ENV}" --autoreload --pidfile="${VIRTUAL_ENV}/worker.pid" --purge
 workermon: flower --broker=amqp://guest:guest@localhost:5672//

--- a/gunicorn.cfg
+++ b/gunicorn.cfg
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+accesslog = "-"
+reload = True

--- a/inspirehep/wsgi.py
+++ b/inspirehep/wsgi.py
@@ -4,6 +4,11 @@
 
 from __future__ import absolute_import, print_function
 
-from .factory import create_app
+from inspirehep.factory import create_app
 
 application = create_app()
+
+if application.debug:
+    # apply Werkzeug WSGI middleware
+    from werkzeug.debug import DebuggedApplication
+    application = DebuggedApplication(application, evalex=True)

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,7 @@ extras_require = {
         'ipdb',
         'kwalitee',
         'honcho',
+        'gunicorn'
     ]
 }
 


### PR DESCRIPTION
* Moves away from the standard development server to use
  gunicorn in order to address the resource unavailable issue
  which often occured during local development.

* NOTE You can edit the gunicorn settings locally in `gunicorn.cfg`

Co-authored-by: Javier Martin Montull <javier.martin.montull@cern.ch>
Co-authored-by: Jacopo Notarstefano <jacopo.notarstefano@cern.ch>
Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>

CC @Panos512 