### PR TITLE
schemas: thesis_supervisor -> thesis_supervisors

### DIFF
--- a/inspirehep/modules/literaturesuggest/dojson/fields/literature.py
+++ b/inspirehep/modules/literaturesuggest/dojson/fields/literature.py
@@ -284,8 +284,8 @@ def field_categories(self, key, value):
         for t in value]
 
 
-@literature.over('thesis_supervisor', '^supervisors$')
-def thesis_supervisor(self, key, value):
+@literature.over('thesis_supervisors', '^supervisors$')
+def thesis_supervisors(self, key, value):
     return value
 
 

--- a/inspirehep/modules/records/jsonschemas/records/hep.json
+++ b/inspirehep/modules/records/jsonschemas/records/hep.json
@@ -848,20 +848,28 @@
             },
             "type": "object"
         },
-        "thesis_supervisor": {
+        "thesis_supervisors": {
             "items": {
                 "properties": {
-                    "affiliation": {
-                        "type": "string"
-                    },
-                    "curated_relation": {
-                        "type": "boolean"
+                    "affiliations": {
+                        "items": {
+                            "properties": {
+                                "curated_relation": {
+                                    "type": "boolean"
+                                },
+                                "record": {
+                                    "$ref": "elements/json_reference.json"
+                                },
+                                "value": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "type": "array"
                     },
                     "full_name": {
                         "type": "string"
-                    },
-                    "record": {
-                        "$ref": "elements/json_reference.json"
                     }
                 },
                 "required": [

--- a/tests/unit/literaturesuggest/test_literaturesuggest_dojson.py
+++ b/tests/unit/literaturesuggest/test_literaturesuggest_dojson.py
@@ -746,7 +746,7 @@ def test_field_categories_from_subject_term():
     assert expected == result['field_categories']
 
 
-def test_thesis_supervisor_from_supervisors():
+def test_thesis_supervisors_from_supervisors():
     form = GroupableOrderedDict([
         ('supervisors', 'foo'),
     ])
@@ -754,7 +754,7 @@ def test_thesis_supervisor_from_supervisors():
     expected = 'foo'
     result = literature.do(form)
 
-    assert expected == result['thesis_supervisor']
+    assert expected == result['thesis_supervisors']
 
 
 def test_titles_from_title():


### PR DESCRIPTION
Sentry: https://sentry.cern.ch/inspire-sentry/inspire-labs-qa/group/601705/

Doesn't yet handle all cases present in the data, but I'm going to fix those when they arrive in Sentry.