### PR TITLE
ci: pip use latest deps

### DIFF
--- a/docker-compose.deps.yml
+++ b/docker-compose.deps.yml
@@ -27,7 +27,7 @@ services:
     extends:
       file: services.yml
       service: base
-    command: pip-accel install -r requirements.txt --pre -e .[tests]
+    command: pip-accel install -r requirements.txt --upgrade --pre -e .[tests]
     volumes_from:
       - static
   assets:


### PR DESCRIPTION
* Upgrade any deps if available too, so we make sure to test with the
  latest version of the deps (and not just use whatever version was
  installed)
* This allows to discover version incompatibilities early in the
  process, before it hits production

Signed-off-by: David Caro <david.caro@cern.ch>