### PR TITLE
holdingpen: hide resume if pending approval

### DIFF
--- a/inspirehep/modules/workflows/static/js/inspire_workflows_ui/templates/details.html
+++ b/inspirehep/modules/workflows/static/js/inspire_workflows_ui/templates/details.html
@@ -320,6 +320,7 @@
               <i class="fa fa-repeat" aria-hidden="true"></i> Restart
             </button>
             <button class="btn btn-default"
+                    ng-if="vm.record._workflow.status !== 'HALTED'"
                     ng-click="Utils.resumeWorkflow()">
               <i class="fa fa-play" aria-hidden="true"></i> Resume
             </button>


### PR DESCRIPTION
* It makes no sense to resume a workflow if it requires manual
  approval, so just hide the button.

Signed-off-by: David Caro <david@dcaro.es>