### PR TITLE
dojson: earliest_date in ES only

### DIFF
--- a/inspirehep/dojson/hep/receivers.py
+++ b/inspirehep/dojson/hep/receivers.py
@@ -26,16 +26,15 @@ from __future__ import absolute_import, division, print_function
 
 from itertools import chain
 
-from invenio_records.signals import before_record_insert, before_record_update
+from invenio_indexer.signals import before_record_index
 
 from inspirehep.utils.date import create_earliest_date
 from inspirehep.utils.helpers import force_force_list
 from inspirehep.utils.record import get_value
 
 
-@before_record_insert.connect
-@before_record_update.connect
-def earliest_date(sender, *args, **kwargs):
+@before_record_index.connect
+def earliest_date(sender, json, *args, **kwargs):
     """Find and assign the earliest date to a HEP paper."""
     date_paths = [
         'preprint_date',
@@ -47,8 +46,8 @@ def earliest_date(sender, *args, **kwargs):
     ]
 
     dates = list(chain.from_iterable(
-        [force_force_list(get_value(sender, path)) for path in date_paths]))
+        [force_force_list(get_value(json, path)) for path in date_paths]))
 
     earliest_date = create_earliest_date(dates)
     if earliest_date:
-        sender['earliest_date'] = earliest_date
+        json['earliest_date'] = earliest_date

--- a/tests/unit/dojson/test_dojson_hep_receivers.py
+++ b/tests/unit/dojson/test_dojson_hep_receivers.py
@@ -29,7 +29,7 @@ from inspirehep.dojson.hep.receivers import earliest_date
 
 def test_earliest_date_from_preprint_date():
     with_preprint_date = Record({'preprint_date': '2014-05-29'})
-    earliest_date(with_preprint_date)
+    earliest_date(None, with_preprint_date)
 
     expected = '2014-05-29'
     result = with_preprint_date['earliest_date']
@@ -41,7 +41,7 @@ def test_earliest_date_from_thesis_date():
     with_thesis_date = Record({
         'thesis': {'date': '2008'}
     })
-    earliest_date(with_thesis_date)
+    earliest_date(None, with_thesis_date)
 
     expected = '2008'
     result = with_thesis_date['earliest_date']
@@ -53,7 +53,7 @@ def test_earliest_date_from_thesis_defense_date():
     with_thesis_defense_date = Record({
         'thesis': {'defense_date': '2012-06-01'}
     })
-    earliest_date(with_thesis_defense_date)
+    earliest_date(None, with_thesis_defense_date)
 
     expected = '2012-06-01'
     result = with_thesis_defense_date['earliest_date']
@@ -67,7 +67,7 @@ def test_earliest_date_from_publication_info_year():
             {'year': '2014'}
         ]
     })
-    earliest_date(with_publication_info_year)
+    earliest_date(None, with_publication_info_year)
 
     expected = '2014'
     result = with_publication_info_year['earliest_date']
@@ -81,7 +81,7 @@ def test_earliest_date_from_creation_modification_date_creation_date():
             {'creation_date': '2015-11-04'}
         ]
     })
-    earliest_date(with_creation_modification_date_creation_date)
+    earliest_date(None, with_creation_modification_date_creation_date)
 
     expected = '2015-11-04'
     result = with_creation_modification_date_creation_date['earliest_date']
@@ -95,7 +95,7 @@ def test_earliest_date_from_imprints_date():
             {'date': '2014-09-26'}
         ]
     })
-    earliest_date(with_imprints_date)
+    earliest_date(None, with_imprints_date)
 
     expected = '2014-09-26'
     result = with_imprints_date['earliest_date']


### PR DESCRIPTION
* Amends earliest_date receiver to be triggered only at index time,
  rather than before_record_* time, thus adding earliest_date bit
  only in ES (it's not a property that is supposed to be touched
  by humans).

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>