### PR TITLE
setup: revert pin on Flask-Admin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,6 @@ install_requires = [
     'invenio>=3.0.0a1,<3.1.0',
     'inspire-crawler>=0.2.0',
     'dojson==1.2.1',
-    'Flask-Admin==1.4.0',
     'Flask-Breadcrumbs>=0.3.0',
     'Flask-Script>=2.0.5',
     'jsmin',


### PR DESCRIPTION
Now that `Flask-Admin==1.4.2.` was released, fixing the bug worked around by #1208, there's no need for that pin.