### PR TITLE
dojson: almost remove strip_empty_values

### DIFF
--- a/inspirehep/dojson/journals/fields/bd1xx.py
+++ b/inspirehep/dojson/journals/fields/bd1xx.py
@@ -28,7 +28,6 @@ from dojson import utils
 from idutils import normalize_issn
 
 from ..model import journals
-from ...utils import strip_empty_values
 
 
 @journals.over('issn', '^022..')

--- a/tests/unit/dojson/test_dojson_dois.py
+++ b/tests/unit/dojson/test_dojson_dois.py
@@ -3,65 +3,104 @@
 # This file is part of INSPIRE.
 # Copyright (C) 2016 CERN.
 #
-# INSPIRE is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License as
-# published by the Free Software Foundation; either version 2 of the
-# License, or (at your option) any later version.
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-# INSPIRE is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
 
 from dojson.contrib.marc21.utils import create_record
+
 from inspirehep.dojson.hep import hep
-from inspirehep.dojson.utils import strip_empty_values
+from inspirehep.dojson.utils import clean_record
 
 
-def test_single_doi():
-    snippet_single_doi = ('<record><datafield tag="024" ind1="7" ind2=" ">'
-                               '<subfield code="2">DOI</subfield>'
-                               '<subfield code="a">10.1088/0264-9381/31/24/245004</subfield>'
-                               '</datafield></record>')
+def test_dois_from_0247_a_2():
+    snippet = (
+        '<record>'
+        '  <datafield tag="024" ind1="7" ind2=" ">'
+        '    <subfield code="2">DOI</subfield>'
+        '    <subfield code="a">10.1088/0264-9381/31/24/245004</subfield>'
+        '  </datafield>'
+        '</record>'
+    )
 
-    x = create_record(snippet_single_doi)
-    assert (strip_empty_values(hep.do(x))['dois'] ==
-            [{'value': '10.1088/0264-9381/31/24/245004'}])
+    expected = [
+        {
+            'value': '10.1088/0264-9381/31/24/245004',
+        },
+    ]
+    result = clean_record(hep.do(create_record(snippet)))
 
-
-def test_duplicate_doi():
-    snippet_duplicate_doi = ('<record><datafield tag="024" ind1="7" ind2=" ">'
-                             '<subfield code="2">DOI</subfield>'
-                             '<subfield code="9">bibmatch</subfield>'
-                             '<subfield code="a">10.1088/1475-7516/2015/03/044</subfield>'
-                             '</datafield>'
-                             '<datafield tag="024" ind1="7" ind2=" ">'
-                             '<subfield code="2">DOI</subfield>'
-                             '<subfield code="a">10.1088/1475-7516/2015/03/044</subfield>'
-                             '</datafield></record>')
-
-    x = create_record(snippet_duplicate_doi)
-    assert (strip_empty_values(hep.do(x))['dois'] ==
-            [{'source': 'bibmatch', 'value': '10.1088/1475-7516/2015/03/044'},
-             {'value': '10.1088/1475-7516/2015/03/044'}])
+    assert expected == result['dois']
 
 
-def test_multiple_dois():
-    snippet_multiple_dois = ('<record><datafield tag="024" ind1="7" ind2=" ">'
-                             '<subfield code="2">DOI</subfield>'
-                             '<subfield code="a">10.1103/PhysRevD.89.072002</subfield>'
-                             '</datafield>'
-                             '<datafield tag="024" ind1="7" ind2=" ">'
-                             '<subfield code="2">DOI</subfield>'
-                             '<subfield code="9">bibmatch</subfield>'
-                             '<subfield code="a">10.1103/PhysRevD.91.019903</subfield>'
-                             '</datafield></record>')
+def test_dois_from_0247_a_2_and_0247_a_2_9():
+    snippet = (
+        '<record>'
+        '  <datafield tag="024" ind1="7" ind2=" ">'
+        '    <subfield code="2">DOI</subfield>'
+        '    <subfield code="9">bibmatch</subfield>'
+        '    <subfield code="a">10.1088/1475-7516/2015/03/044</subfield>'
+        '  </datafield>'
+        '  <datafield tag="024" ind1="7" ind2=" ">'
+        '    <subfield code="2">DOI</subfield>'
+        '    <subfield code="a">10.1088/1475-7516/2015/03/044</subfield>'
+        '  </datafield>'
+        '</record>'
+    )
 
-    x = create_record(snippet_multiple_dois)
-    assert (strip_empty_values(hep.do(x))['dois'] ==
-            [{'value': '10.1103/PhysRevD.89.072002'},
-             {'source': 'bibmatch', 'value': '10.1103/PhysRevD.91.019903'}])
+    expected = [
+        {
+            'source': 'bibmatch',
+            'value': '10.1088/1475-7516/2015/03/044',
+        },
+        {
+            'value': '10.1088/1475-7516/2015/03/044',
+        },
+    ]
+    result = clean_record(hep.do(create_record(snippet)))
+
+    assert expected == result['dois']
+
+
+def test_dois_from_2472_a_2_and_247_a_2_9():
+    snippet = (
+        '<record>'
+        '  <datafield tag="024" ind1="7" ind2=" ">'
+        '    <subfield code="2">DOI</subfield>'
+        '    <subfield code="a">10.1103/PhysRevD.89.072002</subfield>'
+        '  </datafield>'
+        '  <datafield tag="024" ind1="7" ind2=" ">'
+        '    <subfield code="2">DOI</subfield>'
+        '    <subfield code="9">bibmatch</subfield>'
+        '    <subfield code="a">10.1103/PhysRevD.91.019903</subfield>'
+        '  </datafield>'
+        '</record>'
+    )
+
+    expected = [
+        {
+            'value': '10.1103/PhysRevD.89.072002',
+        },
+        {
+            'source': 'bibmatch',
+            'value': '10.1103/PhysRevD.91.019903',
+        },
+    ]
+    result = clean_record(hep.do(create_record(snippet)))
+
+    assert expected == result['dois']

--- a/tests/unit/dojson/test_dojson_hep.py
+++ b/tests/unit/dojson/test_dojson_hep.py
@@ -31,7 +31,7 @@ from dojson import utils
 from dojson.contrib.marc21.utils import create_record
 
 from inspirehep.dojson.hep import hep, hep2marc
-from inspirehep.dojson.utils import get_recid_from_ref, strip_empty_values
+from inspirehep.dojson.utils import clean_record, get_recid_from_ref
 
 
 @pytest.fixture
@@ -135,7 +135,7 @@ def test_external_system_numbers_from_035__a():
             'obsolete': False,
         },
     ]
-    result = strip_empty_values(hep.do(create_record(snippet)))
+    result = clean_record(hep.do(create_record(snippet)))
 
     assert expected == result['external_system_numbers']
 
@@ -155,7 +155,7 @@ def test_external_system_numbers_from_035__a_9():
             'obsolete': False,
         },
     ]
-    result = strip_empty_values(hep.do(create_record(snippet)))
+    result = clean_record(hep.do(create_record(snippet)))
 
     assert expected == result['external_system_numbers']
 
@@ -178,7 +178,7 @@ def test_external_system_numbers_from_035__a_d_h_m_9():
             'obsolete': False,
         }
     ]
-    result = strip_empty_values(hep.do(create_record(snippet)))
+    result = clean_record(hep.do(create_record(snippet)))
 
     assert expected == result['external_system_numbers']
 
@@ -348,7 +348,7 @@ def test_hidden_notes_from_595__a_9():
             'value': 'Title changed from ALLCAPS',
         },
     ]
-    result = strip_empty_values(hep.do(create_record(snippet)))
+    result = clean_record(hep.do(create_record(snippet)))
 
     assert expected == result['hidden_notes']
 
@@ -372,7 +372,7 @@ def test_hidden_notes_from_595__double_a_9():
             'value': 'no affiliation (not clear pn the fulltext)',
         },
     ]
-    result = strip_empty_values(hep.do(create_record(snippet)))
+    result = clean_record(hep.do(create_record(snippet)))
 
     assert expected == result['hidden_notes']
 
@@ -406,7 +406,7 @@ def test_hidden_notes_from_595__a_9_and_595__double_a_9():
             'value': 'no affiliation (not clear pn the fulltext)',
         },
     ]
-    result = strip_empty_values(hep.do(create_record(snippet)))
+    result = clean_record(hep.do(create_record(snippet)))
 
     assert expected == result['hidden_notes']
 
@@ -718,7 +718,7 @@ def test_acquisition_source_field():
         'date': "2015-12-10",
         'submission_number': "339830",
     }
-    result = strip_empty_values(hep.do(create_record(snippet)))
+    result = clean_record(hep.do(create_record(snippet)))
 
     assert expected == result['acquisition_source']
 

--- a/tests/unit/dojson/test_dojson_hepnames.py
+++ b/tests/unit/dojson/test_dojson_hepnames.py
@@ -24,14 +24,13 @@ from __future__ import absolute_import, division, print_function
 
 import os
 import pkg_resources
-import pytest
 
 import pytest
 
 from dojson.contrib.marc21.utils import create_record
 
 from inspirehep.dojson.hepnames import hepnames2marc, hepnames
-from inspirehep.dojson.utils import strip_empty_values
+from inspirehep.dojson.utils import clean_record
 
 
 @pytest.fixture
@@ -160,7 +159,7 @@ def test_positions_from_371__a():
             },
         },
     ]
-    result = strip_empty_values(hepnames.do(create_record(snippet)))
+    result = clean_record(hepnames.do(create_record(snippet)))
 
     assert expected == result['positions']
 
@@ -187,7 +186,7 @@ def test_positions_from_371__a_m_r_z():
             'status': 'Current',
         },
     ]
-    result = strip_empty_values(hepnames.do(create_record(snippet)))
+    result = clean_record(hepnames.do(create_record(snippet)))
 
     assert expected == result['positions']
 
@@ -253,7 +252,7 @@ def test_acquisition_source_field():
         'date': "2015-12-10",
         'submission_number': "339830",
     }
-    result = strip_empty_values(hepnames.do(create_record(snippet)))
+    result = clean_record(hepnames.do(create_record(snippet)))
 
     assert expected == result['acquisition_source']
 

--- a/tests/unit/dojson/test_dojson_institutions.py
+++ b/tests/unit/dojson/test_dojson_institutions.py
@@ -27,7 +27,7 @@ import pytest
 from dojson.contrib.marc21.utils import create_record
 
 from inspirehep.dojson.institutions import institutions
-from inspirehep.dojson.utils import strip_empty_values
+from inspirehep.dojson.utils import clean_record
 
 
 def test_location_from_034__d_f():
@@ -42,7 +42,7 @@ def test_location_from_034__d_f():
         'longitude': 6.07532,
         'latitude': 50.7736,
     }
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['location']
 
@@ -57,7 +57,7 @@ def test_location_from_034__d():
     expected = {
         'longitude': 6.07532,
     }
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['location']
 
@@ -72,7 +72,7 @@ def test_location_from_034__f():
     expected = {
         'latitude': 50.7736,
     }
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['location']
 
@@ -85,7 +85,7 @@ def test_no_location_from_invalid_034__d_f():
         '</datafield>'
     )  # synthetic data
 
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert 'location' not in result
 
@@ -98,7 +98,7 @@ def test_timezone_from_043__t():
     )  # record/902635
 
     expected = ['+05']
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['timezone']
 
@@ -111,7 +111,7 @@ def test_name_from_110__a():
     )  # record/1439728
 
     expected = [['Mid-America Christian U.']]
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['name']
 
@@ -126,7 +126,7 @@ def test_name_from_110__a_b_u():
     )  # record/902812
 
     expected = [['Fukushima University', 'Fukushima U.']]
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['name']
 
@@ -141,7 +141,7 @@ def test_name_from_110__b_t_u():
     )   # record/903416
 
     expected = [['Belgrade, Inst. Phys.', 'Inst. Phys., Belgrade']]
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['name']
 
@@ -157,7 +157,7 @@ def test_name_from_110__a_b_t_u():
     )  # record/902628
 
     expected = [['Adelphi University', 'Adelphi U.', 'Adelphi U., Dept. Phys.']]
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['name']
 
@@ -186,7 +186,7 @@ def test_address_from_marcxml_371__a_b_c_d_e_g():
             'postal_code': '69120',
         },
     ]
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['address']
 
@@ -217,7 +217,7 @@ def test_address_from_marcxml_371__double_a_b_c_d_e_g():
             'postal_code': '69120',
         },
     ]
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['address']
 
@@ -247,7 +247,7 @@ def test_address_from_marcxml_371__a_double_b_c_d_e_g():
             'postal_code': '69120',
         },
     ]
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['address']
 
@@ -276,7 +276,7 @@ def test_address_from_marcxml_371__a_b_c_double_d_e_g():
             'postal_code': '69120',
         },
     ]
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['address']
 
@@ -306,7 +306,7 @@ def test_address_from_marcxml_371__a_b_c_d_double_e_g():
             'postal_code': '69120, DE-119',
         }
     ]
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['address']
 
@@ -336,7 +336,7 @@ def test_address_from_marcxml_371__a_b_c_d_e_double_g():
             "postal_code": "69120",
         },
     ]
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['address']
 
@@ -387,7 +387,7 @@ def test_address_from_multiple_marcxml_371__a_b_c_d_e_g():
             "postal_code": "88003"
         },
     ]
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['address']
 
@@ -400,7 +400,7 @@ def test_field_activity_from_372__a():
     )
 
     expected = ['Research center']
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['field_activity']
 
@@ -421,7 +421,7 @@ def test_name_variants_from_410__a_9():
             ],
         },
     ]
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['name_variants']
 
@@ -442,7 +442,7 @@ def test_name_variants_from_410__double_a():
             ],
         },
     ]
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['name_variants']
 
@@ -475,7 +475,7 @@ def test_extra_words_from_410__decuple_g():
         'phys',
         'I. Physikalisches Institut',
     ]
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['extra_words']
 
@@ -487,7 +487,7 @@ def test_core_from_690c_a_core():
         '</datafield>'
     )  # record/902645
 
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert result['core']
 
@@ -499,7 +499,7 @@ def test_core_from_690c_a_noncore():
         '</datafield>'
     )  # record/916025
 
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert not result['core']
 
@@ -512,7 +512,7 @@ def test_non_public_notes_from_667__a():
     )  # record/902663
 
     expected = ['Former ICN = Negev U.']
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['non_public_notes']
 
@@ -525,7 +525,7 @@ def test_hidden_notes_from_595__a():
     )  # record/902879
 
     expected = [u'The Division is located inside the Department of Physics and Astronomy of the University of Catania Scientific Campus ("Città Universitaria" or "Cittadella"). Via Santa Sofia 64 95123 CATANIA']
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['hidden_notes']
 
@@ -546,7 +546,7 @@ def test_hidden_notes_from_double_595__a():
         u'The Roma II Structure was established in 1989 at the University of Rome “Tor Vergata” - cc',
         u'REDACTED thinks we don\'t have to write 110__t: "INFN, Rome 2" because Rome 2 is only in the url but not in the site. She\'ll ask to REDACTED (from INFN) to have her feedback.',
     ]
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['hidden_notes']
 
@@ -561,7 +561,7 @@ def test_public_notes_from_680__a():
     expected = [
         u'2nd address: Organisation Européenne pour la Recherche Nucléaire (CERN), F-01631 Prévessin Cedex, France'
     ]
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['public_notes']
 
@@ -576,7 +576,7 @@ def test_historical_data_from_6781_a():
     expected = [
         'Became IFH (Inst for Hochenergiephysik)in 1968. Since 1992 the official name of the Inst. is simply DESY Zeuthen. Changed 1/26/99 AMR'
     ]
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['historical_data']
 
@@ -597,7 +597,7 @@ def test_historical_data_from_6781_a():
         u'Sub title: Laboratoire européen pour la Physique des Particules (1984-now)',
         u'Sub title: European Laboratory for Particle Physics (1984-now)',
     ]
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['historical_data']
 
@@ -621,7 +621,7 @@ def test_related_institutes_from__510_a_w_0():
             },
         },
     ]
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['related_institutes']
 
@@ -660,7 +660,7 @@ def test_related_institutes_from__double_510_a_w_0():
             },
         },
     ]
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['related_institutes']
 
@@ -684,7 +684,7 @@ def test_related_institutes_from__510_a_w_0_other():
             },
         },
     ]
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['related_institutes']
 
@@ -723,7 +723,7 @@ def test_related_institutes_from__double_510_a_w_0_predecessor():
             },
         },
     ]
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['related_institutes']
 
@@ -747,7 +747,7 @@ def test_related_institutes_from__510_a_w_0_successor():
             },
         },
     ]
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['related_institutes']
 
@@ -764,6 +764,6 @@ def test_related_institutes_from__invalid_510__0():
             'curated_relation': False,
         },
     ]
-    result = strip_empty_values(institutions.do(create_record(snippet)))
+    result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['related_institutes']

--- a/tests/unit/dojson/test_dojson_journals.py
+++ b/tests/unit/dojson/test_dojson_journals.py
@@ -25,7 +25,7 @@ from __future__ import absolute_import, division, print_function
 from dojson.contrib.marc21.utils import create_record
 
 from inspirehep.dojson.journals import journals
-from inspirehep.dojson.utils import strip_empty_values
+from inspirehep.dojson.utils import clean_record
 
 
 def test_issn_from_marcxml_022_with_a():
@@ -43,7 +43,7 @@ def test_issn_from_marcxml_022_with_a():
             'value': '2213-1337',
         },
     ]
-    result = strip_empty_values(journals.do(create_record(snippet)))
+    result = clean_record(journals.do(create_record(snippet)))
 
     assert expected == result['issn']
 
@@ -65,7 +65,7 @@ def test_issn_from_marcxml_022_with_a_and_b():
             'value': '2213-1337',
         },
     ]
-    result = strip_empty_values(journals.do(create_record(snippet)))
+    result = clean_record(journals.do(create_record(snippet)))
 
     assert expected == result['issn']
 
@@ -91,7 +91,7 @@ def test_issn_from_marcxml_022_with_a_and_b_and_comment():
             'comment': 'ebook',
         },
     ]
-    result = strip_empty_values(journals.do(create_record(snippet)))
+    result = clean_record(journals.do(create_record(snippet)))
 
     assert expected == result['issn']
 
@@ -106,7 +106,7 @@ def test_issn_from_marcxml_022_with_b_no_a():
         '</record>'
     )
 
-    result = strip_empty_values(journals.do(create_record(snippet)))
+    result = clean_record(journals.do(create_record(snippet)))
 
     assert 'issn' not in result
 
@@ -136,7 +136,7 @@ def test_multiple_issn_from_marcxml_022():
             'value': '2349-6088',
         },
     ]
-    result = strip_empty_values(journals.do(create_record(snippet)))
+    result = clean_record(journals.do(create_record(snippet)))
 
     assert expected == result['issn']
 
@@ -156,7 +156,7 @@ def test_issn_from_022__a_b_electronic():
             'value': '2469-9888',
         },
     ]
-    result = strip_empty_values(journals.do(create_record(snippet)))
+    result = clean_record(journals.do(create_record(snippet)))
 
     assert expected == result['issn']
 
@@ -172,7 +172,7 @@ def test_coden_from_030__a_2():
     expected = [
         'HERAS',
     ]
-    result = strip_empty_values(journals.do(create_record(snippet)))
+    result = clean_record(journals.do(create_record(snippet)))
 
     assert expected == result['coden']
 
@@ -195,7 +195,7 @@ def test_coden_from_double_030__a_2():
         '00686',
         'VLUFB',
     ]
-    result = strip_empty_values(journals.do(create_record(snippet)))
+    result = clean_record(journals.do(create_record(snippet)))
 
     assert expected == result['coden']
 
@@ -210,7 +210,7 @@ def test_publisher_from_643__b():
     expected = [
         'ANITA PUBLICATIONS, INDIA',
     ]
-    result = strip_empty_values(journals.do(create_record(snippet)))
+    result = clean_record(journals.do(create_record(snippet)))
 
     assert expected == result['publisher']
 
@@ -231,7 +231,7 @@ def test_publisher_from_double_643__b():
         'Elsevier',
         'Science Press',
     ]
-    result = strip_empty_values(journals.do(create_record(snippet)))
+    result = clean_record(journals.do(create_record(snippet)))
 
     assert expected == result['publisher']
 
@@ -250,7 +250,7 @@ def test_titles_from_marcxml_130_with_single_a():
             'title': 'Physical Review Special Topics - Accelerators and Beams',
         },
     ]
-    result = strip_empty_values(journals.do(create_record(snippet)))
+    result = clean_record(journals.do(create_record(snippet)))
 
     assert expected == result['titles']
 
@@ -271,7 +271,7 @@ def test_titles_from_marcxml_130_with_a_and_b():
             'subtitle': 'Journal of Philosophical Studies',
         },
     ]
-    result = strip_empty_values(journals.do(create_record(snippet)))
+    result = clean_record(journals.do(create_record(snippet)))
 
     assert expected == result['titles']
 
@@ -290,7 +290,7 @@ def test_short_titles_from_marcxml_711():
             'title': 'Phys.Rev.ST Accel.Beams',
         },
     ]
-    result = strip_empty_values(journals.do(create_record(snippet)))
+    result = clean_record(journals.do(create_record(snippet)))
 
     assert expected == result['short_titles']
 
@@ -309,7 +309,7 @@ def test_title_variants_from_marcxml_730():
             'title': 'PHYSICAL REVIEW SPECIAL TOPICS ACCELERATORS AND BEAMS'
         },
     ]
-    result = strip_empty_values(journals.do(create_record(snippet)))
+    result = clean_record(journals.do(create_record(snippet)))
 
     assert expected == result['title_variants']
 
@@ -334,6 +334,6 @@ def test_multiple_title_variants_from_marcxml_730():
             'title': 'PHYSICS REVIEW ST ACCEL BEAMS',
         },
     ]
-    result = strip_empty_values(journals.do(create_record(snippet)))
+    result = clean_record(journals.do(create_record(snippet)))
 
     assert expected == result['title_variants']

--- a/tests/unit/dojson/test_dojson_utils.py
+++ b/tests/unit/dojson/test_dojson_utils.py
@@ -20,6 +20,8 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
+from __future__ import absolute_import, division, print_function
+
 import mock
 
 from inspirehep.dojson.utils import (
@@ -32,6 +34,7 @@ from inspirehep.dojson.utils import (
     get_record_ref,
     legacy_export_as_marc,
     dedupe_all_lists,
+    strip_empty_values,
 )
 
 
@@ -290,4 +293,31 @@ def test_dedupe_all_lists():
 # TODO: test legacy_export_as_marc
 
 
-# TODO: test strip_empty_values
+def test_strip_empty_values():
+    obj = {
+        '_foo': (),
+        'foo': (1, 2, 3),
+        '_bar': [],
+        'bar': [1, 2, 3],
+        '_baz': set(),
+        'baz': set([1, 2, 3]),
+        'qux': True,
+        'quux': False,
+        'plugh': 0,
+    }
+
+    expected = {
+        'foo': (1, 2, 3),
+        'bar': [1, 2, 3],
+        'baz': set([1, 2, 3]),
+        'qux': True,
+        'quux': False,
+        'plugh': 0,
+    }
+    result = strip_empty_values(obj)
+
+    assert expected == result
+
+
+def test_strip_empty_values_returns_none_on_none():
+    assert strip_empty_values(None) is None


### PR DESCRIPTION
We should be using `clean_record` instead of `strip_empty_values`, but the tests contain lots of examples of the latter. This PR removes most of these examples, except for a few legitimate uses.