### PR TITLE
jsonschemas: schema clean up

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -194,7 +194,6 @@ SEARCH_ELASTIC_KEYWORD_MAPPING = {
         "collections.secondary",
         "collections.deleted",
     ],
-    "595__c": ["hidden_notes.cds"],
     "980__a": ["collections.primary"],
     "980__b": ["collections.secondary"],
     "542__l": ["information_relating_to_copyright_status.copyright_status"],

--- a/inspirehep/dojson/hep/fields/bd5xx.py
+++ b/inspirehep/dojson/hep/fields/bd5xx.py
@@ -59,11 +59,12 @@ def hidden_notes(self, key, value):
     """Hidden notes."""
     def _hidden_notes(value):
         def _hidden_note(value, a=None):
+            source = value.get('9')
+            if value.get('c'):
+                source = "CDS"
             return {
-                'value': a,
-                'cern_reference': value.get('b'),
-                'cds': value.get('c'),
-                'source': value.get('9'),
+                'value': a if a else value.get('b'),
+                'source': source,
             }
 
         if value.get('a'):
@@ -84,8 +85,6 @@ def hidden_note2marc(self, key, value):
     """Hidden note."""
     return {
         'a': value.get('value'),
-        'b': value.get('cern_reference'),
-        'c': value.get('cds'),
         '9': value.get('source'),
     }
 

--- a/inspirehep/modules/records/jsonschemas/records/hep.json
+++ b/inspirehep/modules/records/jsonschemas/records/hep.json
@@ -31,10 +31,6 @@
                     "experiment": {
                         "type": "string"
                     },
-                    "facets_experiment": {
-                        "description": "Experiment name to be used on facets.",
-                        "type": "string"
-                    },
                     "institution": {
                         "type": "string"
                     },
@@ -189,11 +185,6 @@
                         "title": "INSPIRE ID",
                         "type": "string"
                     },
-                    "name_variations": {
-                        "description": "All possible variations of the authors full name.",
-                        "title": "Author name variations",
-                        "type": "string"
-                    },
                     "orcid": {
                         "description": "ORCID Id when available",
                         "format": "orcid",
@@ -228,11 +219,6 @@
                     "role": {
                         "description": "Role of the author within the paper. So far only Editor was captured.",
                         "title": "Role of the person",
-                        "type": "string"
-                    },
-                    "signature_block": {
-                        "description": "Phonetic notation of the author's name.",
-                        "title": "Phonetic name",
                         "type": "string"
                     },
                     "uuid": {
@@ -412,11 +398,6 @@
             "type": "array",
             "uniqueItems": true
         },
-        "earliest_date": {
-            "description": "The earliest date of this record among all types of dates",
-            "format": "date",
-            "type": "string"
-        },
         "edition": {
             "items": {
                 "properties": {
@@ -502,13 +483,6 @@
             "description": "FIXME: what about 595__d??",
             "items": {
                 "properties": {
-                    "cds": {
-                        "type": "string"
-                    },
-                    "cern_reference": {
-                        "description": "FIXME: Do we know what this is? do we care?",
-                        "type": "string"
-                    },
                     "source": {
                         "description": "FIXME: What's the semantic of this source?",
                         "type": "string"
@@ -760,14 +734,6 @@
             "$ref": "elements/json_reference.json",
             "description": "Url of the record itself",
             "title": "Url of the record"
-        },
-        "spires_sysnos": {
-            "description": "List of associated legacy SPIRES IDs",
-            "items": {
-                "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": true
         },
         "succeeding_entry": {
             "description": "Reference to previously merged records.",

--- a/inspirehep/modules/records/mappings/records/hep.json
+++ b/inspirehep/modules/records/mappings/records/hep.json
@@ -294,15 +294,6 @@
                 "global_fulltext": {
                     "type": "string"
                 },
-                "hidden_notes": {
-                    "properties": {
-                        "cds": {
-                            "index": "not_analyzed",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
                 "institution": {
                     "properties": {
                         "affiliation": {

--- a/inspirehep/modules/workflows/mappings/holdingpen/authors.json
+++ b/inspirehep/modules/workflows/mappings/holdingpen/authors.json
@@ -169,15 +169,6 @@
                             },
                             "type": "object"
                         },
-                        "hidden_notes": {
-                            "properties": {
-                                "cds": {
-                                    "index": "not_analyzed",
-                                    "type": "string"
-                                }
-                            },
-                            "type": "object"
-                        },
                         "institution": {
                             "properties": {
                                 "affiliation": {

--- a/inspirehep/modules/workflows/mappings/holdingpen/hep.json
+++ b/inspirehep/modules/workflows/mappings/holdingpen/hep.json
@@ -367,15 +367,6 @@
                             },
                             "type": "object"
                         },
-                        "hidden_notes": {
-                            "properties": {
-                                "cds": {
-                                    "index": "not_analyzed",
-                                    "type": "string"
-                                }
-                            },
-                            "type": "object"
-                        },
                         "institution": {
                             "properties": {
                                 "affiliation": {

--- a/tests/unit/dojson/test_dojson_hep.py
+++ b/tests/unit/dojson/test_dojson_hep.py
@@ -88,12 +88,6 @@ def test_dois(marcxml_to_json, json_to_marc):
             [p.get('a') for p in json_to_marc['024'] if 'a' in p])
 
 
-def test_spires_sysnos(marcxml_to_json, json_to_marc):
-    """Test if spires_sysnos is created correctly."""
-    assert (marcxml_to_json['spires_sysnos'][0] in
-            [p.get('a') for p in json_to_marc['970'] if 'a' in p])
-
-
 def test_deleted_records(marcxml_to_json, json_to_marc):
     """Test if deleted_recids is created correctly."""
     assert (get_recid_from_ref(marcxml_to_json['deleted_records'][0]) in
@@ -324,12 +318,9 @@ def test_public_notes(marcxml_to_json, json_to_marc):
 
 def test_hidden_notes(marcxml_to_json, json_to_marc):
     """Test if hidden_notes is created correctly."""
+    assert marcxml_to_json['hidden_notes'][0]['source'] == "CDS"
     assert (marcxml_to_json['hidden_notes'][0]['value'] ==
             json_to_marc['595'][0]['a'])
-    assert (marcxml_to_json['hidden_notes'][0]['cern_reference'] ==
-            json_to_marc['595'][0]['b'])
-    assert (marcxml_to_json['hidden_notes'][0]['cds'] ==
-            json_to_marc['595'][0]['c'])
     assert (marcxml_to_json['hidden_notes'][0]['source'] ==
             json_to_marc['595'][0]['9'])
 


### PR DESCRIPTION
* Removes fields only used on ElasticSearch and not part of the record
  data model.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>