### PR TITLE
dojson: fix field_activity in institutions

### DIFF
--- a/inspirehep/dojson/institutions/fields/bd1xx.py
+++ b/inspirehep/dojson/institutions/fields/bd1xx.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import, division, print_function
 from dojson import utils
 
 from ..model import institutions
-from ...utils import get_record_ref
+from ...utils import force_single_element, get_record_ref
 from ...utils.geo import parse_institution_address
 
 from inspirehep.utils.helpers import force_force_list
@@ -97,7 +97,21 @@ def address(self, key, value):
 @utils.for_each_value
 def field_activity(self, key, value):
     """Field of activity."""
-    return value.get('a')
+    FIELD_ACTIVITIES_MAP = {
+        'Company': 'Company',
+        'Research center': 'Research Center',
+        'Research Center': 'Research Center',
+        'Research center/': 'Research Center',
+        'Research Center-microelectronics': 'Research Center',
+        'university': 'University',
+        'Univesity': 'University',
+        'University': 'University',
+    }
+
+    _field_activity = force_single_element(value.get('a'))
+    field_activity = FIELD_ACTIVITIES_MAP.get(_field_activity, 'Other')
+
+    return field_activity
 
 
 @institutions.over('name_variants', '^410..')

--- a/inspirehep/modules/records/jsonschemas/records/institutions.json
+++ b/inspirehep/modules/records/jsonschemas/records/institutions.json
@@ -37,8 +37,9 @@
             "items": {
                 "enum": [
                     "University",
-                    "Research center",
-                    "Company"
+                    "Research Center",
+                    "Company",
+                    "Other"
                 ],
                 "type": "string"
             },

--- a/tests/unit/dojson/test_dojson_institutions.py
+++ b/tests/unit/dojson/test_dojson_institutions.py
@@ -399,7 +399,7 @@ def test_field_activity_from_372__a():
         '</datafield>'
     )
 
-    expected = ['Research center']
+    expected = ['Research Center']
     result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['field_activity']


### PR DESCRIPTION
Sentry: https://sentry.cern.ch/inspire-sentry/inspire-labs-qa/group/601661/

These are the values (and counts) of `372__a` in Institutions:
```
   1 Laboratory
   1 Natl., Inst., mat., phys., nat., ent., inst., nat., phys., mat., mater, reg., lab., ind., appl., pol., poly.
   1 Research Center-microelectronics
   1 Univesity
   1 university
   2 Research center/
  46 Research Center
  60 Company
 662 Research center
4545 University
```
My solution classifies only the first two as `"Other"`, and normalizes the rest.