### PR TITLE
dojson: idutils version bump

### DIFF
--- a/inspirehep/dojson/hep/fields/bd01x09x.py
+++ b/inspirehep/dojson/hep/fields/bd01x09x.py
@@ -24,7 +24,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-from isbnlib._exceptions import NotValidISBNError
+from isbn import ISBNError
 
 from dojson import utils
 from idutils import normalize_isbn
@@ -42,7 +42,7 @@ def isbns(self, key, value):
     "ISBN, its medium and an additional comment."""
     try:
         isbn = normalize_isbn(value['a'])
-    except (KeyError, NotValidISBNError):
+    except (KeyError, ISBNError):
         return {}
 
     b = value.get('b', '').lower()

--- a/inspirehep/dojson/hep/fields/bd90x99x.py
+++ b/inspirehep/dojson/hep/fields/bd90x99x.py
@@ -26,7 +26,7 @@ from __future__ import absolute_import, division, print_function
 
 import re
 
-from isbnlib._exceptions import NotValidISBNError
+from isbn import ISBNError
 
 from dojson import utils
 from idutils import normalize_isbn
@@ -78,7 +78,7 @@ def references(self, key, value):
 
         try:
             isbn = normalize_isbn(value['i'])
-        except (KeyError, NotValidISBNError):
+        except (KeyError, ISBNError):
             isbn = ''
 
         valid_pubnotes, raw_references = get_valid_pubnotes(utils.force_list(value.get('s')))

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ install_requires = [
     'rt',
     'librabbitmq>=1.6.1',
     'invenio-jsonschemas==1.0.0a3',
-    'idutils>=0.2.0',
+    'idutils>=0.2.1',
     'invenio-access==1.0.0a5',
     'invenio-accounts==1.0.0a10',
     'invenio-admin==1.0.0a3',


### PR DESCRIPTION
* Changes the ISBN parse error to match the isbnid new dependency in
  idutils.

Signed-off-by: Mihai Bivol <mihai.bivol@cern.ch>