### PR TITLE
schemas: remove accelerator enum

### DIFF
--- a/inspirehep/modules/records/jsonschemas/records/experiments.json
+++ b/inspirehep/modules/records/jsonschemas/records/experiments.json
@@ -2,9 +2,6 @@
     "$schema": "http://json-schema.org/schema#",
     "properties": {
         "accelerator": {
-            "enum": [
-                "We need one"
-            ],
             "title": "Accelerator",
             "type": "string"
         },


### PR DESCRIPTION
Sentry: https://sentry.cern.ch/inspire-sentry/inspire-labs-qa/group/601669/

The `accelerator` field is a slowly varying field, but still a varying
field, so not a good fit for an `enum`, since it would require a code
modification per data update.