### PR TITLE
search: enable _all in secondary collections

### DIFF
--- a/inspirehep/modules/records/mappings/records/authors.json
+++ b/inspirehep/modules/records/mappings/records/authors.json
@@ -2,7 +2,7 @@
     "mappings": {
         "authors": {
             "_all": {
-                "enabled": false
+                "enabled": true
             },
             "date_detection": false,
             "dynamic_templates": [

--- a/inspirehep/modules/records/mappings/records/conferences.json
+++ b/inspirehep/modules/records/mappings/records/conferences.json
@@ -2,7 +2,7 @@
     "mappings": {
         "conferences": {
             "_all": {
-                "enabled": false
+                "enabled": true
             },
             "date_detection": false,
             "dynamic_templates": [

--- a/inspirehep/modules/records/mappings/records/experiments.json
+++ b/inspirehep/modules/records/mappings/records/experiments.json
@@ -2,7 +2,7 @@
     "mappings": {
         "experiments": {
             "_all": {
-                "enabled": false
+                "enabled": true
             },
             "date_detection": false,
             "dynamic_templates": [

--- a/inspirehep/modules/records/mappings/records/journals.json
+++ b/inspirehep/modules/records/mappings/records/journals.json
@@ -2,7 +2,7 @@
     "mappings": {
         "journals": {
             "_all": {
-                "enabled": false
+                "enabled": true
             },
             "date_detection": false,
             "dynamic_templates": [

--- a/inspirehep/modules/search/api.py
+++ b/inspirehep/modules/search/api.py
@@ -108,7 +108,7 @@ class AuthorsSearch(RecordsSearch, SearchMixin):
 
     def default_fields(self):
         """What fields to use when no keyword is specified."""
-        return ['global_fulltext']
+        return ['_all']
 
 
 class DataSearch(RecordsSearch, SearchMixin):
@@ -132,7 +132,7 @@ class ConferencesSearch(RecordsSearch, SearchMixin):
 
     def default_fields(self):
         """What fields to use when no keyword is specified."""
-        return ['global_fulltext']
+        return ['_all']
 
 
 class JobsSearch(RecordsSearch, SearchMixin):
@@ -144,7 +144,7 @@ class JobsSearch(RecordsSearch, SearchMixin):
 
     def default_fields(self):
         """What fields to use when no keyword is specified."""
-        return ['global_fulltext']
+        return ['_all']
 
 
 class InstitutionsSearch(RecordsSearch, SearchMixin):
@@ -156,7 +156,7 @@ class InstitutionsSearch(RecordsSearch, SearchMixin):
 
     def default_fields(self):
         """What fields to use when no keyword is specified."""
-        return ['global_fulltext']
+        return ['_all']
 
 
 class ExperimentsSearch(RecordsSearch, SearchMixin):
@@ -168,7 +168,7 @@ class ExperimentsSearch(RecordsSearch, SearchMixin):
 
     def default_fields(self):
         """What fields to use when no keyword is specified."""
-        return ['global_fulltext']
+        return ['_all']
 
 
 class JournalsSearch(RecordsSearch, SearchMixin):
@@ -180,4 +180,4 @@ class JournalsSearch(RecordsSearch, SearchMixin):
 
     def default_fields(self):
         """What fields to use when no keyword is specified."""
-        return ['global_fulltext']
+        return ['_all']


### PR DESCRIPTION
* Enables _all in ES mappings for secondary collections and makes this
  field the default one to search on when no keywords are specified.s

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>