### PR TITLE
dojson: fix identifiers rules

### DIFF
--- a/inspirehep/dojson/hep/fields/bd1xx.py
+++ b/inspirehep/dojson/hep/fields/bd1xx.py
@@ -57,17 +57,11 @@ def authors(self, key, value):
             u_values = force_force_list(value.get('u'))
             z_values = force_force_list(value.get('z'))
 
-            if len(u_values) >= len(z_values):
-                for u_value, z_value in zip_longest(u_values, z_values):
-                    result.append({
-                        'record': get_record_ref(z_value, 'institutions'),
-                        'value': u_value,
-                    })
-
-                if len(u_values) > len(z_values):
-                    current_app.logger.error(
-                        'Mismatched number of 100__u and 100__z: %d %d',
-                        len(u_values), len(z_values))
+            for u_value, z_value in zip_longest(u_values, z_values):
+                result.append({
+                    'record': get_record_ref(z_value, 'institutions'),
+                    'value': u_value,
+                })
 
             return result
 

--- a/tests/unit/dojson/test_dojson_hep.py
+++ b/tests/unit/dojson/test_dojson_hep.py
@@ -656,41 +656,6 @@ def test_authors_from_100__a_v_w_x_y_and_100_a_v_w_y():
     assert expected == result['authors']
 
 
-@mock.patch('inspirehep.dojson.hep.fields.bd1xx.current_app.logger.error')
-def test_authors_from_100__a_u_w_y(error):
-    snippet = (
-        '<datafield tag="100" ind1=" " ind2=" ">'
-        '  <subfield code="a">Kobayashi, Makoto</subfield>'
-        '  <subfield code="u">Kyoto U.</subfield>'
-        '  <subfield code="w">M.Kobayashi.5</subfield>'
-        '  <subfield code="y">0</subfield>'
-        '</datafield>'
-    )  # record/81350/export/xme
-
-    expected = [
-        {
-            'affiliations': [
-                {
-                    'value': 'Kyoto U.',
-                },
-            ],
-            'curated_relation': False,
-            'full_name': 'Kobayashi, Makoto',
-            'ids': [
-                {
-                    'type': 'INSPIRE BAI',
-                    'value': 'M.Kobayashi.5',
-                },
-            ],
-        },
-    ]
-    result = clean_record(hep.do(create_record(snippet)))
-
-    assert expected == result['authors']
-    error.assert_called_with(
-        'Mismatched number of 100__u and 100__z: %d %d', 1, 0)
-
-
 def test_corporate_author(marcxml_to_json, json_to_marc):
     """Test if corporate_author is created correctly."""
     assert (marcxml_to_json['corporate_author'][0] ==

--- a/tests/unit/dojson/test_dojson_hepnames.py
+++ b/tests/unit/dojson/test_dojson_hepnames.py
@@ -231,6 +231,53 @@ def test_ids_from_035__a_9_with_slac():
     assert expected == result['ids']
 
 
+def test_ids_from_035__a_with_bai():
+    snippet = (
+        '<datafield tag="035" ind1=" " ind2=" ">'
+        '  <subfield code="a">Jian.Long.Han.1</subfield>'
+        '</datafield>'
+    )  # record/1464894/export/xme
+
+    expected = [
+        {
+            'type': 'INSPIRE BAI',
+            'value': 'Jian.Long.Han.1',
+        },
+    ]
+    result = clean_record(hepnames.do(create_record(snippet)))
+
+    assert expected == result['ids']
+
+
+def test_ids_from_double_035__a_9_with_kaken():
+    snippet = (
+        '<record>'
+        '  <datafield tag="035" ind1=" " ind2=" ">'
+        '    <subfield code="9">BAI</subfield>'
+        '    <subfield code="a">Toshio.Suzuki.2</subfield>'
+        '  </datafield>'
+        '  <datafield tag="035" ind1=" " ind2=" ">'
+        '    <subfield code="9">KAKEN</subfield>'
+        '    <subfield code="a">70139070</subfield>'
+        '  </datafield>'
+        '</record>'
+    )  # record/1474271/export/xme
+
+    expected = [
+        {
+            'type': 'INSPIRE BAI',
+            'value': 'Toshio.Suzuki.2',
+        },
+        {
+            'type': 'KAKEN',
+            'value': 'KAKEN-70139070',
+        },
+    ]
+    result = clean_record(hepnames.do(create_record(snippet)))
+
+    assert expected == result['ids']
+
+
 def test_name(marcxml_to_json, json_to_marc):
     """Test if name is created correctly."""
     assert (marcxml_to_json['name']['value'] ==


### PR DESCRIPTION
Sentry: https://sentry.cern.ch/inspire-sentry/inspire-labs-qa/group/602865/ and https://sentry.cern.ch/inspire-sentry/inspire-labs-qa/group/602870/. There's also https://sentry.cern.ch/inspire-sentry/inspire-labs-qa/group/602869/, but I can't reproduce it locally...

Merging quickly so I can start again the nightly.