### PR TITLE
holdingpen: cleancss include error

### DIFF
--- a/inspirehep/modules/theme/bundles.py
+++ b/inspirehep/modules/theme/bundles.py
@@ -100,6 +100,7 @@ detailedjs = NpmBundle(
 )
 
 holding_pen_css = NpmBundle(
+    "node_modules/angular-xeditable/dist/css/xeditable.css",
     "scss/holding-pen/holding-pen.scss",
     filters="scss, cleancss",
     output="gen/inspirehep.holding.%(version)s.css",

--- a/inspirehep/modules/theme/static/scss/holding-pen/holding-pen.scss
+++ b/inspirehep/modules/theme/static/scss/holding-pen/holding-pen.scss
@@ -1,5 +1,4 @@
 @import "../base/variables";
-@import "../node_modules/angular-xeditable/dist/css/xeditable.css";
 
 html, body {
   background-color: $dark-blue !important;


### PR DESCRIPTION
Fix the current issue when using a new cleancss module that fails to
import the css file. Moved it to a bundle instead. (fixes #1296)

Signed-off-by: David Caro <david.caro@cern.ch>