### PR TITLE
travis: fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,8 @@ services:
 env:
   global:
     - DOCKER_DATA="$HOME/docker_data"
-    - DOCKER_VERSION=1.10.3-0~trusty
-    - DOCKER_COMPOSE_VERSION=1.6.2
+    - DOCKER_VERSION=1.12.0-0~trusty
+    - DOCKER_COMPOSE_VERSION=1.8.0
   matrix:
     - SUITE=pep8
     - SUITE=unit
@@ -47,10 +47,10 @@ before_install:
   - travis_retry pip install coveralls
   # List available docker versions.
   - apt-cache madison docker-engine
-  # Update Docker to 1.10.1 https://graysonkoonce.com/managing-docker-and-docker-compose-versions-on-travis-ci/.
+  # Update Docker. See: https://graysonkoonce.com/managing-docker-and-docker-compose-versions-on-travis-ci/.
   - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=${DOCKER_VERSION}
   # Add docker-compose at the version specified in ENV.
-  - sudo rm /usr/local/bin/docker-compose
+  - sudo rm -f /usr/local/bin/docker-compose
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin


### PR DESCRIPTION
After https://www.traviscistatus.com/incidents/2p40l49r3yxd the Travis people updated the Ubuntu Trusty images to a newer version:

> We've determined that an image cleanup process malfunctioned and deleted the stable build environment images. Due to various factors our only option at this point is roll forward with newer build environment images, for both Precise and Trusty.

1. This new Trusty image ships with the `1.12.0-0~trusty` version of `docker-engine`. Our Travis script was trying to downgrade it to `1.10.3-0~trusty`, which was failing: https://travis-ci.org/inspirehep/inspire-next/jobs/151099253#L422. The reason why escapes me, but I just decided to bump the `docker-engine` we require on Travis.
2. This new Trusty image ships *without* a `docker-compose` command. Our Travis script was trying to delete it, which was failing: https://travis-ci.org/inspirehep/inspire-next/jobs/151100896#L288. The fix here is just to add a `-f` flag.