### PR TITLE
dojson: faster dedupes

### DIFF
--- a/inspirehep/dojson/hep/fields/bd01x09x.py
+++ b/inspirehep/dojson/hep/fields/bd01x09x.py
@@ -32,7 +32,6 @@ from idutils import normalize_isbn
 from inspirehep.utils.dedupers import dedupe_list_of_dicts
 
 from ..model import hep, hep2marc
-from ...utils import strip_empty_values
 
 
 @hep.over('isbns', '^020..')

--- a/inspirehep/dojson/hep/fields/bd90x99x.py
+++ b/inspirehep/dojson/hep/fields/bd90x99x.py
@@ -31,8 +31,6 @@ from isbn import ISBNError
 from dojson import utils
 from idutils import normalize_isbn
 
-from inspirehep.utils.dedupers import dedupe_list
-
 from ..model import hep, hep2marc
 from ...utils import get_recid_from_ref, get_record_ref, strip_empty_values
 
@@ -108,9 +106,11 @@ def references(self, key, value):
     references = self.get('references', [])
 
     for val in value:
-        references.append(get_value(val))
+        json_val = strip_empty_values(get_value(val))
+        if json_val not in references:
+            references.append(json_val)
 
-    return dedupe_list(strip_empty_values(references))
+    return references
 
 
 @hep2marc.over('999C5', 'references')


### PR DESCRIPTION
* Currently `dedupe_lists` is called on the full list, every time a record is appended. (Dedupe is n^2 or some heavy O(n)) Multiply this with the length of the list and we get to unnecessary n^3 or n^2. Would be cool to have the `freeze` + `set` logic but that would be some massive hack which sets function attributes.