### PR TITLE
global: remove unicode_literals import

### DIFF
--- a/inspirehep/dojson/common/__init__.py
+++ b/inspirehep/dojson/common/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # INSPIRE is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,6 +20,4 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-"""MARC 21 model definition."""
-
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function

--- a/inspirehep/dojson/conferences/fields/__init__.py
+++ b/inspirehep/dojson/conferences/fields/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # INSPIRE is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,6 +20,4 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-"""MARC 21 model definition."""
-
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function

--- a/inspirehep/dojson/experiments/fields/__init__.py
+++ b/inspirehep/dojson/experiments/fields/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # INSPIRE is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,6 +20,4 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-"""MARC 21 model definition."""
-
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function

--- a/inspirehep/dojson/hep/fields/__init__.py
+++ b/inspirehep/dojson/hep/fields/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # INSPIRE is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,6 +20,4 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-"""MARC 21 model definition."""
-
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function

--- a/inspirehep/dojson/hepnames/fields/__init__.py
+++ b/inspirehep/dojson/hepnames/fields/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # INSPIRE is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,6 +20,4 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-"""MARC 21 model definition."""
-
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function

--- a/inspirehep/dojson/institutions/fields/__init__.py
+++ b/inspirehep/dojson/institutions/fields/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # INSPIRE is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,6 +20,4 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-"""MARC 21 model definition."""
-
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function

--- a/inspirehep/dojson/jobs/fields/__init__.py
+++ b/inspirehep/dojson/jobs/fields/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # INSPIRE is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,6 +20,4 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-"""MARC 21 model definition."""
-
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function

--- a/inspirehep/dojson/journals/fields/__init__.py
+++ b/inspirehep/dojson/journals/fields/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # INSPIRE is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,6 +20,4 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-"""MARC 21 model definition."""
-
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function

--- a/inspirehep/modules/authors/ext.py
+++ b/inspirehep/modules/authors/ext.py
@@ -1,38 +1,31 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of Invenio.
+# This file is part of INSPIRE.
 # Copyright (C) 2016 CERN.
 #
-# Invenio is free software; you can redistribute it
-# and/or modify it under the terms of the GNU General Public License as
-# published by the Free Software Foundation; either version 2 of the
-# License, or (at your option) any later version.
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-# Invenio is distributed in the hope that it will be
-# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Invenio; if not, write to the
-# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
-# MA 02111-1307, USA.
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
 #
-# In applying this license, CERN does not
-# waive the privileges and immunities granted to it by virtue of its status
-# as an Intergovernmental Organization or submit itself to any jurisdiction.
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
 
 """INSPIRE module to manage authors."""
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals)
-
-from .views import blueprints
+from __future__ import absolute_import, division, print_function
 
 from . import config
+from .views import blueprints
 
 
 class INSPIREAuthors(object):

--- a/inspirehep/modules/authors/views/__init__.py
+++ b/inspirehep/modules/authors/views/__init__.py
@@ -1,29 +1,28 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# This file is part of INSPIRE.
+# Copyright (C) 2015, 2016 CERN.
 #
-# Invenio is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License as
-# published by the Free Software Foundation; either version 2 of the
-# License, or (at your option) any later version.
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-# Invenio is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Invenio; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 331, Boston, MA 02111-1307, USA.
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
 
-"""View blueprints for Author module."""
+"""View blueprints for the authors module."""
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 from .holdingpen import blueprint as holdingpen_blueprint
 from .publications import blueprint as publications_blueprint

--- a/inspirehep/modules/authors/views/holdingpen.py
+++ b/inspirehep/modules/authors/views/holdingpen.py
@@ -3,40 +3,32 @@
 # This file is part of INSPIRE.
 # Copyright (C) 2016 CERN.
 #
-# INSPIRE is free software; you can redistribute it
-# and/or modify it under the terms of the GNU General Public License as
-# published by the Free Software Foundation; either version 2 of the
-# License, or (at your option) any later version.
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-# INSPIRE is distributed in the hope that it will be
-# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with INSPIRE; if not, write to the
-# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
-# MA 02111-1307, USA.
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
 #
-# In applying this license, CERN does not
-# waive the privileges and immunities granted to it by virtue of its status
-# as an Intergovernmental Organization or submit itself to any jurisdiction.
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
 
 """INSPIRE authors holdingpen views."""
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals)
+from __future__ import absolute_import, division, print_function
 
+import copy
 import os
 import re
+
 import requests
-import copy
-
-from flask_babelex import gettext as _
-
 from flask import (
     abort,
     Blueprint,
@@ -45,15 +37,14 @@ from flask import (
     render_template,
     request,
     url_for,
-    redirect)
-
+    redirect,
+)
+from flask_babelex import gettext as _
 from flask_breadcrumbs import register_breadcrumb
 from flask_login import login_required, current_user
-
 from werkzeug.datastructures import MultiDict
 
 from invenio_db import db
-
 from invenio_workflows import workflow_object_class, start, resume
 
 from inspirehep.dojson.utils import strip_empty_values
@@ -63,11 +54,13 @@ from ..forms import AuthorUpdateForm
 from ..tasks import formdata_to_model
 
 
-blueprint = Blueprint('inspirehep_authors_holdingpen',
-                      __name__,
-                      url_prefix='/submit/author',
-                      template_folder='../templates',
-                      static_folder='../static')
+blueprint = Blueprint(
+    'inspirehep_authors_holdingpen',
+    __name__,
+    url_prefix='/submit/author',
+    template_folder='../templates',
+    static_folder='../static',
+)
 
 
 def convert_for_form(data):

--- a/inspirehep/modules/authors/views/publications.py
+++ b/inspirehep/modules/authors/views/publications.py
@@ -3,49 +3,46 @@
 # This file is part of INSPIRE.
 # Copyright (C) 2016 CERN.
 #
-# INSPIRE is free software; you can redistribute it
-# and/or modify it under the terms of the GNU General Public License as
-# published by the Free Software Foundation; either version 2 of the
-# License, or (at your option) any later version.
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-# INSPIRE is distributed in the hope that it will be
-# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with INSPIRE; if not, write to the
-# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
-# MA 02111-1307, USA.
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
 #
-# In applying this license, CERN does not
-# waive the privileges and immunities granted to it by virtue of its status
-# as an Intergovernmental Organization or submit itself to any jurisdiction.
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
 
 """INSPIRE authors publications views."""
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 from elasticsearch.helpers import scan
 from flask import (
     Blueprint,
     jsonify,
-    request)
+    request,
+)
 
 from invenio_search import current_search_client
 
 from inspirehep.utils.record import get_title
 
 
-blueprint = Blueprint('inspirehep_authors_blueprints',
-                      __name__,
-                      url_prefix='/author',
-                      template_folder='../templates',
-                      static_folder='../static')
+blueprint = Blueprint(
+    'inspirehep_authors_blueprints',
+    __name__,
+    url_prefix='/author',
+    template_folder='../templates',
+    static_folder='../static',
+)
 
 
 @blueprint.route('/publications', methods=['GET'])

--- a/inspirehep/modules/workflows/tasks/arxiv.py
+++ b/inspirehep/modules/workflows/tasks/arxiv.py
@@ -3,32 +3,36 @@
 # This file is part of INSPIRE.
 # Copyright (C) 2014, 2015, 2016 CERN.
 #
-# INSPIRE is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License as
-# published by the Free Software Foundation; either version 2 of the
-# License, or (at your option) any later version.
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-# INSPIRE is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
 
 """Tasks used in OAI harvesting for arXiv record manipulation."""
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 
 import os
 import re
 from functools import wraps
 
-from dojson.contrib.marc21.utils import create_record
 from flask import current_app
 from six import BytesIO
 from werkzeug import secure_filename
+
+from dojson.contrib.marc21.utils import create_record
 
 from inspirehep.dojson.hep import hep
 from inspirehep.modules.refextract.tasks import extract_references
@@ -38,6 +42,7 @@ from inspirehep.utils.helpers import download_file_to_record
 from plotextractor.api import process_tarball
 from plotextractor.converter import untar
 from plotextractor.errors import InvalidTarball, NoTexFilesFound
+
 
 REGEXP_AUTHLIST = re.compile(
     "<collaborationauthorlist.*?>.*?</collaborationauthorlist>", re.DOTALL)

--- a/tests/integration/test_author_views.py
+++ b/tests/integration/test_author_views.py
@@ -20,11 +20,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 import json
 

--- a/tests/unit/authors/test_authors_views.py
+++ b/tests/unit/authors/test_authors_views.py
@@ -20,17 +20,14 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals)
+from __future__ import absolute_import, division, print_function
 
 from invenio_records.api import Record
 
 from inspirehep.modules.authors.views.holdingpen import (
     convert_for_form,
-    get_inspire_url)
+    get_inspire_url,
+)
 
 
 def test_convert_for_form_without_name_urls_fc_positions_advisors_and_ids():


### PR DESCRIPTION
Since #1353 is trying (but will not succeed) to introduce more uses of the `unicode_literals` import I took the occasion of removing all current uses in the codebase.

This might impact your PRs: please ping me if you need help rebasing after conflicts.