### PR TITLE
tests: ignore inspirehep module

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -23,7 +23,7 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 [pytest]
-addopts = --pep8 --ignore=docs --ignore=node_modules --cov=inspirehep --cov-report=term-missing
+addopts = --pep8 --ignore=docs --ignore=inspirehep --ignore=node_modules --cov=inspirehep --cov-report=term-missing
 pep8ignore =
     tests/* ALL
     *.py E501


### PR DESCRIPTION
* As we don't have any tests mixed in with the code, we can skip
  crawling inside the inspirehep module and shave off a few seconds
  and a bunch of useless logs from the test runs.

Signed-off-by: David Caro <david@dcaro.es>