### PR TITLE
dojson: fix identifiers rules

### DIFF
--- a/inspirehep/dojson/hep/fields/bd1xx.py
+++ b/inspirehep/dojson/hep/fields/bd1xx.py
@@ -103,7 +103,7 @@ def authors(self, key, value):
                 if _is_jacow(j_value):
                     result.append({
                         'type': 'JACOW',
-                        'value': j_value[6:],
+                        'value': 'JACoW-' + j_value[6:],
                     })
                 elif _is_orcid(j_value):
                     result.append({
@@ -118,7 +118,7 @@ def authors(self, key, value):
                 elif _is_cern(j_value):
                     result.append({
                         'type': 'CERN',
-                        'value': j_value,
+                        'value': 'CERN-' + j_value[5:],
                     })
 
             w_values = force_force_list(value.get('w'))

--- a/inspirehep/dojson/hepnames/fields/bd1xx.py
+++ b/inspirehep/dojson/hepnames/fields/bd1xx.py
@@ -148,6 +148,9 @@ def ids(self, key, value):
         return IDS_MAP.get(value.get('9', '').upper())
 
     def _guess_type_from_value(a_value):
+        if a_value is None:
+            return
+
         if INSPIRE_BAI.match(a_value):
             return 'INSPIRE BAI'
 

--- a/tests/unit/dojson/test_dojson_hep.py
+++ b/tests/unit/dojson/test_dojson_hep.py
@@ -656,6 +656,46 @@ def test_authors_from_100__a_v_w_x_y_and_100_a_v_w_y():
     assert expected == result['authors']
 
 
+def test_authors_from_100__a_j_m_u_v_w_y():
+    snippet = (
+        '<datafield tag="100" ind1=" " ind2=" ">'
+        '  <subfield code="a">MacNair, David</subfield>'
+        '  <subfield code="j">JACoW-00009522</subfield>'
+        '  <subfield code="m">macnair@slac.stanford.edu</subfield>'
+        '  <subfield code="u">SLAC</subfield>'
+        '  <subfield code="v">SLAC, Menlo Park, California, USA</subfield>'
+        '  <subfield code="w">D.Macnair.2</subfield>'
+        '  <subfield code="y">0</subfield>'
+        '</datafield>'
+    )
+
+    expected = [
+        {
+            'affiliations': [
+                {
+                    'value': 'SLAC',
+                },
+            ],
+            'curated_relation': False,
+            'email': 'macnair@slac.stanford.edu',
+            'full_name': 'MacNair, David',
+            'ids': [
+                {
+                    'type': 'JACOW',
+                    'value': 'JACoW-00009522',
+                },
+                {
+                    'type': 'INSPIRE BAI',
+                    'value': 'D.Macnair.2',
+                },
+            ],
+        },
+    ]
+    result = clean_record(hep.do(create_record(snippet)))
+
+    assert expected == result['authors']
+
+
 def test_corporate_author(marcxml_to_json, json_to_marc):
     """Test if corporate_author is created correctly."""
     assert (marcxml_to_json['corporate_author'][0] ==

--- a/tests/unit/dojson/test_dojson_hepnames.py
+++ b/tests/unit/dojson/test_dojson_hepnames.py
@@ -278,6 +278,18 @@ def test_ids_from_double_035__a_9_with_kaken():
     assert expected == result['ids']
 
 
+def test_ids_from_035__9_malformed_with_value():
+    snippet = (
+        '<datafield>'
+        '  <subfield code="9">E.Giro.1</subfield>'
+        '</datafield>'
+    )  # record/1031883/export/xme
+
+    result = clean_record(hepnames.do(create_record(snippet)))
+
+    assert 'ids' not in result
+
+
 def test_name(marcxml_to_json, json_to_marc):
     """Test if name is created correctly."""
     assert (marcxml_to_json['name']['value'] ==


### PR DESCRIPTION
Sentry: https://sentry.cern.ch/inspire-sentry/inspire-labs-qa/group/602883/ and https://sentry.cern.ch/inspire-sentry/inspire-labs-qa/group/602884.