### PR TITLE
tests: don't delete records when done testing

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -22,6 +22,8 @@
 
 """Pytest configuration for integration tests."""
 
+from __future__ import absolute_import, division, print_function
+
 from time import sleep
 
 import pytest
@@ -37,16 +39,6 @@ def app(request):
     """Flask application fixture."""
     app = create_app()
     app.config.update({'DEBUG': True})
-
-    def teardown():
-        with app.app_context():
-            db.drop_all()
-
-            sleep(10)  # Makes sure that ES is up.
-            _es = app.extensions['invenio-search']
-            list(_es.delete(ignore=[404]))
-
-    request.addfinalizer(teardown)
 
     with app.app_context():
         # Imports must be local, otherwise tasks default to pickle serializer.


### PR DESCRIPTION
There's absolutely no point in deleting the records again after the integration tests have run: It just forces a costly `scripts/recreate_records` for no good reason. I have no idea what I was thinking when I wrote those lines.