### PR TITLE
API: improve /authors endpoint

### DIFF
--- a/inspirehep/modules/authors/rest/publications.py
+++ b/inspirehep/modules/authors/rest/publications.py
@@ -98,8 +98,10 @@ class AuthorAPIPublications(object):
                 publication['journal']['title'] = result_source.get(
                     'publication_info', [])[0]['journal_title']
 
-                # Get journal $self.
+                # Get journal id and $self.
                 try:
+                    publication['journal']['id'] = result_source.get(
+                        'publication_info', [])[0]['journal_recid']
                     publication['journal']['record'] = result_source.get(
                         'publication_info', [])[0]['journal_record']
                 except KeyError:

--- a/tests/integration/test_author_api.py
+++ b/tests/integration/test_author_api.py
@@ -42,35 +42,45 @@ def test_api_authors_root(app):
 def test_api_authors_citations(app):
     schema = {
         'items': {
+            'type': 'object',
             'properties': {
                 'citee': {
+                    'type': 'object',
                     'properties': {
                         'record': {
+                            'type': 'object',
                             'properties': {'$ref': {'type': 'string'}},
-                            'type': 'object'
+                        },
+                        'id': {'type': 'integer'}
+                    }
+                },
+                'citers': {
+                    'type': 'array',
+                    'items': {
+                        'type': 'object',
+                        'properties': {
+                            'date': {'type': 'string'},
+                            'self_citation': {'type': 'boolean'},
+                            'citer': {
+                                'type': 'object',
+                                'properties': {
+                                    'record': {
+                                        'type': 'object',
+                                        'properties': {
+                                            '$ref': {'type': 'string'}
+                                        }
+                                    },
+                                    'id': {'type': 'integer'}
+                                }
+                            },
+                            'published_paper': {
+                                'type': 'boolean'
+                            }
                         }
-                    },
-                    'type': 'object'
-                },
-                'citer': {
-                    'properties': {
-                        'record': {
-                            'properties': {'$ref': {'type': 'string'}},
-                            'type': 'object'
-                        }
-                    },
-                    'type': 'object'
-                },
-                'date': {
-                    'format': 'date',
-                    'type': 'string'
-                },
-                'published_paper': {'type': 'boolean'},
-                'self_citation': {'type': 'boolean'}
-            },
-            'type': 'object'
-        },
-        'type': 'array'
+                    }
+                }
+            }
+        }
     }
 
     with app.test_client() as client:
@@ -81,7 +91,7 @@ def test_api_authors_citations(app):
         response_json = json.loads(response.data)
 
         assert validate(response_json, schema) is None
-        assert len(response_json) == 197
+        assert len(response_json) == 30
 
 
 def test_api_authors_coauthors(app):
@@ -126,12 +136,14 @@ def test_api_authors_publications(app):
                     'type': 'string'
                 },
                 'id': {'type': 'integer'},
-                'journals': {
+                'journal': {
                     'properties': {
+                        'id': {'type': 'integer'},
                         'record': {
                             'properties': {'$ref': {'type': 'string'}},
                             'type': 'object'
-                        }
+                        },
+                        'title': {'type': 'string'}
                     },
                     'type': 'object'
                 },


### PR DESCRIPTION
* Adds ids of journals to /publications endpoint.

* Restructures citee becoming a parent of an array of citers at
  /citations endpoint.

Signed-off-by: Grzegorz Jacenków <grzegorz.jacenkow@cern.ch>