### PR TITLE
dojson: split multiple thesis supervisors

### DIFF
--- a/inspirehep/dojson/hep/fields/bd70x75x.py
+++ b/inspirehep/dojson/hep/fields/bd70x75x.py
@@ -36,12 +36,16 @@ from ...utils import get_record_ref
 
 
 @hep.over('thesis_supervisors', '^701..')
-@utils.for_each_value
 def thesis_supervisors(self, key, value):
     """Thesis supervisors.
 
-    FIXME: handle the presence of multiple 700__a.
     FIXME: handle identifiers from 701__i and 701__j."""
+    def _get_thesis_supervisor(a_value, value):
+        return {
+            'affiliations': _get_affiliations(value),
+            'full_name': a_value,
+        }
+
     def _get_affiliations(value):
         result = []
 
@@ -62,10 +66,13 @@ def thesis_supervisors(self, key, value):
 
         return result
 
-    return {
-        'full_name': value.get('a'),
-        'affiliations': _get_affiliations(value),
-    }
+    thesis_supervisors = self.get('thesis_supervisors', [])
+
+    a_values = force_force_list(value.get('a'))
+    for a_value in a_values:
+        thesis_supervisors.append(_get_thesis_supervisor(a_value, value))
+
+    return thesis_supervisors
 
 
 @hep2marc.over('701', 'thesis_supervisors')

--- a/inspirehep/dojson/hep/fields/bd70x75x.py
+++ b/inspirehep/dojson/hep/fields/bd70x75x.py
@@ -35,7 +35,7 @@ from ..model import hep, hep2marc
 from ...utils import get_record_ref
 
 
-@hep.over('thesis_supervisors', '^701..')
+@hep.over('authors', '^701..')
 def thesis_supervisors(self, key, value):
     """Thesis supervisors.
 
@@ -43,6 +43,12 @@ def thesis_supervisors(self, key, value):
     def _get_thesis_supervisor(a_value, value):
         return {
             'affiliations': _get_affiliations(value),
+            'contributor_roles': [
+                {
+                    'source': 'CRediT',
+                    'value': 'Supervision',
+                },
+            ],
             'full_name': a_value,
         }
 
@@ -66,25 +72,28 @@ def thesis_supervisors(self, key, value):
 
         return result
 
-    thesis_supervisors = self.get('thesis_supervisors', [])
+    authors = self.get('authors', [])
 
     a_values = force_force_list(value.get('a'))
     for a_value in a_values:
-        thesis_supervisors.append(_get_thesis_supervisor(a_value, value))
+        authors.append(_get_thesis_supervisor(a_value, value))
 
-    return thesis_supervisors
+    return authors
 
 
-@hep2marc.over('701', 'thesis_supervisors')
+@hep2marc.over('701', 'authors')
 @utils.for_each_value
 def thesis_supervisors2marc(self, key, value):
     """Thesis supervisors.
 
     FIXME: handle recids to 701__z."""
-    return {
-        'a': value.get('full_name'),
-        'u': get_value(value, 'affiliations.value'),
-    }
+    _is_supervisor = 'Supervision' in value.get('contributor_roles', [])
+
+    if _is_supervisor:
+        return {
+            'a': value.get('full_name'),
+            'u': get_value(value, 'affiliations.value'),
+        }
 
 
 @hep.over('collaboration', '^710[10_2][_2]')

--- a/tests/unit/dojson/test_dojson_hep.py
+++ b/tests/unit/dojson/test_dojson_hep.py
@@ -1089,7 +1089,7 @@ def test_thesaurus_terms(marcxml_to_json, json_to_marc):
             json_to_marc['695'][0]['a'])
 
 
-def test_thesis_supervisors_from_701__a_u():
+def test_authors_supervisors_from_701__a_u():
     snippet = (
         '<datafield tag="701" ind1=" " ind2=" ">'
         '  <subfield code="a">Garutti, Erika</subfield>'
@@ -1105,15 +1105,21 @@ def test_thesis_supervisors_from_701__a_u():
                     'value': 'U. Hamburg (main)',
                 }
             ],
+            'contributor_roles': [
+                {
+                    'source': 'CRediT',
+                    'value': 'Supervision',
+                },
+            ],
             'full_name': 'Garutti, Erika',
         },
     ]
     result = clean_record(hep.do(create_record(snippet)))
 
-    assert expected == result['thesis_supervisors']
+    assert expected == result['authors']
 
 
-def test_thesis_supervisors_from_701__a_double_u():
+def test_authors_supervisors_from_701__a_double_u():
     snippet = (
         '<datafield tag="701" ind1=" " ind2=" ">'
         '  <subfield code="a">Mnich, Joachim</subfield>'
@@ -1134,15 +1140,21 @@ def test_thesis_supervisors_from_701__a_double_u():
                     'value': 'U. Hamburg (main)',
                 },
             ],
+            'contributor_roles': [
+                {
+                    'source': 'CRediT',
+                    'value': 'Supervision',
+                },
+            ],
             'full_name': 'Mnich, Joachim',
         },
     ]
     result = clean_record(hep.do(create_record(snippet)))
 
-    assert expected == result['thesis_supervisors']
+    assert expected == result['authors']
 
 
-def test_thesis_supervisors_from_multiple_701():
+def test_authors_supervisors_from_multiple_701():
     snippet = (
         '<record>'
         '  <datafield tag="701" ind1=" " ind2=" ">'
@@ -1169,6 +1181,12 @@ def test_thesis_supervisors_from_multiple_701():
                     'value': 'U. Hamburg (main)',
                 },
             ],
+            'contributor_roles': [
+                {
+                    'source': 'CRediT',
+                    'value': 'Supervision',
+                },
+            ],
             'full_name': 'Garutti, Erika',
         },
         {
@@ -1182,6 +1200,12 @@ def test_thesis_supervisors_from_multiple_701():
                     'value': 'U. Hamburg (main)',
                 },
             ],
+            'contributor_roles': [
+                {
+                    'source': 'CRediT',
+                    'value': 'Supervision',
+                },
+            ],
             'full_name': 'Mnich, Joachim',
         },
         {
@@ -1191,15 +1215,21 @@ def test_thesis_supervisors_from_multiple_701():
                     'value': 'U. Geneva (main)',
                 },
             ],
+            'contributor_roles': [
+                {
+                    'source': 'CRediT',
+                    'value': 'Supervision',
+                },
+            ],
             'full_name': 'Pohl, Martin',
         },
     ]
     result = clean_record(hep.do(create_record(snippet)))
 
-    assert expected == result['thesis_supervisors']
+    assert expected == result['authors']
 
 
-def test_thesis_supervisors_from_multiple_701_with_z():
+def test_authors_supervisors_from_multiple_701_with_z():
     snippet = (
         '<record>'
         '  <datafield tag="701" ind1=" " ind2=" ">'
@@ -1233,6 +1263,12 @@ def test_thesis_supervisors_from_multiple_701_with_z():
                     'value': 'U. Hamburg (main)',
                 },
             ],
+            'contributor_roles': [
+                {
+                    'source': 'CRediT',
+                    'value': 'Supervision',
+                },
+            ],
             'full_name': 'Garutti, Erika',
         },
         {
@@ -1252,6 +1288,12 @@ def test_thesis_supervisors_from_multiple_701_with_z():
                     'value': 'U. Hamburg (main)',
                 },
             ],
+            'contributor_roles': [
+                {
+                    'source': 'CRediT',
+                    'value': 'Supervision',
+                },
+            ],
             'full_name': 'Mnich, Joachim',
         },
         {
@@ -1264,15 +1306,21 @@ def test_thesis_supervisors_from_multiple_701_with_z():
                     'value': 'U. Geneva (main)',
                 },
             ],
+            'contributor_roles': [
+                {
+                    'source': 'CRediT',
+                    'value': 'Supervision',
+                },
+            ],
             'full_name': 'Pohl, Martin',
         },
     ]
     result = clean_record(hep.do(create_record(snippet)))
 
-    assert expected == result['thesis_supervisors']
+    assert expected == result['authors']
 
 
-def test_thesis_supervisors_from_701__double_a_u_z():
+def test_authors_supervisors_from_701__double_a_u_z():
     snippet = (
         '<datafield tag="701" ind1=" " ind2=" ">'
         '  <subfield code="a">Poling, Ron</subfield>'
@@ -1293,6 +1341,12 @@ def test_thesis_supervisors_from_701__double_a_u_z():
                     'value': 'Minnesota U.',
                 },
             ],
+            'contributor_roles': [
+                {
+                    'source': 'CRediT',
+                    'value': 'Supervision',
+                },
+            ],
             'full_name': 'Poling, Ron',
         },
         {
@@ -1305,12 +1359,18 @@ def test_thesis_supervisors_from_701__double_a_u_z():
                     'value': 'Minnesota U.',
                 },
             ],
+            'contributor_roles': [
+                {
+                    'source': 'CRediT',
+                    'value': 'Supervision',
+                },
+            ],
             'full_name': 'Kubota, Yuichi',
         }
     ]
     result = clean_record(hep.do(create_record(snippet)))
 
-    assert expected == result['thesis_supervisors']
+    assert expected == result['authors']
 
 
 def test_collaboration(marcxml_to_json, json_to_marc):

--- a/tests/unit/dojson/test_dojson_hep.py
+++ b/tests/unit/dojson/test_dojson_hep.py
@@ -1272,6 +1272,46 @@ def test_thesis_supervisors_from_multiple_701_with_z():
     assert expected == result['thesis_supervisors']
 
 
+def test_thesis_supervisors_from_701__double_a_u_z():
+    snippet = (
+        '<datafield tag="701" ind1=" " ind2=" ">'
+        '  <subfield code="a">Poling, Ron</subfield>'
+        '  <subfield code="a">Kubota, Yuichi</subfield>'
+        '  <subfield code="u">Minnesota U.</subfield>'
+        '  <subfield code="z">903010</subfield>'
+        '</datafield>'
+    )  # record/776962/export/xme
+
+    expected = [
+        {
+            'affiliations': [
+                {
+                    'curated_relation': True,
+                    'record': {
+                        '$ref': 'http://localhost:5000/api/institutions/903010',
+                    },
+                    'value': 'Minnesota U.',
+                },
+            ],
+            'full_name': 'Poling, Ron',
+        },
+        {
+            'affiliations': [
+                {
+                    'curated_relation': True,
+                    'record': {
+                        '$ref': 'http://localhost:5000/api/institutions/903010',
+                    },
+                    'value': 'Minnesota U.',
+                },
+            ],
+            'full_name': 'Kubota, Yuichi',
+        }
+    ]
+    result = clean_record(hep.do(create_record(snippet)))
+
+    assert expected == result['thesis_supervisors']
+
 
 def test_collaboration(marcxml_to_json, json_to_marc):
     """Test if collaboration is created correctly."""

--- a/tests/unit/utils/test_utils_bibtex.py
+++ b/tests/unit/utils/test_utils_bibtex.py
@@ -341,25 +341,6 @@ def test_get_author_one_author_without_full_name():
     assert expected == result
 
 
-def test_get_author_one_author_with_full_name_a_list():
-    one_author_with_full_name_a_list = Record({
-        'authors': [
-            {
-                'full_name': [
-                    'Goldstone, Jeffrey',
-                    'Salam, Abdus',
-                    'Weinberg, Steven'
-                ]
-            }
-        ]
-    })
-
-    expected = ['Goldstone, Jeffreyand Salam, Abdusand Weinberg, Steven']
-    result = Bibtex(one_author_with_full_name_a_list)._get_author()
-
-    assert expected == result
-
-
 def test_get_author_one_author_with_one_fullname():
     one_author_with_one_fullname = Record({
         'authors': [
@@ -383,6 +364,28 @@ def test_get_author_two_authors_with_fullnames():
 
     expected = ['Englert, F.', 'Brout, R.']
     result = Bibtex(two_authors_with_fullnames)._get_author()
+
+    assert expected == result
+
+
+def test_get_author_two_authors_one_a_supervisor():
+    two_authors_one_a_supervisor = Record({
+        'authors': [
+            {'full_name': 'Mankuzhiyil, Nijil'},
+            {
+                'contributor_roles': [
+                    {
+                        'source': 'CRediT',
+                        'value': 'Supervision',
+                    },
+                ],
+                'full_name': 'de Angelis, Alessandro',
+            },
+        ],
+    })
+
+    expected = ['Mankuzhiyil, Nijil']
+    result = Bibtex(two_authors_one_a_supervisor)._get_author()
 
     assert expected == result
 


### PR DESCRIPTION
Sentry: https://sentry.cern.ch/inspire-sentry/inspire-labs-qa/group/601938/

A `701` field can contain multiple `a` subfields. A reasonable
interpretation is that they all share the same affiliation(s)
contained in the `u` subfields of the field. This code assumes
this and creates a `thesis_supervisor` per `701__a` field it
finds.

By using the `contributor_roles` added in cf74d6 we can specify
the fact that an author contributed to some work as a supervisor.
This means that the `thesis_supervisor` key is redundant, and
can be merged inside of `authors`.  (Closes #1259)

Also adds some logic to the BibTeX exporter in order not to add
the thesis supervisors as authors. This addition required some
refactoring to the `get_author` method, which removed the support
for multiple `full_name`s, since it should never happen anyway.