### PR TITLE
tests: unit tests for DoJSON journals

### DIFF
--- a/inspirehep/dojson/journals/fields/bd1xx.py
+++ b/inspirehep/dojson/journals/fields/bd1xx.py
@@ -108,10 +108,3 @@ def title_variants(self, key, value):
     return {
         'title': value.get('a'),
     }
-
-
-@journals.over('name_variants', '^730..')
-@utils.for_each_value
-def name_variants(self, key, value):
-    """Variants of the name."""
-    return value.get('a')

--- a/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Journal_HTML_detailed.tpl
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Journal_HTML_detailed.tpl
@@ -1,20 +1,23 @@
 {#
-## This file is part of INSPIRE.
-## Copyright (C) 2015 CERN.
-##
-## INSPIRE is free software; you can redistribute it and/or
-## modify it under the terms of the GNU General Public License as
-## published by the Free Software Foundation; either version 2 of the
-## License, or (at your option) any later version.
-##
-## INSPIRE is distributed in the hope that it will be useful, but
-## WITHOUT ANY WARRANTY; without even the implied warranty of
-## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-## General Public License for more details.
-##
-## You should have received a copy of the GNU General Public License
-## along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
-## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+# This file is part of INSPIRE.
+# Copyright (C) 2015, 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
 #}
 
 {% extends "inspirehep_theme/format/record/Inspire_Default_HTML_detailed.tpl" %}
@@ -97,7 +100,7 @@
   </div>
 </div>
 {% endif %}
-{% if record['name_variants'] %}
+{% if record['title_variants'] %}
 <button type="button" class="btn btn-default pull-left" data-toggle="modal" data-target="#showNameVariants">
   Show name variants
 </button>
@@ -112,7 +115,7 @@
       </div>
       <div class="modal-body">
         <div style="text-align:left;">
-        {{ record['name_variants']|join(', ')}}
+        {{ record['title_variants']|join(', ')}}
         </div>
       </div>
       <div class="modal-footer">

--- a/tests/unit/dojson/test_dojson_journals.py
+++ b/tests/unit/dojson/test_dojson_journals.py
@@ -141,6 +141,100 @@ def test_multiple_issn_from_marcxml_022():
     assert expected == result['issn']
 
 
+def test_issn_from_022__a_b_electronic():
+    snippet = (
+        '<datafield tag="022" ind1=" " ind2=" ">'
+        '  <subfield code="a">2469-9888</subfield>'
+        '  <subfield code="b">electronic</subfield>'
+        '</datafield>'
+    )  # record/1415879
+
+    expected = [
+        {
+            'comment': 'electronic',
+            'medium': 'online',
+            'value': '2469-9888',
+        },
+    ]
+    result = strip_empty_values(journals.do(create_record(snippet)))
+
+    assert expected == result['issn']
+
+
+def test_coden_from_030__a_2():
+    snippet = (
+        '<datafield tag="030" ind1=" " ind2=" ">'
+        '  <subfield code="2">CODEN</subfield>'
+        '  <subfield code="a">HERAS</subfield>'
+        '</datafield>'
+    )  # record/1211568
+
+    expected = [
+        'HERAS',
+    ]
+    result = strip_empty_values(journals.do(create_record(snippet)))
+
+    assert expected == result['coden']
+
+
+def test_coden_from_double_030__a_2():
+    snippet = (
+        '<record>'
+        '  <datafield tag="030" ind1=" " ind2=" ">'
+        '    <subfield code="2">CODEN</subfield>'
+        '    <subfield code="a">00686</subfield>'
+        '  </datafield>'
+        '  <datafield tag="030" ind1=" " ind2=" ">'
+        '    <subfield code="2">CODEN</subfield>'
+        '    <subfield code="a">VLUFB</subfield>'
+        '  </datafield>'
+        '</record>'
+    )
+
+    expected = [
+        '00686',
+        'VLUFB',
+    ]
+    result = strip_empty_values(journals.do(create_record(snippet)))
+
+    assert expected == result['coden']
+
+
+def test_publisher_from_643__b():
+    snippet = (
+        '<datafield tag="643" ind1=" " ind2=" ">'
+        '  <subfield code="b">ANITA PUBLICATIONS, INDIA</subfield>'
+        '</datafield>'
+    )  # record/1211888
+
+    expected = [
+        'ANITA PUBLICATIONS, INDIA',
+    ]
+    result = strip_empty_values(journals.do(create_record(snippet)))
+
+    assert expected == result['publisher']
+
+
+def test_publisher_from_double_643__b():
+    snippet = (
+        '<record>'
+        '  <datafield tag="643" ind1=" " ind2=" ">'
+        '    <subfield code="b">Elsevier</subfield>'
+        '  </datafield>'
+        '  <datafield tag="643" ind1=" " ind2=" ">'
+        '    <subfield code="b">Science Press</subfield>'
+        '  </datafield>'
+        '</record>'
+    )  # record/1212635
+
+    expected = [
+        'Elsevier',
+        'Science Press',
+    ]
+    result = strip_empty_values(journals.do(create_record(snippet)))
+
+    assert expected == result['publisher']
+
 
 def test_titles_from_marcxml_130_with_single_a():
     snippet = (


### PR DESCRIPTION
Continues to address #1240.

- [x] Journals
    - [x] Test `issn`
    - [x] Test `coden`
    - [x] Test `publisher`
    - [x] Test `titles`
    - [x] Test `short_titles`
    - [x] Test `title_variants`
    - [x] ~~Test `name_variants`~~ (obsolete rule)