### PR TITLE
search: authors exact search

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -166,7 +166,7 @@ SEARCH_ELASTIC_KEYWORD_MAPPING = {
     "control_number": ["control_number"],
     "author": ["authors.full_name", "authors.alternative_names"],
     "exactauthor": ["exactauthor.raw", "authors.full_name",
-                    "authors.alternative_names", "authors.inspire_bai"
+                    "authors.alternative_names", "authors.ids.value"
                     ],
     "abstract": ["abstracts.value"],
     "collaboration": ["collaboration.value", "collaboration.raw^2"],

--- a/inspirehep/modules/records/mappings/records/hep.json
+++ b/inspirehep/modules/records/mappings/records/hep.json
@@ -111,13 +111,13 @@
                             ],
                             "type": "string"
                         },
-                        "inspire_bai": {
-                            "copy_to": [
-                                "author",
-                                "exactauthor"
-                            ],
-                            "index": "not_analyzed",
-                            "type": "string"
+                        "ids": {
+                            "properties": {
+                                "value": {
+                                    "index": "not_analyzed",
+                                    "type": "string"
+                                }
+                            }
                         },
                         "name_suggest": {
                             "analyzer": "simple",

--- a/inspirehep/modules/search/query_factory.py
+++ b/inspirehep/modules/search/query_factory.py
@@ -75,7 +75,7 @@ def inspire_query_factory():
             ))
         finally:
             if current_app.debug:
-                current_app.logger.info(json.dumps(query.to_dict(), indent=4))
+                current_app.logger.debug(json.dumps(query.to_dict(), indent=4))
             return query
 
     return invenio_query

--- a/inspirehep/modules/search/walkers/elasticsearch.py
+++ b/inspirehep/modules/search/walkers/elasticsearch.py
@@ -3,25 +3,26 @@
 # This file is part of INSPIRE.
 # Copyright (C) 2015, 2016 CERN.
 #
-# INSPIRE is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License as
-# published by the Free Software Foundation; either version 2 of the
-# License, or (at your option) any later version.
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
 # INSPIRE is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
 #
-# In applying this license, CERN does not waive the privileges and immunities
+# In applying this licence, CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
 """Implement AST convertor to Elastic Search DSL."""
+
+from __future__ import absolute_import, division, print_function
 
 from operator import or_
 

--- a/tests/unit/search/test_search_query.py
+++ b/tests/unit/search/test_search_query.py
@@ -133,7 +133,7 @@ def test_author_bai():
                     },
                     {
                       "term": {
-                        "authors.inspire_bai": "r.j.hill.1"
+                        "authors.ids.value": "r.j.hill.1"
                       }
                     }
                   ]
@@ -225,26 +225,34 @@ def test_author_colon():
     query = IQ('author: vagenas', LiteratureSearch())
 
     expected = {
-        "bool": {
-            "should": [
+          'bool': {
+            'must': [
               {
-                "match": {
-                  "authors.name_variations": "vagenas"
+                'bool': {
+                  'should': [
+                    {
+                      'match': {
+                        u'authors.name_variations': 'vagenas'
+                      }
+                    },
+                    {
+                      'term': {
+                        u'authors.ids.value': 'vagenas'
+                      }
+                    }
+                  ]
                 }
-              },
+              }
+            ],
+            'should': [
               {
-                "match": {
-                  "authors.full_name": "vagenas"
-                }
-              },
-              {
-                "match": {
-                  "authors.inspire_bai": "vagenas"
+                'match': {
+                  u'authors.full_name': 'vagenas'
                 }
               }
             ]
+          }
         }
-    }
     result = query.to_dict()
 
     assert expected == result
@@ -266,7 +274,7 @@ def test_author_colon_with_double_quotes():
                     },
                     {
                       "term": {
-                        "authors.inspire_bai": "tachikawa, yuji"
+                        "authors.ids.value": "tachikawa, yuji"
                       }
                     }
                   ]
@@ -291,26 +299,34 @@ def test_author_colon_bai():
     query = IQ('author:Y.Nomura.1', LiteratureSearch())
 
     expected = {
-        "bool": {
-            "should": [
+          'bool': {
+            'must': [
               {
-                "match": {
-                  "authors.name_variations": "Y.Nomura.1"
+                'bool': {
+                  'should': [
+                    {
+                      'match': {
+                        u'authors.name_variations': 'Y.Nomura.1'
+                      }
+                    },
+                    {
+                      'term': {
+                        u'authors.ids.value': 'Y.Nomura.1'
+                      }
+                    }
+                  ]
                 }
-              },
+              }
+            ],
+            'should': [
               {
-                "match": {
-                  "authors.full_name": "Y.Nomura.1"
-                }
-              },
-              {
-                "match": {
-                  "authors.inspire_bai": "Y.Nomura.1"
+                'match': {
+                  u'authors.full_name': 'Y.Nomura.1'
                 }
               }
             ]
+          }
         }
-    }
     result = query.to_dict()
 
     assert expected == result
@@ -321,36 +337,42 @@ def test_author_colon_bai_and_collection_colon():
         'author:E.Witten.1 AND collection:citeable', LiteratureSearch())
 
     expected = {
-        "bool": {
-            "should": [
+          'bool': {
+            'must': [
               {
-                "match": {
-                  "authors.name_variations": "E.Witten.1"
+                'bool': {
+                  'should': [
+                    {
+                      'match': {
+                        u'authors.name_variations': 'E.Witten.1'
+                      }
+                    },
+                    {
+                      'term': {
+                        u'authors.ids.value': 'E.Witten.1'
+                      }
+                    }
+                  ]
                 }
               },
               {
-                "match": {
-                  "authors.full_name": "E.Witten.1"
-                }
-              },
-              {
-                "match": {
-                  "authors.inspire_bai": "E.Witten.1"
+                'multi_match': {
+                  'fields': [
+                    'collections.primary'
+                  ],
+                  'query': 'citeable'
                 }
               }
             ],
-            "must": [
+            'should': [
               {
-                "multi_match": {
-                  "query": "citeable",
-                  "fields": [
-                    "collections.primary"
-                  ]
+                'match': {
+                  u'authors.full_name': 'E.Witten.1'
                 }
               }
             ]
+          }
         }
-    }
     result = query.to_dict()
     assert expected == result
 
@@ -359,42 +381,43 @@ def test_author_colon_bai_with_double_quotes_and_collection_colon():
     query = IQ('author:"E.Witten.1" AND collection:citeable', LiteratureSearch())
 
     expected = {
-        "bool": {
-            "should": [
+          'bool': {
+            'must': [
               {
-                "match": {
-                  "authors.full_name": "E.Witten.1"
-                }
-              }
-            ],
-            "must": [
-              {
-                "bool": {
-                  "should": [
+                'bool': {
+                  'should': [
                     {
-                      "match": {
-                        "authors.name_variations": "E.Witten.1"
+                      'match': {
+                        u'authors.name_variations': 'E.Witten.1'
                       }
                     },
                     {
-                      "term": {
-                        "authors.inspire_bai": "E.Witten.1"
+                      'term': {
+                        u'authors.ids.value': 'E.Witten.1'
                       }
                     }
                   ]
                 }
               },
               {
-                "multi_match": {
-                  "query": "citeable",
-                  "fields": [
-                    "collections.primary"
-                  ]
+                'multi_match': {
+                  'fields': [
+                    'collections.primary'
+                  ],
+                  'query': 'citeable'
+                }
+              }
+            ],
+            'should': [
+              {
+                'match': {
+                  u'authors.full_name': 'E.Witten.1'
                 }
               }
             ]
+          }
         }
-    }
+
     result = query.to_dict()
 
     assert expected == result
@@ -407,44 +430,50 @@ def test_author_colon_bai_and_collection_colon_and_cited_colon():
         )
 
     expected = {
-        "bool": {
-            "must": [
+          'bool': {
+            'must': [
               {
-                "multi_match": {
-                  "query": "citeable",
-                  "fields": [
-                    "collections.primary"
+                'bool': {
+                  'should': [
+                    {
+                      'match': {
+                        u'authors.name_variations': 'E.Witten.1'
+                      }
+                    },
+                    {
+                      'term': {
+                        u'authors.ids.value': 'E.Witten.1'
+                      }
+                    }
                   ]
                 }
               },
               {
-                "range": {
-                  "citation_count": {
-                    "gte": "500",
-                    "lte": "1000000"
+                'multi_match': {
+                  'fields': [
+                    'collections.primary'
+                  ],
+                  'query': 'citeable'
+                }
+              },
+              {
+                'range': {
+                  'citation_count': {
+                    'gte': '500',
+                    'lte': '1000000'
                   }
                 }
               }
             ],
-            "should": [
+            'should': [
               {
-                "match": {
-                  "authors.name_variations": "E.Witten.1"
-                }
-              },
-              {
-                "match": {
-                  "authors.full_name": "E.Witten.1"
-                }
-              },
-              {
-                "match": {
-                  "authors.inspire_bai": "E.Witten.1"
+                'match': {
+                  u'authors.full_name': 'E.Witten.1'
                 }
               }
             ]
+          }
         }
-    }
     result = query.to_dict()
 
     assert expected == result
@@ -457,50 +486,50 @@ def test_author_colon_bai_with_double_quotes_and_collection_colon_and_cited_colo
     )
 
     expected = {
-        "bool": {
-            "must": [
+          'bool': {
+            'must': [
               {
-                "bool": {
-                  "should": [
+                'bool': {
+                  'should': [
                     {
-                      "match": {
-                        "authors.name_variations": "E.Witten.1"
+                      'match': {
+                        u'authors.name_variations': 'E.Witten.1'
                       }
                     },
                     {
-                      "term": {
-                        "authors.inspire_bai": "E.Witten.1"
+                      'term': {
+                        u'authors.ids.value': 'E.Witten.1'
                       }
                     }
                   ]
                 }
               },
               {
-                "multi_match": {
-                  "query": "citeable",
-                  "fields": [
-                    "collections.primary"
-                  ]
+                'multi_match': {
+                  'fields': [
+                    'collections.primary'
+                  ],
+                  'query': 'citeable'
                 }
               },
               {
-                "range": {
-                  "citation_count": {
-                    "gte": "500",
-                    "lte": "1000000"
+                'range': {
+                  'citation_count': {
+                    'gte': '500',
+                    'lte': '1000000'
                   }
                 }
               }
             ],
-            "should": [
+            'should': [
               {
-                "match": {
-                  "authors.full_name": "E.Witten.1"
+                'match': {
+                  u'authors.full_name': 'E.Witten.1'
                 }
               }
             ]
+          }
         }
-    }
     result = query.to_dict()
 
     assert expected == result
@@ -682,7 +711,7 @@ def test_exactauthor_colon_bai():
               "exactauthor.raw",
               "authors.full_name",
               "authors.alternative_names",
-              "authors.inspire_bai"
+              "authors.ids.value"
             ]
         }
     }
@@ -711,7 +740,7 @@ def test_or_of_exactauthor_colon_queries():
               "exactauthor.raw",
               "authors.full_name",
               "authors.alternative_names",
-              "authors.inspire_bai"
+              "authors.ids.value"
             ]
         }
     }
@@ -822,7 +851,7 @@ def test_find_exactauthor():
               "exactauthor.raw",
               "authors.full_name",
               "authors.alternative_names",
-              "authors.inspire_bai"
+              "authors.ids.value"
             ]
         }
     }
@@ -856,7 +885,7 @@ def test_find_exactauthor_not_affiliation_uppercase():
                     "exactauthor.raw",
                     "authors.full_name",
                     "authors.alternative_names",
-                    "authors.inspire_bai"
+                    "authors.ids.value"
                   ]
                 }
               }
@@ -884,7 +913,7 @@ def test_find_author():
                     },
                     {
                       "term": {
-                        "authors.inspire_bai": "polchinski"
+                        "authors.ids.value": "polchinski"
                       }
                     }
                   ]
@@ -921,7 +950,7 @@ def test_find_author_uppercase():
                     },
                     {
                       "term": {
-                        "authors.inspire_bai": "W F CHANG"
+                        "authors.ids.value": "W F CHANG"
                       }
                     }
                   ]
@@ -966,7 +995,7 @@ def test_find_author_and_date():
                     },
                     {
                       "term": {
-                        "authors.inspire_bai": "hatta"
+                        "authors.ids.value": "hatta"
                       }
                     }
                   ]
@@ -1046,7 +1075,7 @@ def test_find_author_or_author():
                           },
                           {
                             "term": {
-                              "authors.inspire_bai": "gersdorff, g"
+                              "authors.ids.value": "gersdorff, g"
                             }
                           }
                         ]
@@ -1075,7 +1104,7 @@ def test_find_author_or_author():
                           },
                           {
                             "term": {
-                              "authors.inspire_bai": "von gersdorff, g"
+                              "authors.ids.value": "von gersdorff, g"
                             }
                           }
                         ]
@@ -1116,7 +1145,7 @@ def test_find_author_not_author_not_author():
                     },
                     {
                       "term": {
-                        "authors.inspire_bai": "ostapchenko"
+                        "authors.ids.value": "ostapchenko"
                       }
                     }
                   ]
@@ -1144,7 +1173,7 @@ def test_find_author_not_author_not_author():
                           },
                           {
                             "term": {
-                              "authors.inspire_bai": "olinto"
+                              "authors.ids.value": "olinto"
                             }
                           }
                         ]
@@ -1166,7 +1195,7 @@ def test_find_author_not_author_not_author():
                           },
                           {
                             "term": {
-                              "authors.inspire_bai": "haungs"
+                              "authors.ids.value": "haungs"
                             }
                           }
                         ]


### PR DESCRIPTION
* Converts `author-search` without double quotes to an `exact-match` search.
  (closes #1425 and #1431)

Signed-off-by: Panos Paparrigopoulos <panos.paparrigopoulos@cern.ch>