### PR TITLE
dojson: fix bug in HEP hidden_notes

### DIFF
--- a/inspirehep/dojson/hep/fields/bd5xx.py
+++ b/inspirehep/dojson/hep/fields/bd5xx.py
@@ -57,18 +57,24 @@ def public_notes2marc(self, key, value):
 @hep.over('hidden_notes', '^595..')
 def hidden_notes(self, key, value):
     """Hidden notes."""
-    def _get_value(value):
-        return {
-            'value': value.get('a'),
-            'cern_reference': value.get('b'),
-            'cds': value.get('c'),
-            'source': value.get('9'),
-        }
+    def _hidden_notes(value):
+        def _hidden_note(value, a=None):
+            return {
+                'value': a,
+                'cern_reference': value.get('b'),
+                'cds': value.get('c'),
+                'source': value.get('9'),
+            }
 
-    values = self.get('hidden_notes', [])
-    values.extend(_get_value(el) for el in utils.force_list(value))
+        if value.get('a'):
+            return [_hidden_note(value, a) for a in utils.force_list(value['a'])]
+        else:
+            return [_hidden_note(value)]
 
-    return dedupe_list_of_dicts(values)
+    hidden_notes = self.get('hidden_notes', [])
+    hidden_notes.extend(_hidden_notes(value))
+
+    return dedupe_list_of_dicts(hidden_notes)
 
 
 @hep2marc.over('595', 'hidden_notes')

--- a/inspirehep/modules/records/jsonschemas/records/hep.json
+++ b/inspirehep/modules/records/jsonschemas/records/hep.json
@@ -308,8 +308,7 @@
                         "description": "FIXME: Do we know what this is? do we care?"
                     },
                     "value": {
-                        "type": "array",
-                        "items": {"type": "string"}
+                        "type": "string"
                     },
                     "cds": {
                         "type": "string"

--- a/tests/unit/dojson/test_dojson_hep.py
+++ b/tests/unit/dojson/test_dojson_hep.py
@@ -348,6 +348,7 @@ def test_hidden_notes_from_595__a_9():
     assert expected == result['hidden_notes']
 
 
+@pytest.mark.xfail(reason='value is not a list')
 def test_hidden_notes_from_595__double_a_9():
     snippet = (
         '<datafield tag="595" ind1=" " ind2=" ">'
@@ -360,10 +361,11 @@ def test_hidden_notes_from_595__double_a_9():
     expected = [
         {
             'source': 'SPIRES-HIDDEN',
-            'value': (
-                'TeXtitle from script',
-                'no affiliation (not clear pn the fulltext)',
-            ),
+            'value': 'TeXtitle from script',
+        },
+        {
+            'source': 'SPIRES-HIDDEN',
+            'value': 'no affiliation (not clear pn the fulltext)',
         },
     ]
     result = strip_empty_values(hep.do(create_record(snippet)))
@@ -371,6 +373,7 @@ def test_hidden_notes_from_595__double_a_9():
     assert expected == result['hidden_notes']
 
 
+@pytest.mark.xfail(reason='value is not a list')
 def test_hidden_notes_from_595__a_9_and_595__double_a_9():
     snippet = (
         '<record>'
@@ -393,10 +396,11 @@ def test_hidden_notes_from_595__a_9_and_595__double_a_9():
         },
         {
             'source': 'SPIRES-HIDDEN',
-            'value': (
-                'TeXtitle from script',
-                'no affiliation (not clear pn the fulltext)',
-            ),
+            'value': 'TeXtitle from script',
+        },
+        {
+            'source': 'SPIRES-HIDDEN',
+            'value': 'no affiliation (not clear pn the fulltext)',
         },
     ]
     result = strip_empty_values(hep.do(create_record(snippet)))

--- a/tests/unit/dojson/test_dojson_hep.py
+++ b/tests/unit/dojson/test_dojson_hep.py
@@ -348,7 +348,6 @@ def test_hidden_notes_from_595__a_9():
     assert expected == result['hidden_notes']
 
 
-@pytest.mark.xfail(reason='value is not a list')
 def test_hidden_notes_from_595__double_a_9():
     snippet = (
         '<datafield tag="595" ind1=" " ind2=" ">'
@@ -373,7 +372,6 @@ def test_hidden_notes_from_595__double_a_9():
     assert expected == result['hidden_notes']
 
 
-@pytest.mark.xfail(reason='value is not a list')
 def test_hidden_notes_from_595__a_9_and_595__double_a_9():
     snippet = (
         '<record>'


### PR DESCRIPTION
First commit reverts b3ab2fbb98edf5919ad002c6d6cc2d9509c6c045. Second commit xfails two tests that, consequently, had incorrect behaviour, while the third implements the correct one.

cc: @jmartinm