### PR TITLE
IPython shell and warnings adjustments

### DIFF
--- a/inspirehep/modules/warnings/__init__.py
+++ b/inspirehep/modules/warnings/__init__.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation,
+# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Warnings extension that removes deprecation warnings.
+
+Invenio-Base enables deprecation warnings and this extension removes
+this setting unless ``DEBUG_SHOW_DEPRECATION_WARNINGS`` is set to True.
+"""
+
+from __future__ import absolute_import
+
+
+class INSPIREWarnings(object):
+    """INSPIREWarnings extension implementation."""
+
+    def __init__(self, app=None):
+        """Initialize extension."""
+        self.app = app
+        if app is not None:
+            self.init_app(app)
+
+    def init_app(self, app):
+        """Initialize a Flask application."""
+        app.config.setdefault("DEBUG_SHOW_DEPRECATION_WARNINGS",
+                              False)
+
+        if not app.config['DEBUG_SHOW_DEPRECATION_WARNINGS']:
+            import warnings
+            warnings.filterwarnings(
+                'ignore',
+                category=DeprecationWarning
+            )
+        app.extensions["inspire-warnings"] = self
+
+
+__all__ = ("INSPIREWarnings", )

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,4 +37,7 @@
 -e git+https://github.com/inspirehep/invenio-workflows.git@invenio3#egg=invenio-workflows==1.0.0a1.dev20160126
 -e git+https://github.com/inspirehep/invenio-workflows-ui.git@master#egg=invenio-workflows-ui==0.1.0.dev20160000
 
+# Flask CLI with iPython integration
+-e git+https://github.com/inspirehep/flask-cli.git@master#egg=flask-cli==0.3.1.dev20160518
+
 -e .[postgresql]

--- a/setup.py
+++ b/setup.py
@@ -165,6 +165,7 @@ setup(
             'inspire_theme = inspirehep.modules.theme:INSPIRETheme',
             'inspire_search = inspirehep.modules.search:INSPIRESearch',
             'inspire_workflows = inspirehep.modules.workflows:INSPIREWorkflows',
+            'inspire_warnings = inspirehep.modules.warnings:INSPIREWarnings',
         ],
         'invenio_base.apps': [
             'inspire_fixtures = inspirehep.modules.fixtures:INSPIREFixtures',
@@ -175,6 +176,7 @@ setup(
             'inspire_literature_suggest = inspirehep.modules.literaturesuggest:INSPIRELiteratureSuggestion',
             'inspire_forms = inspirehep.modules.forms:INSPIREForms',
             'inspire_workflows = inspirehep.modules.workflows:INSPIREWorkflows',
+            'inspire_warnings = inspirehep.modules.warnings:INSPIREWarnings',
             'arxiv = inspirehep.modules.arxiv:Arxiv',
             'crossref = inspirehep.modules.crossref:CrossRef',
         ],


### PR DESCRIPTION
* Use flask-cli with iPython support.
* Adds warning extension to disable DeprecationWarnings unless `DEBUG_SHOW_DEPRECATION_WARNINGS` is `True`.