### PR TITLE
dojson: use logger, not warnings

### DIFF
--- a/inspirehep/dojson/hep/fields/bd1xx.py
+++ b/inspirehep/dojson/hep/fields/bd1xx.py
@@ -24,9 +24,9 @@
 
 from __future__ import absolute_import, division, print_function
 
+import logging
 import re
 
-from flask import current_app
 from six.moves import zip_longest
 
 from dojson import utils
@@ -40,6 +40,8 @@ from ...utils import (
 
 from inspirehep.utils.helpers import force_force_list
 
+
+logger = logging.getLogger(__name__)
 
 ORCID = re.compile('\d{4}-\d{4}-\d{4}-\d{3}[0-9Xx]')
 
@@ -69,7 +71,7 @@ def authors(self, key, value):
             a_values = force_force_list(value.get('a'))
             if a_values:
                 if len(a_values) > 1:
-                    current_app.logger.error(
+                    logger.warning(
                         'Record with mashed up authors list. '
                         'Taking first author: %s', a_values[0]
                     )

--- a/inspirehep/dojson/hep/fields/bd5xx.py
+++ b/inspirehep/dojson/hep/fields/bd5xx.py
@@ -24,12 +24,17 @@
 
 from __future__ import absolute_import, division, print_function
 
+import logging
+
 from dojson import utils
 
 from ..model import hep, hep2marc
 from ...utils import force_single_element, get_record_ref
 
 from inspirehep.utils.helpers import force_force_list
+
+
+logger = logging.getLogger(__name__)
 
 
 @hep.over('public_notes', '^500..')
@@ -150,11 +155,14 @@ def thesis2marc(self, key, value):
 def abstracts(self, key, value):
     """Summary, Etc.."""
     if isinstance(value.get('a'), (list, tuple)):
-        import warnings
-        warnings.warn(u'Record with double abstract! Taking first abstract: {}'.format(value.get('a')[0]))
+        logger.warning(
+            'Record with double abstract. '
+            'Taking first abstract: %s', value.get('a')
+        )
         abstract = value.get('a')[0]
     else:
         abstract = value.get('a')
+
     return {
         'value': abstract,
         'source': value.get('9'),

--- a/tests/unit/dojson/test_dojson_hep.py
+++ b/tests/unit/dojson/test_dojson_hep.py
@@ -487,8 +487,8 @@ def test_authors_from_700__a_j_v_m_w_y():
     assert expected == result['authors']
 
 
-@mock.patch('inspirehep.dojson.hep.fields.bd1xx.current_app.logger.error')
-def test_authors_from_700__double_a_u_w_x_y_z(error):
+@mock.patch('inspirehep.dojson.hep.fields.bd1xx.logger.warning')
+def test_authors_from_700__double_a_u_w_x_y_z(warning):
     snippet = (
         '<datafield tag="700" ind1=" " ind2=" ">'
         '  <subfield code="a">Gumplinger, P.</subfield>'
@@ -527,7 +527,7 @@ def test_authors_from_700__double_a_u_w_x_y_z(error):
     result = clean_record(hep.do(create_record(snippet)))
 
     assert expected == result['authors']
-    error.assert_called_with(
+    warning.assert_called_with(
         'Record with mashed up authors list. Taking first author: %s',
         'Gumplinger, P.',
     )


### PR DESCRIPTION
Sentry: https://sentry.cern.ch/inspire-sentry/inspire-labs-qa/group/601658/