### PR TITLE
tests: unit tests for DoJSON conferences

### DIFF
--- a/inspirehep/dojson/conferences/fields/bd1xx.py
+++ b/inspirehep/dojson/conferences/fields/bd1xx.py
@@ -82,6 +82,11 @@ def alternative_titles(self, key, value):
 @utils.for_each_value
 def contact_details(self, key, value):
     """Contact details."""
+    extra_place_info = value.get('b')
+    if extra_place_info:
+        address = parse_conference_address(extra_place_info)
+        self.setdefault('address', []).append(address)
+
     name = value.get('p')
     email = value.get('m')
 
@@ -136,10 +141,3 @@ def short_description(self, key, value):
         'value': value.get('a'),
         'source': value.get('9')
     }
-
-
-@conferences.over('extra_place_info', '^270')
-@utils.for_each_value
-def extra_place_info(self, key, value):
-    """Conference extra place info."""
-    return value.get('b')

--- a/inspirehep/dojson/conferences/fields/bd1xx.py
+++ b/inspirehep/dojson/conferences/fields/bd1xx.py
@@ -106,13 +106,6 @@ def keywords(self, key, value):
     return keywords
 
 
-@conferences.over('nonpublic_note', '^595')
-@utils.for_each_value
-def nonpublic_note(self, key, value):
-    """Non public note."""
-    return value.get('a')
-
-
 @conferences.over('note', '^500')
 @utils.for_each_value
 def note(self, key, value):

--- a/tests/unit/dojson/test_dojson_conferences.py
+++ b/tests/unit/dojson/test_dojson_conferences.py
@@ -241,6 +241,58 @@ def test_contact_details_from_multiple_marcxml_270():
     assert expected == result['contact_details']
 
 
+def test_address_from_270__b():
+    snippet = (
+        '<record>'
+        '  <datafield tag="270" ind1=" " ind2=" ">'
+        '    <subfield code="b">British Columbia</subfield>'
+        '  </datafield>'
+        '</record>'
+    )
+
+    expected = [
+        {
+            'country_code': 'CA',
+            'original_address': 'British Columbia',
+        },
+    ]
+    result = clean_record(conferences.do(create_record(snippet)))
+
+    assert expected == result['address']
+
+
+def test_address_from_111__a_c_e_g_x_y_and_270__b():
+    snippet = (
+        '<record>'
+        '  <datafield tag="111" ind1=" " ind2=" ">'
+        '    <subfield code="a">2017 International Workshop on Baryon and Lepton Number Violation: From the Cosmos to the LHC</subfield>'
+        '    <subfield code="c">Cleveland, Ohio, USA</subfield>'
+        '    <subfield code="e">BLV 2017</subfield>'
+        '    <subfield code="g">C17-05-15</subfield>'
+        '    <subfield code="x">2017-05-15</subfield>'
+        '    <subfield code="y">2017-05-18</subfield>'
+        '  </datafield>'
+        '  <datafield tag="270" ind1=" " ind2=" ">'
+        '    <subfield code="b">Case Western Reserve University</subfield>'
+        '  </datafield>'
+        '</record>'
+    )  # record/1353313
+
+    expected = [
+        {
+            'original_address': 'Cleveland, Ohio, USA',
+            'country_code': 'US',
+            'state': 'US-OH',
+        },
+        {
+            'original_address': 'Case Western Reserve University',
+        },
+    ]
+    result = clean_record(conferences.do(create_record(snippet)))
+
+    assert expected == result['address']
+
+
 def test_keywords_from_multiple_6531_a_9():
     snippet = (
         '<record>'


### PR DESCRIPTION
Continues to address #1240.

- [ ] Conferences
    - [x] Test `acronym`
    - [x] Test `keywords`
    - [x] Test `nonpublic_note`
    - [x] Test `note`
    - [x] Test `series`
    - [x] Test `short_description`
    - [x] ~~Test `extra_place_info`~~ (should be merged with `contact_details`)