### PR TITLE
setup: add pin on celery

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ readme = open('README.rst').read()
 
 install_requires = [
     'amqp>=1.4.9,<2.0',
+    'celery<4.0',
     'Flask-Gravatar>=0.4.2',
     'HarvestingKit>=0.6.2',
     'plotextractor>=0.1.2',


### PR DESCRIPTION
Build failed with: https://travis-ci.org/inspirehep/inspire-next/jobs/143751233#L1147. Commit 8f19cb9b added a pin on `aqmp` without an explanation (but it was probably fixing a build). This PR tries to fix the current build failure by removing this pin. If this fails I'll instead add a pin on `kombu`.