### PR TITLE
setup: pin webassets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,8 @@ install_requires = [
     'pytest-runner>=2.7.0',
     'workflow>=2.0.0',
     'html5lib<1.0b9',
-    'SQLAlchemy>=1.0.14,<1.1'
+    'SQLAlchemy>=1.0.14,<1.1',
+    'webassets>=0.11.1,<0.12',
 ]
 
 tests_require = [


### PR DESCRIPTION
`webassets==0.12.0` introduces an unknown regression whose exception can be found on Sentry: https://sentry.cern.ch/inspire-sentry/inspire-labs-qa/group/603057/.

Pinning it to the previous version should work around this issue.