### PR TITLE
authors: remove biography

### DIFF
--- a/inspirehep/modules/theme/templates/inspirehep_theme/format/record/authors/Author_HTML_detailed.html
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/format/record/authors/Author_HTML_detailed.html
@@ -46,7 +46,6 @@
               </author-fields>
             </div>
             <div id="author-biography">
-              <biography></biography>
             </div>
           </div>
         </div>
@@ -66,7 +65,7 @@
       <div class="col-md-12" id="record-statistics">
         <div class="col-md-12 top-box">
           <div class="pull-left">
-            <h4 class="custom-h"><i class="fa fa-bar-chart"></i> Statistics works</h4>
+            <h4 class="custom-h"><i class="fa fa-bar-chart"></i> Statistics</h4>
           </div>
         </div>
         <div class="col-md-12 bottom-box no-padding">


### PR DESCRIPTION
* Removes biography directive. Once we allow for editing of profile we can
  add it back to allow for personalized content.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>