### PR TITLE
docs: add how to build the docs

### DIFF
--- a/docs/building_the_docs.rst
+++ b/docs/building_the_docs.rst
@@ -1,0 +1,63 @@
+..
+    This file is part of INSPIRE.
+    Copyright (C) 2016 CERN.
+
+    INSPIRE is free software; you can redistribute it
+    and/or modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.
+
+    INSPIRE is distributed in the hope that it will be
+    useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with INSPIRE; if not, write to the
+    Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+    MA 02111-1307, USA.
+
+    In applying this license, CERN does not
+    waive the privileges and immunities granted to it by virtue of its status
+    as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+
+Building this docs page
+========================
+
+Sometimes when you modify the docs it's convenient to generate them locally in
+order to check them before sending a pull request, to do so, you'll have to
+install some extra dependencies:
+
+
+.. note::
+
+    Remember that you'll need a relatively newer version of setuptools and
+    pip, so if you just created a virtualenv for the docs, you might have to
+    run:
+
+    .. code-block:: console
+
+        (inspirehep_docs)$ pip install --upgrade setuptools pip
+
+    Also keep in mind that you need all the inspire system dependecies
+    installed too, if you don't have them, go to Installation_
+
+.. code-block:: console
+
+    (inspirehep_docs)$ pip install -e .[docs]
+
+And then, you can generate the html docs pages with:
+
+.. code-block:: console
+
+    (inspirehep_docs)$ make -C docs html
+
+And to view them, you can just open them in your favourite browser:
+
+.. code-block:: console
+
+    (enspirehep_docs)$ firefox docs/_build/html/index.html
+
+
+.. _Installation: installation.html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,6 +36,7 @@ Contents
    harvesting
    grobid
    tools
+   building_the_docs
 
 *Happy hacking!*
 

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,8 @@ tests_require = [
 
 extras_require = {
     'docs': [
+        'six',
+        'mock',
         'Sphinx>=1.3',
     ],
     'postgresql': [


### PR DESCRIPTION
* Add also the requires.txt to the docs directory, with the
  dependencies to build the docs themselves

Signed-off-by: David Caro <david.caro@cern.ch>