### PR TITLE
dojson: make thesis more robust

### DIFF
--- a/inspirehep/dojson/hep/fields/bd5xx.py
+++ b/inspirehep/dojson/hep/fields/bd5xx.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import, division, print_function
 from dojson import utils
 
 from ..model import hep, hep2marc
-from ...utils import get_record_ref
+from ...utils import force_single_element, get_record_ref
 
 from inspirehep.utils.helpers import force_force_list
 
@@ -106,8 +106,11 @@ def thesis(self, key, value):
         'HABILITATION': 'Habilitation',
     }
 
-    _degree_type = value.get('b')
-    degree_type = DEGREE_TYPES_MAP.get(_degree_type.upper(), 'Other')
+    _degree_type = force_single_element(value.get('b'))
+    if _degree_type:
+        degree_type = DEGREE_TYPES_MAP.get(_degree_type.upper(), 'Other')
+    else:
+        degree_type = None
 
     res = {
         '_degree_type': _degree_type,

--- a/tests/unit/dojson/test_dojson_hep.py
+++ b/tests/unit/dojson/test_dojson_hep.py
@@ -939,6 +939,34 @@ def test_thesis_multiple_institutions():
         assert expected_inst['recid'] in result_inst['record']['$ref']
 
 
+def test_thesis_from_502__a_c_d_z():
+    snippet = (
+        '<datafield tag="502" ind1=" " ind2=" ">'
+        '  <subfield code="a">PhD</subfield>'
+        '  <subfield code="c">IIT, Roorkee</subfield>'
+        '  <subfield code="d">2011</subfield>'
+        '  <subfield code="z">909554</subfield>'
+        '</datafield>'
+    )  # record/897773/export/xme
+
+    expected = {
+        'date': '2011',
+        'defense_date': 'PhD',  # XXX: obviously wrong.
+        'institutions': [
+            {
+                'curated_relation': True,
+                'record': {
+                    '$ref': 'http://localhost:5000/api/institutions/909554',
+                },
+                'name': 'IIT, Roorkee',
+            },
+        ],
+    }
+    result = clean_record(hep.do(create_record(snippet)))
+
+    assert expected == result['thesis']
+
+
 def test_abstract(marcxml_to_json, json_to_marc):
     """Test if abstract is created correctly."""
     assert (marcxml_to_json['abstracts'][0]['value'] ==


### PR DESCRIPTION
Sentry: https://sentry.cern.ch/inspire-sentry/inspire-labs-qa/group/602792/events/130178183/

This bug might be the reason why the nightly migration stops at 834028 HEP records.