### PR TITLE
API: extend /authors endpoint

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -360,6 +360,102 @@ RECORDS_REST_ENDPOINTS = dict(
         max_result_window=10000,
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
     ),
+    authors_citations=dict(
+        pid_type='authors',
+        pid_minter='inspire_recid_minter',
+        pid_fetcher='inspire_recid_fetcher',
+        search_class='inspirehep.modules.search:AuthorsSearch',
+        record_serializers={
+            'application/json': ('inspirehep.modules.authors.rest'
+                                 ':citations_v1_response'),
+        },
+        search_serializers={
+            'application/json': ('invenio_records_rest.serializers'
+                                 ':json_v1_search'),
+            'application/vnd+inspire.brief+json': (
+                'inspirehep.modules.records.serializers'
+                ':json_brief_v1_search'
+            ),
+        },
+        list_route='/authors/',
+        item_route='/authors/<pidpath(authors):pid_value>/citations',
+        default_media_type='application/json',
+        max_result_window=10000,
+        search_factory_imp=('inspirehep.modules.search.query'
+                            ':inspire_search_factory'),
+    ),
+    authors_coauthors=dict(
+        pid_type='authors',
+        pid_minter='inspire_recid_minter',
+        pid_fetcher='inspire_recid_fetcher',
+        search_class='inspirehep.modules.search:AuthorsSearch',
+        record_serializers={
+            'application/json': ('inspirehep.modules.authors.rest'
+                                 ':coauthors_v1_response'),
+        },
+        search_serializers={
+            'application/json': ('invenio_records_rest.serializers'
+                                 ':json_v1_search'),
+            'application/vnd+inspire.brief+json': (
+                'inspirehep.modules.records.serializers'
+                ':json_brief_v1_search'
+            ),
+        },
+        list_route='/authors/',
+        item_route='/authors/<pidpath(authors):pid_value>/coauthors',
+        default_media_type='application/json',
+        max_result_window=10000,
+        search_factory_imp=('inspirehep.modules.search.query'
+                            ':inspire_search_factory'),
+    ),
+    authors_publications=dict(
+        pid_type='authors',
+        pid_minter='inspire_recid_minter',
+        pid_fetcher='inspire_recid_fetcher',
+        search_class='inspirehep.modules.search:AuthorsSearch',
+        record_serializers={
+            'application/json': ('inspirehep.modules.authors.rest'
+                                 ':publications_v1_response'),
+        },
+        search_serializers={
+            'application/json': ('invenio_records_rest.serializers'
+                                 ':json_v1_search'),
+            'application/vnd+inspire.brief+json': (
+                'inspirehep.modules.records.serializers'
+                ':json_brief_v1_search'
+            ),
+        },
+        list_route='/authors/',
+        item_route='/authors/<pidpath(authors):pid_value>/publications',
+        default_media_type='application/json',
+        max_result_window=10000,
+        search_factory_imp=('inspirehep.modules.search.query'
+                            ':inspire_search_factory'),
+    ),
+    authors_stats=dict(
+        pid_type='authors',
+        pid_minter='inspire_recid_minter',
+        pid_fetcher='inspire_recid_fetcher',
+        search_class='inspirehep.modules.search:AuthorsSearch',
+        record_serializers={
+            'application/json': ('inspirehep.modules.authors.rest'
+                                 ':stats_v1_response'),
+        },
+        search_serializers={
+            'application/json': ('invenio_records_rest.serializers'
+                                 ':json_v1_search'),
+            'application/vnd+inspire.brief+json': (
+                'inspirehep.modules.records.serializers'
+                ':json_brief_v1_search'
+            ),
+        },
+        list_route='/authors/',
+        item_route='/authors/<pidpath(authors):pid_value>/stats',
+        default_media_type='application/json',
+        max_result_window=10000,
+        search_factory_imp=('inspirehep.modules.search.query'
+                            ':inspire_search_factory'),
+    ),
     data=dict(
         pid_type='data',
         pid_minter='inspire_recid_minter',

--- a/inspirehep/modules/authors/rest/__init__.py
+++ b/inspirehep/modules/authors/rest/__init__.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Record serialization."""
+
+from __future__ import absolute_import, division, print_function
+
+from inspirehep.modules.authors.rest.citations import AuthorAPICitations
+from inspirehep.modules.authors.rest.coauthors import AuthorAPICoauthors
+from inspirehep.modules.authors.rest.publications import AuthorAPIPublications
+from inspirehep.modules.authors.rest.stats import AuthorAPIStats
+from inspirehep.modules.records.serializers.response import (
+    record_responsify_nocache,
+)
+
+citations_v1 = AuthorAPICitations()
+citations_v1_response = record_responsify_nocache(citations_v1,
+                                                  'application/json')
+
+coauthors_v1 = AuthorAPICoauthors()
+coauthors_v1_response = record_responsify_nocache(coauthors_v1,
+                                                  'application/json')
+
+publications_v1 = AuthorAPIPublications()
+publications_v1_response = record_responsify_nocache(publications_v1,
+                                                     'application/json')
+
+stats_v1 = AuthorAPIStats()
+stats_v1_response = record_responsify_nocache(stats_v1,
+                                              'application/json')

--- a/inspirehep/modules/authors/rest/citations.py
+++ b/inspirehep/modules/authors/rest/citations.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import json
+
+from inspirehep.modules.search import LiteratureSearch
+
+
+class AuthorAPICitations(object):
+    """API endpoint for author collection returning citations."""
+
+    def serialize(self, pid, record, links_factory=None):
+        """Return a list of citations for a given author recid.
+
+        :param pid:
+            Persistent identifier instance.
+
+        :param record:
+            Record instance.
+
+        :param links_factory:
+            Factory function for the link generation, which are added to
+            the response.
+        """
+        author_pid = pid.pid_value
+        citations = []
+
+        search = LiteratureSearch().query({
+            "match": {
+                "authors.recid": author_pid
+            }
+        }).params(
+            _source=[
+                "authors.recid",
+                "control_number",
+                "self",
+            ]
+        )
+
+        # For each publication co-authored by a given author...
+        for result in search.scan():
+            result_source = result.to_dict()
+            authors = set([i['recid'] for i in result_source['authors']])
+
+            nested_search = LiteratureSearch().query({
+                "match": {
+                    "references.recid": result_source['control_number']
+                }
+            }).params(
+                _source=[
+                    "authors.recid",
+                    "collections",
+                    "control_number",
+                    "earliest_date",
+                    "self",
+                ]
+            )
+
+            # The source record that is being cited.
+            citee = result_source['self']
+
+            # Check all publications, which cite the parent record.
+            for nested_result in nested_search.scan():
+                nested_result_source = nested_result.to_dict()
+
+                # Not every signature has a recid (at least for demo records).
+                try:
+                    nested_authors = set(
+                        [i['recid'] for i in nested_result_source['authors']]
+                    )
+                except KeyError:
+                    nested_authors = set()
+
+                citation = {}
+                citation['citee'] = {'record': citee}
+                citation['citer'] = {'record': nested_result_source['self']}
+
+                # If at least one author is shared, it's a self-citation.
+                if len(authors & nested_authors):
+                    citation['self_citation'] = True
+                else:
+                    citation['self_citation'] = False
+
+                # Get the earliest date of a citer.
+                try:
+                    citation['date'] = nested_result_source['earliest_date']
+                except KeyError:
+                    pass
+
+                # Get status if a citer is published.
+                # FIXME: As discussed with Sam, we should have a boolean flag
+                #        for this type of information.
+                try:
+                    citation['published_paper'] = "Published" in [
+                        i['primary'] for i in nested_result_source[
+                            'collections']]
+                except KeyError:
+                    citation['published_paper'] = False
+
+                citations.append(citation)
+
+        return json.dumps(citations)

--- a/inspirehep/modules/authors/rest/coauthors.py
+++ b/inspirehep/modules/authors/rest/coauthors.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import json
+
+from inspirehep.modules.search import LiteratureSearch
+
+
+class AuthorAPICoauthors(object):
+    """API endpoint for author collection returning co-authors."""
+
+    def serialize(self, pid, record, links_factory=None):
+        """Return a list of co-authors for a given author recid.
+
+        :param pid:
+            Persistent identifier instance.
+
+        :param record:
+            Record instance.
+
+        :param links_factory:
+            Factory function for the link generation, which are added to
+            the response.
+        """
+        author_pid = pid.pid_value
+        coauthors = {}
+
+        search = LiteratureSearch().query({
+            "match": {
+                "authors.recid": author_pid
+            }
+        }).params(
+            _source=[
+                "authors.full_name",
+                "authors.recid",
+                "authors.record",
+            ]
+        )
+
+        for result in search.scan():
+            result_source = result.to_dict()['authors']
+
+            for author in result_source:
+                try:
+                    # Don't add the reference author.
+                    if author['recid'] != author_pid:
+                        if author['recid'] in coauthors:
+                            coauthors[author['recid']]['count'] += 1
+                        else:
+                            coauthors[author['recid']] = dict(
+                                count=1,
+                                full_name=author['full_name'],
+                                id=author['recid'],
+                                record=author['record'],
+                            )
+                except KeyError:
+                    pass
+
+        return json.dumps(coauthors.values())

--- a/inspirehep/modules/authors/rest/publications.py
+++ b/inspirehep/modules/authors/rest/publications.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import json
+
+from inspirehep.modules.search import LiteratureSearch
+from inspirehep.utils.record import get_title
+
+
+class AuthorAPIPublications(object):
+    """API endpoint for author collection returning publications."""
+
+    def serialize(self, pid, record, links_factory=None):
+        """Return a list of publications for a given author recid.
+
+        :param pid:
+            Persistent identifier instance.
+
+        :param record:
+            Record instance.
+
+        :param links_factory:
+            Factory function for the link generation, which are added to
+            the response.
+        """
+        author_pid = pid.pid_value
+        publications = []
+
+        search = LiteratureSearch().query({
+            "match": {
+                "authors.recid": author_pid
+            }
+        }).params(
+            _source=[
+                "accelerator_experiments",
+                "earliest_date",
+                "citation_count",
+                "control_number",
+                "facet_inspire_doc_type",
+                "publication_info",
+                "self",
+                "thesaurus_terms",
+                "titles",
+            ]
+        )
+
+        for result in search.scan():
+            result_source = result.to_dict()
+
+            publication = {}
+            publication['id'] = int(result_source['control_number'])
+            publication['record'] = result_source['self']
+            publication['title'] = get_title(result_source)
+
+            # Get the earliest date.
+            try:
+                publication['date'] = result_source['earliest_date']
+            except KeyError:
+                pass
+
+            # Get publication type.
+            try:
+                publication['type'] = result_source.get(
+                    'facet_inspire_doc_type', [])[0]
+            except IndexError:
+                pass
+
+            # Get citation count.
+            try:
+                publication['citations'] = result_source['citation_count']
+            except KeyError:
+                pass
+
+            # Get journal.
+            try:
+                publication['journal'] = {}
+                publication['journal']['title'] = result_source.get(
+                    'publication_info', [])[0]['journal_title']
+
+                # Get journal $self.
+                try:
+                    publication['journal']['record'] = result_source.get(
+                        'publication_info', [])[0]['journal_record']
+                except KeyError:
+                    pass
+            except (IndexError, KeyError):
+                del publication['journal']
+
+            # Get collaborations.
+            collaborations = set()
+
+            for experiment in result_source.get('accelerator_experiments', []):
+                collaborations.add(experiment.get('experiment'))
+
+            if collaborations:
+                publication['collaborations'] = list(collaborations)
+
+            publications.append(publication)
+
+        return json.dumps(publications)

--- a/inspirehep/modules/authors/rest/stats.py
+++ b/inspirehep/modules/authors/rest/stats.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+from collections import Counter
+import json
+
+from inspirehep.modules.search import LiteratureSearch
+from inspirehep.utils.stats import calculate_h_index, calculate_i10_index
+
+
+class AuthorAPIStats(object):
+    """API endpoint for author collection returning statistics."""
+
+    def serialize(self, pid, record, links_factory=None):
+        """Return a different metrics for a given author recid.
+
+        :param pid:
+            Persistent identifier instance.
+
+        :param record:
+            Record instance.
+
+        :param links_factory:
+            Factory function for the link generation, which are added to
+            the response.
+        """
+        author_pid = pid.pid_value
+
+        fields = set()
+        keywords = []
+
+        statistics = {}
+        statistics['citations'] = 0
+        statistics['publications'] = 0
+        statistics['types'] = {}
+
+        statistics_citations = {}
+
+        search = LiteratureSearch().query({
+            "match": {
+                "authors.recid": author_pid
+            }
+        }).params(
+            _source=[
+                "citation_count",
+                "control_number",
+                "facet_inspire_doc_type",
+                "facet_inspire_subjects",
+                "thesaurus_terms",
+            ]
+        )
+
+        for result in search.scan():
+            result_source = result.to_dict()
+
+            # Increment the count of the total number of publications.
+            statistics['publications'] += 1
+
+            # Increment the count of citations.
+            citation_count = result_source.get('citation_count', 0)
+
+            statistics['citations'] += citation_count
+            statistics_citations[int(result_source['control_number'])] = \
+                citation_count
+
+            # Count how many times certain type of publication was published.
+            try:
+                publication_type = result_source.get(
+                    'facet_inspire_doc_type', [])[0]
+            except IndexError:
+                pass
+
+            if publication_type:
+                if publication_type in statistics['types']:
+                    statistics['types'][publication_type] += 1
+                else:
+                    statistics['types'][publication_type] = 1
+
+            # Get fields.
+            for field in result_source.get('facet_inspire_subjects', []):
+                fields.add(field)
+
+            # Get keywords.
+            for term in result_source.get('thesaurus_terms', []):
+                if term.get('keyword') is not "* Automatic Keywords *":
+                    keywords.append(term.get('keyword'))
+
+        # Calculate h-index together with i10-index.
+        statistics['hindex'] = calculate_h_index(statistics_citations)
+        statistics['i10index'] = calculate_i10_index(statistics_citations)
+
+        if fields:
+            statistics['fields'] = list(fields)
+
+        # Return the top 25 keywords.
+        if keywords:
+            counter = Counter(keywords)
+            statistics['keywords'] = [{
+                'count': i[1],
+                'keyword': i[0]
+            } for i in counter.most_common(25)]
+
+        return json.dumps(statistics)

--- a/tests/integration/test_author_api.py
+++ b/tests/integration/test_author_api.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import json
+
+import six
+
+
+def test_author_main_path(app):
+    """This test checks only if the status cod and author profile are correct.
+    The functionality is provided by invenio-records-rest, which is not the
+    subject of these tests.
+    """
+    with app.test_client() as client:
+        assert client.get(
+            '/api/authors/983220').status_code == 200
+
+        request = json.loads(
+            client.get('/api/authors/983220').data)
+
+        assert request['id'] == 983220
+
+
+def test_author_citations_endpoint(app):
+    """This test checks for the total count of objects and the availability
+    of required keys and their type.
+    """
+    with app.test_client() as client:
+        assert client.get(
+            '/api/authors/983220/citations').status_code == 200
+
+        request = json.loads(
+            client.get('/api/authors/983220/citations').data)
+
+        assert len(request) == 197
+        assert isinstance(request[0]['date'], six.string_types)
+        assert isinstance(request[0]['self_citation'], bool)
+        assert isinstance(request[0]['citee']['record']['$ref'],
+                          six.string_types)
+        assert isinstance(request[0]['citer']['record']['$ref'],
+                          six.string_types)
+        assert isinstance(request[0]['published_paper'], bool)
+
+
+def test_author_coauthors_endpoint(app):
+    """This test checks for the total count of objects and the availability
+    of required keys and their type.
+    """
+    with app.test_client() as client:
+        assert client.get(
+            '/api/authors/983220/coauthors').status_code == 200
+
+        request = json.loads(
+            client.get('/api/authors/983220/coauthors').data)
+
+        assert len(request) == 100
+        assert isinstance(request[0]['count'], int)
+        assert isinstance(request[0]['record']['$ref'], six.string_types)
+        assert isinstance(request[0]['id'], int)
+        assert isinstance(request[0]['full_name'], six.string_types)
+
+
+def test_author_publications_endpoint(app):
+    """This test checks for the total count of objects and the availability
+    of required keys and their type.
+    """
+    with app.test_client() as client:
+        assert client.get(
+            '/api/authors/983220/publications').status_code == 200
+
+        request = json.loads(
+            client.get('/api/authors/983220/publications').data)
+
+        assert len(request) == 30
+        assert isinstance(request[0]['title'], six.string_types)
+        assert isinstance(request[0]['collaborations'][0], six.string_types)
+        assert isinstance(request[0]['journal']['record']['$ref'],
+                          six.string_types)
+        assert isinstance(request[0]['citations'], int)
+        assert isinstance(request[0]['date'], six.string_types)
+        assert isinstance(request[0]['type'], six.string_types)
+        assert isinstance(request[0]['id'], int)
+
+
+def test_author_stats_endpoint(app):
+    """This test checks for the total count of objects and the availability
+    of required keys and their type.
+    """
+    with app.test_client() as client:
+        assert client.get(
+            '/api/authors/983220/stats').status_code == 200
+
+        request = json.loads(
+            client.get('/api/authors/983220/stats').data)
+
+        assert isinstance(request['fields'][0], six.string_types)
+        assert isinstance(request['hindex'], int)
+        assert isinstance(request['i10index'], int)
+        assert isinstance(request['citations'], int)
+        assert isinstance(request['publications'], int)
+
+        assert len(request['keywords']) == 25
+        assert isinstance(request['keywords'][0]['count'], int)
+        assert isinstance(request['keywords'][0]['keyword'], six.string_types)
+
+        assert isinstance(request['types'], dict)


### PR DESCRIPTION
* Adds a new entry point in RECORDS_REST_ENDPOINTS.

* Adds serializers to authors module.

Signed-off-by: Grzegorz Jacenków <grzegorz.jacenkow@cern.ch>