### PR TITLE
global: force_list -> force_force_list

### DIFF
--- a/inspirehep/dojson/common/base.py
+++ b/inspirehep/dojson/common/base.py
@@ -35,6 +35,7 @@ from ..jobs.model import jobs
 from ..journals.model import journals
 from ..utils import (
     classify_field,
+    force_force_list,
     get_recid_from_ref,
     get_record_ref,
 )
@@ -171,7 +172,7 @@ def creation_modification_date2marc(self, key, value):
 @utils.ignore_value
 def spires_sysnos(self, key, value):
     """Old SPIRES number and new_recid from 970."""
-    value = utils.force_list(value)
+    value = force_force_list(value)
     sysnos = []
     new_recid = None
     for val in value:
@@ -191,7 +192,7 @@ def spires_sysnos(self, key, value):
 @hepnames2marc.over('970', '(spires_sysnos|new_record)')
 def spires_sysnos2marc(self, key, value):
     """970 SPIRES number and new recid."""
-    value = utils.force_list(value)
+    value = force_force_list(value)
     existing_values = self.get('970', [])
 
     if key == 'spires_sysnos':
@@ -215,7 +216,7 @@ def spires_sysnos2marc(self, key, value):
 @jobs.over('collections', '^980..')
 def collections(self, key, value):
     """Collection this record belongs to."""
-    value = utils.force_list(value)
+    value = force_force_list(value)
 
     def get_value(value):
         primary = ''
@@ -324,7 +325,7 @@ def field_categories(self, key, value):
     """Field categories."""
     self.setdefault('field_categories', [])
 
-    _terms = utils.force_list(value.get('a'))
+    _terms = force_force_list(value.get('a'))
 
     if _terms:
         for _term in _terms:
@@ -366,7 +367,7 @@ def urls(self, key, value):
     if isinstance(description, (list, tuple)):
         description = description[0]
 
-    _urls = utils.force_list(value.get('u'))
+    _urls = force_force_list(value.get('u'))
 
     if _urls:
         for _url in _urls:

--- a/inspirehep/dojson/conferences/fields/bd1xx.py
+++ b/inspirehep/dojson/conferences/fields/bd1xx.py
@@ -29,6 +29,7 @@ import six
 from dojson import utils
 
 from ..model import conferences
+from ...utils import force_force_list
 from ...utils.geo import parse_conference_address
 
 
@@ -44,7 +45,7 @@ def acronym(self, key, value):
 
     if value.get('a'):
         self.setdefault('titles', [])
-        raw_titles = utils.force_list(value.get('a'))
+        raw_titles = force_force_list(value.get('a'))
         for raw_title in raw_titles:
             title = {
                 'title': raw_title,
@@ -55,7 +56,7 @@ def acronym(self, key, value):
 
     if value.get('c'):
         self.setdefault('address', [])
-        raw_addresses = utils.force_list(value.get('c'))
+        raw_addresses = force_force_list(value.get('c'))
         for raw_address in raw_addresses:
             address = parse_conference_address(raw_address)
             self['address'].append(address)
@@ -97,7 +98,7 @@ def keywords(self, key, value):
             'value': value.get('a'),
             'source': value.get('9')
         }
-    value = utils.force_list(value)
+    value = force_force_list(value)
     keywords = self.get('keywords', [])
     for val in value:
         keywords.append(get_value(val))

--- a/inspirehep/dojson/experiments/fields/bd1xx.py
+++ b/inspirehep/dojson/experiments/fields/bd1xx.py
@@ -29,7 +29,7 @@ import six
 from dojson import utils
 
 from ..model import experiments
-from ...utils import get_record_ref
+from ...utils import force_force_list, get_record_ref
 
 
 @experiments.over('experiment_names', '^119..')
@@ -38,7 +38,7 @@ def experiment_names(self, key, value):
     """Experiment names."""
     if value.get('u'):
         self.setdefault('affiliation', [])
-        raw_affiliations = utils.force_list(value.get('u'))
+        raw_affiliations = force_force_list(value.get('u'))
         for raw_affiliation in raw_affiliations:
             self['affiliation'].append(raw_affiliation)
 
@@ -104,7 +104,7 @@ def spokesperson(self, key, value):
 @experiments.over('collaboration', '^710..')
 def collaboration(self, key, value):
     """Collaboration of experiment."""
-    value = utils.force_list(value)
+    value = force_force_list(value)
     collaborations = sorted((elem["g"] for elem in value if 'g' in elem), key=lambda x: len(x))
     if len(collaborations) > 1:
         self['collaboration_alternative_names'] = collaborations[1:]
@@ -129,7 +129,7 @@ def related_experiments(self, key, value):
 @experiments.over('date_started', '^046..')
 def date_started(self, key, value):
     """Date started and completed."""
-    value = utils.force_list(value)
+    value = force_force_list(value)
     date_started = None
     for val in value:
         if val.get('t'):

--- a/inspirehep/dojson/hep/fields/bd01x09x.py
+++ b/inspirehep/dojson/hep/fields/bd01x09x.py
@@ -30,6 +30,7 @@ from dojson import utils
 from idutils import normalize_isbn
 
 from ..model import hep, hep2marc
+from ...utils import force_force_list
 
 
 @hep.over('isbns', '^020..')
@@ -83,13 +84,13 @@ def isbns2marc(self, key, value):
 @hep.over('persistent_identifiers', '^024..')
 def persistent_identifiers(self, key, value):
     """Persistent Standard Identifiers."""
-    value = utils.force_list(value)
+    value = force_force_list(value)
 
     dois = self.get('dois', [])
     persistent_identifiers = self.get('persistent_identifiers', [])
     for val in value:
         if val:
-            items = utils.force_list(val.get('a'))
+            items = force_force_list(val.get('a'))
             if val.get("2") and val.get("2", '').lower() == "doi":
                 for v in items:
                     dois.append({
@@ -110,7 +111,7 @@ def persistent_identifiers(self, key, value):
 @hep2marc.over('024', '^(dois|persistent_identifiers)$')
 def dois2marc(self, key, value):
     """Other Standard Identifier."""
-    value = utils.force_list(value)
+    value = force_force_list(value)
 
     def get_value(val):
         return {
@@ -128,7 +129,7 @@ def dois2marc(self, key, value):
 @hep.over('external_system_numbers', '^035..')
 def external_system_numbers(self, key, value):
     """System Control Number."""
-    value = utils.force_list(value)
+    value = force_force_list(value)
 
     def get_value(value):
         return {
@@ -168,13 +169,13 @@ def report_numbers(self, key, value):
     def get_value_arxiv(value):
         return {
             'value': value.get('a'),
-            'categories': utils.force_list(value.get('c')),
+            'categories': force_force_list(value.get('c')),
         }
 
     report_number = self.get('report_numbers', [])
     arxiv_eprints = self.get('arxiv_eprints', [])
 
-    value = utils.force_list(value)
+    value = force_force_list(value)
     for element in value:
         if element.get('9') and element.get('9') == 'arXiv' and 'c' in element:
             arxiv_eprints.append(get_value_arxiv(element))
@@ -188,7 +189,7 @@ def report_numbers(self, key, value):
 @hep2marc.over('037', '(arxiv_eprints|report_numbers)')
 def report_numbers2marc(self, key, value):
     """Source of Acquisition."""
-    value = utils.force_list(value)
+    value = force_force_list(value)
 
     def get_value(value):
         if key == "report_numbers":
@@ -212,7 +213,7 @@ def report_numbers2marc(self, key, value):
 @hep.over('languages', '^041[10_].')
 def languages(self, key, value):
     """Language Code."""
-    values = utils.force_list(value)
+    values = force_force_list(value)
     languages = self.get('languages', [])
     for value in values:
         if value.get('a'):

--- a/inspirehep/dojson/hep/fields/bd1xx.py
+++ b/inspirehep/dojson/hep/fields/bd1xx.py
@@ -27,13 +27,18 @@ from __future__ import absolute_import, division, print_function
 from dojson import utils
 
 from ..model import hep, hep2marc
-from ...utils import create_profile_url, get_recid_from_ref, get_record_ref
+from ...utils import (
+    create_profile_url,
+    force_force_list,
+    get_recid_from_ref,
+    get_record_ref,
+)
 
 
 @hep.over('authors', '^[17]00[103_].')
 def authors(self, key, value):
     """Main Entry-Personal Name."""
-    value = utils.force_list(value)
+    value = force_force_list(value)
 
     def get_value(value):
         affiliations = []
@@ -43,7 +48,7 @@ def authors(self, key, value):
                 recid = int(value.get('z'))
             except:
                 pass
-            affiliations = utils.force_list(value.get('u'))
+            affiliations = force_force_list(value.get('u'))
             record = get_record_ref(recid, 'institutions')
             affiliations = [{'value': aff, 'record': record} for
                             aff in affiliations]
@@ -55,7 +60,7 @@ def authors(self, key, value):
                 pass
         inspire_id = ''
         if value.get('i'):
-            inspire_id = utils.force_list(value.get('i'))[0]
+            inspire_id = force_force_list(value.get('i'))[0]
         person_record = get_record_ref(person_recid, 'authors')
         ret = {
             'full_name': value.get('a'),
@@ -94,7 +99,7 @@ def authors(self, key, value):
 @hep2marc.over('100', '^authors$')
 def authors2marc(self, key, value):
     """Main Entry-Personal Name."""
-    value = utils.force_list(value)
+    value = force_force_list(value)
 
     def get_value(value):
         affiliations = [

--- a/inspirehep/dojson/hep/fields/bd20x24x.py
+++ b/inspirehep/dojson/hep/fields/bd20x24x.py
@@ -27,6 +27,7 @@ from __future__ import absolute_import, division, print_function
 from dojson import utils
 
 from ..model import hep, hep2marc
+from ...utils import force_force_list
 
 
 @hep.over('title_translations', '^242[10_][0_]')
@@ -114,7 +115,7 @@ def titles2marc(self, key, value):
     arxiv_246_title = None
     titles = []
 
-    for title in utils.force_list(value):
+    for title in force_force_list(value):
         transformed_title = {
             'a': title.get('title'),
             'b': title.get('subtitle'),

--- a/inspirehep/dojson/hep/fields/bd5xx.py
+++ b/inspirehep/dojson/hep/fields/bd5xx.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import, division, print_function
 from dojson import utils
 
 from ..model import hep, hep2marc
-from ...utils import get_record_ref
+from ...utils import force_force_list, get_record_ref
 
 
 @hep.over('public_notes', '^500..')
@@ -65,7 +65,7 @@ def hidden_notes(self, key, value):
             }
 
         if value.get('a'):
-            return [_hidden_note(value, a) for a in utils.force_list(value['a'])]
+            return [_hidden_note(value, a) for a in force_force_list(value['a'])]
         else:
             return [_hidden_note(value)]
 
@@ -98,8 +98,8 @@ def thesis(self, key, value):
         'date': value.get('d'),
     }
 
-    inst_names = utils.force_list(value.get('c', []))
-    inst_recids = utils.force_list(value.get('z', []))
+    inst_names = force_force_list(value.get('c', []))
+    inst_recids = force_force_list(value.get('z', []))
     if len(inst_names) != len(inst_recids):
         institutions = [{'name': name} for name in inst_names]
     else:

--- a/inspirehep/dojson/hep/fields/bd6xx.py
+++ b/inspirehep/dojson/hep/fields/bd6xx.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import, division, print_function
 from dojson import utils
 
 from ..model import hep, hep2marc
-from ...utils import get_record_ref
+from ...utils import force_force_list, get_record_ref
 
 
 @hep2marc.over('65017', 'field_categories')
@@ -45,7 +45,7 @@ def field_categories2marc(self, key, value):
 @hep.over('free_keywords', '^653[10_2][_1032546]')
 def free_keywords(self, key, value):
     """Free keywords."""
-    value = utils.force_list(value)
+    value = force_force_list(value)
 
     def get_value(value):
         return {
@@ -107,7 +107,7 @@ def accelerator_experiments2marc(self, key, value):
 @hep.over('thesaurus_terms', '^695..')
 def thesaurus_terms(self, key, value):
     """Controlled keywords."""
-    value = utils.force_list(value)
+    value = force_force_list(value)
 
     def get_value(value):
         try:

--- a/inspirehep/dojson/hep/fields/bd70x75x.py
+++ b/inspirehep/dojson/hep/fields/bd70x75x.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import, division, print_function
 from dojson import utils
 
 from ..model import hep, hep2marc
-from ...utils import get_record_ref
+from ...utils import force_force_list, get_record_ref
 
 
 @hep.over('thesis_supervisor', '^701..')
@@ -59,7 +59,7 @@ def thesis_supervisor2marc(self, key, value):
 @hep.over('collaboration', '^710[10_2][_2]')
 def collaboration(self, key, value):
     """Added Entry-Corporate Name."""
-    value = utils.force_list(value)
+    value = force_force_list(value)
 
     def get_value(value):
         recid = None

--- a/inspirehep/dojson/hep/fields/bd76x78x.py
+++ b/inspirehep/dojson/hep/fields/bd76x78x.py
@@ -27,7 +27,12 @@ from __future__ import absolute_import, division, print_function
 from dojson import utils
 
 from ..model import hep, hep2marc
-from ...utils import get_recid_from_ref, get_record_ref, split_page_artid
+from ...utils import (
+    force_force_list,
+    get_recid_from_ref,
+    get_record_ref,
+    split_page_artid,
+)
 
 
 @hep.over('publication_info', '^773..')
@@ -37,7 +42,7 @@ def publication_info(self, key, value):
     """Publication info about record."""
     def get_int_value(val):
         if val:
-            out = utils.force_list(val)[0]
+            out = force_force_list(val)[0]
             if out.isdigit():
                 out = int(out)
                 return out
@@ -66,7 +71,7 @@ def publication_info(self, key, value):
         'reportnumber': value.get('r'),
         'confpaper_info': value.get('t'),
         'journal_volume': value.get('v'),
-        'cnum': utils.force_list(value.get('w')),
+        'cnum': force_force_list(value.get('w')),
         'pubinfo_freetext': value.get('x'),
         'year': year,
         'isbn': value.get('z'),

--- a/inspirehep/dojson/hep/fields/bd90x99x.py
+++ b/inspirehep/dojson/hep/fields/bd90x99x.py
@@ -32,7 +32,12 @@ from dojson import utils
 from idutils import normalize_isbn
 
 from ..model import hep, hep2marc
-from ...utils import get_recid_from_ref, get_record_ref, strip_empty_values
+from ...utils import (
+    force_force_list,
+    get_recid_from_ref,
+    get_record_ref,
+    strip_empty_values,
+)
 
 
 RE_VALID_PUBNOTE = re.compile(".*,.*,.*(,.*)?")
@@ -41,7 +46,7 @@ RE_VALID_PUBNOTE = re.compile(".*,.*,.*(,.*)?")
 @hep.over('references', '^999C5')
 def references(self, key, value):
     """Produce list of references."""
-    value = utils.force_list(value)
+    value = force_force_list(value)
 
     def get_valid_pubnotes(pubnotes):
         valid_pubnotes = []
@@ -79,26 +84,26 @@ def references(self, key, value):
         except (KeyError, ISBNError):
             isbn = ''
 
-        valid_pubnotes, raw_references = get_valid_pubnotes(utils.force_list(value.get('s')))
+        valid_pubnotes, raw_references = get_valid_pubnotes(force_force_list(value.get('s')))
 
         if value.get('x'):
-            raw_references += list(utils.force_list(value.get('x')))
+            raw_references += list(force_force_list(value.get('x')))
 
         return {
             'record': get_record_ref(recid, 'literature'),
             'texkey': value.get('1'),
             'doi': value.get('a'),
-            'collaboration': utils.force_list(value.get('c')),
+            'collaboration': force_force_list(value.get('c')),
             'editors': value.get('e'),
-            'authors': utils.force_list(value.get('h')),
-            'misc': utils.force_list(value.get('m')),
+            'authors': force_force_list(value.get('h')),
+            'misc': force_force_list(value.get('m')),
             'number': number,
             'isbn': isbn,
-            'publisher': utils.force_list(value.get('p')),
+            'publisher': force_force_list(value.get('p')),
             'maintitle': value.get('q'),
-            'report_number': utils.force_list(value.get('r')),
-            'title': utils.force_list(value.get('t')),
-            'urls': utils.force_list(value.get('u')),
+            'report_number': force_force_list(value.get('r')),
+            'title': force_force_list(value.get('t')),
+            'urls': force_force_list(value.get('u')),
             'journal_pubnote': valid_pubnotes,
             'raw_reference': raw_references,
             'year': year,

--- a/inspirehep/dojson/hep/model.py
+++ b/inspirehep/dojson/hep/model.py
@@ -25,10 +25,9 @@
 from __future__ import absolute_import, division, print_function
 
 from dojson import Overdo
-from dojson.utils import force_list
 
 from ..schema import SchemaOverdo
-from ..utils import get_record_ref
+from ..utils import force_force_list, get_record_ref
 
 
 def add_book_info(record, blob):
@@ -39,12 +38,12 @@ def add_book_info(record, blob):
             if c.get('primary', ''):
                 collections.append(c.get('primary').lower())
         if 'bookchapter' in collections:
-            pubinfos = force_list(blob.get("773__", []))
+            pubinfos = force_force_list(blob.get("773__", []))
             for pubinfo in pubinfos:
                 if pubinfo.get('0'):
                     record['book'] = {
                         'record': get_record_ref(
-                            int(force_list(pubinfo.get('0'))[0]), 'literature')
+                            int(force_force_list(pubinfo.get('0'))[0]), 'literature')
                     }
 
 

--- a/inspirehep/dojson/hepnames/fields/bd1xx.py
+++ b/inspirehep/dojson/hepnames/fields/bd1xx.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import, division, print_function
 from dojson import utils
 
 from ..model import hepnames, hepnames2marc
-from ...utils import classify_rank, get_record_ref
+from ...utils import classify_rank, force_force_list, get_record_ref
 
 
 @hepnames.over('acquisition_source', '^541[10_].')
@@ -77,7 +77,7 @@ def name(self, key, value):
     + Sr.
     + roman numbers (like VII)
     """
-    value = utils.force_list(value)
+    value = force_force_list(value)
     self.setdefault('breadcrumb_title', value[0].get('a'))
     self.setdefault('dates', value[0].get('d'))
     return {
@@ -219,17 +219,16 @@ def positions(self, key, value):
     curated_relation = False
     recid = None
     status = ''
-    recid_status = utils.force_list(value.get('z'))
-    if recid_status:
-        for val in recid_status:
-            if val.lower() == 'current':
-                status = val
-            else:
-                try:
-                    recid = int(val)
-                    curated_relation = True
-                except ValueError:
-                    pass
+    recid_status = force_force_list(value.get('z'))
+    for val in recid_status:
+        if val.lower() == 'current':
+            status = val
+        else:
+            try:
+                recid = int(val)
+                curated_relation = True
+            except ValueError:
+                pass
 
     inst = {
         'name': value.get('a'),
@@ -290,7 +289,7 @@ def source(self, key, value):
         }
     source = self.get('source', [])
 
-    value = utils.force_list(value)
+    value = force_force_list(value)
 
     for val in value:
         source.append(get_value(val))
@@ -407,7 +406,7 @@ def phd_advisors(self, key, value):
     }
     degree_type = None
     if value.get("g"):
-        degree_type_raw = utils.force_list(value.get('g'))[0]
+        degree_type_raw = force_force_list(value.get('g'))[0]
         degree_type = degree_type_map.get(
             degree_type_raw.lower(),
             degree_type_raw

--- a/inspirehep/dojson/institutions/fields/bd1xx.py
+++ b/inspirehep/dojson/institutions/fields/bd1xx.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import, division, print_function
 from dojson import utils
 
 from ..model import institutions
-from ...utils import get_record_ref
+from ...utils import force_force_list, get_record_ref
 from ...utils.geo import parse_institution_address
 
 
@@ -59,7 +59,7 @@ def timezone(self, key, value):
 def name(self, key, value):
     """List of names."""
     def set_value(key, val):
-        val = utils.force_list(val) or []
+        val = force_force_list(val)
         if val:
             self.setdefault(key, [])
             self[key].extend(val)
@@ -73,9 +73,9 @@ def name(self, key, value):
     set_value('obsolete_ICN', value.get('x'))
     set_value('new_ICN', value.get('t'))
 
-    names = list(utils.force_list(value.get('a')) or [])
-    names.extend(utils.force_list(value.get('u')) or [])
-    names.extend(utils.force_list(value.get('t')) or [])
+    names = force_force_list(value.get('a'))
+    names.extend(force_force_list(value.get('u')))
+    names.extend(force_force_list(value.get('t')))
     return names
 
 
@@ -90,7 +90,7 @@ def address(self, key, value):
         value.get('c'),
         value.get('d'),
         value.get('e'),
-        utils.force_list(value.get('g')),
+        force_force_list(value.get('g')),
     )
 
 
@@ -106,12 +106,12 @@ def name_variants(self, key, value):
     """Variants of the name."""
     if value.get('g'):
         self.setdefault('extra_words', [])
-        self['extra_words'].extend(utils.force_list(value.get('g')))
+        self['extra_words'].extend(force_force_list(value.get('g')))
 
     values = self.get('name_variants', [])
     values.append({
         'source': value.get('9'),
-        'value': utils.force_list(value.get('a', [])),
+        'value': force_force_list(value.get('a', [])),
     })
 
     return values
@@ -134,7 +134,7 @@ def non_public_notes(self, key, value):
 def hidden_notes(self, key, value):
     """Hidden note."""
     values = self.get('hidden_notes', [])
-    values.extend(el for el in utils.force_list(value.get('a')))
+    values.extend(el for el in force_force_list(value.get('a')))
 
     return values
 

--- a/inspirehep/dojson/jobs/fields/bd1xx.py
+++ b/inspirehep/dojson/jobs/fields/bd1xx.py
@@ -29,7 +29,12 @@ import six
 from dojson import utils
 
 from ..model import jobs
-from ...utils import classify_rank, force_single_element, get_record_ref
+from ...utils import (
+    classify_rank,
+    force_force_list,
+    force_single_element,
+    get_record_ref,
+)
 
 
 @jobs.over('date_closed', '^046..')
@@ -128,9 +133,9 @@ def ranks(self, key, value):
     self.setdefault('_ranks', [])
     self.setdefault('ranks', [])
 
-    values = utils.force_list(value)
+    values = force_force_list(value)
     for el in values:
-        _ranks = utils.force_list(el.get('a'))
+        _ranks = force_force_list(el.get('a'))
         for _rank in _ranks:
             self['_ranks'].append(_rank)
             self['ranks'].append(classify_rank(_rank))

--- a/inspirehep/dojson/processors.py
+++ b/inspirehep/dojson/processors.py
@@ -24,8 +24,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-from dojson.utils import force_list
-
 from inspirehep.dojson.conferences import conferences
 from inspirehep.dojson.experiments import experiments
 from inspirehep.dojson.hep import hep
@@ -33,7 +31,7 @@ from inspirehep.dojson.hepnames import hepnames
 from inspirehep.dojson.institutions import institutions
 from inspirehep.dojson.jobs import jobs
 from inspirehep.dojson.journals import journals
-from inspirehep.dojson.utils import clean_record
+from inspirehep.dojson.utils import clean_record, force_force_list
 
 
 def overdo_marc_dict(record):
@@ -57,9 +55,9 @@ def overdo_marc_dict(record):
 
 def _collection_in_record(record, collection):
     """Returns True if record is in collection"""
-    colls = force_list(record.get("980__", []))
+    colls = force_force_list(record.get("980__", []))
     for coll in colls:
-        coll = force_list(coll.get('a', []))
+        coll = force_force_list(coll.get('a', []))
         if collection in [c.lower() for c in coll]:
             return True
     return False

--- a/inspirehep/dojson/utils/__init__.py
+++ b/inspirehep/dojson/utils/__init__.py
@@ -96,6 +96,21 @@ def create_profile_url(profile_id):
         return ''
 
 
+def force_force_list(data):
+    """Wrap data in list.
+
+    We need to define this awkardly named method because DoJSON's method
+    force_list returns tuples or None instead of lists.
+    """
+    if data is None:
+        return []
+    elif not isinstance(data, (list, tuple, set)):
+        return [data]
+    elif isinstance(data, (tuple, set)):
+        return list(data)
+    return data
+
+
 def force_single_element(obj):
     """Force an object to a list and return the first element."""
     lst = force_list(obj)

--- a/inspirehep/dojson/utils/__init__.py
+++ b/inspirehep/dojson/utils/__init__.py
@@ -32,8 +32,6 @@ try:
 except ImportError:  # pragma: no cover
     current_app = None
 
-from dojson.utils import force_list
-
 from inspirehep.config import (
     ARXIV_TO_INSPIRE_CATEGORY_MAPPING,
     INSPIRE_RANK_TYPES,
@@ -113,7 +111,7 @@ def force_force_list(data):
 
 def force_single_element(obj):
     """Force an object to a list and return the first element."""
-    lst = force_list(obj)
+    lst = force_force_list(obj)
     if lst:
         return lst[0]
     return None
@@ -271,7 +269,7 @@ def split_page_artid(page_artid):
     page_end = None
     artid = None
 
-    for page_artid in force_list(page_artid) or []:
+    for page_artid in force_force_list(page_artid):
         if page_artid:
             if '-' in page_artid:
                 # if it has a dash it's a page range

--- a/inspirehep/dojson/utils/geo.py
+++ b/inspirehep/dojson/utils/geo.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import, division, print_function
 
 import six
 
-from dojson.utils import force_list
+from . import force_force_list
 
 
 country_to_iso_code = {
@@ -544,11 +544,11 @@ def parse_conference_address(address_string):
 def parse_institution_address(address, city, state_province,
                               country, postal_code, country_code):
     """Parse an institution address."""
-    address_string = force_list(address)
+    address_string = force_force_list(address)
     state_province = match_us_state(state_province) or state_province
 
-    postal_code = force_list(postal_code)
-    country = force_list(country)
+    postal_code = force_force_list(postal_code)
+    country = force_force_list(country)
     country_code = match_country_code(country_code)
 
     if isinstance(postal_code, (tuple, list)):
@@ -567,7 +567,7 @@ def parse_institution_address(address, city, state_province,
         country_code = 'US'
 
     return {
-        'original_address': force_list(address),
+        'original_address': force_force_list(address),
         'city': city,
         'state': state_province,
         'country': country,

--- a/inspirehep/modules/orcid/schema.py
+++ b/inspirehep/modules/orcid/schema.py
@@ -24,8 +24,7 @@ from HTMLParser import HTMLParser
 
 import dojson
 
-from dojson import utils
-
+from inspirehep.dojson.utils import force_force_list
 from inspirehep.utils.record import get_abstract, get_subtitle, get_title
 
 from .config import ORCID_WORK_TYPES
@@ -117,7 +116,7 @@ def external_id_rule(self, key, value):
 
 @orcid_overdo.over('contributors', 'authors')
 def authors_rule(self, key, value):
-    value = utils.force_list(value)
+    value = force_force_list(value)
     orcid_authors = []
     for index, author in enumerate(value):
         orcid_authors.append({

--- a/inspirehep/utils/bibtex.py
+++ b/inspirehep/utils/bibtex.py
@@ -24,8 +24,7 @@ from __future__ import absolute_import, division, print_function
 
 import re
 
-from dojson.utils import force_list
-
+from inspirehep.dojson.utils import force_force_list
 from inspirehep.utils import bibtex_booktitle
 from inspirehep.utils.record_getter import get_es_record
 from inspirehep.utils.record import is_submitted_but_not_published
@@ -300,7 +299,7 @@ class Bibtex(Export):
         """Return record titles"""
         record_title = ''
         if 'titles' in self.record:
-            titles = force_list(self.record['titles'])
+            titles = force_force_list(self.record['titles'])
             for title in titles:
                 if 'title' in title:
                     record_title = title['title']

--- a/tests/unit/dojson/test_dojson_institutions.py
+++ b/tests/unit/dojson/test_dojson_institutions.py
@@ -180,7 +180,9 @@ def test_address_from_marcxml_371__a_b_c_d_e_g():
             'country': 'Germany',
             'country_code': 'DE',
             'state': 'Baden-Wuerttemberg',
-            'original_address': ('Philosophenweg 16',),
+            'original_address': [
+                'Philosophenweg 16',
+            ],
             'postal_code': '69120',
         },
     ]
@@ -208,7 +210,10 @@ def test_address_from_marcxml_371__double_a_b_c_d_e_g():
             'country': 'Germany',
             'country_code': 'DE',
             'state': 'Baden-Wuerttemberg',
-            'original_address': ('Philosophenweg 16', 'Heidelberg'),
+            'original_address': [
+                'Philosophenweg 16',
+                'Heidelberg',
+            ],
             'postal_code': '69120',
         },
     ]
@@ -236,7 +241,9 @@ def test_address_from_marcxml_371__a_double_b_c_d_e_g():
             'country': 'Germany',
             'country_code': 'DE',
             'state': 'Baden-Wuerttemberg',
-            'original_address': ('Philosophenweg 16',),
+            'original_address': [
+                'Philosophenweg 16',
+            ],
             'postal_code': '69120',
         },
     ]
@@ -293,7 +300,9 @@ def test_address_from_marcxml_371__a_b_c_d_double_e_g():
             'country': 'Germany',
             'country_code': 'DE',
             'state': 'Baden-Wuerttemberg',
-            'original_address': ('Philosophenweg 16',),
+            'original_address': [
+                'Philosophenweg 16',
+            ],
             'postal_code': '69120, DE-119',
         }
     ]
@@ -321,7 +330,9 @@ def test_address_from_marcxml_371__a_b_c_d_e_double_g():
             "country": "Germany",
             "country_code": "DE",
             "state": "Baden-Wuerttemberg",
-            "original_address": ("Philosophenweg 16",),
+            "original_address": [
+                "Philosophenweg 16",
+            ],
             "postal_code": "69120",
         },
     ]
@@ -359,7 +370,9 @@ def test_address_from_multiple_marcxml_371__a_b_c_d_e_g():
             'country': 'Germany',
             'country_code': 'DE',
             'state': 'Baden-Wuerttemberg',
-            'original_address': ('Philosophenweg 16',),
+            'original_address': [
+                'Philosophenweg 16',
+            ],
             'postal_code': '69120'
         },
         {
@@ -367,10 +380,10 @@ def test_address_from_multiple_marcxml_371__a_b_c_d_e_g():
             'country': 'USA',
             'country_code': 'US',
             'state': 'US-NM',
-            'original_address': (
+            'original_address': [
                 'Physical Science Lab',
                 'Las Cruces, NM 88003',
-            ),
+            ],
             "postal_code": "88003"
         },
     ]
@@ -403,9 +416,9 @@ def test_name_variants_from_410__a_9():
     expected = [
         {
             'source': 'DESY',
-            'value': (
+            'value': [
                 'Aachen Tech. Hochsch.',
-            ),
+            ],
         },
     ]
     result = strip_empty_values(institutions.do(create_record(snippet)))
@@ -423,10 +436,10 @@ def test_name_variants_from_410__double_a():
 
     expected = [
         {
-            'value': (
+            'value': [
                 'Theoretische Teilchenphysik und Kosmologie',
                 'Elementarteilchenphysik',
-            ),
+            ],
         },
     ]
     result = strip_empty_values(institutions.do(create_record(snippet)))

--- a/tests/unit/dojson/test_dojson_utils.py
+++ b/tests/unit/dojson/test_dojson_utils.py
@@ -23,6 +23,7 @@
 import mock
 
 from inspirehep.dojson.utils import (
+    force_force_list,
     classify_field,
     classify_rank,
     create_profile_url,
@@ -33,6 +34,27 @@ from inspirehep.dojson.utils import (
     legacy_export_as_marc,
     dedupe_all_lists,
 )
+
+
+def test_force_force_list_returns_empty_list_on_none():
+    expected = []
+    result = force_force_list(None)
+
+    assert expected == result
+
+
+def test_force_force_list_wraps_strings_in_a_list():
+    expected = ['foo']
+    result = force_force_list('foo')
+
+    assert expected == result
+
+
+def test_force_force_list_converts_tuples_to_lists():
+    expected = ['foo', 'bar', 'baz']
+    result = force_force_list(('foo', 'bar', 'baz'))
+
+    assert expected == result
 
 
 def test_classify_field_returns_none_on_falsy_value():

--- a/tests/unit/dojson/test_dojson_utils_geo.py
+++ b/tests/unit/dojson/test_dojson_utils_geo.py
@@ -122,7 +122,7 @@ def test_parse_institution_address_adds_country_code():
         'city': 'Beijing',
         'country': 'China',
         'country_code': 'CN',
-        'original_address': None,
+        'original_address': [],
         'postal_code': '123-CFG',
         'state': None,
     }
@@ -136,16 +136,18 @@ def test_parse_institution_address_preserves_the_original_address():
         'address': 'Tuscaloosa, AL 35487-0324',
         'city': 'Tuscaloosa',
         'state_province': 'AL',
-        'country': None,
+        'country': '',
         'postal_code': 'PO Box 870324',
         'country_code': None,
     }
 
     expected = {
         'city': 'Tuscaloosa',
-        'country': None,
+        'country': '',
         'country_code': 'US',
-        'original_address': ('Tuscaloosa, AL 35487-0324',),
+        'original_address': [
+            'Tuscaloosa, AL 35487-0324',
+        ],
         'postal_code': 'PO Box 870324',
         'state': 'US-AL',
     }
@@ -166,9 +168,9 @@ def test_parse_institution_address_handles_state_province_none():
 
     expected = {
         'city': 'Beijing',
-        'country': None,
+        'country': '',
         'country_code': None,
-        'original_address': None,
+        'original_address': [],
         'postal_code': '123-CFG',
         'state': None,
     }


### PR DESCRIPTION
First commit adds a `force_force_list` util that **always** returns a `list`, unlike `force_list` from DoJSON that returns either a `tuple` or `None`. Second commit amends all uses of `force_list` to `force_force_list`.