### PR TITLE
jinja2filters: pubinfo sanity check

### DIFF
--- a/inspirehep/modules/theme/jinja2filters.py
+++ b/inspirehep/modules/theme/jinja2filters.py
@@ -575,7 +575,8 @@ def publication_info(record):
                     conference_recid = conference_rec['control_number']
             if 'parent_record' in pub_info:
                 parent_rec = replace_refs(pub_info['parent_record'], 'es')
-                parent_recid = parent_rec['control_number']
+                if parent_rec and parent_rec.get('control_number'):
+                    parent_recid = parent_rec['control_number']
 
             if conference_recid and parent_recid:
                 try:

--- a/tests/unit/theme/test_theme_jinja2filters.py
+++ b/tests/unit/theme/test_theme_jinja2filters.py
@@ -1097,6 +1097,34 @@ def test_publication_info_with_pub_info_and_conf_info(r_r, mock_replace_refs):
 
 
 @mock.patch('inspirehep.modules.theme.jinja2filters.replace_refs')
+def test_publication_info_with_pub_info_and_conf_info_not_found(r_r):
+    conf_rec = {'$ref': 'http://x/y/976391'}
+    parent_rec = {'$ref': 'http://x/y/706120'}
+
+    r_r.return_value = None
+
+    with_pub_info_and_conf_info = Record({
+        'publication_info': [
+            {
+                'journal_title': 'eConf',
+                'journal_volume': 'C050318'
+            },
+            {
+                'conference_record': conf_rec,
+                'parent_record': parent_rec
+            }
+        ]
+    })
+
+    expected = {
+        'pub_info': ['<i>eConf</i> C050318']
+    }
+    result = publication_info(with_pub_info_and_conf_info)
+
+    assert expected == result
+
+
+@mock.patch('inspirehep.modules.theme.jinja2filters.replace_refs')
 def test_publication_info_from_conference_recid_and_not_parent_recid(r_r, mock_replace_refs):
     with_title = '20th International Workshop on Deep-Inelastic Scattering and Related Subjects'
     conf_rec = {'$ref': 'http://x/y/1086512'}


### PR DESCRIPTION
* Avoids crash when parent recid does not exist in ES.

* Adds testcase.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>