### PR TITLE
dojson: make parse_conference_address more robust

### DIFF
--- a/inspirehep/dojson/utils/geo.py
+++ b/inspirehep/dojson/utils/geo.py
@@ -518,7 +518,7 @@ def parse_conference_address(address_string):
     # Try to match the country
     country_code = match_country_name_to_its_code(country_name, city)
 
-    if country_code == 'US':
+    if country_code == 'US' and len(geo_elements) > 1:
         us_state = match_us_state(geo_elements[-2].upper().strip()
                                   .replace('.', ''))
 

--- a/tests/unit/dojson/test_dojson_conferences.py
+++ b/tests/unit/dojson/test_dojson_conferences.py
@@ -149,6 +149,29 @@ def test_address_from_marcxml__111_multiple_c():
     assert expected == result['address']
 
 
+def test_address_from_111__a_c_d_g_x_y():
+    snippet = (
+        '<datafield tag="111" ind1=" " ind2=" ">'
+        '  <subfield code="a">Twentieth Power Modulator Symposium, 1992</subfield>'
+        '  <subfield code="d">23-25 Jun 1992</subfield>'
+        '  <subfield code="x">1992-06-23</subfield>'
+        '  <subfield code="c">UNITED STATES</subfield>'
+        '  <subfield code="g">C92-06-23.1</subfield>'
+        '  <subfield code="y">1992-06-25</subfield>'
+        '</datafield>'
+    )
+
+    expected = [
+        {
+            'country_code': 'US',
+            'original_address': 'UNITED STATES',
+        },
+    ]
+    result = clean_record(conferences.do(create_record(snippet)))
+
+    assert expected == result['address']
+
+
 def test_contact_details_from_marcxml_270_single_p_single_m():
     snippet = (
         '<record> '


### PR DESCRIPTION
Sentry: https://sentry.cern.ch/inspire-sentry/inspire-labs-qa/group/601668/

This file isn't great code, but is useful, so I made the smallest possible modification to prevent the exception, because I anticipate that this will be entirely rewritten.