### PR TITLE
migrator.tasks: use logger instead of logging

### DIFF
--- a/inspirehep/modules/migrator/tasks.py
+++ b/inspirehep/modules/migrator/tasks.py
@@ -362,7 +362,7 @@ def migrate_and_insert_record(raw_record):
     except Exception as e:
         # Receivers can always cause exceptions and we could dump the entire
         # chunk because of a single broken record.
-        logging.exception('Migrator Record Insert Error')
+        logger.exception('Migrator Record Insert Error')
         error = e
 
     if error:


### PR DESCRIPTION
* There was a leftover statement using logging module directly instead
  of the logger object.

Signed-off-by: David Caro <david@dcaro.es>