### PR TITLE
migrator: migrating one INSPIRE record

### DIFF
--- a/inspirehep/modules/migrator/cli.py
+++ b/inspirehep/modules/migrator/cli.py
@@ -24,6 +24,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import logging
 import os
 import sys
 
@@ -43,7 +44,7 @@ from .tasks import (
 @click.group()
 def migrator():
     """Command related to migrating INSPIRE data."""
-
+    logging.basicConfig()
 
 @migrator.command()
 @click.option('--file-input', '-f',

--- a/inspirehep/modules/migrator/cli.py
+++ b/inspirehep/modules/migrator/cli.py
@@ -29,6 +29,7 @@ import os
 import sys
 
 import click
+import requests
 from flask import current_app
 from flask_cli import with_appcontext
 
@@ -38,6 +39,8 @@ from .tasks import (
     add_citation_counts,
     migrate,
     migrate_broken_records,
+    migrate_chunk,
+    split_blob,
 )
 
 
@@ -45,6 +48,7 @@ from .tasks import (
 def migrator():
     """Command related to migrating INSPIRE data."""
     logging.basicConfig()
+
 
 @migrator.command()
 @click.option('--file-input', '-f',
@@ -69,6 +73,14 @@ def populate(file_input=None,
         click.echo("Migrating records from file: {0}".format(file_input))
 
         migrate(os.path.abspath(file_input), wait_for_results=wait)
+
+
+@migrator.command()
+@click.option('--recid', '-r', type=int, help="recid on INSPIRE")
+def one(recid):
+    click.echo("Migrating record {recid} from INSPIRE legacy".format(recid=recid))
+    raw_record = requests.get("http://inspirehep.net/record/{recid}/export/xme".format(recid=recid)).content
+    migrate_chunk(split_blob(raw_record))
 
 
 @migrator.command()

--- a/inspirehep/modules/migrator/cli.py
+++ b/inspirehep/modules/migrator/cli.py
@@ -60,12 +60,12 @@ def populate(file_input=None,
     Usage: inveniomanage migrator populate -f prodsync20151117173222.xml.gz
     """
     if remigrate:
-        print("Remigrate broken records...")
+        click.echo("Remigrate broken records...")
         migrate_broken_records.delay()
     elif file_input and not os.path.isfile(file_input):
-        print("{0} is not a file!".format(file_input), file=sys.stderr)
+        click.echo("{0} is not a file!".format(file_input), err=True)
     elif file_input:
-        print("Migrating records from file: {0}".format(file_input))
+        click.echo("Migrating records from file: {0}".format(file_input))
 
         migrate(os.path.abspath(file_input), wait_for_results=wait)
 
@@ -73,7 +73,7 @@ def populate(file_input=None,
 @migrator.command()
 def count_citations():
     """Adds field citation_count to every record in 'HEP' and calculates its proper value."""
-    print("Adding citation_count to all records")
+    click.echo("Adding citation_count to all records")
     add_citation_counts()
 
 
@@ -148,7 +148,7 @@ def clean_records():
             return
 
         click.secho('Truncating tables...', fg='red', bold=True,
-                    file=sys.stderr)
+                    err=True)
         with click.progressbar(tables_to_truncate) as tables:
             for table in tables:
                 db.engine.execute("TRUNCATE TABLE {0} RESTART IDENTITY CASCADE".format(table))
@@ -163,7 +163,7 @@ def clean_records():
         click.secho('Destroying indexes...',
                     fg='red',
                     bold=True,
-                    file=sys.stderr)
+                    err=True)
         with click.progressbar(
                 current_search.delete(ignore=[400, 404])) as bar:
             for name, response in bar:
@@ -172,7 +172,7 @@ def clean_records():
         click.secho('Creating indexes...',
                     fg='green',
                     bold=True,
-                    file=sys.stderr)
+                    err=True)
         with click.progressbar(
                 current_search.create(ignore=[400])) as bar:
             for name, response in bar:
@@ -196,5 +196,5 @@ def drop_tables(table_filter):
     ).fetchall()
     for table in table_names:
         db.engine.execute("DROP TABLE {0}".format(table[0]))
-        print(">>> Dropped {0}.".format(table[0]))
-    print(">>> Removed {0} tables.".format(len(table_names)))
+        click.echo(">>> Dropped {0}.".format(table[0]))
+    click.echo(">>> Removed {0} tables.".format(len(table_names)))


### PR DESCRIPTION
* Introduces "migrator one --recid RECID" to migrate automatically
  a single record directly from INSPIRE legacy.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>