### PR TITLE
dojson: normalize degree_type

### DIFF
--- a/inspirehep/dojson/hep/fields/bd5xx.py
+++ b/inspirehep/dojson/hep/fields/bd5xx.py
@@ -91,12 +91,29 @@ def hidden_note2marc(self, key, value):
 
 
 @hep.over('thesis', '^502..')
-@utils.filter_values
 def thesis(self, key, value):
     """Get Thesis Information."""
+    DEGREE_TYPES_MAP = {
+        'RAPPORT DE STAGE': 'Internship Report',
+        'INTERNSHIP REPORT': 'Internship Report',
+        'DIPLOMA': 'Diploma',
+        'BACHELOR': 'Bachelor',
+        'LAUREA': 'Laurea',
+        'MASTER': 'Master',
+        'THESIS': 'Thesis',
+        'PHD': 'PhD',
+        'PDF': 'PhD',
+        'PH.D. THESIS': 'PhD',
+        'HABILITATION': 'Habilitation',
+    }
+
+    _degree_type = value.get('b')
+    degree_type = DEGREE_TYPES_MAP.get(_degree_type.upper(), 'Other')
+
     res = {
+        '_degree_type': _degree_type,
         'defense_date': value.get('a'),
-        'degree_type': value.get('b'),
+        'degree_type': degree_type,
         'date': value.get('d'),
     }
 
@@ -115,12 +132,11 @@ def thesis(self, key, value):
 
 
 @hep2marc.over('502', '^thesis$')
-@utils.filter_values
 def thesis2marc(self, key, value):
     """Get Thesis Information."""
     return {
         'a': value.get('defense_date'),
-        'b': value.get('degree_type'),
+        'b': value.get('_degree_type'),
         'c': [inst['name'] for inst in value.get('institutions', [])],
         'd': value.get('date'),
     }

--- a/inspirehep/modules/records/jsonschemas/records/hep.json
+++ b/inspirehep/modules/records/jsonschemas/records/hep.json
@@ -816,15 +816,16 @@
                     "type": "string"
                 },
                 "degree_type": {
-                    "description": "FIXME: this enum must be reviewed",
                     "enum": [
-                        "PhD",
-                        "Master",
-                        "Bachelor",
+                        "Other",
+                        "Internship Report",
                         "Diploma",
-                        "Habilitation",
+                        "Bachelor",
                         "Laurea",
-                        "Thesis"
+                        "Master",
+                        "Thesis",
+                        "PhD",
+                        "Habilitation"
                     ],
                     "type": "string"
                 },


### PR DESCRIPTION
Sentry: https://sentry.cern.ch/inspire-sentry/inspire-labs-qa/group/601706/

This is the partial status of the `502__b` field (I interrupted a query that had been running for a few hours...):
```
   1 Dubna, JINR
   1 Licencia
   1 Maitrise Communication
   1 PDF
   1 Ph.D Thesis
   1 master
   2 Internship report
   2 PHD
   2 Rapport de stage
   3 phD
   3 thesis
   4 Licentiate
   4 Mainz U.
   6 Licenciate
   7 Phd
  85 Habilitation
  99 Laurea
 160 Bachelor
 412 Diploma
1063 Thesis
1159 Master
13047 PhD
```

This PR adds a little normalization to the DoJSON rule so that less values will result in invalid records. It's not a complete solution because I don't know if we should ignore the rest of the cases, or we want to have "Internship report"s and similar entries.