### PR TITLE
jsonschema: simple titles

### DIFF
--- a/inspirehep/dojson/hep/fields/bd20x24x.py
+++ b/inspirehep/dojson/hep/fields/bd20x24x.py
@@ -24,111 +24,69 @@
 
 from __future__ import absolute_import, division, print_function
 
-from dojson import utils
+import langdetect
 
 from ..model import hep, hep2marc
 
+from inspirehep.dojson.utils import force_single_element
 from inspirehep.utils.helpers import force_force_list
 
 
-@hep.over('title_translations', '^242[10_][0_]')
-@hep.over('titles_old', '^247[10_][10_]')
-@utils.for_each_value
-@utils.filter_values
-def title_translations_old(self, key, value):
-    """Translation of Title by Cataloging Agency."""
-    return {
-        'source': value.get('9'),
-        'title': value.get('a'),
-        'subtitle': value.get('b')
-    }
-
-
-@hep2marc.over('210', '^title_variations$')
-@hep2marc.over('242', '^title_translations$')
-@hep2marc.over('247', '^titles_old$')
-@utils.for_each_value
-@utils.filter_values
-def title_trans_var_old2marc(self, key, value):
-    """Translation of Title by Cataloging Agency."""
-    return {
-        'a': value.get('title'),
-        'b': value.get('subtitle'),
-        '9': value.get('source'),
-    }
-
-
-@hep.over('title_variations', '^210[10_][0_]')
-def title_variations(self, key, value):
-    """Title variations."""
-    def get_value(existing):
-        if not isinstance(value, (tuple, list)):
-            values = [value]
-        else:
-            values = value
-        out = []
-        for val in values:
-            out.append({
-                'title': val.get('a'),
-                'subtitle': val.get('b'),
-                'source': val.get('9'),
-            })
-        cleaned_titles = existing + out
-        return cleaned_titles
-
-    if 'title_variations' in self:
-        titles = get_value(self['title_variations'])
-    else:
-        titles = get_value([])
-
-    return titles
-
-
-@hep.over('titles', '^24[56][10_][0_]')
+@hep.over('titles', '^(210|24[2567])[10_][0_]')
 def titles(self, key, value):
-    """Title Statement."""
-    def get_value(existing):
-        if not isinstance(value, (tuple, list)):
-            values = [value]
-        else:
-            values = value
-        out = []
-        for val in values:
-            out.append({
-                'title': val.get('a'),
-                'subtitle': val.get('b'),
-                'source': val.get('9'),
-            })
-        cleaned_titles = existing + out
-        return cleaned_titles
+    def is_main_title(key):
+        return key.startswith('245')
 
-    if 'titles' in self:
-        titles = get_value(self['titles'])
-    else:
-        titles = get_value([])
+    def is_translated_title(key):
+        return key.startswith('242')
 
-    return titles
-
-
-@hep2marc.over('245', '^titles$')
-def titles2marc(self, key, value):
-    """Title Statement for 245/246."""
-    arxiv_246_title = None
-    titles = []
-
-    for title in force_force_list(value):
-        transformed_title = {
-            'a': title.get('title'),
-            'b': title.get('subtitle'),
-            '9': title.get('source'),
+    titles = self.setdefault('titles', [])
+    values = force_force_list(value)
+    for val in values:
+        title_obj = {
+            'title': val.get('a'),
+            'subtitle': force_single_element(val.get('b')),  # FIXME: #1484
+            'source': val.get('9'),
         }
-        if title.get('source', '').lower() == 'arxiv':
-            arxiv_246_title = transformed_title
+        if is_main_title(key):
+            titles.insert(0, title_obj)
+        elif is_translated_title(key):
+            title = val.get('a')
+            if title:
+                lang = langdetect.detect(title)
+                if lang:
+                    title_obj['language'] = lang
+                    self.setdefault('title_translations', []).append(title_obj)
         else:
-            titles.append(transformed_title)
+            titles.append(title_obj)
 
-    if len(titles) == 0 and arxiv_246_title is not None:
-        titles.append(arxiv_246_title)
-    if arxiv_246_title is not None:
-        self['246'] = arxiv_246_title
     return titles
+
+
+@hep2marc.over('246', '^titles$')
+def titles2marc(self, key, value):
+    def get_transformed_title(val):
+        return {
+            'a': val.get('title'),
+            'b': val.get('subtitle'),
+            '9': val.get('source'),
+        }
+
+    values = force_force_list(value)
+    if values:
+        # Anything but the first element is the main title
+        self['245'] = [get_transformed_title(values[0])]
+    return [get_transformed_title(value) for value in values[1:]]
+
+
+@hep2marc.over('242', r'^title_translations$')
+def title_translations2marc(self, key, value):
+    def get_transformed_title(val):
+        return {
+            'a': val.get('title'),
+            'b': val.get('subtitle'),
+            '9': val.get('source'),
+        }
+
+    values = force_force_list(value)
+    return [get_transformed_title(value) for value in values]

--- a/inspirehep/modules/records/jsonschemas/records/hep.json
+++ b/inspirehep/modules/records/jsonschemas/records/hep.json
@@ -498,10 +498,10 @@
         },
         "languages": {
             "items": {
-                "title": "Language",
-                "type": "string",
+                "format": "ISO 639-1",
                 "pattern": "\\w{2}",
-                "format": "ISO 639-1"
+                "title": "Language",
+                "type": "string"
             },
             "type": "array"
         },
@@ -815,26 +815,28 @@
         },
         "title_translations": {
             "items": {
-                "$ref": "elements/title.json"
-            },
-            "type": "array",
-            "uniqueItems": true
-        },
-        "title_variations": {
-            "items": {
-                "$ref": "elements/title.json"
+                "properties": {
+                    "language": {
+                        "format": "ISO 639-1",
+                        "pattern": "\\w{2}",
+                        "type": "string"
+                    },
+                    "source": {
+                        "type": "string"
+                    },
+                    "subtitle": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
             },
             "type": "array",
             "uniqueItems": true
         },
         "titles": {
-            "items": {
-                "$ref": "elements/title.json"
-            },
-            "type": "array",
-            "uniqueItems": true
-        },
-        "titles_old": {
             "items": {
                 "$ref": "elements/title.json"
             },

--- a/inspirehep/utils/record.py
+++ b/inspirehep/utils/record.py
@@ -29,36 +29,12 @@ SPLIT_KEY_PATTERN = re.compile('\.|\[')
 
 def get_title(record):
     """Get preferred title from record."""
-    chosen_title = ""
-
-    for title in record.get('titles', []):
-        if 'source' in title and title.get('source') != 'arXiv':
-            return title.get('title')
-        elif 'source' in title and title.get('source') == 'arXiv':
-            pass
-        else:
-            chosen_title = title.get('title')
-
-    if not chosen_title and len(record.get('titles', [])) > 0:
-        chosen_title = record['titles'][0]['title']
-
-    return chosen_title
+    return get_value(record, 'titles[0].title', default='')
 
 
 def get_subtitle(record):
     """Get preferred subtitle from record."""
-    chosen_subtitle = ""
-
-    for title in record.get('titles', []):
-        if 'source' in title and 'subtitle' in title and title.get('source') != 'arXiv':
-            return title.get('subtitle')
-        elif 'source' in title and 'subtitle' in title and title.get('source') == 'arXiv':
-            if not chosen_subtitle:
-                chosen_subtitle = title.get('subtitle')
-        else:
-            if 'subtitle' in title:
-                chosen_subtitle = title.get('subtitle')
-    return chosen_subtitle
+    return get_value(record, 'titles[0].subtitle', default='')
 
 
 def get_abstract(record):

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ install_requires = [
     'retrying',
     'flower',
     'rt',
+    'langdetect>=1.0.6',
     'librabbitmq>=1.6.1',
     'idutils>=0.2.1',
     'invenio-jsonschemas>=1.0.0a3',

--- a/tests/unit/dojson/test_dojson_hep.py
+++ b/tests/unit/dojson/test_dojson_hep.py
@@ -980,13 +980,10 @@ def test_corporate_author(marcxml_to_json, json_to_marc):
 def test_titles(marcxml_to_json, json_to_marc):
     """Test if titles is created correctly."""
     assert (marcxml_to_json['titles'][0]['title'] ==
+            'S-Duality Constraints on 1D Patterns Associated with Fractional '
+            'Quantum Hall States')
+    assert (marcxml_to_json['titles'][0]['title'] ==
             json_to_marc['245'][0]['a'])
-
-
-def test_title_variations(marcxml_to_json, json_to_marc):
-    """Test if title_variations is created correctly."""
-    assert (marcxml_to_json['title_variations'][0]['title'] ==
-            json_to_marc['210'][0]['a'])
 
 
 def test_title_translations(marcxml_to_json, json_to_marc):
@@ -995,26 +992,22 @@ def test_title_translations(marcxml_to_json, json_to_marc):
             json_to_marc['242'][0]['a'])
     assert (marcxml_to_json['title_translations'][0]['subtitle'] ==
             json_to_marc['242'][0]['b'])
+    assert (marcxml_to_json['title_translations'][0]['language'] == 'en')
 
 
-def test_title_arxiv(marcxml_to_json, json_to_marc):
+def test_title_variations(marcxml_to_json, json_to_marc):
     """Test if title arxiv is created correctly."""
-    def get(key):
-        return [d.get(key) for d in marcxml_to_json['titles']]
+    def build_candidate(candidate, key, value):
+        if value:
+            candidate[key] = value
 
-    assert (json_to_marc['246']['9'] in get('source'))
-    assert (json_to_marc['246']['b'] in get('subtitle'))
-    assert (json_to_marc['246']['a'] in get('title'))
-
-
-def test_titles_old(marcxml_to_json, json_to_marc):
-    """Test if titles_old is created correctly."""
-    assert (marcxml_to_json['titles_old'][0]['source'] ==
-            json_to_marc['247'][0]['9'])
-    assert (marcxml_to_json['titles_old'][0]['subtitle'] ==
-            json_to_marc['247'][0]['b'])
-    assert (marcxml_to_json['titles_old'][0]['title'] ==
-            json_to_marc['247'][0]['a'])
+    title_variations = marcxml_to_json['titles'][1:]
+    for variation in json_to_marc['246']:
+        candidate = {}
+        build_candidate(candidate, 'source', variation.get('9'))
+        build_candidate(candidate, 'title', variation.get('a'))
+        build_candidate(candidate, 'subtitle', variation.get('b'))
+        assert candidate in title_variations
 
 
 def test_imprints(marcxml_to_json, json_to_marc):

--- a/tests/unit/orcid/test_orcid_converter.py
+++ b/tests/unit/orcid/test_orcid_converter.py
@@ -139,7 +139,7 @@ def test_successfull_conversion():
                                                                        'external-identifier-type': 'ARXIV'}]},
                 'journal-title': 'Nuovo Cim.',
                 'short-description': 'Abstract',
-                'title': {'subtitle': 'Subtitle', 'title': 'Title3'},
+                'title': {'subtitle': 'Subtitle', 'title': 'Title'},
                 'type': 'REPORT'}
     result = convert_to_orcid(record)
     assert expected == result

--- a/tests/unit/utils/test_utils_record.py
+++ b/tests/unit/utils/test_utils_record.py
@@ -55,24 +55,6 @@ def test_get_abstract_returns_empty_string_when_no_titles():
     assert expected == result
 
 
-def test_get_title_returns_empty_string_when_titles_is_empty():
-    empty_titles = Record({'titles': []})
-
-    expected = ''
-    result = get_title(empty_titles)
-
-    assert expected == result
-
-
-def test_get_subtitle_returns_empty_string_when_titles_is_empty():
-    empty_titles = Record({'titles': []})
-
-    expected = ''
-    result = get_subtitle(empty_titles)
-
-    assert expected == result
-
-
 def test_get_abstract_returns_empty_string_when_abstracts_is_empty():
     empty_abstracts = Record({'abstracts': []})
 


### PR DESCRIPTION
* Merge title_variations (210) and titles_old(247) into titles with
  the convention that the main title is the first in the list and all
  the others are variations or previous versions. (closes #1257)

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>