### PR TITLE
setup: add flask-shell-ipython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ install_requires = [
     'Flask>=0.11.1',
     'Flask-Breadcrumbs>=0.3.0',
     'Flask-Script>=2.0.5',
-    'Flask-CLI>=0.4.0',
+    'flask-shell-ipython>=0.2.2',
     'jsmin',
     'pytest-runner>=2.7.0',
     'workflow>=2.0.0',


### PR DESCRIPTION
* Incorporates @jirikuncar's suggestion of trying to avoid `Flask-CLI`, which is still going to be installed because it's required by a lot of other Invenio packages.
* Incorporates @Panos512's suggestion of requiring at least version 0.2.2 to support IPython 5.0.0.

Closes #1305