### PR TITLE
schema: better thesis field for HEP

### DIFF
--- a/inspirehep/dojson/hep/receivers.py
+++ b/inspirehep/dojson/hep/receivers.py
@@ -38,11 +38,10 @@ def earliest_date(sender, *args, **kwargs):
         dates.append(sender['preprint_date'])
 
     if 'thesis' in sender:
-        for thesis_key in sender['thesis']:
-            if 'date' in thesis_key:
-                dates.append(thesis_key['date'])
-            if 'defense_date' in thesis_key:
-                dates.append(thesis_key['defense_date'])
+        if 'date' in sender['thesis']:
+            dates.append(sender['thesis']['date'])
+        if 'defense_date' in sender['thesis']:
+            dates.append(sender['thesis']['defense_date'])
 
     if 'publication_info' in sender:
         for publication_info_key in sender['publication_info']:

--- a/inspirehep/modules/literaturesuggest/dojson/fields/literature.py
+++ b/inspirehep/modules/literaturesuggest/dojson/fields/literature.py
@@ -138,9 +138,9 @@ def preprint_created(self, key, value):
 @utils.for_each_value
 def defense_date(self, key, value):
     if 'thesis' in self:
-        self['thesis'][0].update(dict(defense_date=value))
+        self['thesis'].update(dict(defense_date=value))
     else:
-        self['thesis'] = [dict(defense_date=value)]
+        self['thesis'] = dict(defense_date=value)
 
     defense_note = {'value': 'Presented on {0}'.format(value)}
     self.setdefault("public_notes", []).append(defense_note)
@@ -150,27 +150,27 @@ def defense_date(self, key, value):
 @literature.over('_degree_type', '^degree_type$')
 def degree_type(self, key, value):
     if 'thesis' in self:
-        self['thesis'][0].update(dict(degree_type=value))
+        self['thesis'].update(dict(degree_type=value))
     else:
-        self['thesis'] = [dict(degree_type=value)]
+        self['thesis'] = dict(degree_type=value)
     raise IgnoreKey
 
 
-@literature.over('_institution', '^institution$')
+@literature.over('_institutions', '^institution$')
 def institution(self, key, value):
     if 'thesis' in self:
-        self['thesis'][0].update(dict(university=value))
+        self['thesis'].update(dict(institutions=[{'name': value}]))
     else:
-        self['thesis'] = [dict(university=value)]
+        self['thesis'] = dict(institutions=[{'name': value}])
     raise IgnoreKey
 
 
 @literature.over('_thesis_date', '^thesis_date$')
 def thesis_date(self, key, value):
     if 'thesis' in self:
-        self['thesis'][0].update(dict(date=value))
+        self['thesis'].update(dict(date=value))
     else:
-        self['thesis'] = [dict(date=value)]
+        self['thesis'] = dict(date=value)
     raise IgnoreKey
 
 

--- a/inspirehep/modules/records/jsonschemas/records/hep.json
+++ b/inspirehep/modules/records/jsonschemas/records/hep.json
@@ -246,45 +246,48 @@
             "type": "array"
         },
         "thesis": {
-            "uniqueItems": true,
-            "items": {
-                "type": "object",
-                "properties": {
-                    "date": {
-                        "type": "string",
-                        "format": "date"
-                    },
-                    "defense_date": {
-                        "type": "string",
-                        "format": "date"
-                    },
-                    "curated_relation": {
-                        "type": "boolean"
-                    },
-                    "university": {
-                        "type": "string",
-                        "description": "FIXME: shall we match these with the insitution database? I guess so."
-                    },
-                    "degree_type": {
-                        "enum": [
-                            "PhD",
-                            "Master",
-                            "Bachelor",
-                            "Diploma",
-                            "Habilitation",
-                            "Laurea",
-                            "Thesis"
-                        ],
-                        "type": "string",
-                        "description": "FIXME: this enum must be reviewed"
-                    },
-                    "record": {
-                        "description": "URI of the matched insitution record.",
-                        "$ref": "json_reference.json"
+            "type": "object",
+            "properties": {
+                "date": {
+                    "type": "string",
+                    "format": "date"
+                },
+                "defense_date": {
+                    "type": "string",
+                    "format": "date"
+                },
+                "institutions": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "record": {
+                                "description": "URI of the matched insitution record.",
+                                "$ref": "json_reference.json"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "curated_relation": {
+                                "type": "boolean"
+                            }
+                        }
                     }
+                },
+                "degree_type": {
+                    "enum": [
+                        "PhD",
+                        "Master",
+                        "Bachelor",
+                        "Diploma",
+                        "Habilitation",
+                        "Laurea",
+                        "Thesis"
+                    ],
+                    "type": "string",
+                    "description": "FIXME: this enum must be reviewed"
                 }
-            },
-            "type": "array"
+            }
         },
         "hidden_notes": {
             "uniqueItems": true,

--- a/inspirehep/utils/bibtex.py
+++ b/inspirehep/utils/bibtex.py
@@ -98,16 +98,13 @@ class Bibtex(Export):
     def _format_thesis(self):
         """Format thesis entry type"""
         thesis = ''
-        if 'thesis' in self.record:
-            for type_of_thesis in self.record['thesis']:
-                if 'degree_type' in type_of_thesis:
-                    thesis = type_of_thesis['degree_type']
-            if thesis == 'Master':
+        name = 'phdthesis'
+
+        if 'thesis' in self.record and 'degree_type' in self.record['thesis']:
+            thesis_type = self.record['thesis']['degree_type']
+            if thesis_type == 'Master':
                 name = 'mastersthesis'
-            else:
-                name = 'phdthesis'
-        else:
-            name = 'phdthesis'
+
         required_fields = ['key', 'author', 'title', 'address',
                            'school', 'journal', 'volume']
         optional_fields = ['year', 'url', 'number', 'pages', 'doi', 'note',
@@ -399,9 +396,8 @@ class Bibtex(Export):
                 elif 'preprint_date' in self.record:
                     year = self.record['preprint_date'][0].split('-')[0]
         elif self.original_entry == 'thesis' and 'thesis' in self.record:
-            for date in self.record['thesis']:
-                if 'date' in date and date['date']:
-                    year = date['date']
+            if 'date' in self.record['thesis']:
+                year = self.record['thesis']['date']
             if not year:
                 if 'preprint_date' in self.record:
                     year = self.record['preprint_date'].split('-')[0]

--- a/inspirehep/utils/cv_latex.py
+++ b/inspirehep/utils/cv_latex.py
@@ -306,15 +306,13 @@ class Cv_latex(Export):
             if datestruct:
                 return self._format_date(datestruct)
 
-        if 'thesis' in self.record:
-            for field in self.record['thesis']:
-                if 'date' in field:
-                    date = field['date']
-                    if date:
-                        datestruct = self.parse_date(str(date))
-                    break
+        if 'thesis' in self.record and 'date' in self.record['thesis']:
+            date = self.record['thesis']['date']
+            if date:
+                datestruct = self.parse_date(str(date))
             if datestruct:
                 return self._format_date(datestruct)
+
         return None
 
     def _format_date(self, datestruct):

--- a/tests/unit/dojson/test_dojson_hep_receivers.py
+++ b/tests/unit/dojson/test_dojson_hep_receivers.py
@@ -37,9 +37,7 @@ def test_earliest_date_from_preprint_date():
 
 def test_earliest_date_from_thesis_date():
     with_thesis_date = Record({
-        'thesis': [
-            {'date': '2008'}
-        ]
+        'thesis': {'date': '2008'}
     })
     earliest_date(with_thesis_date)
 
@@ -51,9 +49,7 @@ def test_earliest_date_from_thesis_date():
 
 def test_earliest_date_from_thesis_defense_date():
     with_thesis_defense_date = Record({
-        'thesis': [
-            {'defense_date': '2012-06-01'}
-        ]
+        'thesis': {'defense_date': '2012-06-01'}
     })
     earliest_date(with_thesis_defense_date)
 

--- a/tests/unit/literaturesuggest/test_literaturesuggest_dojson.py
+++ b/tests/unit/literaturesuggest/test_literaturesuggest_dojson.py
@@ -329,11 +329,9 @@ def test_thesis_defense_date_and_public_notes_from_defense_date():
 
     result = literature.do(form)
 
-    assert result['thesis'] == [
-        {
-            'defense_date': 'foo',
-        }
-    ]
+    assert result['thesis'] == {
+        'defense_date': 'foo',
+    }
     assert result['public_notes'] == [
         {
             'value': 'Presented on foo',
@@ -349,18 +347,16 @@ def test_thesis_defense_date_and_public_notes_from_multiple_defense_date_updates
 
     result = literature.do(form)
 
-    assert result['thesis'] == [
-        {
-            'defense_date': 'bar',
-        },
-    ]
+    assert result['thesis'] == {
+        'defense_date': 'bar',
+    }
     assert result['public_notes'] == [
         {
             'value': 'Presented on foo',
         },
         {
             'value': 'Presented on bar',
-        },
+        }
     ]
 
 
@@ -369,11 +365,9 @@ def test_thesis_degree_type_from_degree_type():
         ('degree_type', 'foo'),
     ])
 
-    expected = [
-        {
+    expected = {
             'degree_type': 'foo',
-        },
-    ]
+    }
     result = literature.do(form)
 
     assert expected == result['thesis']
@@ -385,11 +379,9 @@ def test_thesis_degree_type_from_multiple_degree_type_updates():
         ('degree_type', 'bar'),
     ])
 
-    expected = [
-        {
-            'degree_type': 'bar',
-        },
-    ]
+    expected = {
+        'degree_type': 'bar',
+    }
     result = literature.do(form)
 
     assert expected == result['thesis']
@@ -400,27 +392,23 @@ def test_thesis_university_from_institution():
         ('institution', 'foo'),
     ])
 
-    expected = [
-        {
-            'university': 'foo',
-        },
-    ]
+    expected = {
+        'institutions': [{'name': 'foo'}]
+    }
     result = literature.do(form)
 
     assert expected == result['thesis']
 
 
-def test_thesis_university_from_multiple_institution_updates():
+def test_thesis_institution_from_multiple_institution_updates():
     form = GroupableOrderedDict([
         ('institution', 'foo'),
         ('institution', 'bar'),
     ])
 
-    expected = [
-        {
-            'university': 'bar',
-        },
-    ]
+    expected = {
+        'institutions': [{'name': 'bar'}]
+    }
     result = literature.do(form)
 
     assert expected == result['thesis']
@@ -431,11 +419,9 @@ def test_thesis_date_from_thesis_date():
         ('thesis_date', 'foo'),
     ])
 
-    expected = [
-        {
-            'date': 'foo',
-        },
-    ]
+    expected = {
+        'date': 'foo'
+    }
     result = literature.do(form)
 
     assert expected == result['thesis']
@@ -447,11 +433,9 @@ def test_thesis_date_from_multiple_thesis_date_updates():
         ('thesis_date', 'bar'),
     ])
 
-    expected = [
-        {
-            'date': 'bar',
-        },
-    ]
+    expected = {
+        'date': 'bar'
+    }
     result = literature.do(form)
 
     assert expected == result['thesis']

--- a/tests/unit/utils/test_utils_bibtex.py
+++ b/tests/unit/utils/test_utils_bibtex.py
@@ -758,9 +758,9 @@ def test_get_year_from_publication_info_a_list_from_preprint_date():
     assert expected == result
 
 
-def test_get_year_from_thesis_an_empty_list():
+def test_get_year_from_thesis_an_empty_obj():
     record = Record({
-        'thesis': []
+        'thesis': {}
     })
 
     thesis_an_empty_list = Bibtex(record)
@@ -772,10 +772,10 @@ def test_get_year_from_thesis_an_empty_list():
     assert expected == result
 
 
-def test_get_year_from_thesis_an_empty_list_but_preprint_date():
+def test_get_year_from_thesis_an_empty_obj_but_preprint_date():
     record = Record({
         'preprint_date': '1998-04-30',
-        'thesis': []
+        'thesis': {}
     })
 
     thesis_an_empty_list_but_preprint_date = Bibtex(record)
@@ -787,10 +787,10 @@ def test_get_year_from_thesis_an_empty_list_but_preprint_date():
     assert expected == result
 
 
-def test_get_year_from_thesis_an_empty_list_but_imprints():
+def test_get_year_from_thesis_an_empty_obj_but_imprints():
     record = Record({
         'imprints': [{'date': '2015-12-04'}],
-        'thesis': []
+        'thesis': {}
     })
 
     thesis_an_empty_list_but_imprints = Bibtex(record)
@@ -804,9 +804,7 @@ def test_get_year_from_thesis_an_empty_list_but_imprints():
 
 def test_get_year_from_thesis_one_date():
     record = Record({
-        'thesis': [
-            {'date': '2008'}
-        ]
+        'thesis': {'date': '2008'}
     })
 
     thesis_one_date = Bibtex(record)
@@ -814,23 +812,6 @@ def test_get_year_from_thesis_one_date():
 
     expected = '2008'
     result = thesis_one_date._get_year()
-
-    assert expected == result
-
-
-def test_get_year_from_thesis_two_dates():
-    record = Record({
-        'thesis': [
-            {'date': '2008'},
-            {'date': '2015'}
-        ]
-    })
-
-    thesis_two_dates = Bibtex(record)
-    thesis_two_dates.original_entry = 'thesis'
-
-    expected = '2015'
-    result = thesis_two_dates._get_year()
 
     assert expected == result
 

--- a/tests/unit/utils/test_utils_cv_latex.py
+++ b/tests/unit/utils/test_utils_cv_latex.py
@@ -549,7 +549,7 @@ def test_get_date_from_imprints_uses_first_date_found():
 
 def test_get_date_from_thesis_returns_none_when_no_date():
     thesis_without_a_date = Record({
-        'thesis': []
+        'thesis': {}
     })
 
     assert Cv_latex(thesis_without_a_date)._get_date() is None
@@ -557,10 +557,7 @@ def test_get_date_from_thesis_returns_none_when_no_date():
 
 def test_get_date_from_thesis_uses_first_date_found():
     thesis = Record({
-        'thesis': [
-            {},
-            {'date': '1966'}
-        ]
+        'thesis': {'date': '1966'}
     })
 
     expected = 1966


### PR DESCRIPTION
* Makes `thesis` field a single field instead of a list;
* Adds support for multiple institiutions and records for a given
  thesis.
* Closes #1260

Signed-off-by: Mihai Bivol <mihai.bivol@cern.ch>