### PR TITLE
tests: unit tests for DoJSON institutions

### DIFF
--- a/inspirehep/dojson/institutions/fields/bd1xx.py
+++ b/inspirehep/dojson/institutions/fields/bd1xx.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # INSPIRE is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,6 +21,8 @@
 # or submit itself to any jurisdiction.
 
 """MARC 21 model definition."""
+
+from __future__ import absolute_import, division, print_function
 
 from dojson import utils
 
@@ -144,8 +146,10 @@ def public_notes(self, key, value):
     return value.get('i')
 
 
-@institutions.over('historical_data', '^6781..')
-@utils.for_each_value
+@institutions.over('historical_data', '^6781.')
 def historical_data(self, key, value):
     """Historical data."""
-    return value.get('a')
+    values = self.get('historical_data', [])
+    values.extend(el for el in value.get('a'))
+
+    return values

--- a/inspirehep/dojson/institutions/fields/bd1xx.py
+++ b/inspirehep/dojson/institutions/fields/bd1xx.py
@@ -36,20 +36,15 @@ from ...utils.geo import parse_institution_address
 @utils.filter_values
 def location(self, key, value):
     """GPS location info."""
-    longitude, latitude = ('', '')
-    if value.get('d'):
+    def _get_float(value, c):
         try:
-            longitude = float(value.get('d'))
-        except:
-            pass
-    if value.get('f'):
-        try:
-            latitude = float(value.get('f'))
-        except:
-            pass
+            return float(value[c])
+        except (KeyError, ValueError):
+            return ''
+
     return {
-        'longitude': longitude,
-        'latitude': latitude
+        'longitude': _get_float(value, 'd'),
+        'latitude': _get_float(value, 'f'),
     }
 
 

--- a/inspirehep/dojson/institutions/fields/bd1xx.py
+++ b/inspirehep/dojson/institutions/fields/bd1xx.py
@@ -26,6 +26,8 @@ from __future__ import absolute_import, division, print_function
 
 from dojson import utils
 
+from inspirehep.utils.dedupers import dedupe_list_of_dicts
+
 from ..model import institutions
 from ...utils.geo import parse_institution_address
 
@@ -106,17 +108,19 @@ def field_activity(self, key, value):
 
 
 @institutions.over('name_variants', '^410..')
-@utils.for_each_value
-@utils.filter_values
 def name_variants(self, key, value):
     """Variants of the name."""
     if value.get('g'):
         self.setdefault('extra_words', [])
         self['extra_words'].extend(utils.force_list(value.get('g')))
-    return {
-        "source": value.get('9'),
-        "value": utils.force_list(value.get('a'))
-    }
+
+    values = self.get('name_variants', [])
+    values.append({
+        'source': value.get('9'),
+        'value': utils.force_list(value.get('a', [])),
+    })
+
+    return dedupe_list_of_dicts(values)
 
 
 @institutions.over('core', '^690C.')

--- a/inspirehep/modules/records/jsonschemas/records/institutions.json
+++ b/inspirehep/modules/records/jsonschemas/records/institutions.json
@@ -61,8 +61,8 @@
             "uniqueItems": true
         },
         "historical_data": {
-            "title": "Historical data",
-            "type": "string"
+            "type": "array",
+            "items": {"type": "string"}
         },
         "institution_acronym": {
             "description": "Corporate well-known acronym",

--- a/inspirehep/modules/records/jsonschemas/records/institutions.json
+++ b/inspirehep/modules/records/jsonschemas/records/institutions.json
@@ -104,8 +104,9 @@
                         "type": "string"
                     },
                     "value": {
-                        "title": "Name variant",
-                        "type": "array"
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "uniqueItems": true
                     }
                 },
                 "title": "Name variant",

--- a/tests/unit/dojson/test_dojson_institutions.py
+++ b/tests/unit/dojson/test_dojson_institutions.py
@@ -30,6 +30,123 @@ from inspirehep.dojson.institutions import institutions
 from inspirehep.dojson.utils import strip_empty_values
 
 
+def test_location_from_034__d_f():
+    snippet = (
+        '<datafield tag="034" ind1=" " ind2=" ">'
+        '  <subfield code="d">6.07532</subfield>'
+        '  <subfield code="f">50.7736</subfield>'
+        '</datafield>'
+    )  # record/902624
+
+    expected = {
+        'longitude': 6.07532,
+        'latitude': 50.7736,
+    }
+    result = strip_empty_values(institutions.do(create_record(snippet)))
+
+    assert expected == result['location']
+
+
+def test_location_from_034__d():
+    snippet = (
+        '<datafield tag="034" ind1=" " ind2=" ">'
+        '  <subfield code="d">6.07532</subfield>'
+        '</datafield>'
+    )  # synthetic data
+
+    expected = {
+        'longitude': 6.07532,
+    }
+    result = strip_empty_values(institutions.do(create_record(snippet)))
+
+    assert expected == result['location']
+
+
+def test_location_from_034__f():
+    snippet = (
+        '<datafield tag="034" ind1=" " ind2=" ">'
+        '  <subfield code="f">50.7736</subfield>'
+        '</datafield>'
+    )  # synthetic data
+
+    expected = {
+        'latitude': 50.7736,
+    }
+    result = strip_empty_values(institutions.do(create_record(snippet)))
+
+    assert expected == result['location']
+
+
+def test_no_location_from_invalid_034__d_f():
+    snippet = (
+        '<datafield tag="034" ind1=" " ind2=" ">'
+        '  <subfield code="d">foo</subfield>'
+        '  <subfield code="f">bar</subfield>'
+        '</datafield>'
+    )  # synthetic data
+
+    result = strip_empty_values(institutions.do(create_record(snippet)))
+
+    assert 'location' not in result
+
+
+def test_timezone_from_043__t():
+    snippet = (
+        '<datafield tag="043" ind1=" " ind2=" ">'
+        '  <subfield code="t">+05</subfield>'
+        '</datafield>'
+    )  # record/902635
+
+    expected = ['+05']
+    result = strip_empty_values(institutions.do(create_record(snippet)))
+
+    assert expected == result['timezone']
+
+
+def test_name_from_100__a():
+    snippet = (
+        '<datafield tag="110" ind1=" " ind2=" ">'
+        '  <subfield code="a">Mid-America Christian U.</subfield>'
+        '</datafield>'
+    )  # record/1439728
+
+    expected = [['Mid-America Christian U.']]
+    result = strip_empty_values(institutions.do(create_record(snippet)))
+
+    assert expected == result['name']
+
+
+def test_name_from_100__a_b_u():
+    snippet = (
+        '<datafield tag="110" ind1=" " ind2=" ">'
+        '  <subfield code="a">Fukushima University</subfield>'
+        '  <subfield code="b">Department of Physics</subfield>'
+        '  <subfield code="u">Fukushima U.</subfield>'
+        '</datafield>'
+    )  # record/902812
+
+    expected = [['Fukushima University', 'Fukushima U.']]
+    result = strip_empty_values(institutions.do(create_record(snippet)))
+
+    assert expected == result['name']
+
+
+def test_name_from_100__a_b_t_u():
+    snippet = (
+        '<datafield tag="110" ind1=" " ind2=" ">'
+        '  <subfield code="a">Adelphi University</subfield>'
+        '  <subfield code="b">Department of Physics</subfield>'
+        '  <subfield code="t">Adelphi U., Dept. Phys.</subfield>'
+        '  <subfield code="u">Adelphi U.</subfield>'
+        '</datafield>'
+    )  # record/902628
+
+    expected = [['Adelphi University', 'Adelphi U.', 'Adelphi U., Dept. Phys.']]
+    result = strip_empty_values(institutions.do(create_record(snippet)))
+
+    assert expected == result['name']
+
+
 def test_address_from_marcxml_371__a_b_c_d_e_g():
     snippet = (
         '<datafield tag="371" ind1=" " ind2=" ">'
@@ -245,3 +362,232 @@ def test_address_from_multiple_marcxml_371__a_b_c_d_e_g():
     result = strip_empty_values(institutions.do(create_record(snippet)))
 
     assert expected == result['address']
+
+
+def test_field_activity_from_372__a():
+    snippet = (
+        '<datafield tag="372" ind1=" " ind2=" ">'
+        '  <subfield code="a">Research center</subfield>'
+        '</datafield>'
+    )
+
+    expected = ['Research center']
+    result = strip_empty_values(institutions.do(create_record(snippet)))
+
+    assert expected == result['field_activity']
+
+
+def test_name_variants_from_410__a_9():
+    snippet = (
+        '<datafield tag="410" ind1=" " ind2=" ">'
+        '  <subfield code="9">DESY</subfield>'
+        '  <subfield code="a">Aachen Tech. Hochsch.</subfield>'
+        '</datafield>'
+    )  # record/902624
+
+    expected = [
+        {
+            'source': 'DESY',
+            'value': (
+                'Aachen Tech. Hochsch.',
+            ),
+        },
+    ]
+    result = strip_empty_values(institutions.do(create_record(snippet)))
+
+    assert expected == result['name_variants']
+
+
+def test_name_variants_from_410__double_a():
+    snippet = (
+        '<datafield tag="410" ind1=" " ind2=" ">'
+        '  <subfield code="a">Theoretische Teilchenphysik und Kosmologie</subfield>'
+        '  <subfield code="a">Elementarteilchenphysik</subfield>'
+        '</datafield>'
+    )  # record/902624
+
+    expected = [
+        {
+            'value': (
+                'Theoretische Teilchenphysik und Kosmologie',
+                'Elementarteilchenphysik',
+            ),
+        },
+    ]
+    result = strip_empty_values(institutions.do(create_record(snippet)))
+
+    assert expected == result['name_variants']
+
+
+def test_extra_words_from_410__decuple_g():
+    snippet = (
+        '<datafield tag="410" ind1=" " ind2=" ">'
+        '  <subfield code="g">Institut Theoretische Physik,</subfield>'
+        '  <subfield code="g">RWTH, Inst.</subfield>'
+        '  <subfield code="g">institute A</subfield>'
+        '  <subfield code="g">III. Physikalisches Institut, Technische Hochschule Aachen, Aachen, West</subfield>'
+        '  <subfield code="g">physics</subfield>'
+        '  <subfield code="g">52056</subfield>'
+        '  <subfield code="g">D-52056</subfield>'
+        '  <subfield code="g">DE-52056</subfield>'
+        '  <subfield code="g">phys</subfield>'
+        '  <subfield code="g">I. Physikalisches Institut</subfield>'
+        '</datafield>'
+    )  # record/902624
+
+    expected = [
+        'Institut Theoretische Physik,',
+        'RWTH, Inst.',
+        'institute A',
+        'III. Physikalisches Institut, Technische Hochschule Aachen, Aachen, West',
+        'physics',
+        '52056',
+        'D-52056',
+        'DE-52056',
+        'phys',
+        'I. Physikalisches Institut',
+    ]
+    result = strip_empty_values(institutions.do(create_record(snippet)))
+
+    assert expected == result['extra_words']
+
+
+def test_core_from_690c_a_core():
+    snippet = (
+        '<datafield tag="690" ind1="C" ind2=" ">'
+        '  <subfield code="a">CORE</subfield>'
+        '</datafield>'
+    )  # record/902645
+
+    result = strip_empty_values(institutions.do(create_record(snippet)))
+
+    assert result['core']
+
+
+def test_core_from_690c_a_noncore():
+    snippet = (
+        '<datafield tag="690" ind1="C" ind2=" ">'
+        '  <subfield code=a">NONCORE</subfield>'
+        '</datafield>'
+    )  # record/916025
+
+    result = strip_empty_values(institutions.do(create_record(snippet)))
+
+    assert not result['core']
+
+
+def test_non_public_notes_from_667__a():
+    snippet = (
+        '<datafield tag="667" ind1=" " ind2=" ">'
+        '  <subfield code="a">Former ICN = Negev U.</subfield>'
+        '</datafield>'
+    )  # record/902663
+
+    expected = ['Former ICN = Negev U.']
+    result = strip_empty_values(institutions.do(create_record(snippet)))
+
+    assert expected == result['non_public_notes']
+
+
+def test_hidden_notes_from_595__a():
+    snippet = (
+        '<datafield tag="595" ind1=" " ind2=" ">'
+        '  <subfield code="a">The Division is located inside the Department of Physics and Astronomy of the University of Catania Scientific Campus ("Città Universitaria" or "Cittadella"). Via Santa Sofia 64 95123 CATANIA</subfield>'
+        '</datafield>'
+    )  # record/902879
+
+    expected = [u'The Division is located inside the Department of Physics and Astronomy of the University of Catania Scientific Campus ("Città Universitaria" or "Cittadella"). Via Santa Sofia 64 95123 CATANIA']
+    result = strip_empty_values(institutions.do(create_record(snippet)))
+
+    assert expected == result['hidden_notes']
+
+
+def test_hidden_notes_from_double_595__a():
+    snippet = (
+        '<record>'
+        '  <datafield tag="595" ind1=" " ind2=" ">'
+        '    <subfield code="a">The Roma II Structure was established in 1989 at the University of Rome “Tor Vergata” - cc</subfield>'
+        '  </datafield>'
+        '  <datafield tag="595" ind1=" " ind2=" ">'
+        '    <subfield code="a">REDACTED thinks we don\'t have to write 110__t: "INFN, Rome 2" because Rome 2 is only in the url but not in the site. She\'ll ask to REDACTED (from INFN) to have her feedback.</subfield>'
+        '  </datafield>'
+        '</record>'
+    )  # record/907691
+
+    expected = [
+        u'The Roma II Structure was established in 1989 at the University of Rome “Tor Vergata” - cc',
+        u'REDACTED thinks we don\'t have to write 110__t: "INFN, Rome 2" because Rome 2 is only in the url but not in the site. She\'ll ask to REDACTED (from INFN) to have her feedback.',
+    ]
+    result = strip_empty_values(institutions.do(create_record(snippet)))
+
+    assert expected == result['hidden_notes']
+
+
+@pytest.mark.xfail(reason='duplicates are preserved')
+def test_hidden_notes_from_double_595__a_removes_duplicates():
+    snippet = (
+        '<record>'
+        '  <datafield tag="595" ind1=" " ind2=" ">'
+        '    <subfield code="a">error in 371_b</subfield>'
+        '  </datafield>'
+        '  <datafield tag="595" ind1=" " ind2=" ">'
+        '    <subfield code="a">error in 371_b</subfield>'
+        '  </datafield>'
+        '</record>'
+    )  # record/907275
+
+    expected = ['error in 371_b']
+    result = strip_empty_values(institutions.do(create_record(snippet)))
+
+    assert expected == result['hidden_notes']
+
+
+def test_public_notes_from_680__a():
+    snippet = (
+        '<datafield tag="680" ind1=" " ind2=" ">'
+        '  <subfield code="i">2nd address: Organisation Européenne pour la Recherche Nucléaire (CERN), F-01631 Prévessin Cedex, France</subfield>'
+        '</datafield>'
+    )  # record/902725
+
+    expected = [
+        u'2nd address: Organisation Européenne pour la Recherche Nucléaire (CERN), F-01631 Prévessin Cedex, France'
+    ]
+    result = strip_empty_values(institutions.do(create_record(snippet)))
+
+    assert expected == result['public_notes']
+
+
+def test_historical_data_from_6781_a():
+    snippet = (
+        '<datafield tag="678" ind1="1" ind2=" ">'
+        '  <subfield code="a">Became IFH (Inst for Hochenergiephysik)in 1968. Since 1992 the official name of the Inst. is simply DESY Zeuthen. Changed 1/26/99 AMR</subfield>'
+        '</datafield>'
+    )  # record/902666
+
+    expected = [
+        'Became IFH (Inst for Hochenergiephysik)in 1968. Since 1992 the official name of the Inst. is simply DESY Zeuthen. Changed 1/26/99 AMR'
+    ]
+    result = strip_empty_values(institutions.do(create_record(snippet)))
+
+    assert expected == result['historical_data']
+
+
+def test_historical_data_from_6781_a():
+    snippet = (
+        '<datafield tag="678" ind1="1" ind2=" ">'
+        '  <subfield code="a">Conseil européen pour la Recherche Nucléaire (1952-1954)</subfield>'
+        '  <subfield code="a">Organisation européenne pour la Recherche nucléaire (1954-now)</subfield>'
+        '  <subfield code="a">Sub title: Laboratoire européen pour la Physique des Particules (1984-now)</subfield>'
+        '  <subfield code="a">Sub title: European Laboratory for Particle Physics (1984-now)</subfield>'
+        '</datafield>'
+    )  # record/902725
+
+    expected = [
+        u'Conseil européen pour la Recherche Nucléaire (1952-1954)',
+        u'Organisation européenne pour la Recherche nucléaire (1954-now)',
+        u'Sub title: Laboratoire européen pour la Physique des Particules (1984-now)',
+        u'Sub title: European Laboratory for Particle Physics (1984-now)',
+    ]
+    result = strip_empty_values(institutions.do(create_record(snippet)))
+
+    assert expected == result['historical_data']


### PR DESCRIPTION
~~This PR adds more tests to the DoJSON conversions for the "minor" collections: Institutions, Conferences, Experiments, Jobs, and Journals.~~

~~The main purpose is to see what we actually have in the data and discover its quirks. Some will have to be solved in Legacy (like https://github.com/inspirehep/inspire/issues/170), others will have to be taken in account when building the DoJSON rules.~~

This was growing too much in scope, so in this PR I will only deal with Institutions. Other minor collections are tracked in #1240.

Only the assertions will have to be changed when we finalise the schemas, the test cases will stay the same (which is why this work will not be wasted).

- [x] Institutions
    - [x] Test `location`
    - [x] Fix population of `name_variants`
    - [x] Test `name_variants`
    - [x] Fix population of `hidden_notes`
    - [x] Test `hidden_notes`
    - [x] Refactor `location`

Closes #1202