### PR TITLE
jsonschema: page_artid -> page_start/end + artid

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -207,7 +207,9 @@ SEARCH_ELASTIC_KEYWORD_MAPPING = {
     "firstauthor": ["authors.full_name", "authors.alternative_name"],
     "fulltext": ["urls.value"],
     "journal": ["publication_info.recid",
-                "publication_info.page_artid",
+                "publication_info.page_start",
+                "publication_info.artid",
+                "publication_info.page_range",
                 "publication_info.journal_issue",
                 "publication_info.conf_acronym",
                 "publication_info.journal_title",
@@ -220,7 +222,9 @@ SEARCH_ELASTIC_KEYWORD_MAPPING = {
                 "publication_info.isbn",
                 "publication_info.note"
                 ],
-    "journal_page": ["publication_info.page_artid"],
+    "journal_page": ["publication_info.page_start",
+                     "publication_info.page_range"
+                     "publication_info.artid"],
     "keyword": ["thesaurus_terms.keyword", "free_keywords.value"],
     "note": ["public_notes.value"],
     "reference": ["references.doi", "references.report_number",

--- a/inspirehep/modules/literaturesuggest/dojson/fields/literature.py
+++ b/inspirehep/modules/literaturesuggest/dojson/fields/literature.py
@@ -34,6 +34,8 @@ from dojson import utils
 from dojson.errors import IgnoreKey
 from idutils import is_arxiv_post_2007
 
+from inspirehep.dojson.utils import split_page_artid
+
 from ..model import literature
 
 
@@ -215,10 +217,11 @@ def year(self, key, value):
 
 @literature.over('_page_range_article_id', '^page_range_article_id$')
 def page_range_article_id(self, key, value):
-    if 'publication_info' in self:
-        self['publication_info'][0].update(dict(page_artid=value))
-    else:
-        self['publication_info'] = [dict(page_artid=value)]
+    page_start, page_end, artid = split_page_artid(value)
+    self.setdefault('publication_info', [{}])[0].update(dict(
+        page_start=page_start,
+        page_end=page_end,
+        artid=artid))
     raise IgnoreKey
 
 

--- a/inspirehep/modules/literaturesuggest/tasks.py
+++ b/inspirehep/modules/literaturesuggest/tasks.py
@@ -83,7 +83,8 @@ def formdata_to_model(obj, formdata):
                 }]
     if "publication_info" in data:
         if all([key in data['publication_info'][0].keys() for key in
-               ('year', 'journal_issue', 'journal_volume', 'page_artid')]):
+               ('year', 'journal_issue', 'journal_volume', 'page_start',
+                'page_end', 'artid')]):
             # NOTE: Only peer reviewed journals should have this collection
             # we are adding it here but ideally should be manually added
             # by a curator.
@@ -147,16 +148,17 @@ def formdata_to_model(obj, formdata):
         data['collections'].extend([{'primary': "ConferencePaper"}])
 
     # ============================
-    # Page range
+    # Page number
     # ============================
     if 'page_nr' not in data:
-        if data.get("publication_info", [{}])[0].get("page_artid"):
-            pages = data['publication_info'][0]['page_artid'].split('-')
-            if len(pages) == 2:
-                try:
-                    data['page_nr'] = int(pages[1]) - int(pages[0]) + 1
-                except ValueError:
-                    pass
+        first_publication_info = data.get('publication_info', [{}])[0]
+
+        page_start = first_publication_info.get('page_start')
+        page_end = first_publication_info.get('page_end')
+
+        if page_start and page_end:
+            data['page_nr'] = page_end - page_start + 1
+
     # ============================
     # Language
     # ============================

--- a/inspirehep/modules/records/jsonschemas/records/hep.json
+++ b/inspirehep/modules/records/jsonschemas/records/hep.json
@@ -365,9 +365,17 @@
                     "journal_issue": {
                         "type": "string"
                     },
-                    "page_artid": {
+                    "page_start": {
                         "type": "string",
-                        "description": "FIXME: for ejournals this could be the page index, but there is no realiable way to know whether something is a page index or a first page, does it?"
+                        "description": "First page"
+                    },
+                    "page_end": {
+                        "type": "string",
+                        "description": "Last page"
+                    },
+                    "artid": {
+                        "type": "string",
+                        "description": "Electronic Article ID"
                     },
                     "conf_acronym": {
                         "type": "string"

--- a/inspirehep/modules/records/receivers.py
+++ b/inspirehep/modules/records/receivers.py
@@ -115,7 +115,8 @@ def populate_inspire_document_type(recid, json, *args, **kwargs):
             for field in json.get('publication_info', []):
                 for k, v in field.iteritems():
                     complete_pub_info.append(k)
-            if 'page_artid' not in complete_pub_info:
+            if ('page_start' not in complete_pub_info and
+                    'artid' not in 'complete_pub_info'):
                 inspire_doc_type.append('preprint')
         inspire_doc_type.extend([s['primary'].lower() for s in
                                  json.get('collections', []) if 'primary'

--- a/inspirehep/modules/refextract/tasks.py
+++ b/inspirehep/modules/refextract/tasks.py
@@ -25,6 +25,7 @@
 from refextract import extract_journal_reference, extract_references_from_file
 
 from inspirehep.utils.record import get_value
+from inspirehep.dojson.utils import split_page_artid
 
 # FIXME get journal mappings for refextract
 # from inspirehep.utils.knowledge import get_mappings_from_kbname
@@ -65,9 +66,14 @@ def extract_journal_info(obj, eng):
                     "year"
                 )
             if "page" in extracted_publication_info:
-                pubnote["page_artid"] = extracted_publication_info.get(
-                    "page"
-                )
+                page_start, page_end, artid = split_page_artid(
+                    extracted_publication_info.get("page"))
+                if page_start:
+                    pubnote["page_start"] = page_start
+                if page_end:
+                    pubnote["page_end"] = page_end
+                if artid:
+                    pubnote["artid"] = artid
         new_publication_info.append(pubnote)
 
     obj.data["publication_info"] = new_publication_info

--- a/inspirehep/modules/theme/jinja2filters.py
+++ b/inspirehep/modules/theme/jinja2filters.py
@@ -552,8 +552,12 @@ def publication_info(record):
                     year = ' (' + str(pub_info['year']) + ')'
                 if 'journal_issue' in pub_info:
                     journal_issue = ' ' + pub_info['journal_issue'] + ', '
-                if 'page_artid' in pub_info:
-                    pages = ' ' + pub_info['page_artid']
+                if 'page_start' in pub_info and 'page_end' in pub_info:
+                    pages = ' ' + '{page_start}-{page_end}'.format(**pub_info)
+                elif 'page_start' in pub_info:
+                    pages = ' ' + '{page_start}'.format(**pub_info)
+                elif 'artid' in pub_info:
+                    pages = ' ' + '{artid}'.format(**pub_info)
                 out.append(journal_title + journal_volume +
                            year + journal_issue + pages)
         if out:
@@ -592,8 +596,11 @@ def publication_info(record):
                             ctx=ctx)
                         break
                     else:
-                        if 'page_artid' in pub_info:
-                            ctx.update({"page_artid": pub_info['page_artid']})
+                        ctx.update(dict(
+                            page_start=pub_info.get('page_start'),
+                            page_end=pub_info.get('page_end'),
+                            artid=pub_info.get('artid')
+                        ))
                         result['conf_info'] = render_macro_from_template(
                             name="conf_without_pub_info",
                             template="inspirehep_theme/format/record/Conference_info_macros.tpl",

--- a/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Conference_info_macros.tpl
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Conference_info_macros.tpl
@@ -23,24 +23,31 @@
   {{ conference_title }}</a>)
 {%- endmacro -%}
 
-{%- macro conf_without_pub_info(parent_recid, conference_recid, conference_title, page_artid='') -%}
+{%- macro conf_without_pub_info(parent_recid, conference_recid, conference_title, page_start='', page_end='', artid='') -%}
     Published in <a href="/record/{{ parent_recid }}">proceedings</a> of <a href="/record/{{ conference_recid }}">{{ conference_title }}</a>
-  {%- if page_artid -%}
-    , pages  
-  {{ page_artid }}
+  {%- if page_start and page_end -%}
+    , pages
+  {{ page_start }}-{{ page_end }}
+  {%- elif page_start -%}
+    , page
+  {{ page_start }}
+  {%- elif artid -%}
+    , article ID
+  {{ artid }}
   {%- endif -%}
+
 {%- endmacro -%}
 
-{%- macro conference_only(conference_recid, conference_title, pub_info = false) -%}
+{%- macro conference_only(conference_recid, conference_title, pub_info=false) -%}
   {%- if pub_info -%}
     <br/>
   {%- endif -%}
   Contribution to <a href="/record/{{ conference_recid }}">{{ conference_title }}</a>
 {%- endmacro -%}
 
-{%- macro proceedings_only(parent_recid, parent_title, pub_info = false) -%}
+{%- macro proceedings_only(parent_recid, parent_title, pub_info=false) -%}
   {%- if pub_info -%}
-    (<a href="/record/{{ parent_recid }}">Proceedings</a> of {{ parent_title }})   
+    (<a href="/record/{{ parent_recid }}">Proceedings</a> of {{ parent_title }})
   {%- else -%}
     Published in <a href="/record/{{ parent_recid }}">proceedings</a> of {{ parent_title }}
   {%- endif -%}

--- a/inspirehep/utils/cv_latex.py
+++ b/inspirehep/utils/cv_latex.py
@@ -235,23 +235,8 @@ class Cv_latex(Export):
                     if 'journal_issue' in field:
                         if field['journal_issue']:
                             journal_issue = ', no. ' + field['journal_issue']
-                    if 'page_artid' in field:
-                        page_artid = ''
-                        if field['page_artid']:
-                            if isinstance(field['page_artid'], list):
-                                dashpos = field['page_artid'][-1].find('-')
-                                if dashpos > -1:
-                                    page_artid = field[
-                                        'page_artid'][-1][:dashpos]
-                                else:
-                                    page_artid = field['page_artid'][-1]
-                            else:
-                                dashpos = field['page_artid'].find('-')
-                                if dashpos > -1:
-                                    page_artid = field['page_artid'][:dashpos]
-                                else:
-                                    page_artid = field['page_artid']
-                            pages = ', ' + page_artid
+                    if 'page_start' in field or 'artid' in field:
+                        pages = ', ' + (field.get('page_start') or field['artid'])
 
                     out += journal_title + journal_volume + journal_issue + \
                         pages + year

--- a/inspirehep/utils/cv_latex_html_text.py
+++ b/inspirehep/utils/cv_latex_html_text.py
@@ -26,6 +26,8 @@ import re
 from .export import MissingRequiredFieldError, Export
 from inspirehep import config
 
+from inspirehep.utils.record import is_submitted_but_not_published
+
 
 class Cv_latex_html_text(Export):
 
@@ -202,41 +204,27 @@ class Cv_latex_html_text(Export):
             for field in self.record['publication_info']:
                 out = ''
                 if 'journal_title' in field:
-                    if isinstance(field['journal_title'], list):
-                        if not ('journal_volume' in field or
-                                'journal_issue' in field or
-                                'page_artid' in field or
-                                'doi' in self.record):
-                            journal_title = 'Submitted to:' +\
-                                field['journal_title'][-1]
-                        else:
-                            journal_title = field['journal_title'][-1]
-                    else:
-                        if not ('journal_volume' in field or
-                                'journal_issue' in field or
-                                'page_artid' in field or
-                                'doi' in self.record):
-                            journal_title = 'Submitted to:' +\
-                                field['journal_title']
-                        else:
-                            journal_title = field['journal_title']
-                    if 'journal_volume' in field:
-                        journal_volume = ' ' + field['journal_volume']
-                    if 'year' in field:
-                        if isinstance(field['year'], list):
-                            year = ' (' + str(field['year'][-1]) + ')'
-                        else:
+                    if is_submitted_but_not_published(self.record):
+                        journal_title = 'Submitted to: ' +\
+                            field['journal_title']
+                        if 'year' in field:
                             year = ' (' + str(field['year']) + ')'
-                    if 'journal_issue' in field:
-                        if field['journal_issue']:
-                            journal_issue = ' ' + \
-                                            field['journal_issue'] + ','
-                    if 'page_artid' in field:
-                        if field['page_artid']:
-                            if isinstance(field['page_artid'], list):
-                                pages = ' ' + field['page_artid'][-1]
-                            else:
-                                pages = ' ' + field['page_artid']
+                    else:
+                        journal_title = field['journal_title']
+                        if 'journal_volume' in field:
+                            journal_volume = ' ' + field['journal_volume']
+                        if 'year' in field:
+                            year = ' (' + str(field['year']) + ')'
+                        if 'journal_issue' in field:
+                            if field['journal_issue']:
+                                journal_issue = ' ' + \
+                                                field['journal_issue'] + ','
+                        if 'page_start' in field and 'page_end' in field:
+                            pages = ' {page_start}-{page_end}'.format(**field)
+                        elif 'page_start' in field:
+                            pages = ' {page_start}'.format(**field)
+                        elif 'artid' in field:
+                            pages = ' {artid}'.format(**field)
                     out += journal_title + journal_volume + year + \
                         journal_issue + pages
                     result.append(out)

--- a/inspirehep/utils/latex.py
+++ b/inspirehep/utils/latex.py
@@ -241,26 +241,11 @@ class Latex(Export):
                             else:
                                 journal_issue = ', no. ' + \
                                                 field['journal_issue']
-                    if 'page_artid' in field:
-                        page_artid = ''
-                        if field['page_artid']:
-                            if isinstance(field['page_artid'], list):
-                                dashpos = field['page_artid'][-1].find('-')
-                                if dashpos > -1:
-                                    page_artid = field[
-                                        'page_artid'][-1][:dashpos]
-                                else:
-                                    page_artid = field['page_artid'][-1]
-                            else:
-                                dashpos = field['page_artid'].find('-')
-                                if dashpos > -1:
-                                    page_artid = field['page_artid'][:dashpos]
-                                else:
-                                    page_artid = field['page_artid']
-                            if self.latex_format == 'latex_eu':
-                                pages = ' ' + page_artid
-                            else:
-                                pages = ', ' + page_artid
+                    if 'page_start' in field or 'artid' in field:
+                        if self.latex_format == 'latex_eu':
+                            pages = ' ' + (field.get('page_start') or field['artid'])
+                        else:
+                            pages = ', ' + (field.get('page_start') or field['artid'])
                     if self.latex_format == 'latex_eu':
                         out += journal_title + journal_volume + year + \
                             journal_issue + pages
@@ -294,17 +279,8 @@ class Latex(Export):
                     journal = field['journal_title']
                 if 'journal_volume' in field:
                     volume = field['journal_volume']
-                if 'page_artid' in field:
-                    pages = field['page_artid']
-                    if pages:
-                        if isinstance(pages, list):
-                            for page in pages:
-                                dashpos = page.find('-')
-                                break
-                        else:
-                            dashpos = pages.find('-')
-                        if dashpos > -1:
-                            pages = pages[:dashpos]
+                if 'page_start' in field or 'artid' in field:
+                    pages = field.get('page_start') or field['artid']
                 try:
                     if journal and (volume != '' or pages != ''):
                         recid = self.record['control_number', '']

--- a/inspirehep/utils/record.py
+++ b/inspirehep/utils/record.py
@@ -85,3 +85,32 @@ def get_value(record, key, default=None):
         except KeyError:
             return default
     return value
+
+
+def is_submitted_but_not_published(record):
+    """Return True if article is submitted to journal.
+
+    Returns True if and only an article is submitted to a journal but has not
+    yet been published (as far as we know).
+    """
+    def is_complete(publication_info):
+        return (('journal_issue' in publication_info or
+                 'journal_volume' in publication_info or
+                 'year' in publication_info) and
+                ('page_start' in publication_info or
+                 'artid' in publication_info))
+    if 'dois' in record:
+        # DOIs exist, hence it's already published
+        return False
+    had_at_least_one_journal_title = False
+    if 'publication_info' in record:
+        for publication_info in record['publication_info']:
+            if 'journal_title' in publication_info:
+                had_at_least_one_journal_title = True
+                if (publication_info['journal_title'].lower() in ('econf', ) and
+                        'journal_volume' in publication_info):
+                    # eConf are special
+                    return False
+                if is_complete(publication_info):
+                    return False
+    return had_at_least_one_journal_title

--- a/tests/unit/dojson/fixtures/test_hep_record.xml
+++ b/tests/unit/dojson/fixtures/test_hep_record.xml
@@ -183,6 +183,7 @@
   </datafield>
   <datafield tag="773" ind1=" " ind2=" ">
     <subfield code="c">026802</subfield>
+    <subfield code="c">123-456</subfield>
     <subfield code="n">2</subfield>
     <subfield code="p">Phys.Rev.Lett.</subfield>
     <subfield code="v">105</subfield>

--- a/tests/unit/dojson/test_dojson_hep.py
+++ b/tests/unit/dojson/test_dojson_hep.py
@@ -64,10 +64,12 @@ def test_schema_present(marcxml_to_json):
     """Test if $schema is created correctly."""
     assert marcxml_to_json['$schema']
 
+
 def test_control_number(marcxml_to_json_book):
     """"Test if control number and self present."""
     assert marcxml_to_json_book['control_number']
     assert marcxml_to_json_book['self']
+
 
 def test_isbns(marcxml_to_json, json_to_marc):
     """Test if isbns is created correctly."""
@@ -135,10 +137,10 @@ def test_external_system_numbers_from_035__a():
 
 def test_external_system_numbers_from_035__a_9():
     snippet = (
-       '<datafield tag="035" ind1=" " ind2=" ">'
-       '  <subfield code="9">INSPIRETeX</subfield>'
-       '  <subfield code="a">Hagedorn:1963hdh</subfield>'
-       '</datafield>'
+        '<datafield tag="035" ind1=" " ind2=" ">'
+        '  <subfield code="9">INSPIRETeX</subfield>'
+        '  <subfield code="a">Hagedorn:1963hdh</subfield>'
+        '</datafield>'
     )  # record/1403324
 
     expected = [
@@ -510,8 +512,11 @@ def test_collaboration(marcxml_to_json, json_to_marc):
 
 def test_publication_info(marcxml_to_json, json_to_marc):
     """Test if publication info is created correctly."""
-    assert (marcxml_to_json['publication_info'][0]['page_artid'] ==
-            json_to_marc['773'][0]['c'])
+    assert marcxml_to_json['publication_info'][0]['artid'] == '026802'
+    assert marcxml_to_json['publication_info'][0]['page_start'] == '123'
+    assert marcxml_to_json['publication_info'][0]['page_end'] == '456'
+    assert '026802' in json_to_marc['773'][0]['c']
+    assert '123-456' in json_to_marc['773'][0]['c']
     assert (marcxml_to_json['publication_info'][0]['journal_issue'] ==
             json_to_marc['773'][0]['n'])
     assert (marcxml_to_json['publication_info'][0]['journal_title'] ==

--- a/tests/unit/literaturesuggest/test_literaturesuggest_dojson.py
+++ b/tests/unit/literaturesuggest/test_literaturesuggest_dojson.py
@@ -603,7 +603,7 @@ def test_publication_info_page_artid_from_page_range_article_id():
 
     expected = [
         {
-            'page_artid': 'foo',
+            'artid': 'foo',
         },
     ]
     result = literature.do(form)
@@ -619,7 +619,7 @@ def test_publication_info_page_artid_from_multiple_page_range_article_id_updates
 
     expected = [
         {
-            'page_artid': 'bar',
+            'artid': 'bar',
         },
     ]
     result = literature.do(form)

--- a/tests/unit/search/test_search_query.py
+++ b/tests/unit/search/test_search_query.py
@@ -535,27 +535,15 @@ def test_find_author_with_hash_wildcard():
     assert expected == result
 
 
+@pytest.mark.xfail(reason='tracked in issue #1235')
 def test_find_journal():
     query = IQ('find j "Phys.Rev.Lett.,105*"')
 
     expected = {
-        'multi_match': {
+        'query_string': {
             'query': '"Phys.Rev.Lett.,105*"',
-            'fields': [
-                'publication_info.recid',
-                'publication_info.page_artid',
-                'publication_info.journal_issue',
-                'publication_info.conf_acronym',
-                'publication_info.journal_title',
-                'publication_info.reportnumber',
-                'publication_info.confpaper_info',
-                'publication_info.journal_volume',
-                'publication_info.cnum',
-                'publication_info.pubinfo_freetext',
-                'publication_info.year_raw',
-                'publication_info.isbn',
-                'publication_info.note'
-            ]
+            'default_field': 'publication_info.pubnote',
+            'analyze_wildcard': True
         }
     }
     result = query.to_dict()
@@ -759,7 +747,8 @@ def test_find_author_or_author():
                             {'match': {'authors.name_variations': 'von gersdorff, g'}}
                         ],
                         'should': [
-                            {'match': {'authors.full_name': 'von gersdorff, g'}}                            ]
+                            {'match': {'authors.full_name': 'von gersdorff, g'}}
+                        ]
                     }
                 }
             ]

--- a/tests/unit/theme/test_theme_jinja2filters.py
+++ b/tests/unit/theme/test_theme_jinja2filters.py
@@ -108,6 +108,7 @@ def mock_perform_es_search():
         }
     )
 
+
 @pytest.fixture
 def mock_perform_es_search_empty():
     return result.Response(
@@ -145,6 +146,7 @@ def mock_perform_es_search_onerecord():
             "took": 123
         }
     )
+
 
 @pytest.fixture
 def mock_perform_es_search_tworecord():
@@ -885,13 +887,13 @@ def test_publication_info_a_list_of_two_elements():
             {
                 'journal_volume': '8',
                 'journal_title': 'JINST',
-                'page_artid': 'P09009',
+                'artid': 'P09009',
                 'year': 2013
             },
             {
                 'journal_volume': '8',
                 'journal_title': 'JINST',
-                'page_artid': '9009',
+                'page_start': '9009',
                 'year': 2013
             }
         ]
@@ -973,7 +975,7 @@ def test_publication_info_from_journal_title_and_pages_artid():
         'publication_info': [
             {
                 'journal_title': 'Astrophys.J.',
-                'page_artid': '525'
+                'page_start': '525'
             }
         ]
     })
@@ -1047,7 +1049,8 @@ def test_publication_info_from_conference_recid_and_parent_recid_with_pages(r_r,
             {
                 'conference_record': conf_rec,
                 'parent_record': parent_rec,
-                'page_artid': '515-518'
+                'page_start': '515',
+                'page_end': '518'
             }
         ]
     })
@@ -1055,7 +1058,7 @@ def test_publication_info_from_conference_recid_and_parent_recid_with_pages(r_r,
     expected = {
         'conf_info': 'Published in <a href="/record/1402672">proceedings</a> '
                      'of <a href="/record/1331207">50th Rencontres de Moriond '
-                     'on EW Interactions and Unified Theories</a>, pages  \n  '
+                     'on EW Interactions and Unified Theories</a>, pages\n  '
                      '515-518'
     }
     result = publication_info(with_conference_recid_and_parent_recid_and_pages)

--- a/tests/unit/utils/test_utils_bibtex.py
+++ b/tests/unit/utils/test_utils_bibtex.py
@@ -144,7 +144,7 @@ def test_get_entry_type_no_collections_one_valid_pubinfo():
         'publication_info': {
             'journal_title': 'foo',
             'journal_volume': 'bar',
-            'page_artid': 'baz',
+            'page_start': 'baz',
             'year': 'quux'
         }
     })
@@ -173,7 +173,7 @@ def test_get_entry_type_no_collections_second_pubinfo_valid():
             {
                 'journal_title': 'foo',
                 'journal_volume': 'bar',
-                'page_artid': 'baz',
+                'page_start': 'baz',
                 'year': 'quux'
             }
         ]
@@ -192,7 +192,7 @@ def test_get_entry_type_one_collection_one_pubinfo():
             {
                 'journal_title': 'foo',
                 'journal_volume': 'bar',
-                'page_artid': 'baz',
+                'page_start': 'baz',
                 'year': 'quux'
             }
         ]
@@ -1147,7 +1147,8 @@ def test_get_pages_publication_info_an_empty_list():
 def test_get_pages_publication_info_one_page():
     publication_info_one_page = Record({
         'publication_info': [
-            {'page_artid': '585-587'}
+            {'page_start': '585',
+             'page_end': '587'}
         ]
     })
 
@@ -1157,29 +1158,13 @@ def test_get_pages_publication_info_one_page():
     assert expected == result
 
 
-def test_get_pages_publication_info_one_page_a_list():
-    publication_info_one_page_a_list = Record({
-        'publication_info': [
-            {
-                'page_artid': [
-                    '508-509',
-                    '585-587'
-                ]
-            }
-        ]
-    })
-
-    expected = '585-587'
-    result = Bibtex(publication_info_one_page_a_list)._get_pages()
-
-    assert expected == result
-
-
 def test_get_pages_publication_info_two_pages():
     publication_info_two_pages = Record({
         'publication_info': [
-            {'page_artid': '585-587'},
-            {'page_artid': '508-509'}
+            {'page_start': '585',
+             'page_end': '587'},
+            {'page_start': '508',
+             'page_end': '509'}
         ]
     })
 
@@ -1273,7 +1258,7 @@ def test_get_note_publication_info_a_list_not_a_note_with_volume():
         ]
     })
 
-    expected = '[D69]'
+    expected = '[]'
     result = Bibtex(publication_info_a_list_not_a_note_with_volume)._get_note()
 
     assert expected == result
@@ -1293,7 +1278,7 @@ def test_get_note_publication_info_a_list_not_a_note_with_volume_JHEP():
         ]
     })
 
-    expected = '[JHEP12]'
+    expected = '[Submitted to: JHEP]'
     result = Bibtex(publication_info_a_list_not_a_note_with_volume_JHEP)._get_note()
 
     assert expected == result
@@ -1307,7 +1292,7 @@ def test_get_note_publication_info_a_list_not_a_note_with_issue():
         ]
     })
 
-    expected = '[,no.11]'
+    expected = '[]'
     result = Bibtex(publication_info_a_list_not_a_note_with_issue)._get_note()
 
     assert expected == result
@@ -1316,12 +1301,14 @@ def test_get_note_publication_info_a_list_not_a_note_with_issue():
 def test_get_note_publication_info_a_list_not_a_note_with_pages():
     publication_info_a_list_not_a_note_with_pages = Record({
         'publication_info': [
-            {'page_artid': 'pp.2067-2414'},
-            {'page_artid': 'pp.2067-2414'}
+            {'page_start': 'pp.2067',
+             'page_end': '2414'},
+            {'page_start': 'pp.2067',
+             'page_end': '2414'}
         ]
     })
 
-    expected = '[,pp.2067]'
+    expected = '[]'
     result = Bibtex(publication_info_a_list_not_a_note_with_pages)._get_note()
 
     assert expected == result
@@ -1364,13 +1351,15 @@ def test_get_note_publication_info_a_list_not_a_note_with_everything():
                 'journal_title': 'Acta Phys.Polon.',
                 'journal_volume': 'B46',
                 'journal_issue': '11',
-                'page_artid': 'pp.2067-2414'
+                'page_start': 'pp.2067',
+                'page_end': '2414'
             },
             {
                 'journal_title': 'Acta Phys.Polon.',
                 'journal_volume': 'B46',
                 'journal_issue': '11',
-                'page_artid': 'pp.2067-2414'
+                'page_start': 'pp.2067',
+                'page_end': '2414'
             },
         ]
     })
@@ -1468,11 +1457,11 @@ def test_get_note_publication_info_a_list_a_note_with_pages():
         'publication_info': [
             {
                 'note': 'Reprint',
-                'page_artid': '019903'
+                'artid': '019903'
             },
             {
                 'note': 'Reprint',
-                'page_artid': '019903'
+                'artid': '019903'
             }
         ]
     })
@@ -1869,61 +1858,14 @@ def test_get_pubnote_publication_info_a_list_one_with_title_and_pages_not_a_list
         'publication_info': [
             {
                 'journal_title': 'Nucl.Phys.',
-                'page_artid': '579-588'
+                'page_start': '579',
+                'page_end': '588'
             }
         ]
     })
 
     expected = 'Nucl. Phys.,,579'
     result = Bibtex(publication_info_a_list_one_with_title_and_pages_not_a_list)._get_pubnote()
-
-    assert expected == result
-
-
-@pytest.mark.xfail
-@mock.patch('inspirehep.utils.bibtex.get_kbr_keys')
-def test_get_pubnote_publication_info_a_list_one_with_title_and_pages_a_list_first_without_dash(self, g_k_k):
-    # TODO: mock the actual invenio_knowledge API.
-    g_k_k.return_value = [['Nucl. Phys.']]
-
-    publication_info_a_list_one_with_title_and_pages_a_list = Record({
-        'publication_info': [
-            {
-                'journal_title': 'Nucl.Phys.',
-                'page_artid': [
-                    '550',
-                    '579-588'
-                ]
-            }
-        ]
-    })
-
-    expected = 'Nucl.Phys.,,550'
-    result = Bibtex(publication_info_a_list_one_with_title_and_pages_a_list)._get_pubnote()
-
-    assert expected == result
-
-
-@pytest.mark.xfail
-@mock.patch('inspirehep.utils.bibtex.get_kbr_keys')
-def test_get_pubnote_publication_info_a_list_one_with_title_and_pages_a_list_first_with_dash(self, g_k_k):
-    # TODO: mock the actual invenio_knowledge API.
-    g_k_k.return_value = [['Nucl. Phys.']]
-
-    publication_info_a_list_one_with_title_and_pages_a_list = Record({
-        'publication_info': [
-            {
-                'journal_title': 'Nucl.Phys.',
-                'page_artid': [
-                    '579-588',
-                    '550'
-                ]
-            }
-        ]
-    })
-
-    expected = 'Nucl.Phys.,,579'
-    result = Bibtex(publication_info_a_list_one_with_title_and_pages_a_list)._get_pubnote()
 
     assert expected == result
 
@@ -1939,7 +1881,8 @@ def test_get_pubnote_publication_info_a_list_one_with_everything(self, g_k_k):
             {
                 'journal_title': 'Nucl.Phys.',
                 'journal_volume': '22',
-                'page_artid': '579-588'
+                'page_start': '579',
+                'page_end': '588'
             }
         ]
     })
@@ -1961,7 +1904,8 @@ def test_get_pubnote_publication_info_a_list_get_kbr_keys_raises(self, g_k_k):
             {
                 'journal_title': 'Nucl.Phys.',
                 'journal_volume': '22',
-                'page_artid': '579-588'
+                'page_start': '579',
+                'page_end': '588'
             }
         ]
     })

--- a/tests/unit/utils/test_utils_cv_latex.py
+++ b/tests/unit/utils/test_utils_cv_latex.py
@@ -350,69 +350,18 @@ def test_get_publi_info_from_publication_info_with_journal_issue():
     assert expected == result
 
 
-def test_get_publi_info_from_publication_info_with_page_artid_not_a_list():
-    page_artid_not_a_list = Record({
+def test_get_publi_info_from_publication_info_with_page_start():
+    page_start = Record({
         'publication_info': [
             {
                 'journal_title': 'JHEP',
-                'page_artid': '190'
+                'page_start': '190'
             }
         ]
     })
 
     expected = ['JHEP, 190']
-    result = Cv_latex(page_artid_not_a_list)._get_publi_info()
-
-    assert expected == result
-
-
-def test_get_publi_info_from_publication_info_with_page_artid_an_empty_list():
-    page_artid_an_empty_list = Record({
-        'publication_info': [
-            {
-                'journal_title': 'Phys.Lett.',
-                'page_artid': []
-            }
-        ]
-    })
-
-    expected = ['Phys.\\ Lett.\\ ']
-    result = Cv_latex(page_artid_an_empty_list)._get_publi_info()
-
-    assert expected == result
-
-
-def test_get_publi_info_from_publication_info_with_page_artid_a_list_of_one_element():
-    page_artid_a_list_of_one_element = Record({
-        'publication_info': [
-            {
-                'journal_title': 'Eur.Phys.J.',
-                'page_artid': ['2466']
-            }
-        ]
-    })
-
-    expected = ['Eur.\\ Phys.\\ J.\\ , 2466']
-    result = Cv_latex(page_artid_a_list_of_one_element)._get_publi_info()
-
-    assert expected == result
-
-
-def test_get_publi_info_from_publication_info_with_page_artid_a_list_of_two_elements():
-    page_artid_a_list_of_two_elements = Record({
-        'publication_info': [
-            {
-                'journal_title': 'Phys.Rev.Lett.',
-                'page_artid': [
-                    '321-323',
-                    '1-188'
-                ]
-            }
-        ]
-    })
-
-    expected = ['Phys.\\ Rev.\\ Lett.\\ , 1']
-    result = Cv_latex(page_artid_a_list_of_two_elements)._get_publi_info()
+    result = Cv_latex(page_start)._get_publi_info()
 
     assert expected == result
 
@@ -425,7 +374,7 @@ def test_get_publi_info_from_pubinfo_freetext():
     })
 
     expected = 'Phys. Lett. 12 (1964) 132-133'
-    result = Cv_latex(pubinfo_freetext)._get_publi_info() 
+    result = Cv_latex(pubinfo_freetext)._get_publi_info()
 
     assert expected == result
 
@@ -436,13 +385,15 @@ def test_get_publi_info_from_publication_info_a_list_of_two_elements():
             {
                 'journal_title': 'Int.J.Theor.Phys.',
                 'journal_volume': '38',
-                'page_artid': '1113-1133',
+                'page_start': '1113',
+                'page_end': '1133',
                 'year': 1999
             },
             {
                 'journal_title': 'Adv.Theor.Math.Phys.',
                 'journal_volume': '2',
-                'page_artid': '231-252',
+                'page_start': '231',
+                'page_end': '252',
                 'year': 1998
             }
         ]

--- a/tests/unit/utils/test_utils_cv_latex_html_text.py
+++ b/tests/unit/utils/test_utils_cv_latex_html_text.py
@@ -20,7 +20,6 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-import mock
 import pytest
 
 from invenio_records.api import Record
@@ -329,62 +328,16 @@ def test_get_publi_info_from_publication_info_an_empty_list():
     assert expected == result
 
 
-def test_get_publi_info_from_publication_info_with_journal_title_not_a_list():
-    journal_title_not_a_list = Record({
+def test_get_publi_info_from_publication_info_with_journal_title():
+    journal_title = Record({
         'publication_info': [
             {'journal_title': 'Nucl.Phys.'}
         ]
     })
     cv_latex_html_text = Cv_latex_html_text(
-        journal_title_not_a_list, 'cv_latex_html_text', ',')
+        journal_title, 'cv_latex_html_text', ',')
 
-    expected = ['Submitted to:Nucl.Phys.']
-    result = cv_latex_html_text._get_publi_info()
-
-    assert expected == result
-
-
-@pytest.mark.xfail(reason='IndexError when accessing last element')
-def test_get_publi_info_from_publication_info_with_journal_title_an_empty_list():
-    journal_title_an_empty_list = Record({
-        'publication_info': [
-            {'journal_title': []}
-        ]
-    })
-    cv_latex_html_text = Cv_latex_html_text(
-        journal_title_an_empty_list, 'cv_latex_html_text', ',')
-
-    expected = []
-    result = cv_latex_html_text._get_publi_info()
-
-    assert expected == result
-
-
-def test_get_publi_info_from_publication_info_with_journal_title_a_list_of_one_element():
-    journal_title_a_list_of_one_element = Record({
-        'publication_info': [
-            {'journal_title': ['foo']}
-        ]
-    })
-    cv_latex_html_text = Cv_latex_html_text(
-        journal_title_a_list_of_one_element, 'cv_latex_html_text', ',')
-
-    expected = ['Submitted to:foo']
-    result = cv_latex_html_text._get_publi_info()
-
-    assert expected == result
-
-
-def test_get_publi_info_from_publication_info_with_journal_title_a_list_of_two_elements():
-    journal_title_a_list_of_two_elements = Record({
-        'publication_info': [
-            {'journal_title': ['foo', 'bar']}
-        ]
-    })
-    cv_latex_html_text = Cv_latex_html_text(
-        journal_title_a_list_of_two_elements, 'cv_latex_html_text', ',')
-
-    expected = ['Submitted to:bar']
+    expected = ['Submitted to: Nucl.Phys.']
     result = cv_latex_html_text._get_publi_info()
 
     assert expected == result
@@ -420,13 +373,13 @@ def test_get_publi_info_from_publication_info_with_journal_volume_with_letter():
     cv_latex_html_text = Cv_latex_html_text(
         journal_volume_with_letter, 'cv_latex_html_text', ',')
 
-    expected = ['Eur.Phys.J. C73']
+    expected = ['Submitted to: Eur.Phys.J.']
     result = cv_latex_html_text._get_publi_info()
 
     assert expected == result
 
 
-def test_get_publi_info_from_publication_info_with_year_not_a_list():
+def test_get_publi_info_from_publication_info_with_year():
     year_not_a_list = Record({
         'publication_info': [
             {
@@ -438,62 +391,7 @@ def test_get_publi_info_from_publication_info_with_year_not_a_list():
     cv_latex_html_text = Cv_latex_html_text(
         year_not_a_list, 'cv_latex_html_text', ',')
 
-    expected = ['Submitted to:Phys.Lett. (1999)']
-    result = cv_latex_html_text._get_publi_info()
-
-    assert expected == result
-
-
-@pytest.mark.xfail(reason='IndexError when accessing last element')
-def test_get_publi_info_from_publication_info_with_year_an_empty_list():
-    year_an_empty_list = Record({
-        'publication_info': [
-            {
-                'journal_title': 'Phys.Rev.',
-                'year': []
-            }
-        ]
-    })
-    cv_latex_html_text = Cv_latex_html_text(
-        year_an_empty_list, 'cv_latex_html_text', ',')
-
-    expected = ['Submitted to:Phys.Rev.']
-    result = cv_latex_html_text._get_publi_info()
-
-    assert expected == result
-
-
-def test_get_publi_info_from_publication_info_with_year_a_list_of_one_element():
-    year_a_list_of_one_element = Record({
-        'publication_info': [
-            {
-                'journal_title': 'JHEP',
-                'year': ['1999']
-            }
-        ]
-    })
-    cv_latex_html_text = Cv_latex_html_text(
-        year_a_list_of_one_element, 'cv_latex_html_text', ',')
-
-    expected = ['Submitted to:JHEP (1999)']
-    result = cv_latex_html_text._get_publi_info()
-
-    assert expected == result
-
-
-def test_get_publi_info_from_publication_info_with_year_a_list_of_two_elements():
-    year_a_list_of_two_elements = Record({
-        'publication_info': [
-            {
-                'journal_title': 'Phys.Rev.Lett.',
-                'year': ['1999', '2000']
-            }
-        ]
-    })
-    cv_latex_html_text = Cv_latex_html_text(
-        year_a_list_of_two_elements, 'cv_latex_html_text', ',')
-
-    expected = ['Submitted to:Phys.Rev.Lett. (2000)']
+    expected = ['Submitted to: Phys.Lett. (1999)']
     result = cv_latex_html_text._get_publi_info()
 
     assert expected == result
@@ -511,82 +409,25 @@ def test_get_publi_info_from_publication_info_with_journal_issue():
     cv_latex_html_text = Cv_latex_html_text(
         journal_issue, 'cv_latex_html_text', ',')
 
-    expected = ['Class.Quant.Grav. 10,']
+    expected = ['Submitted to: Class.Quant.Grav.']
     result = cv_latex_html_text._get_publi_info()
 
     assert expected == result
 
 
-def test_get_publi_info_from_publication_info_with_page_artid_not_a_list():
-    page_artid_not_a_list = Record({
+def test_get_publi_info_from_publication_info_with_page_start():
+    page_start = Record({
         'publication_info': [
             {
                 'journal_title': 'JHEP',
-                'page_artid': '190'
+                'page_start': '190'
             }
         ]
     })
     cv_latex_html_text = Cv_latex_html_text(
-        page_artid_not_a_list, 'cv_latex_html_text', ',')
+        page_start, 'cv_latex_html_text', ',')
 
-    expected = ['JHEP 190']
-    result = cv_latex_html_text._get_publi_info()
-
-    assert expected == result
-
-
-def test_get_publi_info_from_publication_info_with_page_artid_an_empty_list():
-    page_artid_an_empty_list = Record({
-        'publication_info': [
-            {
-                'journal_title': 'Phys.Lett.',
-                'page_artid': []
-            }
-        ]
-    })
-    cv_latex_html_text = Cv_latex_html_text(
-        page_artid_an_empty_list, 'cv_latex_html_text', ',')
-
-    expected = ['Phys.Lett.']
-    result = cv_latex_html_text._get_publi_info()
-
-    assert expected == result
-
-
-def test_get_publi_info_from_publication_info_with_page_artid_a_list_of_one_element():
-    page_artid_a_list_of_one_element = Record({
-        'publication_info': [
-            {
-                'journal_title': 'Eur.Phys.J.',
-                'page_artid': ['2466']
-            }
-        ]
-    })
-    cv_latex_html_text = Cv_latex_html_text(
-        page_artid_a_list_of_one_element, 'cv_latex_html_text', ',')
-
-    expected = ['Eur.Phys.J. 2466']
-    result = cv_latex_html_text._get_publi_info()
-
-    assert expected == result
-
-
-def test_get_publi_info_from_publication_info_with_page_artid_a_list_of_two_elements():
-    page_artid_a_list_of_two_elements = Record({
-        'publication_info': [
-            {
-                'journal_title': 'Phys.Rev.Lett.',
-                'page_artid': [
-                    '321-323',
-                    '1-188'
-                ]
-            }
-        ]
-    })
-    cv_latex_html_text = Cv_latex_html_text(
-        page_artid_a_list_of_two_elements, 'cv_latex_html_text', ',')
-
-    expected = ['Phys.Rev.Lett. 1-188']
+    expected = ['Submitted to: JHEP']
     result = cv_latex_html_text._get_publi_info()
 
     assert expected == result
@@ -613,13 +454,15 @@ def test_get_publi_info_from_publication_info_a_list_of_two_elements():
             {
                 'journal_title': 'Int.J.Theor.Phys.',
                 'journal_volume': '38',
-                'page_artid': '1113-1133',
+                'page_start': '1113',
+                'page_end': '1133',
                 'year': 1999
             },
             {
                 'journal_title': 'Adv.Theor.Math.Phys.',
                 'journal_volume': '2',
-                'page_artid': '231-252',
+                'page_start': '231',
+                'page_end': '252',
                 'year': 1998
             }
         ]

--- a/tests/unit/utils/test_utils_latex.py
+++ b/tests/unit/utils/test_utils_latex.py
@@ -610,72 +610,18 @@ def test_get_publi_info_from_publication_info_with_journal_issue_latex_us():
     assert expected == result
 
 
-def test_get_publi_info_from_publication_info_with_page_artid_not_a_list():
-    page_artid_not_a_list = Record({
+def test_get_publi_info_from_publication_info_with_page_start():
+    page_start = Record({
         'publication_info': [
             {
                 'journal_title': 'JHEP',
-                'page_artid': '190'
+                'page_start': '190'
             }
         ]
     })
-    latex = Latex(page_artid_not_a_list, 'latex_eu')
+    latex = Latex(page_start, 'latex_eu')
 
     expected = ['JHEP 190']
-    result = latex._get_publi_info()
-
-    assert expected == result
-
-
-def test_get_publi_info_from_publication_info_with_page_artid_an_empty_list():
-    page_artid_an_empty_list = Record({
-        'publication_info': [
-            {
-                'journal_title': 'Phys.Lett.',
-                'page_artid': []
-            }
-        ]
-    })
-    latex = Latex(page_artid_an_empty_list, 'latex_eu')
-
-    expected = ['Phys.\\ Lett.\\ ']
-    result = latex._get_publi_info()
-
-    assert expected == result
-
-
-def test_get_publi_info_from_publication_info_with_page_artid_a_list_of_one_element():
-    page_artid_a_list_of_one_element = Record({
-        'publication_info': [
-            {
-                'journal_title': 'Eur.Phys.J.',
-                'page_artid': ['2466']
-            }
-        ]
-    })
-    latex = Latex(page_artid_a_list_of_one_element, 'latex_eu')
-
-    expected = ['Eur.\\ Phys.\\ J.\\  2466']
-    result = latex._get_publi_info()
-
-    assert expected == result
-
-
-def test_get_publi_info_from_publication_info_with_page_artid_a_list_of_two_elements():
-    page_artid_a_list_of_two_elements = Record({
-        'publication_info': [
-            {
-                'journal_title': 'Phys.Rev.Lett.',
-                'page_artid': [
-                    '321-323',
-                    '1-188'
-                ]
-            }
-        ]
-    })
-    latex = Latex(page_artid_a_list_of_two_elements, 'latex_eu')
-
-    expected = ['Phys.\\ Rev.\\ Lett.\\  1']
     result = latex._get_publi_info()
 
     assert expected == result
@@ -701,13 +647,15 @@ def test_get_publi_info_from_publication_info_a_list_of_two_elements():
             {
                 'journal_title': 'Int.J.Theor.Phys.',
                 'journal_volume': '38',
-                'page_artid': '1113-1133',
+                'page_start': '1113',
+                'page_end': '1133',
                 'year': 1999
             },
             {
                 'journal_title': 'Adv.Theor.Math.Phys.',
                 'journal_volume': '2',
-                'page_artid': '231-252',
+                'page_start': '231',
+                'page_end': '252',
                 'year': 1998
             }
         ]


### PR DESCRIPTION
* Amends JSONSchema, dojson, serializer, search, Jinja templates in
  order to correctly capture the concepts of page_start, page_end,
  and artid.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>