### PR TITLE
utils: add test for error raised by get_es_records

### DIFF
--- a/tests/unit/utils/test_utils_record_getter.py
+++ b/tests/unit/utils/test_utils_record_getter.py
@@ -21,6 +21,7 @@
 # or submit itself to any jurisdiction.
 
 import pytest
+from elasticsearch import RequestError
 
 from inspirehep.utils import record_getter
 
@@ -38,3 +39,10 @@ def test_error_decorator():
 
     with pytest.raises(record_getter.RecordGetterError):
         badfn(None, None)
+
+
+def test_get_empty_recid_list():
+    recids = []
+
+    with pytest.raises(RequestError):
+        record_getter.get_es_records("literature", recids)


### PR DESCRIPTION
When get_es_records is called with an empty list for the parameter `recids`, it throws a `RequestError: TransportError(400, u'action_request_validation_exception', u'Validation Failed: 1: no documents to get;')` error. This adds a test for that.
