### PR TITLE
WIP schemas: add magpie as field_categories source

### DIFF
--- a/inspirehep/modules/records/jsonschemas/records/elements/fields.json
+++ b/inspirehep/modules/records/jsonschemas/records/elements/fields.json
@@ -33,7 +33,8 @@
                     "INSPIRE",
                     "submitter",
                     "curator",
-                    "publisher"
+                    "publisher",
+                    "magpie"
                 ],
                 "type": "string"
             },


### PR DESCRIPTION
Addresses #1206 by adding `magpie` as a possible source of `field_categories`.