### PR TITLE
tests: unit tests for DoJSON jobs

### DIFF
--- a/inspirehep/dojson/jobs/fields/bd1xx.py
+++ b/inspirehep/dojson/jobs/fields/bd1xx.py
@@ -130,9 +130,3 @@ def ranks(self, key, value):
         for _rank in _ranks:
             self['_ranks'].append(_rank)
             self['ranks'].append(classify_rank(_rank))
-
-
-@jobs.over('experiment', '^693..')
-@utils.for_each_value
-def experiment(self, key, value):
-    return value.get('e')

--- a/inspirehep/dojson/jobs/fields/bd1xx.py
+++ b/inspirehep/dojson/jobs/fields/bd1xx.py
@@ -29,36 +29,41 @@ import six
 from dojson import utils
 
 from ..model import jobs
-from ...utils import classify_rank, get_record_ref
+from ...utils import classify_rank, force_single_element, get_record_ref
 
 
 @jobs.over('date_closed', '^046..')
 def date_closed(self, key, value):
     """Date the job was closed."""
-    value = utils.force_list(value)
-    closed_date = None
-    deadline_date = None
-    for val in value:
-        if val.get('i'):
-            deadline_date = val.get('i')
-        if val.get('l'):
-            if "@" in val.get('l'):
-                # Its an email
-                if "reference_email" in self:
-                    self["reference_email"].append(val.get('l'))
-                else:
-                    self["reference_email"] = [val.get('l')]
-            elif "www" in val.get('l') or "http" in val.get('l'):
-                # Its a URL
-                if "urls" in self:
-                    self["urls"].append({'value': val.get('l')})
-                else:
-                    self["urls"] = [{'value': val.get('l')}]
-            else:
-                closed_date = val.get('l')
+    def _contains_email(val):
+        return '@' in val
+
+    def _contains_url(val):
+        return 'www' in val or 'http' in val
+
+    el = force_single_element(value)
+
+    deadline_date = force_single_element(el.get('i'))
     if deadline_date:
         self['deadline_date'] = deadline_date
-    return closed_date
+
+    closing_date = None
+    closing_info = force_single_element(el.get('l'))
+    if closing_info:
+        if _contains_email(closing_info):
+            if 'reference_email' in self:
+                self['reference_email'].append(closing_info)
+            else:
+                self['reference_email'] = [closing_info]
+        elif _contains_url(closing_info):
+            if 'urls' in self:
+                self['urls'].append({'value': closing_info})
+            else:
+                self['urls'] = [{'value': closing_info}]
+        else:
+            closing_date = closing_info
+
+    return closing_date
 
 
 @jobs.over('contact_details', '^270..')

--- a/inspirehep/dojson/jobs/fields/bd1xx.py
+++ b/inspirehep/dojson/jobs/fields/bd1xx.py
@@ -74,7 +74,6 @@ def contact_details(self, key, value):
 
 
 @jobs.over('continent', '^043..')
-@utils.for_each_value
 def continent(self, key, value):
     """Continent"""
     return value.get('a')

--- a/inspirehep/dojson/jobs/fields/bd1xx.py
+++ b/inspirehep/dojson/jobs/fields/bd1xx.py
@@ -51,9 +51,9 @@ def date_closed(self, key, value):
             elif "www" in val.get('l') or "http" in val.get('l'):
                 # Its a URL
                 if "urls" in self:
-                    self["urls"].append(val.get('l'))
+                    self["urls"].append({'value': val.get('l')})
                 else:
-                    self["urls"] = [val.get('l')]
+                    self["urls"] = [{'value': val.get('l')}]
             else:
                 closed_date = val.get('l')
     if deadline_date:

--- a/inspirehep/dojson/utils/__init__.py
+++ b/inspirehep/dojson/utils/__init__.py
@@ -96,6 +96,14 @@ def create_profile_url(profile_id):
         return ''
 
 
+def force_single_element(obj):
+    """Force an object to a list and return the first element."""
+    lst = force_list(obj)
+    if lst:
+        return lst[0]
+    return None
+
+
 def get_int_value(d, k):
     """Get a value in a dict and cast it to int if possible."""
     try:

--- a/inspirehep/modules/records/jsonschemas/records/jobs.json
+++ b/inspirehep/modules/records/jsonschemas/records/jobs.json
@@ -22,21 +22,16 @@
             "uniqueItems": true
         },
         "continent": {
-            "items": {
-                "enum": [
-                    "North America",
-                    "Europe",
-                    "Asia",
-                    "South America",
-                    "Africa",
-                    "Oceania"
-                ],
-                "title": "Continent",
-                "type": "string"
-            },
-            "title": "Continent",
-            "type": "array",
-            "uniqueItems": true
+            "type": "string",
+            "enum": [
+                "Africa",
+                "Antarctica",
+                "Asia",
+                "Europe",
+                "North America",
+                "Oceania",
+                "South America"
+            ]
         },
         "deadline_date": {
             "format": "date",

--- a/tests/unit/dojson/test_dojson_jobs.py
+++ b/tests/unit/dojson/test_dojson_jobs.py
@@ -22,10 +22,81 @@
 
 from __future__ import absolute_import, division, print_function
 
+import pytest
+
 from dojson.contrib.marc21.utils import create_record
 
 from inspirehep.dojson.jobs import jobs
-from inspirehep.dojson.utils import strip_empty_values
+from inspirehep.dojson.utils import clean_record
+
+
+def test_date_closed_from_046__i():
+    snippet = (
+        '<datafield tag="046" ind1=" " ind2=" ">'
+        '  <subfield code="i">2015-12-15</subfield>'
+        '</datafield>'
+    )  # record/1310294
+
+    expected = '2015-12-15'
+    result = clean_record(jobs.do(create_record(snippet)))
+
+    assert expected == result['deadline_date']
+
+
+def test_date_closed_from_046__l():
+    snippet = (
+        '<datafield tag="046" ind1=" " ind2=" ">'
+        '  <subfield code="l">2008-02-11</subfield>'
+        '</datafield>'
+    )  # record/934304
+
+    expected = '2008-02-11'
+    result = clean_record(jobs.do(create_record(snippet)))
+
+    assert expected == result['date_closed']
+
+
+@pytest.mark.xfail(reason='incorrect structure')
+def test_date_closed_from_046__i_l_an_url():
+    snippet = (
+        '<record>'
+        '  <datafield tag="046" ind1=" " ind2=" ">'
+        '    <subfield code="i">2012-06-01</subfield>'
+        '  </datafield>'
+        '  <datafield tag="046" ind1=" " ind2=" ">'
+        '    <subfield code="l">http://www.pma.caltech.edu/physics-search</subfield>'
+        '  </datafield>'
+        '</record>'
+    )  # record/963314
+
+    result = clean_record(jobs.do(create_record(snippet)))
+
+    assert result['deadline_date'] == '2012-06-01'
+    assert result['urls'] == [
+        {
+            'value': 'http://www.pma.caltech.edu/physics-search',
+        },
+    ]
+
+
+def test_date_closed_from_046_i_l_an_email():
+    snippet = (
+        '<record>'
+        '  <datafield tag="046" ind1=" " ind2=" ">'
+        '    <subfield code="l">yejb@smu.edu</subfield>'
+        '  </datafield>'
+        '  <datafield tag="046" ind1=" " ind2=" ">'
+        '    <subfield code="i">8888</subfield>'
+        '  </datafield>'
+        '</record>'
+    )  # record/1089529
+
+    result = clean_record(jobs.do(create_record(snippet)))
+
+    assert result['deadline_date'] == '8888'
+    assert result['reference_email'] == [
+        'yejb@smu.edu',
+    ]
 
 
 def test_contact_details_from_marcxml_270_single_p_single_m():
@@ -44,7 +115,7 @@ def test_contact_details_from_marcxml_270_single_p_single_m():
             'email': 'lindner@mpi-hd.mpg.de',
         },
     ]
-    result = strip_empty_values(jobs.do(create_record(snippet)))
+    result = clean_record(jobs.do(create_record(snippet)))
 
     assert expected == result['contact_details']
 
@@ -66,7 +137,7 @@ def test_contact_details_from_marcxml_270_double_p_single_m():
             'email': 'lindner@mpi-hd.mpg.de',
         },
     ]
-    result = strip_empty_values(jobs.do(create_record(snippet)))
+    result = clean_record(jobs.do(create_record(snippet)))
 
     assert expected == result['contact_details']
 
@@ -88,7 +159,7 @@ def test_contact_details_from_marcxml_270_single_p_double_m():
             'name': 'Manfred Lindner'
         },
     ]
-    result = strip_empty_values(jobs.do(create_record(snippet)))
+    result = clean_record(jobs.do(create_record(snippet)))
 
     assert expected == result['contact_details']
 
@@ -115,9 +186,161 @@ def test_contact_details_from_multiple_marcxml_270():
             'name': 'Wynton Marsalis',
         },
     ]
-    result = strip_empty_values(jobs.do(create_record(snippet)))
+    result = clean_record(jobs.do(create_record(snippet)))
 
     assert expected == result['contact_details']
+
+
+@pytest.mark.xfail(reason='produces an array')
+def test_continent_from_043__a():
+    snippet = (
+        '<datafield tag="043" ind1=" " ind2=" ">'
+        '  <subfield code="a">Asia</subfield>'
+        '</datafield>'
+    )
+
+    expected = 'Asia'
+    result = clean_record(jobs.do(create_record(snippet)))
+
+    assert expected == result['continent']
+
+
+def test_experiments_from_693__e():
+    snippet = (
+        '<datafield tag="693" ind1=" " ind2=" ">'
+        '  <subfield code="e">CERN-LHC-ATLAS</subfield>'
+        '</datafield>'
+    )  # record/1471772
+
+    expected = [
+        'CERN-LHC-ATLAS',
+    ]
+    result = clean_record(jobs.do(create_record(snippet)))
+
+    assert expected == result['experiments']
+
+
+def test_experiments_from_triple_693__e():
+    snippet = (
+        '<record>'
+        '  <datafield tag="693" ind1=" " ind2=" ">'
+        '    <subfield code="e">CERN-LHC-CMS</subfield>'
+        '  </datafield>'
+        '  <datafield tag="693" ind1=" " ind2=" ">'
+        '    <subfield code="e">CALICE</subfield>'
+        '  </datafield>'
+        '  <datafield tag="693" ind1=" " ind2=" ">'
+        '    <subfield code="e">ILC</subfield>'
+        '  </datafield>'
+        '</record>'
+    )  # record/1447878
+
+    expected = [
+        'CERN-LHC-CMS',
+        'CALICE',
+        'ILC',
+    ]
+    result = clean_record(jobs.do(create_record(snippet)))
+
+    assert expected == result['experiments']
+
+
+def test_institution_from_110__a():
+    snippet = (
+        '<datafield tag="110" ind1=" " ind2=" ">'
+        '  <subfield code="a">Coll. William and Mary</subfield>'
+        '</datafield>'
+    )  # record/1427342
+
+    expected = [
+        {
+            'curated_relation': False,
+            'name': 'Coll. William and Mary',
+        },
+    ]
+    result = clean_record(jobs.do(create_record(snippet)))
+
+    assert expected == result['institution']
+
+
+def test_institution_from_double_110__a():
+    snippet = (
+        '<record>'
+        '  <datafield tag="110" ind1=" " ind2=" ">'
+        '    <subfield code="a">Coll. William and Mary</subfield>'
+        '  </datafield>'
+        '  <datafield tag="110" ind1=" " ind2=" ">'
+        '    <subfield code="a">Jefferson Lab</subfield>'
+        '  </datafield>'
+        '</record>'
+    )  # record/1427342
+
+    expected = [
+        {
+            'curated_relation': False,
+            'name': 'Coll. William and Mary',
+        },
+        {
+            'curated_relation': False,
+            'name': 'Jefferson Lab',
+        },
+    ]
+    result = clean_record(jobs.do(create_record(snippet)))
+
+    assert expected == result['institution']
+
+
+@pytest.mark.xfail(reason='institution has length one')
+def test_institution_from_100__double_a():
+    snippet = (
+        '<datafield tag="110" ind1=" " ind2=" ">'
+        '  <subfield code="a">Indiana U.</subfield>'
+        '  <subfield code="a">NIST, Wash., D.C.</subfield>'
+        '</datafield>'
+    )  # record/1328021
+
+    expected = [
+        {
+            'curated_relation': False,
+            'name': 'Indiana U.',
+        },
+        {
+            'curated_relation': False,
+            'name': 'NIST, Wash., D.C.',
+        },
+    ]
+    result = clean_record(jobs.do(create_record(snippet)))
+
+    assert expected == result['institution']
+
+
+# XXX: no record has a 110__z field.
+
+
+def test_description_from_520__a():
+    snippet = (
+        '<datafield tag="520" ind1=" " ind2=" ">'
+        '  <subfield code="a">(1) Conduct independent research in string theory related theoretical sciences;&lt;br /> &lt;br /> (2) Advising graduate students in their research;&lt;br /> &lt;br /> (3) A very small amount of teaching of undergraduate courses.&amp;nbsp;</subfield>'
+        '</datafield>'
+    )  # record/1239755
+
+    expected = '(1) Conduct independent research in string theory related theoretical sciences;<br /> <br /> (2) Advising graduate students in their research;<br /> <br /> (3) A very small amount of teaching of undergraduate courses.&nbsp;'
+    result = clean_record(jobs.do(create_record(snippet)))
+
+    assert expected == result['description']
+
+
+def test_position_from_245__a():
+    snippet = (
+        '<datafield tag="245" ind1=" " ind2=" ">'
+        '  <subfield code="a">Neutrino Physics</subfield>'
+        '</datafield>'
+    )  # record/1467312
+
+    expected = 'Neutrino Physics'
+    result = clean_record(jobs.do(create_record(snippet)))
+
+    assert expected == result['position']
 
 
 def test_ranks_from_marcxml_656_with_single_a():
@@ -130,7 +353,7 @@ def test_ranks_from_marcxml_656_with_single_a():
         '</record>'
     )
 
-    result = strip_empty_values(jobs.do(create_record(snippet)))
+    result = clean_record(jobs.do(create_record(snippet)))
 
     assert result['_ranks'] == ['Senior']
     assert result['ranks'] == ['SENIOR']
@@ -147,7 +370,7 @@ def test_ranks_from_marcxml_656_with_double_a():
         '</record>'
     )
 
-    result = strip_empty_values(jobs.do(create_record(snippet)))
+    result = clean_record(jobs.do(create_record(snippet)))
 
     assert result['_ranks'] == ['Senior', 'Junior']
     assert result['ranks'] == ['SENIOR', 'JUNIOR']
@@ -166,7 +389,7 @@ def test_ranks_from_marcxml_double_656():
         '</record>'
     )
 
-    result = strip_empty_values(jobs.do(create_record(snippet)))
+    result = clean_record(jobs.do(create_record(snippet)))
 
     assert result['_ranks'] == ['Senior', 'Junior']
     assert result["ranks"] == ['SENIOR', 'JUNIOR']

--- a/tests/unit/dojson/test_dojson_jobs.py
+++ b/tests/unit/dojson/test_dojson_jobs.py
@@ -190,7 +190,6 @@ def test_contact_details_from_multiple_marcxml_270():
     assert expected == result['contact_details']
 
 
-@pytest.mark.xfail(reason='produces an array')
 def test_continent_from_043__a():
     snippet = (
         '<datafield tag="043" ind1=" " ind2=" ">'

--- a/tests/unit/dojson/test_dojson_jobs.py
+++ b/tests/unit/dojson/test_dojson_jobs.py
@@ -56,7 +56,6 @@ def test_date_closed_from_046__l():
     assert expected == result['date_closed']
 
 
-@pytest.mark.xfail(reason='incorrect structure')
 def test_date_closed_from_046__i_l_an_url():
     snippet = (
         '<record>'

--- a/tests/unit/dojson/test_dojson_utils.py
+++ b/tests/unit/dojson/test_dojson_utils.py
@@ -26,6 +26,7 @@ from inspirehep.dojson.utils import (
     classify_field,
     classify_rank,
     create_profile_url,
+    force_single_element,
     get_int_value,
     get_recid_from_ref,
     get_record_ref,
@@ -125,6 +126,24 @@ def test_create_profile_url_returns_empty_string_when_not_given_an_int():
     result = create_profile_url('foo')
 
     assert expected == result
+
+
+def test_force_single_element_returns_first_element_on_a_list():
+    expected = 'foo'
+    result = force_single_element(['foo', 'bar', 'baz'])
+
+    assert expected == result
+
+
+def test_force_single_element_returns_element_when_not_a_list():
+    expected = 'foo'
+    result = force_single_element('foo')
+
+    assert expected == result
+
+
+def test_force_single_element_returns_none_on_empty_list():
+    assert force_single_element([]) is None
 
 
 def test_get_int_value_returns_int_with_valid_input():


### PR DESCRIPTION
Continues to address #1240.

- [x] Jobs
    - [x] Test `date_closed`
    - [x] Test `contact_details`
    - [x] Test `continent`
    - [x] Test `experiments`
    - [x] Test `institution`
    - [x] Test `description`
    - [x] Test `position`
    - [x] Test `ranks`
    - [x] ~~Test `experiment`~~ (obsolete rule)