### PR TITLE
config: missing env var override

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -33,6 +33,7 @@ services:
       - BROKER_URL=amqp://guest:guest@rabbitmq:5672//
       - CELERY_RESULT_BACKEND=amqp://guest:guest@rabbitmq:5672//
       - CACHE_REDIS_URL=redis://redis:6379/0
+      - ACCOUNTS_SESSION_REDIS_URL=redis://redis:6379/2
       - SEARCH_ELASTIC_HOSTS=indexer
 
   unit:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - BROKER_URL=amqp://guest:guest@rabbitmq:5672//
       - CELERY_RESULT_BACKEND=amqp://guest:guest@rabbitmq:5672//
       - CACHE_REDIS_URL=redis://redis:6379/0
+      - ACCOUNTS_SESSION_REDIS_URL=redis://redis:6379/2
       - SEARCH_ELASTIC_HOSTS=indexer
 
   # Services using the inspirehep code.

--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -83,7 +83,9 @@ CACHE_REDIS_URL = os.environ.get(
     "CACHE_REDIS_URL",
     "redis://localhost:6379/0")
 CACHE_TYPE = "redis"
-ACCOUNTS_SESSION_REDIS_URL = "redis://localhost:6379/2"
+ACCOUNTS_SESSION_REDIS_URL = os.environ.get(
+    "ACCOUNTS_SESSION_REDIS_URL",
+    "redis://localhost:6379/2")
 
 # Files
 # =====


### PR DESCRIPTION
* Override ACCOUNTS_SESSION_REDIS_URL conf key with the env var if
  available
* Update docker compose files to use it

Signed-off-by: David Caro <david.caro@cern.ch>