### PR TITLE
dojson: rewrite positions rule

### DIFF
--- a/inspirehep/modules/records/jsonschemas/records/authors.json
+++ b/inspirehep/modules/records/jsonschemas/records/authors.json
@@ -159,17 +159,17 @@
             "uniqueItems": true
         },
         "positions": {
-            "description": "Contains position information.",
             "items": {
                 "properties": {
                     "current": {
-                        "description": "FIXME: do we need other states?",
                         "type": "boolean"
                     },
-                    "email": {
-                        "description": "FIXME: this is redundant?",
-                        "format": "email",
-                        "type": "string"
+                    "emails": {
+                        "items": {
+                            "format": "email",
+                            "type": "string"
+                        },
+                        "type": "array"
                     },
                     "end_date": {
                         "format": "date",
@@ -181,20 +181,13 @@
                                 "type": "boolean"
                             },
                             "name": {
-                                "description": "The raw institution name",
                                 "type": "string"
                             },
                             "record": {
-                                "$ref": "elements/json_reference.json",
-                                "description": "Corresponding URI for the institution record"
+                                "$ref": "elements/json_reference.json"
                             }
                         },
                         "type": "object"
-                    },
-                    "old_email": {
-                        "description": "FIXME: this is redundant?",
-                        "format": "email",
-                        "type": "string"
                     },
                     "rank": {
                         "$ref": "elements/rank.json"

--- a/inspirehep/modules/theme/templates/inspirehep_theme/format/record/authors/Author_HTML_detailed.html
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/format/record/authors/Author_HTML_detailed.html
@@ -38,8 +38,8 @@
         <div class="col-md-12 summary" id="detailed-header-top">
           <div class="col-md-2">
             {% set email = '' %}
-            {% if record.positions | length > 0 %}
-              {% set email = record['positions'][0].get('email', '') %}
+            {% if record.positions | length %}
+              {% set email = record['positions'][0].get('email', [''])[0] %}
             {% endif %}
             <img class="profile-image img-circle" src="{{ email | gravatar(size=90, default='identicon') }}" data-toggle='tooltip' data-placement='left' title='Your profile picture can be set at gravatar.com' width="100%">
           </div>

--- a/tests/unit/dojson/test_dojson_hepnames.py
+++ b/tests/unit/dojson/test_dojson_hepnames.py
@@ -489,14 +489,10 @@ def test_positions(marcxml_to_json, json_to_marc):
             json_to_marc['371'][0]['r'])
     assert (marcxml_to_json['positions'][0]['start_date'] ==
             json_to_marc['371'][0]['s'])
-    assert (marcxml_to_json['positions'][0]['email'] ==
-            json_to_marc['371'][0]['m'])
-    assert (marcxml_to_json['positions'][0]['status'] ==
+    assert (marcxml_to_json['positions'][0]['current'] ==
             json_to_marc['371'][0]['z'])
     assert (marcxml_to_json['positions'][1]['end_date'] ==
             json_to_marc['371'][1]['t'])
-    assert (marcxml_to_json['positions'][2]['old_email'] ==
-            json_to_marc['371'][2]['o'])
 
 
 def test_positions_from_371__a():
@@ -508,11 +504,40 @@ def test_positions_from_371__a():
 
     expected = [
         {
-            'curated_relation': False,
+            'current': False,
             'institution': {
+                'curated_relation': False,
                 'name': 'Aachen, Tech. Hochsch.',
             },
         },
+    ]
+    result = clean_record(hepnames.do(create_record(snippet)))
+
+    assert expected == result['positions']
+
+
+def test_positions_from_371__a_double_m_z():
+    snippet = (
+        '<datafield tag="371" ind1=" " ind2=" ">'
+        '  <subfield code="a">Argonne</subfield>'
+        '  <subfield code="m">rcyoung@anl.gov</subfield>'
+        '  <subfield code="m">rcyoung@hep.anl.gov</subfield>'
+        '  <subfield code="z">current</subfield>'
+        '</datafield>'
+    )  # record/1408378
+
+    expected = [
+        {
+            'current': True,
+            'emails': [
+                'rcyoung@anl.gov',
+                'rcyoung@hep.anl.gov',
+            ],
+            'institution': {
+                'curated_relation': False,
+                'name': 'Argonne',
+            },
+        }
     ]
     result = clean_record(hepnames.do(create_record(snippet)))
 
@@ -531,14 +556,16 @@ def test_positions_from_371__a_m_r_z():
 
     expected = [
         {
-            'curated_relation': False,
-            'email': 'pierre.vanmechelen@ua.ac.be',
+            'current': True,
+            'emails': [
+                'pierre.vanmechelen@ua.ac.be',
+            ],
             'institution': {
+                'curated_relation': False,
                 'name': 'Antwerp U.',
             },
             'rank': 'SENIOR',
             '_rank': 'SENIOR',
-            'status': 'Current',
         },
     ]
     result = clean_record(hepnames.do(create_record(snippet)))


### PR DESCRIPTION
* Unifies `email` and `old_email` in a single field called `emails`,
  with the convention that the first emails are the most current.

* Consolidates the treatment of `status`/`current`, and moves
  `curated_relation` where it belongs (near the institution).

Signed-off-by: Jacopo Notarstefano <jacopo.notarstefano@cern.ch>