### PR TITLE
dojson: remove OAI-PMH handling

### DIFF
--- a/inspirehep/dojson/common/base.py
+++ b/inspirehep/dojson/common/base.py
@@ -102,37 +102,6 @@ def date_and_time_of_latest_transaction2marc(self, key, value):
     return value
 
 
-@hep.over('oai_pmh', '^909CO')
-@conferences.over('oai_pmh', '^909CO')
-@institutions.over('oai_pmh', '^909CO')
-@experiments.over('oai_pmh', '^909CO')
-@journals.over('oai_pmh', '^909CO')
-@hepnames.over('oai_pmh', '^909CO')
-@jobs.over('oai_pmh', '^909CO')
-@utils.for_each_value
-@utils.filter_values
-def oai_pmh(self, key, value):
-    """Local OAI-PMH record information."""
-    return {
-        'id': value.get('o'),
-        'set': value.get('p'),
-        'previous_set': value.get('q'),
-    }
-
-
-@hep2marc.over('909CO', 'oai_pmh')
-@hepnames2marc.over('909CO', 'oai_pmh')
-@utils.for_each_value
-@utils.filter_values
-def oai_pmh2marc(self, key, value):
-    """Local OAI-PMH record information."""
-    return {
-        'o': value.get('id'),
-        'p': value.get('set'),
-        'q': value.get('previous_set')
-    }
-
-
 @hep.over('creation_modification_date', '^961..')
 @conferences.over('creation_modification_date', '^961..')
 @institutions.over('creation_modification_date', '^961..')

--- a/inspirehep/modules/records/jsonschemas/records/hep.json
+++ b/inspirehep/modules/records/jsonschemas/records/hep.json
@@ -518,7 +518,8 @@
                         },
                         "type": "array"
                     }
-                }
+                },
+                "type": "object"
             },
             "type": "array"
         },
@@ -557,21 +558,6 @@
                         "description": "Title of the book series"
                     }
                 }
-            },
-            "type": "array"
-        },
-        "oai_pmh": {
-            "items": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    },
-                    "previous_set": {
-                        "type": "string"
-                    }
-                },
-                "description": "Local OAI-PMH information"
             },
             "type": "array"
         },

--- a/tests/unit/dojson/test_dojson_hep.py
+++ b/tests/unit/dojson/test_dojson_hep.py
@@ -578,7 +578,7 @@ def test_succeeding_entry(marcxml_to_json, json_to_marc):
             ['relationship_code'] ==
             json_to_marc['785']['r'])
     assert (get_recid_from_ref(
-                marcxml_to_json['succeeding_entry']['record']) ==
+            marcxml_to_json['succeeding_entry']['record']) ==
             json_to_marc['785']['w'])
     assert (marcxml_to_json['succeeding_entry']['isbn'] ==
             json_to_marc['785']['z'])
@@ -590,14 +590,6 @@ def test_url(marcxml_to_json, json_to_marc):
             json_to_marc['8564'][0]['u'])
     assert (marcxml_to_json['urls'][0]['description'] ==
             json_to_marc['8564'][0]['y'])
-
-
-def test_oai_pmh(marcxml_to_json, json_to_marc):
-    """Test if oal_pmh is created correctly."""
-    assert (marcxml_to_json['oai_pmh'][0]['id'] ==
-            json_to_marc['909CO'][0]['o'])
-    assert (marcxml_to_json['oai_pmh'][0]['set'] ==
-            json_to_marc['909CO'][0]['p'])
 
 
 def test_collections(marcxml_to_json, json_to_marc):


### PR DESCRIPTION
* Removes OAI-PMH handling which should be better handled
  natively via invenio-oaiserver. (closes #1339)

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>