### PR TITLE
WIP exporting: fix xfailed tests

### DIFF
--- a/tests/integration/test_bibtex_exporting.py
+++ b/tests/integration/test_bibtex_exporting.py
@@ -20,6 +20,8 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
+from __future__ import absolute_import, division, print_function
+
 from inspirehep.utils.bibtex import Bibtex
 from inspirehep.utils.record_getter import get_db_record
 
@@ -49,7 +51,7 @@ def test_format_inproceeding(app):
       author         = "Hu, Wayne",
       title          = "{CMB anisotropies: A Decadal survey}",
       url            = "http://alice.cern.ch/format/showfull?sysnb=2178340",
-      year           = "2",
+      year           = "2000",
       eprint         = "astro-ph/0002520",
       archivePrefix  = "arXiv",
       primaryClass   = "astro-ph",
@@ -67,7 +69,7 @@ def test_format_proceeding(app):
       author         = "Alekhin, S. and others",
       title          = "{HERA and the LHC: A Workshop on the implications of HERA for LHC physics: Proceedings Part A}",
       url            = "http://weblib.cern.ch/abstract?CERN-2005-014",
-      year           = "2",
+      year           = "2005",
       eprint         = "hep-ph/0601012",
       archivePrefix  = "arXiv",
       primaryClass   = "hep-ph",

--- a/tests/integration/test_cvlatex_exporting.py
+++ b/tests/integration/test_cvlatex_exporting.py
@@ -20,15 +20,14 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
+from __future__ import absolute_import, division, print_function
+
 from datetime import date
 
 from inspirehep.utils.cv_latex import Cv_latex
 from inspirehep.utils.record_getter import get_db_record
 
-import pytest
 
-
-@pytest.mark.xfail(reason='wrong output')
 def test_format_cv_latex(app):
     article = get_db_record('literature', 4328)
     today = date.today().strftime('%d %b %Y')

--- a/tests/integration/test_cvlatex_html_text_exporting.py
+++ b/tests/integration/test_cvlatex_html_text_exporting.py
@@ -20,6 +20,8 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
+from __future__ import absolute_import, division, print_function
+
 from inspirehep.utils.cv_latex_html_text import Cv_latex_html_text
 from inspirehep.utils.record_getter import get_db_record
 
@@ -32,5 +34,14 @@ def test_format_cv_latex_html(app):
         '</a>,By S.L. Glashow.,<a href="http://dx.doi.org/10.1016/0029-5582(61)90469-2"'
         '>10.1016/0029-5582(61)90469-2</a>.,Nucl.Phys. 22 (1961) 579-588.,,')
     result = Cv_latex_html_text(record, 'cv_latex_html', ',').format()
+
+    assert expected == result
+
+
+def test_format_cv_latex_html_text(app):
+    record = get_db_record('literature', 4328)
+
+    expected = ''
+    result = Cv_latex_html_text(record, 'cv_latex_html_text', ',').format()
 
     assert expected == result

--- a/tests/integration/test_latex_exporting.py
+++ b/tests/integration/test_latex_exporting.py
@@ -20,15 +20,14 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
+from __future__ import absolute_import, division, print_function
+
 from datetime import date
 
 from inspirehep.utils.latex import Latex
 from inspirehep.utils.record_getter import get_db_record
 
-import pytest
 
-
-@pytest.mark.xfail(reason='wrong output')
 def test_format_latex_eu(app):
     article = get_db_record('literature', 4328)
     today = date.today().strftime('%d %b %Y')
@@ -46,7 +45,6 @@ def test_format_latex_eu(app):
     assert expected == result
 
 
-@pytest.mark.xfail(reason='wrong output')
 def test_format_latex_us(app):
     article = get_db_record('literature', 4328)
     today = date.today().strftime('%d %b %Y')


### PR DESCRIPTION
While working on documenting/testing the API I noticed this blocker: it's time to fix the xfailed tests about exporting records in the various formats.

This PR is expected to fail.