### PR TITLE
theme: search bar improvements

### DIFF
--- a/inspirehep/modules/search/static/js/search/app.js
+++ b/inspirehep/modules/search/static/js/search/app.js
@@ -27,12 +27,5 @@ require([
     'inspirehep-search',
     'inspirehep'
   ], function() {
-    // When the DOM is ready bootstrap the AngularJS modules
-    angular.element(document).ready(function() {
-      angular.bootstrap(
-        document.getElementById("invenio-search"), ['angular-loading-bar',
-                                                    'inspirehepSearch',
-                                                    'inspirehep']
-      );
-    });
+    // Requirements are needed in order to create the search bundle JS
 });

--- a/inspirehep/modules/search/templates/search/search.html
+++ b/inspirehep/modules/search/templates/search/search.html
@@ -31,11 +31,31 @@
 {%- block javascript %}
   {{ super() }}
   {{ mathjax() | safe }}
-  {% assets "invenio_search_ui_search_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
+  {% assets "invenio_search_ui_search_js" %}
+    <script src="{{ ASSET_URL }}"></script>
+  {% endassets %}
 {%- endblock javascript %}
 
 {%- block additional_javascript -%}
   {% include "inspirehep_theme/typeahead.html" %}
+  <script>
+    require([
+      'angular-loading-bar',
+      'invenio-search',
+      'inspirehep-search',
+      'inspirehep'
+    ], function() {
+      // When the DOM is ready bootstrap the AngularJS modules
+      angular.element(document).ready(function() {
+        angular.bootstrap(
+          document.getElementById("invenio-search"), ['angular-loading-bar',
+                                                      'inspirehepSearch',
+                                                      'inspirehep',
+                                                      'invenioSearchAutocomplete']
+        );
+      });
+    });
+  </script>
 {%- endblock additional_javascript -%}
 
 {%- block body_inner %}

--- a/inspirehep/modules/theme/static/scss/base/header.scss
+++ b/inspirehep/modules/theme/static/scss/base/header.scss
@@ -497,7 +497,7 @@ a.external-link::after {
     padding: 0;
     height: 40px;
 
-    #searchform-input-group #search-form-input,
+    #searchform-input-group #search,
     .navbar-form .input-group .form-control {
         width: 100%;
     }
@@ -525,7 +525,7 @@ a.external-link::after {
         border-radius: 0;
     }
 
-    .twitter-typeahead > input, #search-form-input {
+    .twitter-typeahead > input, #search {
         border: 0;
         border-radius: 0;
         font-size: 17px;

--- a/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Inspire_Default_HTML_detailed.tpl
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Inspire_Default_HTML_detailed.tpl
@@ -153,4 +153,5 @@
         }
     );
   </script>
+  {% include "inspirehep_theme/typeahead.html" %}
 {% endblock additional_javascript %}

--- a/inspirehep/modules/theme/templates/inspirehep_theme/header.html
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/header.html
@@ -182,11 +182,17 @@
           {%- endif %}
         </ul>
       </div>
-      {% if request.endpoint in ['inspirehep_search.search', 'invenio_records_ui.literature'] %}
-        <div id="top-search-bar" class="{{ collection_name }}">
+      <div id="top-search-bar" class="{{ collection_name }}">
+        {% if request.endpoint in ['inspirehep_search.search'] %}
+          <invenio-search-autocomplete-bar
+            template="{{ url_for('static', filename='node_modules/inspirehep-search-js/dist/templates/searchbar.html') }}"
+            placeholder="Search {{collection_name}}"
+            collection={{collection_name}}>
+          </invenio-search-autocomplete-bar>
+        {% elif request.blueprint == 'invenio_records_ui' %}
           {% include 'inspirehep_theme/search/form/form.html' %}
-        </div>
-      {% endif %}
+        {% endif %}
+      </div>
     </div>
   </nav>
 </section>

--- a/inspirehep/modules/theme/templates/inspirehep_theme/search/form/controls.html
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/search/form/controls.html
@@ -24,7 +24,7 @@
 {% endif %}
 
 <input autocomplete="off"
-  id="search-form-input"
+  id="search"
   data-items="4"
   name="q"
   class="form-control"

--- a/inspirehep/modules/theme/templates/inspirehep_theme/typeahead.html
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/typeahead.html
@@ -26,7 +26,11 @@ require(
     'jquery',
     'inspirehep-typeahead',
     'invenio_with_spires_typeahead_configuration',
-    'hogan'
+    'hogan',
+    {% if request.endpoint in ['inspirehep_search.search'] %}
+    'angular',
+    'invenio-search'
+    {% endif %}
   ],
 
   function(
@@ -64,12 +68,48 @@ require(
         return DefaultSuggestionTemplate.render.call(DefaultSuggestionTemplate, data);
       }
 
-      $('form[name=search] input[name=q]').searchTypeahead({
-        value_hints_url: "{{config.get('SEARCH_TYPEAHEAD_HINT_URL')|safe}}",
-        options_sets: parser_config,
-        default_set: "{{config.get('SEARCH_TYPEAHEAD_DEFAULT_SET')}}",
-        suggestion_fn: suggestion_fn
-      });
+      {% if request.endpoint in ['inspirehep_search.search'] %}
+        angular.module('invenioSearchAutocomplete', [])
+        .directive('invenioSearchAutocompleteBar', function() {
+            function link(scope, element, attrs, vm) {
+              function updateQuery() {
+                vm.invenioSearchArgs.q = vm.userQuery;
+              }
+              scope.placeholder = attrs.placeholder;
+              scope.updateQuery = updateQuery;
+              scope.collection = attrs.collection;
+
+              $("#search").searchTypeahead({
+                // A server returning a list of values is needed
+                // Also CORS needs to be enabled, e.g with a browser extension
+                value_hints_url: "{{config.get('SEARCH_TYPEAHEAD_HINT_URL')|safe}}",
+                options_sets: parser_config,
+                default_set: "{{config.get('SEARCH_TYPEAHEAD_DEFAULT_SET')}}",
+                suggestion_fn: suggestion_fn
+              });
+            }
+            function templateUrl(element, attrs) {
+              return attrs.template;
+            }
+            return {
+              restrict: 'AE',
+              require: '^invenioSearch',
+              scope: false,
+              templateUrl: templateUrl,
+              link: link,
+            };
+        });
+      {% else %}
+        $("#search").searchTypeahead({
+          // A server returning a list of values is needed
+          // Also CORS needs to be enabled, e.g with a browser extension
+          value_hints_url: "{{config.get('SEARCH_TYPEAHEAD_HINT_URL')|safe}}",
+          options_sets: parser_config,
+          default_set: "{{config.get('SEARCH_TYPEAHEAD_DEFAULT_SET')}}",
+          suggestion_fn: suggestion_fn
+        });
+      {% endif %}
+
     });
 });
 </script>


### PR DESCRIPTION
* Changes search bar in search results to use Angular directive.

* Makes typeahead work with and without Angular.

* Shows search bar in all detailed pages.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>