### PR TITLE
dojson: hidden publication_info

### DIFF
--- a/inspirehep/dojson/hep/fields/bd76x78x.py
+++ b/inspirehep/dojson/hep/fields/bd76x78x.py
@@ -78,6 +78,7 @@ def publication_info(self, key, value):
         'year': year,
         'isbn': force_single_element(value.get('z')),
         'notes': dedupe_list(force_force_list(value.get('m'))),
+        'hidden': key[3:4] == '1' or None,  # ind1="1" means hidden
     }
 
     return res
@@ -94,9 +95,8 @@ def publication_info2marc(self, key, value):
         page_artid.append('{page_start}'.format(**value))
     if value.get('artid'):
         page_artid.append('{artid}'.format(**value))
-    return {
-        '0': get_recid_from_ref(
-            value.get('parent_record')),
+    ret = {
+        '0': get_recid_from_ref(value.get('parent_record')),
         'c': page_artid,
         'n': value.get('journal_issue'),
         'o': value.get('conf_acronym'),
@@ -110,6 +110,10 @@ def publication_info2marc(self, key, value):
         'z': value.get('isbn'),
         'm': value.get('notes')
     }
+    if value.get('hidden'):
+        self.setdefault('7731_', []).append(ret)
+        return {}
+    return ret
 
 
 @hep.over('succeeding_entry', '^785..')

--- a/inspirehep/modules/records/jsonschemas/records/hep.json
+++ b/inspirehep/modules/records/jsonschemas/records/hep.json
@@ -611,6 +611,11 @@
                     "curated_relation": {
                         "type": "boolean"
                     },
+                    "hidden": {
+                        "default": false,
+                        "description": "Whether these publication info are hidden because (e.g. because of legacy reasons)",
+                        "type": "boolean"
+                    },
                     "isbn": {
                         "type": "string"
                     },

--- a/inspirehep/modules/theme/jinja2filters.py
+++ b/inspirehep/modules/theme/jinja2filters.py
@@ -488,6 +488,8 @@ def publication_info(record):
     pub_infos = []
     if 'publication_info' in record:
         for pub_info in record.publication_information:
+            if pub_info.get('hidden'):
+                continue
             pub_info_html = render_macro_from_template(
                 name="pub_info",
                 template="inspirehep_theme/format/record/Publication_info.tpl",

--- a/tests/unit/dojson/fixtures/test_hep_record.xml
+++ b/tests/unit/dojson/fixtures/test_hep_record.xml
@@ -225,6 +225,21 @@
     <subfield code="o">ConfAcr</subfield>
     <subfield code="0">1</subfield>
   </datafield>
+  <datafield tag="773" ind1="1" ind2=" ">
+    <subfield code="c">R123</subfield>
+    <subfield code="n">2</subfield>
+    <subfield code="p">Phys.Rev.Lett.</subfield>
+    <subfield code="v">105</subfield>
+    <subfield code="y">2010</subfield>
+    <subfield code="m">note</subfield>
+    <subfield code="z">isbn</subfield>
+    <subfield code="x">pubinfo_freetext</subfield>
+    <subfield code="w">cnum</subfield>
+    <subfield code="t">confpaper_info</subfield>
+    <subfield code="r">reportNumber</subfield>
+    <subfield code="o">ConfAcr</subfield>
+    <subfield code="0">1</subfield>
+  </datafield>
   <datafield tag="785" ind1="0" ind2="2">
     <subfield code="r">CERN-PH-EP-2014-262</subfield>
     <subfield code="w">recid</subfield>

--- a/tests/unit/dojson/test_dojson_hep.py
+++ b/tests/unit/dojson/test_dojson_hep.py
@@ -1649,8 +1649,11 @@ def test_publication_info(marcxml_to_json, json_to_marc):
     assert marcxml_to_json['publication_info'][0]['artid'] == '026802'
     assert marcxml_to_json['publication_info'][0]['page_start'] == '123'
     assert marcxml_to_json['publication_info'][0]['page_end'] == '456'
+    assert marcxml_to_json['publication_info'][1]['artid'] == 'R123'
+    assert marcxml_to_json['publication_info'][1]['hidden']
     assert '026802' in json_to_marc['773'][0]['c']
     assert '123-456' in json_to_marc['773'][0]['c']
+    assert 'R123' in json_to_marc['7731_'][0]['c']
     assert (marcxml_to_json['publication_info'][0]['journal_issue'] ==
             json_to_marc['773'][0]['n'])
     assert (marcxml_to_json['publication_info'][0]['journal_title'] ==


### PR DESCRIPTION
- Introduces support for hidden publication_info, i.e. 7731_ in
  MARCXML.

Signed-off-by: Samuele Kaplun samuele.kaplun@cern.ch
