### PR TITLE
references: support for old refextract authors strings

### DIFF
--- a/inspirehep/dojson/hep/fields/bd90x99x.py
+++ b/inspirehep/dojson/hep/fields/bd90x99x.py
@@ -70,7 +70,7 @@ def references(self, key, value):
             ('c', rb.add_collaboration),
             ('q', rb.add_title),
             ('t', rb.add_title),
-            ('h', rb.add_author),
+            ('h', rb.add_refextract_authors_str),
             ('e', partial(rb.add_author, role='ed.'))
         ]
 

--- a/tests/unit/dojson/test_dojson_hep.py
+++ b/tests/unit/dojson/test_dojson_hep.py
@@ -633,12 +633,12 @@ def test_references(marcxml_to_json, json_to_marc, marcxml_record):
             assert _force_set(marc_val['e']) == _force_set(marc_init['e'])
         if 'h' in marc_init:
             assert 'authors' in json_val and 'h' in marc_val
-            initial_name_set = _force_set(marc_init['h'])
             json_names = _force_set([a['full_name']
                                      for a in json_val['authors']])
             roundtrip_names = _force_set(marc_val['h'])
-            assert initial_name_set == roundtrip_names
-            assert initial_name_set.issubset(json_names)
+            roundtrip_editors = _force_set(marc_val.get('e', []))
+            assert json_names and roundtrip_names
+            assert json_names.difference(roundtrip_editors) == roundtrip_names
         if 'm' in marc_init:
             assert 'misc' in json_val and 'm' in marc_val
             assert _force_set(json_val['misc']) == _force_set(marc_val['m'])

--- a/tests/unit/references/test_processors.py
+++ b/tests/unit/references/test_processors.py
@@ -20,7 +20,10 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-from inspirehep.modules.references.processors import ReferenceBuilder
+import six
+
+from inspirehep.modules.references.processors import (
+    _split_refextract_authors_str, ReferenceBuilder)
 
 def test_reference_builder_no_uids():
     rb = ReferenceBuilder()
@@ -120,3 +123,31 @@ def test_reference_builder_add_uid():
     }
 
     assert expected == rb.obj
+
+
+def test_refextract_authors():
+    author_strings = [
+        'Butler, D., Demarque, P., & Smith, H. A.',
+        'Cenko, S. B., Kasliwal, M. M., Perley, D. A., et al.',
+        'J. Kätlne et al.', # Also test some unicode cases.
+        u'J. Kätlne et al.',
+        'Hoaglin D. C., Mostellar F., Tukey J. W.',
+        'V.M. Zhuravlev, S.V. Chervon, and V.K. Shchigolev',
+        'Gómez R, Reilly P, Winicour J and Isaacson R'
+    ]
+
+    expected = [
+        ['Butler, D.', 'Demarque, P.', 'Smith, H. A.'],
+        ['Cenko, S. B.', 'Kasliwal, M. M.', 'Perley, D. A.'],
+        ['J. Kätlne'],
+        ['J. Kätlne'],
+        ['Hoaglin D. C.', 'Mostellar F.', 'Tukey J. W.'],
+        ['V.M. Zhuravlev', 'S.V. Chervon', 'V.K. Shchigolev'],
+        ['Gómez R', 'Reilly P', 'Winicour J', 'Isaacson R']
+    ]
+
+    for idx, authors_str in enumerate(author_strings):
+        # Expect that the function returns correct unicode representations.
+        expected_authors = [six.text_type(e.decode('utf8'))
+                            for e in expected[idx]]
+        assert _split_refextract_authors_str(authors_str) == expected_authors


### PR DESCRIPTION
* Adds method to parse out individual authors from legacy refextract
  author strings containing multiple authors.
* Uses added method in dojson.

Closes #1344 

Signed-off-by: Mihai Bivol <mihai.bivol@cern.ch>