### PR TITLE
setup: gunicorn.cfg update

### DIFF
--- a/gunicorn.cfg
+++ b/gunicorn.cfg
@@ -24,3 +24,5 @@
 
 accesslog = "-"
 reload = True
+bind = ['localhost:5000']
+timeout = 3600


### PR DESCRIPTION
* Sets bind address to correctly run outside of honcho.

* Increases timeout to make sure an ipdb session does not get killed.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>