### PR TITLE
WIP global: fix treatment of dates

### DIFF
--- a/inspirehep/modules/records/receivers.py
+++ b/inspirehep/modules/records/receivers.py
@@ -3,40 +3,35 @@
 # This file is part of INSPIRE.
 # Copyright (C) 2014, 2015, 2016 CERN.
 #
-# INSPIRE is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License as
-# published by the Free Software Foundation; either version 2 of the
-# License, or (at your option) any later version.
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-# INSPIRE is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
 
 """Pre-record receivers."""
 
+from __future__ import absolute_import, division, print_function
+
+import six
 from flask import current_app
 
 from invenio_indexer.signals import before_record_index
-from invenio_records.signals import (
-    before_record_insert,
-    before_record_update,
-)
+from invenio_records.signals import before_record_insert, before_record_update
 
 from inspirehep.utils.date import create_valid_date
 from inspirehep.dojson.utils import get_recid_from_ref, classify_field
-
-from inspirehep.dojson.utils import get_recid_from_ref
-
-from inspirehep.utils.date import create_valid_date
-
-from invenio_indexer.signals import before_record_index
-
-import six
 
 from .signals import after_record_enhanced
 

--- a/tests/unit/dojson/test_dojson_hep_receivers.py
+++ b/tests/unit/dojson/test_dojson_hep_receivers.py
@@ -20,6 +20,8 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
+from __future__ import absolute_import, division, print_function
+
 from invenio_records.api import Record
 
 from inspirehep.dojson.hep.receivers import earliest_date

--- a/tests/unit/utils/test_utils_date.py
+++ b/tests/unit/utils/test_utils_date.py
@@ -3,29 +3,33 @@
 # This file is part of INSPIRE.
 # Copyright (C) 2016 CERN.
 #
-# INSPIRE is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License as
-# published by the Free Software Foundation; either version 2 of the
-# License, or (at your option) any later version.
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-# INSPIRE is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
 
-"""TODO."""
+from __future__ import absolute_import, division, print_function
 
-from inspirehep.utils.date import (create_valid_date,
-                                   create_earliest_date,
-                                   create_datestruct)
+from inspirehep.utils.date import (
+    create_datestruct,
+    create_earliest_date,
+    create_valid_date,
+)
 
 
 def test_create_valid_date():
-    """TODO."""
     assert create_valid_date(1877) == '1877'
     assert create_valid_date('1877') == '1877'
     assert create_valid_date('1877-02') == '1877-02'
@@ -38,13 +42,11 @@ def test_create_valid_date():
 
 
 def test_create_earliest_date():
-    """TODO."""
     assert create_earliest_date([1877, '2002-01-05']) == '1877'
     assert create_earliest_date(['1877-02-03', '1877']) == '1877-02-03'
 
 
 def test_create_datestruct():
-    """TODO."""
     assert create_datestruct('2002-01-05') == (2002, 1, 5)
     assert create_datestruct('1877-02') == (1877, 2)
     assert create_datestruct('1900') == (1900, )


### PR DESCRIPTION
As the work of @zifeo has shown, our treatment of dates is pretty broken ATM. In particular, `inspirehep/utils/date.py` has to be rewritten in terms of the standard library, and as many dates as possible have to be coerced to ISO 8601 as early as possible.

I'm still too deep in this to make a list of actionable tasks.

- [ ] Refactor `earliest_date`
- [ ] Get test data for `create_earliest_date`
- [ ] Fix bug in `create_earliest_date`
- [ ] Remove unused methods in `inspirehep/utils/date.py`
- [ ] Refactor remaining methods in `inspirehep/utils/date.py`
- [ ] Merge `inspirehep/utils/datefilter.py` in `inspirehep/utils/date.py`