### PR TITLE
travis: improve build reliability

### DIFF
--- a/docker-compose.deps.yml
+++ b/docker-compose.deps.yml
@@ -27,7 +27,7 @@ services:
     extends:
       file: services.yml
       service: base
-    command: pip-accel install -r requirements.txt --pre
+    command: pip-accel install -r requirements.txt --pre -e .[tests]
     volumes_from:
       - static
   assets:


### PR DESCRIPTION
Last two merge builds were bad because PyPI went down while installing test dependencies: https://travis-ci.org/inspirehep/inspire-next/jobs/141055132#L1478 and https://travis-ci.org/inspirehep/inspire-next/jobs/140783712#L1602.

This PR should improve this by installing test dependencies as part of the development dependencies, whose installation is automatically retried on failure by Travis.