### PR TITLE
dojson: fix acquisition_source

### DIFF
--- a/inspirehep/dojson/hep/fields/bd5xx.py
+++ b/inspirehep/dojson/hep/fields/bd5xx.py
@@ -199,8 +199,6 @@ def license2marc(self, key, value):
 
 
 @hep.over('acquisition_source', '^541[10_].')
-@utils.for_each_value
-@utils.filter_values
 def acquisition_source(self, key, value):
     """Immediate Source of Acquisition Note."""
     return {
@@ -213,8 +211,6 @@ def acquisition_source(self, key, value):
 
 
 @hep2marc.over('541', 'acquisition_source')
-@utils.for_each_value
-@utils.filter_values
 def acquisition_source2marc(self, key, value):
     """Immediate Source of Acquisition Note."""
     return {

--- a/inspirehep/dojson/hep/fields/bd5xx.py
+++ b/inspirehep/dojson/hep/fields/bd5xx.py
@@ -206,7 +206,7 @@ def acquisition_source(self, key, value):
         'email': value.get('b'),
         'method': value.get('c'),
         'date': value.get('d'),
-        'submission_number': value.get('e')
+        'submission_number': str(value.get('e'))
     }
 
 

--- a/inspirehep/dojson/hepnames/fields/bd1xx.py
+++ b/inspirehep/dojson/hepnames/fields/bd1xx.py
@@ -33,8 +33,6 @@ from ...utils import classify_rank, get_record_ref
 
 
 @hepnames.over('acquisition_source', '^541[10_].')
-@utils.for_each_value
-@utils.filter_values
 def acquisition_source(self, key, value):
     """Immediate Source of Acquisition Note."""
     return {
@@ -47,8 +45,6 @@ def acquisition_source(self, key, value):
 
 
 @hepnames2marc.over('541', 'acquisition_source')
-@utils.for_each_value
-@utils.filter_values
 def acquisition_source2marc(self, key, value):
     """Immediate Source of Acquisition Note."""
     return {

--- a/inspirehep/dojson/hepnames/fields/bd1xx.py
+++ b/inspirehep/dojson/hepnames/fields/bd1xx.py
@@ -40,7 +40,7 @@ def acquisition_source(self, key, value):
         'email': value.get('b'),
         'method': value.get('c'),
         'date': value.get('d'),
-        'submission_number': value.get('e')
+        'submission_number': str(value.get('e'))
     }
 
 

--- a/inspirehep/modules/authors/tasks.py
+++ b/inspirehep/modules/authors/tasks.py
@@ -78,7 +78,7 @@ def formdata_to_model(obj, eng):
         email=user_email,
         date=date.today().isoformat(),
         method="submission",
-        submission_number=obj.id,
+        submission_number=str(obj.id),
     )
     # Finally, set data
     obj.data = data

--- a/inspirehep/modules/literaturesuggest/tasks.py
+++ b/inspirehep/modules/literaturesuggest/tasks.py
@@ -24,6 +24,8 @@ from __future__ import absolute_import, print_function
 
 import copy
 
+from datetime import date
+
 from sqlalchemy.orm.exc import NoResultFound
 
 from idutils import is_arxiv_post_2007
@@ -170,8 +172,9 @@ def formdata_to_model(obj, eng):
     data['acquisition_source'] = dict(
         source=source,
         email=email,
+        date=date.today().isoformat(),
         method="submission",
-        submission_number=obj.id,
+        submission_number=str(obj.id),
     )
     # ==============
     # References

--- a/inspirehep/modules/records/jsonschemas/records/hep.json
+++ b/inspirehep/modules/records/jsonschemas/records/hep.json
@@ -668,8 +668,7 @@
                     "type": "string",
                     "description": "Special submission ID"
                 }
-            },
-            "type": "array"
+            }
         },
         "collaboration": {
             "uniqueItems": true,

--- a/tests/unit/dojson/fixtures/test_hepnames_record.xml
+++ b/tests/unit/dojson/fixtures/test_hepnames_record.xml
@@ -76,7 +76,7 @@
     </datafield>
     <datafield tag="541" ind1=" " ind2=" ">
         <subfield code="a">inspire:uid:50000</subfield>
-        <subfield code="b">montull@gmail.com</subfield>
+        <subfield code="b">example@gmail.com</subfield>
         <subfield code="c">submission</subfield>
         <subfield code="d">2015-12-10</subfield>
         <subfield code="e">339830</subfield>


### PR DESCRIPTION
I would like this to be a single item field. Then we can more easily filter/display this field for new Holding Pen, and keep our sanity. 

Thoughts?