### PR TITLE
dojson: more fixes to ids

### DIFF
--- a/inspirehep/dojson/hepnames/fields/bd1xx.py
+++ b/inspirehep/dojson/hepnames/fields/bd1xx.py
@@ -149,6 +149,7 @@ def ids(self, key, value):
             'KAKEN': 'KAKEN',
             'ORCID': 'ORCID',
             'SLAC': 'SLAC',
+            'VIAF': 'VIAF',
             'WIKIPEDIA': 'WIKIPEDIA',
         }
 

--- a/inspirehep/dojson/hepnames/fields/bd1xx.py
+++ b/inspirehep/dojson/hepnames/fields/bd1xx.py
@@ -40,6 +40,7 @@ from inspirehep.utils.helpers import force_force_list
 
 
 INSPIRE_BAI = re.compile('(\w+\.)+\d+')
+LOOKS_LIKE_CERN = re.compile('^\d+$|^CER[MN]?-|^CNER-|^CVERN-', re.I)
 NON_DIGIT = re.compile('[^\d]+')
 
 
@@ -160,7 +161,7 @@ def ids(self, key, value):
             return 'INSPIRE BAI'
 
     def _try_to_correct_value(type_, a_value):
-        if type_ == 'CERN' and a_value.startswith('CERN-'):
+        if type_ == 'CERN' and LOOKS_LIKE_CERN.match(a_value):
             return 'CERN-' + NON_DIGIT.sub('', a_value)
         elif type_ == 'KAKEN':
             return 'KAKEN-' + a_value

--- a/inspirehep/dojson/hepnames/fields/bd1xx.py
+++ b/inspirehep/dojson/hepnames/fields/bd1xx.py
@@ -151,6 +151,7 @@ def ids(self, key, value):
             'RESEARCHID': 'RESEARCHERID',
             'RESEARCHERID': 'RESEARCHERID',
             'SLAC': 'SLAC',
+            'SCOPUS': 'SCOPUS',
             'VIAF': 'VIAF',
             'WIKIPEDIA': 'WIKIPEDIA',
         }

--- a/inspirehep/dojson/hepnames/fields/bd1xx.py
+++ b/inspirehep/dojson/hepnames/fields/bd1xx.py
@@ -175,10 +175,11 @@ def ids(self, key, value):
 
     a_value = _try_to_correct_value(type_, a_value)
 
-    return {
-        'type': type_,
-        'value': a_value,
-    }
+    if type_ and a_value:
+        return {
+            'type': type_,
+            'value': a_value,
+        }
 
 
 @hepnames2marc.over('035', '^ids$')

--- a/inspirehep/dojson/hepnames/fields/bd1xx.py
+++ b/inspirehep/dojson/hepnames/fields/bd1xx.py
@@ -144,6 +144,7 @@ def ids(self, key, value):
             'BAI': 'INSPIRE BAI',
             'CERN': 'CERN',
             'DESY': 'DESY',
+            'GOOGLESCHOLAR': 'GOOGLESCHOLAR',
             'INSPIRE': 'INSPIRE ID',
             'KAKEN': 'KAKEN',
             'ORCID': 'ORCID',

--- a/inspirehep/dojson/hepnames/fields/bd1xx.py
+++ b/inspirehep/dojson/hepnames/fields/bd1xx.py
@@ -159,16 +159,21 @@ def ids(self, key, value):
         if INSPIRE_BAI.match(a_value):
             return 'INSPIRE BAI'
 
+    def _try_to_correct_value(type_, a_value):
+        if type_ == 'CERN' and a_value.startswith('CERN-'):
+            return 'CERN-' + NON_DIGIT.sub('', a_value)
+        elif type_ == 'KAKEN':
+            return 'KAKEN-' + a_value
+        else:
+            return a_value
+
     a_value = force_single_element(value.get('a'))
 
     type_ = _get_type(value)
     if type_ is None:
         type_ = _guess_type_from_value(a_value)
 
-    if type_ == 'CERN' and a_value.startswith('CERN-'):
-        a_value = 'CERN-' + NON_DIGIT.sub('', a_value)
-    elif type_ == 'KAKEN':
-        a_value = 'KAKEN-' + a_value
+    a_value = _try_to_correct_value(type_, a_value)
 
     return {
         'type': type_,

--- a/inspirehep/dojson/hepnames/fields/bd1xx.py
+++ b/inspirehep/dojson/hepnames/fields/bd1xx.py
@@ -148,6 +148,8 @@ def ids(self, key, value):
             'INSPIRE': 'INSPIRE ID',
             'KAKEN': 'KAKEN',
             'ORCID': 'ORCID',
+            'RESEARCHID': 'RESEARCHERID',
+            'RESEARCHERID': 'RESEARCHERID',
             'SLAC': 'SLAC',
             'VIAF': 'VIAF',
             'WIKIPEDIA': 'WIKIPEDIA',

--- a/inspirehep/modules/records/jsonschemas/records/elements/id.json
+++ b/inspirehep/modules/records/jsonschemas/records/elements/id.json
@@ -149,6 +149,19 @@
             "properties": {
                 "type": {
                     "enum": [
+                        "RESEARCHERID"
+                    ]
+                },
+                "value": {
+                    "pattern": "[A-z]-\\d{4}-\\d{4}",
+                    "type": "string"
+                }
+            }
+        },
+        {
+            "properties": {
+                "type": {
+                    "enum": [
                         "WIKIPEDIA"
                     ],
                     "type": "string"

--- a/inspirehep/modules/records/jsonschemas/records/elements/id.json
+++ b/inspirehep/modules/records/jsonschemas/records/elements/id.json
@@ -136,6 +136,19 @@
             "properties": {
                 "type": {
                     "enum": [
+                        "VIAF"
+                    ]
+                },
+                "value": {
+                    "pattern": "\\d{7,9}",
+                    "type": "string"
+                }
+            }
+        },
+        {
+            "properties": {
+                "type": {
+                    "enum": [
                         "WIKIPEDIA"
                     ],
                     "type": "string"

--- a/inspirehep/modules/records/jsonschemas/records/elements/id.json
+++ b/inspirehep/modules/records/jsonschemas/records/elements/id.json
@@ -123,6 +123,19 @@
             "properties": {
                 "type": {
                     "enum": [
+                        "GOOGLESCHOLAR"
+                    ]
+                },
+                "value": {
+                    "pattern": "\\w{12}",
+                    "type": "string"
+                }
+            }
+        },
+        {
+            "properties": {
+                "type": {
+                    "enum": [
                         "WIKIPEDIA"
                     ],
                     "type": "string"

--- a/inspirehep/modules/records/jsonschemas/records/elements/id.json
+++ b/inspirehep/modules/records/jsonschemas/records/elements/id.json
@@ -162,6 +162,19 @@
             "properties": {
                 "type": {
                     "enum": [
+                        "SCOPUS"
+                    ]
+                },
+                "value": {
+                    "pattern": "\\d{10,11}",
+                    "type": "string"
+                }
+            }
+        },
+        {
+            "properties": {
+                "type": {
+                    "enum": [
                         "WIKIPEDIA"
                     ],
                     "type": "string"

--- a/tests/unit/dojson/test_dojson_hepnames.py
+++ b/tests/unit/dojson/test_dojson_hepnames.py
@@ -312,6 +312,25 @@ def test_ids_from_double_035__a_9_with_kaken():
     assert expected == result['ids']
 
 
+def test_ids_from_035__a_9_with_googlescholar():
+    snippet = (
+        '<datafield tag="035" ind1=" " ind2=" ">'
+        '  <subfield code="9">GoogleScholar</subfield>'
+        '  <subfield code="a">Tnl-9KoAAAAJ</subfield>'
+        '</datafield>'
+    )  # record/1467553/export/xme
+
+    expected = [
+        {
+            'type': 'GOOGLESCHOLAR',
+            'value': 'Tnl-9KoAAAAJ',
+        },
+    ]
+    result = clean_record(hepnames.do(create_record(snippet)))
+
+    assert expected == result['ids']
+
+
 def test_ids_from_035__9():
     snippet = (
         '<datafield tag="035" ind1=" " ind2=" ">'

--- a/tests/unit/dojson/test_dojson_hepnames.py
+++ b/tests/unit/dojson/test_dojson_hepnames.py
@@ -278,12 +278,12 @@ def test_ids_from_double_035__a_9_with_kaken():
     assert expected == result['ids']
 
 
-def test_ids_from_035__9_malformed_with_value():
+def test_ids_from_035__9():
     snippet = (
-        '<datafield>'
-        '  <subfield code="9">E.Giro.1</subfield>'
+        '<datafield tag="035" ind1=" " ind2=" ">'
+        '  <subfield code="9">INSPIRE</subfield>'
         '</datafield>'
-    )  # record/1031883/export/xme
+    )  # record/edit/?ln=en#state=edit&recid=1474355&recrev=20160707223728
 
     result = clean_record(hepnames.do(create_record(snippet)))
 

--- a/tests/unit/dojson/test_dojson_hepnames.py
+++ b/tests/unit/dojson/test_dojson_hepnames.py
@@ -369,6 +369,25 @@ def test_ids_from_035__a_9_with_researcherid():
     assert expected == result['ids']
 
 
+def test_ids_from_035__a_9_with_scopus():
+    snippet = (
+        '<datafield tag="035" ind1=" " ind2=" ">'
+        '  <subfield code="9">SCOPUS</subfield>'
+        '  <subfield code="a">7103280792</subfield>'
+        '</datafield>'
+    )  # record/1017182/export/xme
+
+    expected = [
+        {
+            'type': 'SCOPUS',
+            'value': '7103280792',
+        },
+    ]
+    result = clean_record(hepnames.do(create_record(snippet)))
+
+    assert expected == result['ids']
+
+
 def test_ids_from_035__9():
     snippet = (
         '<datafield tag="035" ind1=" " ind2=" ">'

--- a/tests/unit/dojson/test_dojson_hepnames.py
+++ b/tests/unit/dojson/test_dojson_hepnames.py
@@ -331,6 +331,25 @@ def test_ids_from_035__a_9_with_googlescholar():
     assert expected == result['ids']
 
 
+def test_ids_from_035__a_9_with_viaf():
+    snippet = (
+        '<datafield tag="035" ind1=" " ind2=" ">'
+        '  <subfield code="9">VIAF</subfield>'
+        '  <subfield code="a">34517183</subfield>'
+        '</datafield>'
+    )  # record/1008109/export/xme
+
+    expected = [
+        {
+            'type': 'VIAF',
+            'value': '34517183',
+        },
+    ]
+    result = clean_record(hepnames.do(create_record(snippet)))
+
+    assert expected == result['ids']
+
+
 def test_ids_from_035__9():
     snippet = (
         '<datafield tag="035" ind1=" " ind2=" ">'

--- a/tests/unit/dojson/test_dojson_hepnames.py
+++ b/tests/unit/dojson/test_dojson_hepnames.py
@@ -155,18 +155,52 @@ def test_ids_from_035__a_9_with_cern():
     assert expected == result['ids']
 
 
-def test_ids_from_035__a_9_with_malformed_cern():
+def test_ids_from_035__a_9_with_cern_malformed():
     snippet = (
-        '<datafield tag="035" ind1=" " ind2=" ">'
-        '  <subfield code="9">CERN</subfield>'
-        '  <subfield code="a">CERN-CERN-645257</subfield>'
-        '</datafield>'
-    )  # record/1030771/export/xme
+        '<record>'
+        '  <datafield tag="035" ind1=" " ind2=" ">'
+        '    <subfield code="9">CERN</subfield>'
+        '    <subfield code="a">CERN-CERN-645257</subfield>'
+        '  </datafield>'  # record/1030771/export/xme
+        '  <datafield tag="035" ind1=" " ind2=" ">'
+        '    <subfield code="9">CERN</subfield>'
+        '    <subfield code="a">cern-783683</subfield>'
+        '  </datafield>'  # record/1408145/export/xme
+        '  <datafield tag="035" ind1=" " ind2=" ">'
+        '    <subfield code="9">CERN</subfield>'
+        '    <subfield code="a">CERM-724319</subfield>'
+        '  </datafield>'  # record/1244430/export/xme
+        '  <datafield tag="035" ind1=" " ind2=" ">'
+        '    <subfield code="9">CERN</subfield>'
+        '    <subfield code="a">CNER-727986</subfield>'
+        '  </datafield>'  # record/1068077/export/xme
+        '  <datafield tag="035" ind1=" " ind2=" ">'
+        '    <subfield code="9">CERN</subfield>'
+        '    <subfield code="a">CVERN-765559</subfield>'
+        '  </datafield>'  # record/1340631/export/xme
+        '</record>'
+    )
 
     expected = [
         {
             'type': 'CERN',
             'value': 'CERN-645257',
+        },
+        {
+            'type': 'CERN',
+            'value': 'CERN-783683',
+        },
+        {
+            'type': 'CERN',
+            'value': 'CERN-724319',
+        },
+        {
+            'type': 'CERN',
+            'value': 'CERN-727986',
+        },
+        {
+            'type': 'CERN',
+            'value': 'CERN-765559',
         },
     ]
     result = clean_record(hepnames.do(create_record(snippet)))

--- a/tests/unit/dojson/test_dojson_hepnames.py
+++ b/tests/unit/dojson/test_dojson_hepnames.py
@@ -350,6 +350,25 @@ def test_ids_from_035__a_9_with_viaf():
     assert expected == result['ids']
 
 
+def test_ids_from_035__a_9_with_researcherid():
+    snippet = (
+        '<datafield tag="035" ind1=" " ind2=" ">'
+        '  <subfield code="9">RESEARCHERID</subfield>'
+        '  <subfield code="a">B-4717-2008</subfield>'
+        '</datafield>'
+    )  # record/1051026/export/xme
+
+    expected = [
+        {
+            'type': 'RESEARCHERID',
+            'value': 'B-4717-2008',
+        },
+    ]
+    result = clean_record(hepnames.do(create_record(snippet)))
+
+    assert expected == result['ids']
+
+
 def test_ids_from_035__9():
     snippet = (
         '<datafield tag="035" ind1=" " ind2=" ">'


### PR DESCRIPTION
Sentry: https://sentry.cern.ch/inspire-sentry/inspire-labs-qa/group/602869/

~~Needs an answer to https://github.com/inspirehep/inspire/issues/211 in order to know which ID schemes we want to implement.~~

- [x] Don't produce incomplete ids
- [x] Recognize malformed CERN ids
- [x] Support GoogleScholar ids
- [x] Support VIAF ids
- [x] Support ResearcherId ids
- [x] Support SCOPUS ids
- [x] ~~Support SLAC ids~~ We already supported them...
- [x] Correct record with SPIRES
- [x] ~~Correct record with TWITTER~~ Under debate in https://github.com/inspirehep/inspire/issues/211#issuecomment-242202346