### PR TITLE
submodules: add inspirehep-search-js as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "submodules/inspirehep-search-js"]
+	path = submodules/inspirehep-search-js
+	url = https://github.com/inspirehep/inspirehep-search-js.git


### PR DESCRIPTION
* NOTE: run `git submodule update --init --recursive` to fetch the contents of the
  inspirehep-search-js repo.
  Once that is done, working inside the folder inspirehep-search-js/
  will be equivalent to working on the standalone repo and you can create
  PRs on the inspirehep-search-js repo.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>