### PR TITLE
dojson: add links between collections

### DIFF
--- a/inspirehep/dojson/experiments/fields/bd1xx.py
+++ b/inspirehep/dojson/experiments/fields/bd1xx.py
@@ -40,10 +40,17 @@ from inspirehep.utils.helpers import force_force_list
 def experiment_names(self, key, value):
     """Experiment names."""
     if value.get('u'):
-        self.setdefault('affiliation', [])
-        raw_affiliations = force_force_list(value.get('u'))
-        for raw_affiliation in raw_affiliations:
-            self['affiliation'].append(raw_affiliation)
+        self.setdefault('affiliations', [])
+
+        name = value.get('u')
+        recid = value.get('z')
+        record = get_record_ref(recid, 'institutions')
+
+        self['affiliations'].append({
+            'curated_relation': record is not None,
+            'name': name,
+            'record': record
+        })
 
     return {
         'source': value.get('9'),

--- a/inspirehep/dojson/hepnames/fields/bd1xx.py
+++ b/inspirehep/dojson/hepnames/fields/bd1xx.py
@@ -29,7 +29,12 @@ import re
 from dojson import utils
 
 from ..model import hepnames, hepnames2marc
-from ...utils import classify_rank, force_single_element, get_record_ref
+from ...utils import (
+    classify_rank,
+    force_single_element,
+    get_record_ref,
+    get_recid_from_ref
+)
 
 from inspirehep.utils.helpers import force_force_list
 
@@ -451,10 +456,15 @@ def advisors(self, key, value):
     _degree_type = force_single_element(value.get('g'))
     degree_type = DEGREE_TYPES_MAP.get(_degree_type, 'Other')
 
+    recid = force_single_element(value.get('x'))
+    record = get_record_ref(recid, 'authors')
+
     return {
         'name': value.get('a'),
         'degree_type': degree_type,
         '_degree_type': _degree_type,
+        'record': record,
+        'curated_relation': value.get('y') == '1'
     }
 
 
@@ -464,7 +474,9 @@ def advisors2marc(self, key, value):
     """The advisors for all types of degrees."""
     return {
         'a': value.get('name'),
-        'g': value.get('_degree_type')
+        'g': value.get('_degree_type'),
+        'x': get_recid_from_ref(value.get('record')),
+        'y': '1' if value.get('curated_relation') else None
     }
 
 

--- a/inspirehep/dojson/jobs/fields/bd1xx.py
+++ b/inspirehep/dojson/jobs/fields/bd1xx.py
@@ -119,10 +119,21 @@ def regions(self, key, value):
 
 
 @jobs.over('experiments', '^693..')
-@utils.for_each_value
 def experiments(self, key, value):
-    """Contact person."""
-    return value.get('e')
+    """Experiments associated with Job."""
+    experiments = self.get('experiments', [])
+
+    name = value.get('e')
+    recid = value.get('0')
+    record = get_record_ref(recid, 'experiments')
+
+    experiments.append({
+        'curated_relation': record is not None,
+        'name': name,
+        'record': record
+    })
+
+    return experiments
 
 
 @jobs.over('institutions', '^110..')

--- a/inspirehep/modules/records/jsonschemas/records/experiments.json
+++ b/inspirehep/modules/records/jsonschemas/records/experiments.json
@@ -5,14 +5,26 @@
             "title": "Accelerator",
             "type": "string"
         },
-        "affiliation": {
-            "description": "Institution ICN",
-            "title": "Affiliation",
-            "type": "array"
-        },
-        "affiliation_record": {
-            "$ref": "elements/json_reference.json",
-            "title": "Institution record URI"
+        "affiliations": {
+            "items": {
+                "properties": {
+                    "curated_relation": {
+                        "type": "boolean"
+                    },
+                    "name": {
+                        "title": "Name of the institution",
+                        "type": "string"
+                    },
+                    "record": {
+                        "$ref": "elements/json_reference.json",
+                        "title": "Record URI of the institution."
+                    }
+                },
+                "type": "object"
+            },
+            "title": "Institutions with which experiment is affiliated.",
+            "type": "array",
+            "uniqueItems": true
         },
         "collaboration": {
             "title": "Collaboration",

--- a/inspirehep/modules/records/jsonschemas/records/jobs.json
+++ b/inspirehep/modules/records/jsonschemas/records/jobs.json
@@ -31,9 +31,21 @@
         },
         "experiments": {
             "items": {
-                "description": "FIXME: we can simply store here the ID of the experiment.",
-                "title": "Experiment associated with Job",
-                "type": "string"
+                "properties": {
+                    "curated_relation": {
+                        "type": "boolean"
+                    },
+                    "name": {
+                        "title": "Experiment name",
+                        "type": "string"
+                    },
+                    "record": {
+                        "$ref": "elements/json_reference.json",
+                        "title": "Experiment Record URI"
+                    }
+                },
+                "title": "Experiments associated with Job",
+                "type": "object"
             },
             "type": "array",
             "uniqueItems": true

--- a/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Experiment_HTML_detailed.tpl
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Experiment_HTML_detailed.tpl
@@ -26,8 +26,8 @@
       <div class="panel-heading">
         <h1 class="record-detailed-title">
           {{ record['experiment_names'][0].title }}
-            {% if record['affiliation'] %}
-              ({{ record['affiliation'][0] }})
+            {% if record['affiliations'] %}
+              ({{ record['affiliations'][0]['name'] }})
             {% endif %}
         </h1>
         {% if record['titles'] %}

--- a/tests/unit/dojson/test_dojson_experiments.py
+++ b/tests/unit/dojson/test_dojson_experiments.py
@@ -145,30 +145,63 @@ def test_experiment_names_and_affiliation_from_marcxml_119():
         '  <datafield tag="119" ind1=" " ind2=" ">'
         '    <subfield code="a">CERN-ALPHA</subfield>'
         '    <subfield code="u">CERN</subfield>'
+        '    <subfield code="z">902725</subfield>'
         '  </datafield>'
         '</record>'
-    )
+    )  # record/1108206
 
     result = clean_record(experiments.do(create_record(snippet)))
 
-    assert result['affiliation'][0] == 'CERN'
-    assert result['experiment_names'][0]['title'] == 'CERN-ALPHA'
+    assert result['affiliations'] == [
+        {
+            'curated_relation': True,
+            'name': 'CERN',
+            'record': {
+                '$ref': 'http://localhost:5000/api/institutions/902725',
+            },
+        },
+    ]
+    assert result['experiment_names'] == [{'title': 'CERN-ALPHA'}]
 
 
-def test_experiment_names_and_affiliation_from_marcxml_119_two_u():
+def test_experiment_names_and_affiliation_from_marcxml_multiple_119():
     snippet = (
         '<record>'
         '  <datafield tag="119" ind1=" " ind2=" ">'
         '    <subfield code="a">LATTICE-UKQCD</subfield>'
+        '  </datafield>'
+        '  <datafield tag="119" ind1=" " ind2=" ">'
         '    <subfield code="u">Cambridge U.</subfield>'
+        '  </datafield>'
+        '  <datafield tag="119" ind1=" " ind2=" ">'
         '    <subfield code="u">Edinburgh U.</subfield>'
+        '    <subfield code="z">902787</subfield>'
+        '  </datafield>'
+        '  <datafield tag="119" ind1=" " ind2=" ">'
+        '    <subfield code="u">Swansea U.</subfield>'
         '  </datafield>'
         '</record>'
-    )
+    )  # record/1228417
 
     result = clean_record(experiments.do(create_record(snippet)))
-
-    assert result['affiliation'] == ['Cambridge U.', 'Edinburgh U.']
+    expected_affiliations = [
+        {
+            'curated_relation': False,
+            'name': 'Cambridge U.'
+        },
+        {
+            'curated_relation': True,
+            'name': 'Edinburgh U.',
+            'record': {
+                '$ref': 'http://localhost:5000/api/institutions/902787',
+            },
+        },
+        {
+            'curated_relation': False,
+            'name': 'Swansea U.'
+        }
+    ]
+    assert result['affiliations'] == expected_affiliations
     assert result['experiment_names'][0]['title'] == 'LATTICE-UKQCD'
 
 

--- a/tests/unit/dojson/test_dojson_hepnames.py
+++ b/tests/unit/dojson/test_dojson_hepnames.py
@@ -30,7 +30,7 @@ import pytest
 from dojson.contrib.marc21.utils import create_record
 
 from inspirehep.dojson.hepnames import hepnames2marc, hepnames
-from inspirehep.dojson.utils import clean_record
+from inspirehep.dojson.utils import clean_record, get_recid_from_ref
 
 
 @pytest.fixture
@@ -331,6 +331,8 @@ def test_advisors_from_701__a_g_i():
         '  <subfield code="a">Rivelles, Victor O.</subfield>'
         '  <subfield code="g">PhD</subfield>'
         '  <subfield code="i">INSPIRE-00120420</subfield>'
+        '  <subfield code="x">991627</subfield>'
+        '  <subfield code="y">1</subfield>'
         '</datafield>'
     )  # record/1474091
 
@@ -339,6 +341,10 @@ def test_advisors_from_701__a_g_i():
             'name': 'Rivelles, Victor O.',
             'degree_type': 'PhD',
             '_degree_type': 'PhD',
+            'record': {
+                '$ref': 'http://localhost:5000/api/authors/991627',
+            },
+            'curated_relation': True
         },
     ]
     result = clean_record(hepnames.do(create_record(snippet)))

--- a/tests/unit/dojson/test_dojson_jobs.py
+++ b/tests/unit/dojson/test_dojson_jobs.py
@@ -231,38 +231,119 @@ def test_regions_from_043__a_splits_on_commas():
 
 def test_experiments_from_693__e():
     snippet = (
-        '<datafield tag="693" ind1=" " ind2=" ">'
-        '  <subfield code="e">CERN-LHC-ATLAS</subfield>'
-        '</datafield>'
-    )  # record/1471772
+        '<record>'
+        '  <datafield tag="693" ind1=" " ind2=" ">'
+        '    <subfield code="e">ALIGO</subfield>'
+        '  </datafield>'
+        '</record>'
+    )  # record/1375852
 
     expected = [
-        'CERN-LHC-ATLAS',
+        {
+            'curated_relation': False,
+            'name': 'ALIGO',
+        },
     ]
     result = clean_record(jobs.do(create_record(snippet)))
 
     assert expected == result['experiments']
 
 
-def test_experiments_from_triple_693__e():
+def test_experiments_from_693__e__0():
     snippet = (
         '<record>'
         '  <datafield tag="693" ind1=" " ind2=" ">'
-        '    <subfield code="e">CERN-LHC-CMS</subfield>'
-        '  </datafield>'
-        '  <datafield tag="693" ind1=" " ind2=" ">'
-        '    <subfield code="e">CALICE</subfield>'
-        '  </datafield>'
-        '  <datafield tag="693" ind1=" " ind2=" ">'
-        '    <subfield code="e">ILC</subfield>'
+        '    <subfield code="e">CERN-LHC-ATLAS</subfield>'
+        '    <subfield code="0">1108541</subfield>'
         '  </datafield>'
         '</record>'
-    )  # record/1447878
+    )  # record/1332138
 
     expected = [
-        'CERN-LHC-CMS',
-        'CALICE',
-        'ILC',
+        {
+            'curated_relation': True,
+            'name': 'CERN-LHC-ATLAS',
+            'record': {
+                '$ref': 'http://localhost:5000/api/experiments/1108541',
+            },
+        },
+    ]
+    result = clean_record(jobs.do(create_record(snippet)))
+
+    assert expected == result['experiments']
+
+
+def test_experiments_from_693__e__0_and_e():
+    snippet = (
+        '<record>'
+        '  <datafield tag="693" ind1=" " ind2=" ">'
+        '    <subfield code="e">CERN-LHC-ATLAS</subfield>'
+        '    <subfield code="0">1108541</subfield>'
+        '  </datafield>'
+        '  <datafield tag="693" ind1=" " ind2=" ">'
+        '    <subfield code="e">IHEP-CEPC</subfield>'
+        '  </datafield>'
+        '</record>'
+    )  # record/1393583 /export/xme
+
+    expected = [
+        {
+            'curated_relation': True,
+            'name': 'CERN-LHC-ATLAS',
+            'record': {
+                '$ref': 'http://localhost:5000/api/experiments/1108541',
+            },
+        },
+        {
+            'curated_relation': False,
+            'name': 'IHEP-CEPC'
+        }
+    ]
+    result = clean_record(jobs.do(create_record(snippet)))
+
+    assert expected == result['experiments']
+
+
+def test_experiments_from_triple_693__e__0():
+    snippet = (
+        '<record>'
+        '  <datafield tag="693" ind1=" " ind2=" ">'
+        '    <subfield code="e">CERN-NA-049</subfield>'
+        '    <subfield code="0">1110308</subfield>'
+        '  </datafield>'
+        '  <datafield tag="693" ind1=" " ind2=" ">'
+        '    <subfield code="e">CERN-NA-061</subfield>'
+        '    <subfield code="0">1108234</subfield>'
+        '  </datafield>'
+        '  <datafield tag="693" ind1=" " ind2=" ">'
+        '    <subfield code="e">CERN-LHC-ALICE</subfield>'
+        '    <subfield code="0">1110642</subfield>'
+        '  </datafield>'
+        '</record>'
+    )  # record/1469159
+
+    expected = [
+        {
+            'curated_relation': True,
+            'name': 'CERN-NA-049',
+            'record': {
+                '$ref': 'http://localhost:5000/api/experiments/1110308',
+            },
+        },
+        {
+            'curated_relation': True,
+            'name': 'CERN-NA-061',
+            'record': {
+                '$ref': 'http://localhost:5000/api/experiments/1108234',
+            },
+        },
+        {
+            'curated_relation': True,
+            'name': 'CERN-LHC-ALICE',
+            'record': {
+                '$ref': 'http://localhost:5000/api/experiments/1110642',
+            },
+        }
     ]
     result = clean_record(jobs.do(create_record(snippet)))
 


### PR DESCRIPTION
* Adds links by recid between Experiments and Institutions,
Jobs and Experiments and HepNames and PhdAdvisors.

* Updates JSON schemas.

* Includes tests.

Signed-off-by: Tomasz Gargas <tomaszgy@gmail.com>