### PR TITLE
references: use mget instead of a parsed query

### DIFF
--- a/inspirehep/modules/references/view_utils.py
+++ b/inspirehep/modules/references/view_utils.py
@@ -22,10 +22,9 @@
 
 from __future__ import absolute_import, division, print_function
 
-from invenio_records.api import Record
-
+from inspirehep.utils.helpers import force_force_list
 from inspirehep.utils.jinja2 import render_template_to_string
-from inspirehep.modules.search import LiteratureSearch
+from inspirehep.utils.record_getter import get_es_records
 
 
 class Reference(object):
@@ -45,14 +44,13 @@ class Reference(object):
         out = []
         references = self.record.get('references')
         if references:
-            refs_to_get_from_es = [
-                ref['recid'] for ref in references if ref.get('recid')
+            reference_recids = [
+                str(ref['recid']) for ref in references if ref.get('recid')
             ]
-            records_from_es = LiteratureSearch().query_from_iq(
-                ' OR '.join('recid:' + str(ref)
-                            for ref in refs_to_get_from_es)
-            ).params(
-                size=9999,
+
+            resolved_references = get_es_records(
+                'literature',
+                reference_recids,
                 _source=[
                     'control_number',
                     'citation_count',
@@ -63,39 +61,27 @@ class Reference(object):
                     'corporate_author',
                     'publication_info'
                 ]
-            ).execute().to_dict()['hits']['hits']
+            )
 
-            refs_from_es = {
-                str(ref['_source']['control_number']): ref['_source'] for ref in records_from_es
+            # Create mapping to keep reference order
+            recid_to_reference = {
+                str(ref['control_number']): ref for ref in resolved_references
             }
             for reference in references:
                 row = []
-                recid = reference.get('recid')
-                ref_record = refs_from_es.get(str(recid)) if recid else None
-
-                if recid and ref_record:
-                    ref_record = Record(ref_record)
-                    if ref_record:
-                        row.append(render_template_to_string(
-                            "inspirehep_theme/references.html",
-                            record=ref_record,
-                            reference=reference
-                        ))
-                        row.append(ref_record.get('citation_count', ''))
-                        out.append(row)
-                else:
-                    # Easier to use record macros over reference records.
-                    if 'publication_info' in reference:
-                        reference['publication_info'] = [
-                            reference['publication_info']]
-                    else:
-                        reference['publication_info'] = []
-                    reference = Record(reference)
-
-                    row.append(render_template_to_string(
-                        "inspirehep_theme/references.html",
-                        reference=reference))
-                    row.append('')
-                    out.append(row)
+                ref_record = recid_to_reference.get(
+                    str(reference.get('recid')), {}
+                )
+                if 'publication_info' in reference:
+                    reference['publication_info'] = force_force_list(
+                        reference['publication_info']
+                    )
+                row.append(render_template_to_string(
+                    "inspirehep_theme/references.html",
+                    record=ref_record,
+                    reference=reference
+                ))
+                row.append(ref_record.get('citation_count', ''))
+                out.append(row)
 
         return out


### PR DESCRIPTION
* Fixes issue were the generated query is too long which throws a
  recursion depth error.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>