### PR TITLE
travis: dummy PR to find out which tests are slow

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -47,11 +47,11 @@ services:
       service: service_base
     volumes_from:
       - static
-    command: python setup.py test --addopts="tests/unit"
+    command: python setup.py test --addopts="tests/unit --durations=0"
   disambiguation:
     extends:
       service: service_base
-    command: python setup.py test --addopts="tests/integration/disambiguation"
+    command: python setup.py test --addopts="tests/integration/disambiguation --durations=0"
     volumes_from:
       - static
     links:
@@ -64,7 +64,7 @@ services:
   integration:
     extends:
       service: service_base
-    command: python setup.py test --addopts="tests/integration --ignore tests/integration/disambiguation"
+    command: python setup.py test --addopts="tests/integration --ignore tests/integration/disambiguation --durations=0"
     volumes_from:
       - static
     links:


### PR DESCRIPTION
Uses the [`--durations`](http://doc.pytest.org/en/latest/usage.html#profiling-test-execution-duration) argument in py.test to measure the time that each test takes. The objective is to split the tests in the way I described in https://github.com/inspirehep/inspire-next/pull/1353#issuecomment-237524229.