### PR TITLE
setup: unpin webassets

### DIFF
--- a/inspirehep/modules/authors/bundles.py
+++ b/inspirehep/modules/authors/bundles.py
@@ -29,7 +29,7 @@ update_css = Bundle(
     "scss/authors/authors-update-form.scss",
     output='gen/inspire-author-update.%(version)s.css',
     depends='scss/forms/*.scss',
-    filters="scss, cleancss"
+    filters="node-scss, cleancss"
 )
 
 js = NpmBundle(

--- a/inspirehep/modules/forms/bundles.py
+++ b/inspirehep/modules/forms/bundles.py
@@ -47,7 +47,7 @@ css = NpmBundle(
     "node_modules/bootstrap-multiselect/dist/css/bootstrap-multiselect.css",
     output='gen/inspire-form.%(version)s.css',
     depends='scss/forms/*.scss',
-    filters="scss, cleancss",
+    filters="node-scss, cleancss",
     npm={
         "typeahead.js-bootstrap-css": "~1.2.1"
     }

--- a/inspirehep/modules/theme/bundles.py
+++ b/inspirehep/modules/theme/bundles.py
@@ -79,7 +79,7 @@ detailedjs = NpmBundle(
 
 css = NpmBundle(
     "scss/inspirehep.scss",
-    filters="scss, cleancss",
+    filters="node-scss, cleancss",
     output="gen/inspirehep.%(version)s.css",
     depends="scss/**/*.scss",
     npm={
@@ -102,7 +102,7 @@ detailedjs = NpmBundle(
 holding_pen_css = NpmBundle(
     "node_modules/angular-xeditable/dist/css/xeditable.css",
     "scss/holding-pen/holding-pen.scss",
-    filters="scss, cleancss",
+    filters="node-scss, cleancss",
     output="gen/inspirehep.holding.%(version)s.css",
     depends="scss/**/*.scss"
 )

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ install_requires = [
     'invenio-access>=1.0.0a7',
     'invenio-accounts>=1.0.0a12',
     'invenio-admin>=1.0.0a3',
-    'invenio-assets>=1.0.0a4',
+    'invenio-assets>=1.0.0b2',
     'invenio-base>=1.0.0a11',
     'invenio-celery>=1.0.0a4',
     'invenio-config>=1.0.0a1',
@@ -79,7 +79,6 @@ install_requires = [
     'workflow>=2.0.0',
     'html5lib<1.0b9',
     'SQLAlchemy>=1.0.14,<1.1',
-    'webassets>=0.11.1,<0.12',
 ]
 
 tests_require = [


### PR DESCRIPTION
Removes the pin introduced in f00e62b, and consequently bumps the
`invenio-assets` dependency. This requires us to use the `node-scss`
filter everywhere instead of the `scss` filter.