### PR TITLE
setup: pin Flask-Admin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ install_requires = [
     'invenio>=3.0.0a1,<3.1.0',
     'inspire-crawler>=0.2.0',
     'dojson==1.2.1',
+    'Flask-Admin==1.4.0',
     'Flask-Breadcrumbs>=0.3.0',
     'Flask-Script>=2.0.5',
     'jsmin',


### PR DESCRIPTION
`invenio-admin==1.0.0a3` and `Flask-Admin==1.4.1` are incompatible, causing this error: https://travis-ci.org/inspirehep/inspire-next/jobs/137282868#L1094

This PR works around that by requiring `Flask-Admin==1.4.0`, the last known working version.