### PR TITLE
dojson: dedupe and clean once per record

### DIFF
--- a/inspirehep/dojson/common/base.py
+++ b/inspirehep/dojson/common/base.py
@@ -26,8 +26,6 @@ from __future__ import absolute_import, division, print_function
 
 from dojson import utils
 
-from inspirehep.utils.dedupers import dedupe_list_of_dicts
-
 from ..conferences.model import conferences
 from ..experiments.model import experiments
 from ..hep.model import hep, hep2marc
@@ -39,7 +37,6 @@ from ..utils import (
     classify_field,
     get_recid_from_ref,
     get_record_ref,
-    strip_empty_values,
 )
 
 
@@ -237,16 +234,7 @@ def collections(self, key, value):
     for val in value:
         collections.append(get_value(val))
 
-    contains_list = False
-    for element in collections:
-        for k, v in enumerate(element):
-            if isinstance(element[v], list):
-                contains_list = True
-                break
-    if contains_list:
-        return strip_empty_values(collections)
-    else:
-        return dedupe_list_of_dicts(collections)
+    return collections
 
 
 @hep2marc.over('980', 'collections')
@@ -361,9 +349,6 @@ def field_categories(self, key, value):
                 'term': term,
             })
 
-        self['field_categories'] = dedupe_list_of_dicts(
-            self['field_categories'])
-
 
 @conferences.over('urls', '^8564')
 @experiments.over('urls', '^8564')
@@ -389,5 +374,3 @@ def urls(self, key, value):
                 'description': description,
                 'value': _url,
             })
-
-        self['urls'] = dedupe_list_of_dicts(self['urls'])

--- a/inspirehep/dojson/hep/fields/bd01x09x.py
+++ b/inspirehep/dojson/hep/fields/bd01x09x.py
@@ -29,8 +29,6 @@ from isbn import ISBNError
 from dojson import utils
 from idutils import normalize_isbn
 
-from inspirehep.utils.dedupers import dedupe_list_of_dicts
-
 from ..model import hep, hep2marc
 
 
@@ -105,9 +103,8 @@ def persistent_identifiers(self, key, value):
                         'source': val.get('9'),
                         'type': val.get('2')
                     })
-    if dois:
-        self['dois'] = dedupe_list_of_dicts(dois)
-    return dedupe_list_of_dicts(persistent_identifiers)
+    self['dois'] = dois
+    return persistent_identifiers
 
 
 @hep2marc.over('024', '^(dois|persistent_identifiers)$')
@@ -144,7 +141,7 @@ def external_system_numbers(self, key, value):
 
     for val in value:
         external_system_numbers.append(get_value(val))
-    return dedupe_list_of_dicts(external_system_numbers)
+    return external_system_numbers
 
 
 @hep2marc.over('035', 'external_system_numbers')
@@ -184,8 +181,8 @@ def report_numbers(self, key, value):
         else:
             report_number.append(get_value(element))
 
-    self['arxiv_eprints'] = dedupe_list_of_dicts(arxiv_eprints)
-    return dedupe_list_of_dicts(report_number)
+    self['arxiv_eprints'] = arxiv_eprints
+    return report_number
 
 
 @hep2marc.over('037', '(arxiv_eprints|report_numbers)')

--- a/inspirehep/dojson/hep/fields/bd20x24x.py
+++ b/inspirehep/dojson/hep/fields/bd20x24x.py
@@ -26,8 +26,6 @@ from __future__ import absolute_import, division, print_function
 
 from dojson import utils
 
-from inspirehep.utils.dedupers import dedupe_list
-
 from ..model import hep, hep2marc
 
 
@@ -74,7 +72,7 @@ def title_variations(self, key, value):
                 'source': val.get('9'),
             })
         cleaned_titles = existing + out
-        return dedupe_list(cleaned_titles)
+        return cleaned_titles
 
     if 'title_variations' in self:
         titles = get_value(self['title_variations'])
@@ -100,7 +98,7 @@ def titles(self, key, value):
                 'source': val.get('9'),
             })
         cleaned_titles = existing + out
-        return dedupe_list(cleaned_titles)
+        return cleaned_titles
 
     if 'titles' in self:
         titles = get_value(self['titles'])

--- a/inspirehep/dojson/hep/fields/bd5xx.py
+++ b/inspirehep/dojson/hep/fields/bd5xx.py
@@ -26,8 +26,6 @@ from __future__ import absolute_import, division, print_function
 
 from dojson import utils
 
-from inspirehep.utils.dedupers import dedupe_list_of_dicts
-
 from ..model import hep, hep2marc
 from ...utils import get_record_ref
 
@@ -74,7 +72,7 @@ def hidden_notes(self, key, value):
     hidden_notes = self.get('hidden_notes', [])
     hidden_notes.extend(_hidden_notes(value))
 
-    return dedupe_list_of_dicts(hidden_notes)
+    return hidden_notes
 
 
 @hep2marc.over('595', 'hidden_notes')

--- a/inspirehep/dojson/hep/fields/bd6xx.py
+++ b/inspirehep/dojson/hep/fields/bd6xx.py
@@ -26,8 +26,6 @@ from __future__ import absolute_import, division, print_function
 
 from dojson import utils
 
-from inspirehep.utils.dedupers import dedupe_list_of_dicts
-
 from ..model import hep, hep2marc
 from ...utils import get_record_ref
 
@@ -59,7 +57,7 @@ def free_keywords(self, key, value):
     for val in value:
         free_keywords.append(get_value(val))
 
-    return dedupe_list_of_dicts(free_keywords)
+    return free_keywords
 
 
 @hep2marc.over('653', 'free_keywords')
@@ -127,7 +125,7 @@ def thesaurus_terms(self, key, value):
     for element in value:
         thesaurus_terms.append(get_value(element))
 
-    return dedupe_list_of_dicts(thesaurus_terms)
+    return thesaurus_terms
 
 
 @hep2marc.over('695', 'thesaurus_terms')

--- a/inspirehep/dojson/hep/fields/bd70x75x.py
+++ b/inspirehep/dojson/hep/fields/bd70x75x.py
@@ -26,8 +26,6 @@ from __future__ import absolute_import, division, print_function
 
 from dojson import utils
 
-from inspirehep.utils.dedupers import dedupe_list_of_dicts
-
 from ..model import hep, hep2marc
 from ...utils import get_record_ref
 
@@ -76,7 +74,7 @@ def collaboration(self, key, value):
         }
     collaboration = self.get('collaboration', [])
 
-    filtered_value = dedupe_list_of_dicts(value)
+    filtered_value = value
     for element in filtered_value:
         collaboration.append(get_value(element))
 

--- a/inspirehep/dojson/hep/receivers.py
+++ b/inspirehep/dojson/hep/receivers.py
@@ -25,7 +25,6 @@
 from invenio_records.signals import before_record_insert, before_record_update
 
 from inspirehep.utils.date import create_earliest_date
-from inspirehep.utils.dedupers import dedupe_list_of_dicts
 
 
 @before_record_insert.connect
@@ -61,16 +60,3 @@ def earliest_date(sender, *args, **kwargs):
     earliest_date = create_earliest_date(dates)
     if earliest_date:
         sender['earliest_date'] = earliest_date
-
-
-@before_record_insert.connect
-@before_record_update.connect
-def remove_duplicate_authors(sender, *args, **kwargs):
-    """Remove duplicate authors.
-
-    Has to be done here rather than when importing the record
-    for performance reasons."""
-    try:
-        sender['authors'] = dedupe_list_of_dicts(sender['authors'])
-    except KeyError:
-        pass

--- a/inspirehep/dojson/hepnames/fields/bd1xx.py
+++ b/inspirehep/dojson/hepnames/fields/bd1xx.py
@@ -26,8 +26,6 @@ from __future__ import absolute_import, division, print_function
 
 from dojson import utils
 
-from inspirehep.utils.dedupers import dedupe_list_of_dicts
-
 from ..model import hepnames, hepnames2marc
 from ...utils import classify_rank, get_record_ref
 
@@ -297,7 +295,7 @@ def source(self, key, value):
     for val in value:
         source.append(get_value(val))
 
-    return dedupe_list_of_dicts(source)
+    return source
 
 
 @hepnames2marc.over('670', '^source$')

--- a/inspirehep/dojson/processors.py
+++ b/inspirehep/dojson/processors.py
@@ -26,37 +26,33 @@ from __future__ import absolute_import, division, print_function
 
 from dojson.utils import force_list
 
+from inspirehep.dojson.conferences import conferences
+from inspirehep.dojson.experiments import experiments
+from inspirehep.dojson.hep import hep
+from inspirehep.dojson.hepnames import hepnames
+from inspirehep.dojson.institutions import institutions
+from inspirehep.dojson.jobs import jobs
+from inspirehep.dojson.journals import journals
+from inspirehep.dojson.utils import clean_record
 
-def convert_marcxml(source):
-    """Convert MARC XML to JSON."""
-    from dojson.contrib.marc21.utils import create_record, split_blob
 
-    from inspirehep.dojson.conferences import conferences
-    from inspirehep.dojson.experiments import experiments
-    from inspirehep.dojson.hep import hep
-    from inspirehep.dojson.hepnames import hepnames
-    from inspirehep.dojson.institutions import institutions
-    from inspirehep.dojson.jobs import jobs
-    from inspirehep.dojson.journals import journals
-    from inspirehep.dojson.utils import strip_empty_values
-
-    for data in split_blob(source.read()):
-        record = create_record(data)
-        if _collection_in_record(record, 'institution'):
-            yield strip_empty_values(institutions.do(record))
-        elif _collection_in_record(record, 'experiment'):
-            yield strip_empty_values(experiments.do(record))
-        elif _collection_in_record(record, 'journals'):
-            yield strip_empty_values(journals.do(record))
-        elif _collection_in_record(record, 'hepnames'):
-            yield strip_empty_values(hepnames.do(record))
-        elif _collection_in_record(record, 'job') or \
-                _collection_in_record(record, 'jobhidden'):
-            yield strip_empty_values(jobs.do(record))
-        elif _collection_in_record(record, 'conferences'):
-            yield strip_empty_values(conferences.do(record))
-        else:
-            yield strip_empty_values(hep.do(record))
+def overdo_marc_dict(record):
+    """Convert MARC Groupable Ordered Dict into JSON."""
+    if _collection_in_record(record, 'institution'):
+        return clean_record(institutions.do(record))
+    elif _collection_in_record(record, 'experiment'):
+        return clean_record(experiments.do(record))
+    elif _collection_in_record(record, 'journals'):
+        return clean_record(journals.do(record))
+    elif _collection_in_record(record, 'hepnames'):
+        return clean_record(hepnames.do(record))
+    elif _collection_in_record(record, 'job') or \
+            _collection_in_record(record, 'jobhidden'):
+        return clean_record(jobs.do(record))
+    elif _collection_in_record(record, 'conferences'):
+        return clean_record(conferences.do(record))
+    else:
+        return clean_record(hep.do(record))
 
 
 def _collection_in_record(record, collection):

--- a/inspirehep/modules/migrator/tasks.py
+++ b/inspirehep/modules/migrator/tasks.py
@@ -43,14 +43,7 @@ from elasticsearch.helpers import scan as es_scan
 
 from flask import current_app, url_for
 
-from inspirehep.dojson.conferences import conferences
-from inspirehep.dojson.experiments import experiments
-from inspirehep.dojson.hep import hep
-from inspirehep.dojson.hepnames import hepnames
-from inspirehep.dojson.institutions import institutions
-from inspirehep.dojson.jobs import jobs
-from inspirehep.dojson.journals import journals
-from inspirehep.dojson.processors import _collection_in_record
+from inspirehep.dojson.processors import overdo_marc_dict
 from inspirehep.modules.pidstore.providers import InspireRecordIdProvider
 
 
@@ -325,21 +318,7 @@ def add_citation_counts(chunk_size=500, request_timeout=120):
 
 def create_record(record):
     """Create record from marc21 model."""
-    if _collection_in_record(record, 'institution'):
-        json = institutions.do(record)
-    elif _collection_in_record(record, 'experiment'):
-        json = experiments.do(record)
-    elif _collection_in_record(record, 'journals'):
-        json = journals.do(record)
-    elif _collection_in_record(record, 'hepnames'):
-        json = hepnames.do(record)
-    elif _collection_in_record(record, 'job') or \
-            _collection_in_record(record, 'jobhidden'):
-        json = jobs.do(record)
-    elif _collection_in_record(record, 'conferences'):
-        json = conferences.do(record)
-    else:
-        json = hep.do(record)
+    json = overdo_marc_dict(record)
 
     if '$schema' in json:
         json['$schema'] = url_for(

--- a/tests/unit/dojson/test_dojson_common_base.py
+++ b/tests/unit/dojson/test_dojson_common_base.py
@@ -27,7 +27,7 @@ from dojson.contrib.marc21.utils import create_record
 from inspirehep.dojson.hep import hep
 from inspirehep.dojson.hepnames import hepnames
 
-from inspirehep.dojson.utils import strip_empty_values
+from inspirehep.dojson.utils import clean_record
 
 
 def test_field_from_marcxml_650_with_single_a_and_9():
@@ -55,7 +55,7 @@ def test_field_from_marcxml_650_with_single_a_and_9():
             'term': 'Phenomenology-HEP',
         },
     ]
-    result = strip_empty_values(hepnames.do(create_record(snippet)))
+    result = clean_record(hepnames.do(create_record(snippet)))
 
     assert expected == result['field_categories']
 
@@ -89,7 +89,7 @@ def test_field_from_marcxml_650_with_two_a():
             'term': 'Gravitation and Cosmology',
         },
     ]
-    result = strip_empty_values(hepnames.do(create_record(snippet)))
+    result = clean_record(hepnames.do(create_record(snippet)))
 
     assert expected == result['field_categories']
 
@@ -117,7 +117,7 @@ def test_field_from_marcxml_650_with_two_2():
             'term': 'Experiment-HEP',
         },
     ]
-    result = strip_empty_values(hepnames.do(create_record(snippet)))
+    result = clean_record(hepnames.do(create_record(snippet)))
 
     assert expected == result['field_categories']
 
@@ -154,34 +154,7 @@ def test_field_from_multiple_marcxml_650():
             'term': 'Instrumentation',
         },
     ]
-    result = strip_empty_values(hepnames.do(create_record(snippet)))
-
-    assert expected == result['field_categories']
-
-
-def test_field_categories_from_duplicate_marcxml_650_is_deduped():
-    snippet = (
-        '<record>'
-        '  <datafield tag="650" ind1="1" ind2="7">'
-        '    <subfield code="2">INSPIRE</subfield>'
-        '    <subfield code="a">Experiment-Nucl</subfield>'
-        '  </datafield>'
-        '  <datafield tag="650" ind1="1" ind2="7">'
-        '    <subfield code="2">INSPIRE</subfield>'
-        '    <subfield code="a">Experiment-Nucl</subfield>'
-        '  </datafield>'
-        '</record>'
-    )
-
-    expected = [
-        {
-            '_scheme': 'INSPIRE',
-            'scheme': 'INSPIRE',
-            '_term': 'Experiment-Nucl',
-            'term': 'Experiment-Nucl'
-        },
-    ]
-    result = strip_empty_values(hep.do(create_record(snippet)))
+    result = clean_record(hepnames.do(create_record(snippet)))
 
     assert expected == result['field_categories']
 
@@ -196,7 +169,7 @@ def test_field_from_marcxml_650_with_no_a():
         '</record>'
     )
 
-    result = strip_empty_values(hepnames.do(create_record(snippet)))
+    result = clean_record(hepnames.do(create_record(snippet)))
 
     assert 'field_categories' not in result
 
@@ -217,7 +190,7 @@ def test_urls_from_marcxml_856_with_single_u_single_y():
             'value': 'http://www.physics.unlv.edu/labastro/'
         }
     ]
-    result = strip_empty_values(hep.do(create_record(snippet)))
+    result = clean_record(hep.do(create_record(snippet)))
 
     assert expected == result['urls']
 
@@ -239,7 +212,7 @@ def test_urls_from_marcxml_856_with_single_u_two_y():
             'value': 'http://www.physics.unlv.edu/labastro/'
         }
     ]
-    result = strip_empty_values(hep.do(create_record(snippet)))
+    result = clean_record(hep.do(create_record(snippet)))
 
     assert expected == result['urls']
 
@@ -258,7 +231,7 @@ def test_urls_from_marcxml_856_with_single_u_no_y():
             'value': 'http://www.physics.unlv.edu/labastro/',
         },
     ]
-    result = strip_empty_values(hep.do(create_record(snippet)))
+    result = clean_record(hep.do(create_record(snippet)))
 
     assert expected == result['urls']
 
@@ -284,7 +257,7 @@ def test_urls_from_marcxml_856_with_two_u_single_y():
             'value': 'http://www.physics.unlv.edu/',
          },
     ]
-    result = strip_empty_values(hep.do(create_record(snippet)))
+    result = clean_record(hep.do(create_record(snippet)))
 
     assert expected == result['urls']
 
@@ -306,7 +279,7 @@ def test_urls_from_marcxml_856_with_two_u_duplicates_single_y():
             'value': 'http://www.physics.unlv.edu/labastro/',
         },
     ]
-    result = strip_empty_values(hep.do(create_record(snippet)))
+    result = clean_record(hep.do(create_record(snippet)))
 
     assert expected == result['urls']
 
@@ -333,7 +306,7 @@ def test_urls_from_marcxml_856_with_two_u_two_y():
             'value': 'http://www.physics.unlv.edu/',
         },
     ]
-    result = strip_empty_values(hep.do(create_record(snippet)))
+    result = clean_record(hep.do(create_record(snippet)))
 
     assert expected == result['urls']
 
@@ -356,7 +329,7 @@ def test_urls_from_marcxml_856_with_two_u_no_y():
             'value': 'http://www.physics.unlv.edu/',
         },
     ]
-    result = strip_empty_values(hep.do(create_record(snippet)))
+    result = clean_record(hep.do(create_record(snippet)))
 
     assert expected == result['urls']
 
@@ -385,6 +358,6 @@ def test_urls_from_marcxml_multiple_8564():
             'value': 'http://www.cern.ch/',
         },
     ]
-    result = strip_empty_values(hep.do(create_record(snippet)))
+    result = clean_record(hep.do(create_record(snippet)))
 
     assert expected == result['urls']

--- a/tests/unit/dojson/test_dojson_utils.py
+++ b/tests/unit/dojson/test_dojson_utils.py
@@ -30,7 +30,7 @@ from inspirehep.dojson.utils import (
     get_recid_from_ref,
     get_record_ref,
     legacy_export_as_marc,
-    strip_empty_values,
+    dedupe_all_lists,
 )
 
 
@@ -254,6 +254,18 @@ def test_legacy_export_as_marc_json_with_controlfield():
     result = legacy_export_as_marc(json_with_controlfield)
 
     assert expected == result
+
+
+def test_dedupe_all_lists():
+    obj = {'l0': range(10) + range(10),
+           'o1': [{'foo': 'bar'}] * 10,
+           'o2': [{'foo': [1, 2]}, {'foo': [1, 1, 2]}] * 10}
+
+    expected = {'l0': range(10),
+                'o1': [{'foo': 'bar'}],
+                'o2': [{'foo': [1, 2]}]}
+
+    assert dedupe_all_lists(obj) == expected
 
 
 # TODO: test legacy_export_as_marc


### PR DESCRIPTION
* Adds `dedupe_all_lists` function
* Calls `dedupe_all_lists` for any `dojson` output

Signed-off-by: Mihai Bivol <mm.bivol@gmail.com>