### PR TITLE
authors: make the profiles great again

### DIFF
--- a/inspirehep/modules/authors/bundles.py
+++ b/inspirehep/modules/authors/bundles.py
@@ -38,7 +38,8 @@ js = NpmBundle(
     depends=(
         'js/authors/author.js',
         'js/authors/profile.js',
-        'js/authors/publications.js'
+        'js/authors/publications.js',
+        'js/authors/statistics.js'
     ),
     output="gen/authors.%(version)s.js"
 )

--- a/inspirehep/modules/authors/static/js/authors/app.js
+++ b/inspirehep/modules/authors/static/js/authors/app.js
@@ -24,13 +24,16 @@ require(['angular',
          'd3',
          'datatables',
          'author',
+         'impact-graphs',
          'profile',
-         'publications'], function() {
+         'publications',
+         'statistics'], function() {
   angular.element(document).ready(function() {
     angular.bootstrap(
       document.getElementById("record_content"), [
         'author',
-        'publications'
+        'publications',
+        'statistics'
       ]
     );
   });

--- a/inspirehep/modules/authors/static/js/authors/author.js
+++ b/inspirehep/modules/authors/static/js/authors/author.js
@@ -52,6 +52,14 @@ define(['author'], function(Author) {
     };
   });
 
+  app.directive('authorCollaborators', function() {
+    return {
+      require: '^profileInit',
+      restrict: 'E',
+      templateUrl: '/static/js/authors/templates/collaborators.html',
+    };
+  });
+
   app.directive('authorEmail', function() {
     return {
       require: '^profileInit',
@@ -88,6 +96,7 @@ define(['author'], function(Author) {
       scope: true,
       link: function(scope) {
         scope.positions = scope.education;
+        scope.icon = 'university';
       }
     };
   });
@@ -97,23 +106,9 @@ define(['author'], function(Author) {
       require: '^profileInit',
       restrict: 'E',
       template: '<ul class="research-area">' +
-                '<li ng-repeat="field in authorFields">' +
+                '<li ng-repeat="field in statistics.fields">' +
                 '<a href="/search?subject={{ field }}"> {{ field }}' +
-                '</a></li></ul>',
-      scope: true,
-      link: function(scope, element, attrs) {
-        if ('field_categories' in scope.record) {
-          var fields = [];
-          var fieldCategories = JSON.parse(attrs.fields);
-          var fieldsObject = scope.record.field_categories;
-
-          angular.forEach(fieldsObject, function(field) {
-            fields.push(fieldCategories[field.toLowerCase()]);
-          });
-
-          scope.authorFields = fields;
-        }
-      }
+                '</a></li></ul>'
     };
   });
 
@@ -137,10 +132,23 @@ define(['author'], function(Author) {
     };
   });
 
+  app.directive('authorKeywords', function() {
+    return {
+      require: '^profileInit',
+      restrict: 'E',
+      template: '<p ng-repeat="keyword in statistics.keywords">' +
+                '<a href="/search?keyword={{ keyword.keyword }}">' +
+                '{{ keyword.keyword }}</a></p>'
+    };
+  });
+
   app.directive('authorPositions', function() {
     return {
       require: '^profileInit',
-      restrict: 'A',
+      restrict: 'E',
+      template: '<author-work ng-show="work.length"></author-work>' +
+                '<author-education ng-show="education.length">' +
+                '</author-education>',
       scope: true,
       link: function(scope) {
         if ('positions' in scope.record) {
@@ -149,7 +157,6 @@ define(['author'], function(Author) {
           scope.work = [];
 
           var spaces = '\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0';
-          // TODO: Maybe move this part to config.py
           var ranks = {
             UG: 'Undergraduate',
             MAS: 'Master',
@@ -211,6 +218,7 @@ define(['author'], function(Author) {
       scope: true,
       link: function(scope) {
         scope.positions = scope.work;
+        scope.icon = 'suitcase';
       }
     };
   });

--- a/inspirehep/modules/authors/static/js/authors/profile.js
+++ b/inspirehep/modules/authors/static/js/authors/profile.js
@@ -26,57 +26,36 @@ define(['profile'], function(Profile) {
   app.controller('ProfileController', ['$http', '$scope', '$element', '$attrs',
       function($http, $scope, $element, $attrs) {
 
-    // Initialise data variables.
-    $scope.publications = {
-      collaborations: [],
-      keywords: [],
-      publications: []
-    };
+    $scope.citations = []
+    $scope.coauthors = []
+    $scope.publications = []
+    $scope.statistics = {}
 
-    // Author profile object.
+    // Author profile object from Jinja.
     $scope.record = JSON.parse($attrs.record);
-
-    // Publications per year, total publications, count of different types.
-    $scope.statistics = [[], 0, {}];
-
-    var countPublications = function(data) {
-      var publications = data.publications,
-          publicationsCountMap = {},
-          publicationsDataToPlot = [],
-          researchWorksCount = publications.length,
-          researchWorksTypes = {};
-
-      angular.forEach(publications, function(publication) {
-        if (publication.year in publicationsCountMap) {
-          publicationsCountMap[publication.year]++;
-        } else {
-          publicationsCountMap[publication.year] = 1;
-        }
-
-        if (publication.type in researchWorksTypes) {
-          researchWorksTypes[publication.type]++;
-        } else {
-          researchWorksTypes[publication.type] = 1;
-        }
-      });
-
-      angular.forEach(publicationsCountMap, function(count, year) {
-        publicationsDataToPlot.push({
-          year: parseInt(year),
-          publications: count
-        });
-      });      
-
-      return [publicationsDataToPlot, researchWorksCount, researchWorksTypes];
-    };
-
     var recid = $scope.record.control_number;
-    $http.get("/author/publications?recid=" + recid)
+
+    // Collect data from /authors API.
+    $http.get("/api/authors/" + recid + "/citations")
+      .success(function(data) {
+        $scope.citations = data;
+    });
+
+    $http.get("/api/authors/" + recid + "/coauthors")
+      .success(function(data) {
+        $scope.coauthors = data;
+    });
+
+    $http.get("/api/authors/" + recid + "/publications")
       .success(function(data) {
         $scope.publications = data;
-        $scope.statistics = countPublications(data);
-      });
-    }]);
+    });
+
+    $http.get("/api/authors/" + recid + "/stats")
+      .success(function(data) {
+        $scope.statistics = data;
+    });
+  }]);
 
   app.directive('profileInit', function() {
     return {

--- a/inspirehep/modules/authors/static/js/authors/publications.js
+++ b/inspirehep/modules/authors/static/js/authors/publications.js
@@ -23,176 +23,6 @@
 define(['publications'], function(Publications) {
   var app = angular.module('publications', ['profile']);
 
-  app.directive('biography', function() {
-    return {
-      require: '^profileInit',
-      restrict: 'E',
-      template: '<ul class="categories">' +
-                '<li ng-repeat="category in categories">' +
-                '<a href="/search?q=keyword:{{ category }}">' +
-                '{{ category }}</a></li></ul>',
-      scope: true,
-      link: function(scope) {
-        scope.$watch('publications', function() {
-          var categories = scope.publications.keywords;
-          scope.categories = categories.slice(0, 25);          
-        });
-      }
-    };
-  });
-
-  app.directive('statisticsChart', function($parse) {
-    return {
-      require: '^profileInit',
-      restrict: 'E',
-      template: '<div id="plot"></div>',
-      scope: true,
-      link: function(scope, element, attrs) {
-        scope.$watch('statistics', function() {
-          // Data.
-          var publicationsDataToPlot = scope.statistics[0];
-
-          var drawBarChart = function(width) {
-            var margins = 40;
-            var width = getDivWidth() - margins;
-            var height = 220 - 2 * margins;
-
-            var svg = d3.select('#plot').append("svg")
-                .attr("width", width)
-                .attr("height", height + 2 * margins)
-              .append("g")
-                .attr("transform", "translate(" + margins + "," + margins + ")");
-
-            var date_parser = d3.time.format("%Y").parse
-            var year_extent = d3.extent(publicationsDataToPlot, function(d) {
-                return d.year;
-              });
-
-            var bar_width = width / (year_extent[1] - year_extent[0]) / 4;
-
-            yearScale = d3.time.scale()
-              .domain([date_parser(String(year_extent[0]-1)),
-                date_parser(String(year_extent[1]+1))]).range([0, width - (margins * 2)]);
-
-            publicationsScale = d3.scale.linear()
-              .domain([0, d3.max(publicationsDataToPlot, function(d) {
-                return d.publications;
-              })])
-              .range([0, height]);
-
-            publicationsScaleAxis = d3.scale.linear()
-              .domain([d3.max(publicationsDataToPlot, function(d) {
-                return d.publications;
-              }), 0])
-              .range([0, height]);
-
-            yearAxis = d3.svg.axis()
-              .scale(yearScale)
-              .orient("bottom")
-              .tickSize(0)
-              .tickPadding(12)
-              .tickFormat(d3.time.format("%Y"));
-
-            publicationsAxis = d3.svg.axis()
-              .scale(publicationsScaleAxis)
-              .orient("left")
-              .tickSize(0)
-              .tickPadding(8)
-              .ticks(4);
-
-            svg.append("svg:g")
-              .attr("class", "xAxis axis")
-              .attr("transform", "translate(0," + (height) +")")
-              .call(yearAxis);
-
-            svg.append("svg:g")
-              .attr("class", "yAxis axis")
-              .attr("transform", "translate(0, 0)")
-              .call(publicationsAxis);
-
-            svg.append("text")
-              .attr("class", "publicationsLabel")
-              .attr("text-anchor", "end")
-              .attr("x", -22)
-              .attr("y", -30)
-              .attr("transform", "rotate(-90)")
-              .text("Research works");
-
-            svg.append("text")
-              .attr("class", "citationsLabel")
-              .attr("text-anchor", "end")
-              .attr("x", 95)
-              .attr("y", -width+50)
-              .attr("transform", "rotate(-270)")
-              .text("Citations");
-
-            svg.selectAll("publications")
-                .data(publicationsDataToPlot)
-              .enter().append("rect")
-                .style("fill", "rgb(13, 131, 183)")
-                .attr("x", function(d) { 
-                  return yearScale(date_parser(String(d.year))) - bar_width; })
-                .attr("width", bar_width)
-                .attr("y", height)
-                .attr("height", 0)
-                .transition()
-                  .duration(1000)
-                  .attr("y", function(d) {
-                    return (height) - publicationsScale(d.publications); })
-                  .attr("height", function(d) { 
-                    return publicationsScale(d.publications); })
-          }
-
-          var getDivWidth = function() {
-            // Example: 570px.
-            var width_str = d3.select('#statistics-chart').style('width');
-            width_str = width_str.slice(0, -2);
-
-            return parseInt(width_str);
-          }
-
-          var resizeListener = function() {
-            d3.select("#statistics-chart").selectAll("svg").remove();
-
-            if (publicationsDataToPlot.length != 0) {
-              drawBarChart();
-            }
-          }
-
-          // Event handlers.
-          if (window.attachEvent) {
-            // Internet Explorer.
-            window.attachEvent('onresize', resizeListener);
-          }
-          else if (window.addEventListener) {
-            window.addEventListener('resize', resizeListener, true);
-          }
-          else {
-            // The webbrowser does not support JavaScript event binding.
-            var alert_text = "You are using an outdated browser. " +
-                             "Please upgrade your browser to improve " +
-                             "your experience.";
-            alert(alert_text);
-          }
-
-          // Initial graph.
-          if (publicationsDataToPlot.length != 0) {
-            drawBarChart();
-          }
-        });
-      }
-    };
-  });
-
-  app.directive('collaborators', function() {
-    return {
-      require: '^profileInit',
-      restrict: 'E',
-      templateUrl: '/static/js/authors/templates/collaborators.html',
-      scope: false,
-    };
-  });
-
   app.directive('publicationsList', function($timeout) {
     return {
       require: '^profileInit',
@@ -201,12 +31,30 @@ define(['publications'], function(Publications) {
       scope: true,
       link: function(scope, element) {
         scope.$watch('publications', function() {
-          scope.publicationsList = scope.publications.publications;
-
           // Inject DataTable.
           $timeout(function() {
-            if (scope.publicationsList.length > 0) {
+            if (scope.publications.length > 0) {
               $('#publications-table').DataTable( {
+                'drawCallback': function(settings) {
+                  $('[id^=impact-graph-]').each(function() {
+                    var _id = $(this).attr('id');
+                    if ($(this).html() === '') {
+                      var _publication_id = $(this).attr('id').split('-')[2];
+
+                      ImpactGraph.draw_impact_graph(
+                        '/api/literature/' + _publication_id,
+                        '#impact-graph-' + _publication_id,
+                        {
+                          width: 150,
+                          height: 50,
+                          'content-type': 'application/x-impact.graph+json',
+                          y_scale: 'linear',
+                          render_citations: false
+                        }
+                      );
+                    }
+                  })
+                },
                 'bFilter': false,
                 'bLengthChange': false,
                 'info' : false,
@@ -222,18 +70,11 @@ define(['publications'], function(Publications) {
     };
   });
 
-  app.directive('statistics', function() {
+  app.directive('impactGraph', function($timeout) {
     return {
       require: '^profileInit',
       restrict: 'E',
-      templateUrl: '/static/js/authors/templates/statistics.html',
-      scope: true,
-      link: function(scope) {
-        scope.$watch('statistics', function() {
-          scope.count = scope.statistics[1];
-          scope.researchWorks = scope.statistics[2];
-        });
-      }
+      template: '<div id="impact-graph-{{ publication.id }}"></div>',
     };
   });
 });

--- a/inspirehep/modules/authors/static/js/authors/statistics.js
+++ b/inspirehep/modules/authors/static/js/authors/statistics.js
@@ -1,0 +1,271 @@
+/*
+ * This file is part of INSPIRE.
+ * Copyright (C) 2016 CERN.
+ *
+ * INSPIRE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * INSPIRE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * In applying this licence, CERN does not waive the privileges and immunities
+ * granted to it by virtue of its status as an Intergovernmental Organization
+ * or submit itself to any jurisdiction.
+ */
+
+define(['statistics'], function(Profile) {
+  var app = angular.module('statistics', ['profile']);
+
+  app.directive('statisticsChart', function($parse) {
+    return {
+      require: '^profileInit',
+      restrict: 'E',
+      template: '<div id="statistics-plot"></div>',
+      scope: true,
+      link: function(scope, element, attrs) {
+        scope.$watch('statistics', function() {
+          // Count publications, must be in {year: YYYY, publications: X} format.
+          publicationsCount = {}
+          publicationsStats = []
+          yearStats = []
+
+          angular.forEach(scope.publications, function(publication) {
+            year = new Date(publication.date).getFullYear();
+
+            if (publicationsCount.hasOwnProperty(year)) {
+              publicationsCount[year]++;
+            }
+            else {
+              publicationsCount[year] = 1;
+            }
+          });
+
+          for (var year in publicationsCount) {
+            publicationsStats.push({
+              year: parseInt(year),
+              publications: publicationsCount[year]
+            });
+
+            yearStats.push({
+              year: parseInt(year)
+            });
+          }
+
+          // Count citations.
+          citationsCount = {}
+          citationsStats = []
+
+          angular.forEach(scope.citations, function(citations) {
+            angular.forEach(citations.citers, function(citation) {
+              year = new Date(citation.date).getFullYear();
+
+              if (citationsCount.hasOwnProperty(year)) {
+                citationsCount[year]++;
+              }
+              else {
+                citationsCount[year] = 1;
+              }
+            });
+          });
+
+          for (var year in citationsCount) {
+            citationsStats.push({
+              year: parseInt(year),
+              citations: citationsCount[year]
+            });
+
+            yearStats.push({
+              year: parseInt(year)
+            });
+          }
+
+          // Logic.
+          var drawBarChart = function(width) {
+            var margins = 40;
+            var width = getDivWidth() - margins;
+            var height = 220 - 2 * margins;
+
+            var svg = d3.select('#statistics-plot').append("svg")
+                .attr("width", width)
+                .attr("height", height + 2 * margins)
+              .append("g")
+                .attr("transform", "translate(" + margins + "," + margins + ")");
+
+            var date_parser = d3.time.format("%Y").parse
+            var year_extent = d3.extent(yearStats, function(d) {
+                return d.year;
+              });
+
+            var bar_width = width / (year_extent[1] - year_extent[0]) / 4;
+
+            yearScale = d3.time.scale()
+              .domain([date_parser(String(year_extent[0]-1)),
+                date_parser(String(year_extent[1]+1))]).range([0, width - (margins * 2)]);
+
+            citationsScale = d3.scale.linear()
+              .domain([0, d3.max(citationsStats, function(d) {
+                return d.citations;
+              })])
+              .range([0, height]);
+
+            publicationsScale = d3.scale.linear()
+              .domain([0, d3.max(publicationsStats, function(d) {
+                return d.publications;
+              })])
+              .range([0, height]);
+
+            citationsScaleAxis = d3.scale.linear()
+              .domain([d3.max(citationsStats, function(d) {
+                return d.citations;
+              }), 0])
+              .range([0, height]);
+
+            publicationsScaleAxis = d3.scale.linear()
+              .domain([d3.max(publicationsStats, function(d) {
+                return d.publications;
+              }), 0])
+              .range([0, height]);
+
+            yearAxis = d3.svg.axis()
+              .scale(yearScale)
+              .orient("bottom")
+              .tickSize(0)
+              .tickPadding(12)
+              .tickFormat(d3.time.format("%Y"));
+
+            citationsAxis = d3.svg.axis()
+              .scale(citationsScaleAxis)
+              .orient("right")
+              .tickSize(0)
+              .tickPadding(8)
+              .ticks(4);
+
+            publicationsAxis = d3.svg.axis()
+              .scale(publicationsScaleAxis)
+              .orient("left")
+              .tickSize(0)
+              .tickPadding(8)
+              .ticks(4);
+
+            svg.append("svg:g")
+              .attr("class", "xAxis axis")
+              .attr("transform", "translate(0," + (height) +")")
+              .call(yearAxis);
+
+            svg.append("svg:g")
+              .attr("class", "citationsAxis axis")
+              .attr("transform", "translate(" + (width - 2 * margins) + ", 0)")
+              .call(citationsAxis);
+
+            svg.append("svg:g")
+              .attr("class", "publicationsAxis axis")
+              .attr("transform", "translate(0, 0)")
+              .call(publicationsAxis);
+
+            svg.append("text")
+              .attr("class", "citationsLabel")
+              .attr("text-anchor", "end")
+              .attr("x", 103)
+              .attr("y", -width+50)
+              .attr("transform", "rotate(-270)")
+              .text("Citations");
+
+            svg.append("text")
+              .attr("class", "publicationsLabel")
+              .attr("text-anchor", "end")
+              .attr("x", -22)
+              .attr("y", -30)
+              .attr("transform", "rotate(-90)")
+              .text("Research works");
+
+            svg.selectAll("publications")
+                .data(publicationsStats)
+              .enter().append("rect")
+                .style("fill", "rgb(13, 131, 183)")
+                .attr("x", function(d) { 
+                  return yearScale(date_parser(String(d.year))) - bar_width; })
+                .attr("width", bar_width)
+                .attr("y", height)
+                .attr("height", 0)
+                .transition()
+                  .duration(1000)
+                  .attr("y", function(d) {
+                    return (height) - publicationsScale(d.publications); })
+                  .attr("height", function(d) { 
+                    return publicationsScale(d.publications); })
+
+            svg.selectAll("citations")
+                .data(citationsStats)
+              .enter().append("rect")
+                .style("fill", "rgb(44, 62, 80)")
+                .attr("x", function(d) {
+                  return yearScale(date_parser(String(d.year))); })
+                .attr("width", bar_width)
+                .attr("y", height)
+                .attr("height", 0)
+                .transition()
+                  .duration(1000)
+                  .attr("y", function(d) {
+                    return (height) - citationsScale(d.citations); })
+                  .attr("height", function(d) {
+                    return citationsScale(d.citations); })
+          }
+
+          // Get the total width of the div, where the chart is placed.
+          var getDivWidth = function() {
+            // Example: 570px.
+            var width_str = d3.select('#statistics-chart').style('width');
+            width_str = width_str.slice(0, -2);
+
+            return parseInt(width_str);
+          }
+
+          // Listen for changes in the width of the website.
+          var resizeListener = function() {
+            d3.select("#statistics-chart").selectAll("svg").remove();
+
+            if (Object.keys(publicationsCount).length !== 0) {
+              drawBarChart();
+            }
+          }
+
+          // Event handlers.
+          if (window.attachEvent) {
+            // Internet Explorer.
+            window.attachEvent('onresize', resizeListener);
+          }
+          else if (window.addEventListener) {
+            window.addEventListener('resize', resizeListener, true);
+          }
+          else {
+            // The webbrowser does not support JavaScript event binding.
+            var alert_text = "You are using an outdated browser. " +
+                             "Please upgrade your browser to improve " +
+                             "your experience.";
+            alert(alert_text);
+          }
+
+          // Initial graph.
+          if (Object.keys(publicationsCount).length !== 0) {
+            drawBarChart();
+          }
+        });
+      }
+    };
+  });
+
+  app.directive('statisticsSummary', function() {
+    return {
+      require: '^profileInit',
+      restrict: 'E',
+      templateUrl: '/static/js/authors/templates/statistics.html',
+    };
+  });
+});

--- a/inspirehep/modules/authors/static/js/authors/templates/collaborators.html
+++ b/inspirehep/modules/authors/static/js/authors/templates/collaborators.html
@@ -1,8 +1,9 @@
 <div>
   <table class="table no-table-line" id="author-collaborators">
     <tbody>
-      <tr ng-repeat="collaboration in publications.collaborations">
-        <td><a href="/search?experiment={{ collaboration }}">{{ collaboration }}</a></td>
+      <tr ng-repeat="coauthor in coauthors | orderBy:'-count' | limitTo:5">
+        <td><a href="/authors/{{ coauthor.id }}">{{ coauthor.full_name }}</a></td>
+        <td>{{ coauthor.count }}</td>
       </tr>
     </tbody>
   </table>

--- a/inspirehep/modules/authors/static/js/authors/templates/position.html
+++ b/inspirehep/modules/authors/static/js/authors/templates/position.html
@@ -1,11 +1,16 @@
-<div>
-  <table class="table no-table-line" id="author-position">
-    <tbody>
-      <tr ng-repeat="position in positions">
-        <td class="left">{{ position.date }}</td>
-        <td class="center">{{ position.rank }}</td>
-        <td class="right" align="right">{{ position.institution }}</td>
-      </tr>
-    </tbody>
-  </table>
+<div class="col-md-12 box">
+  <div class="pull-left">
+    <h4><i class="fa fa-{{ icon }}"></i> Work</h4>
+  </div>
+  <div>
+    <table class="table no-table-line" id="author-position">
+      <tbody>
+        <tr ng-repeat="position in positions">
+          <td class="left">{{ position.date }}</td>
+          <td class="center">{{ position.rank }}</td>
+          <td class="right" align="right">{{ position.institution }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 </div>

--- a/inspirehep/modules/authors/static/js/authors/templates/publications.html
+++ b/inspirehep/modules/authors/static/js/authors/templates/publications.html
@@ -1,29 +1,41 @@
 <div>
   <table class="table no-table-line" id="publications-table">
-      <thead>
+    <thead>
       <tr>
         <th>Title</th>
         <th>Journal</th>
+        <th>Citations</th>
+        <th>Impact Graph</th>
         <th>Year</th>
       </tr>
     </thead>
     <tbody>
-      <tr ng-repeat="publication in publicationsList">
+      <tr ng-repeat="publication in publications">
         <td width="50%">
-          <a href="/literature/{{ publication.recid }}">
+          <a href="/literature/{{ publication.id }}">
             {{ publication.title | limitTo: 120 }}
           </a>
           <span ng-if="publication.title.length > 120">...</span>
         </td>
-        <td ng-if="publication.journal_recid !== undefined">
-          <a href="/journals/{{ publication.journal_recid }}">
-            {{ publication.journal_title }}
+        <td ng-if="publication.journal.id !== undefined">
+          <a href="/journals/{{ publication.journal.id }}">
+            {{ publication.journal.title }}
           </a>
         </td>
-        <td ng-if="publication.journal_recid === undefined">
-          {{ publication.journal_title }}
+        <td ng-if="publication.journal.id === undefined">
+          {{ publication.journal.title }}
         </td>
-        <td>{{ publication.year }}</td>
+        <td ng-if="publication.citations !== undefined">
+          {{ publication.citations}}
+        </td>
+        <td ng-if="publication.citations === undefined">
+          0
+        </td>
+        <td>
+          <impact-graph publication="{{ publication.id }}">
+          </impact-graph>
+        </td>
+        <td>{{ publication.date | limitTo:4 }}</td>
       </tr>
     </tbody>
   </table>

--- a/inspirehep/modules/authors/static/js/authors/templates/statistics.html
+++ b/inspirehep/modules/authors/static/js/authors/templates/statistics.html
@@ -3,17 +3,17 @@
     <tbody>
       <tr>
         <td>HEP Index</td>
-        <td align="right">NaN</td>
+        <td align="right">{{ statistics.hindex }}</td>
       </tr>
       <tr>
         <td>Citations</td>
-        <td align="right">NaN</td>
+        <td align="right">{{ statistics.citations }}</td>
       </tr>
       <tr class="blue">
         <td>Research works</td>
-        <td align="right">{{ count }}</td>
+        <td align="right">{{ statistics.publications }}</td>
       </tr>
-      <tr ng-repeat="(type, typeCount) in researchWorks" class="blue sub">
+      <tr ng-repeat="(type, typeCount) in statistics.types" class="blue sub">
         <td>{{ type.charAt(0) | uppercase }}{{ type.substr(1) }}</td>
         <td align="right"> {{ typeCount }}</td>
       </tr>

--- a/inspirehep/modules/theme/static/js/settings.js
+++ b/inspirehep/modules/theme/static/js/settings.js
@@ -73,6 +73,7 @@ require.config({
     toastr: 'node_modules/toastr/toastr',
     typeahead: 'node_modules/typeahead.js/dist/typeahead.bundle',
     sifter: 'node_modules/sifter/sifter',
+    'statistics': 'js/authors/statistics',
     microplugin: 'node_modules/microplugin/src/microplugin'
   },
   shim: {

--- a/inspirehep/modules/theme/static/scss/authors/profiles.scss
+++ b/inspirehep/modules/theme/static/scss/authors/profiles.scss
@@ -101,6 +101,11 @@ $white: #ffffff;
 
 #author-biography {
   padding-top: 8px;
+
+  p {
+    display: inline;
+    padding-right: 8px;
+  }
 }
 
 #author-collaborators, #author-position {
@@ -165,7 +170,7 @@ $white: #ffffff;
 }
 
 // Statistics graph.
-#plot {
+#statistics-plot {
   margin-top: -30px;
 
   .axis path, .axis line {
@@ -175,7 +180,7 @@ $white: #ffffff;
   }
 
   .axis {
-    font-size: 0.75em;
+    font-size: 1em;
   }
 
   .xAxis text {
@@ -183,15 +188,25 @@ $white: #ffffff;
     text-anchor: start;
   }
 
-  .yAxis text, .publicationsLabel {
+  .citationsAxis text, .citationsAxis {
+    fill: $dark-blue;
+  }
+
+  .publicationsLabel {
+    font-size: 0.9em;
     fill: $light-blue;
   }
 
   .citationsLabel {
+    font-size: 0.9em;
     fill: $dark-blue;
   }
 
-  .yAxis path, .yAxis line {
+  .citationsAxis path, .citationsAxis line {
+    stroke: $dark-blue !important;
+  }
+
+  .publicationsAxis path, .publicationsAxis line {
     stroke: $light-blue !important;
   }
 }

--- a/inspirehep/modules/theme/templates/inspirehep_theme/format/record/authors/Author_HTML_detailed.html
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/format/record/authors/Author_HTML_detailed.html
@@ -36,7 +36,7 @@
     <div class="record-header" id="detailed-header">
       <div class="row">
         <div class="col-md-12 summary" id="detailed-header-top">
-          <div class="col-md-2">
+          <div class="col-md-2 hidden-xs hidden-sm">
             {% set email = '' %}
             {% if record.positions | length %}
               {% set email = record['positions'][0].get('email', [''])[0] %}
@@ -49,10 +49,10 @@
               <author-affiliation id="affiliation"></author-affiliation>
             </div>
             <div id="author-fields">
-              <author-fields fields='{{ config.ARXIV_TO_INSPIRE_CATEGORY_MAPPING|tojson|safe }}'>
-              </author-fields>
+              <author-fields></author-fields>
             </div>
             <div id="author-biography">
+              <author-keywords></author-keywords>
             </div>
           </div>
         </div>
@@ -77,7 +77,7 @@
         </div>
         <div class="col-md-12 bottom-box no-padding">
           <div class="col-md-4">
-            <statistics></statistics>
+            <statistics-summary></statistics-summary>
           </div>
           <div class="col-md-2">
           </div>
@@ -102,20 +102,8 @@
     </div>
 
     <div class="row">
-      <div class="col-md-6" author-positions>
-        <div class="col-md-12 box">
-          <div class="pull-left">
-            <h4><i class="fa fa-briefcase"></i> Work</h4>
-          </div>
-          <author-work></author-work>
-        </div>
-
-        <div class="col-md-12 box">
-          <div class="pull-left">
-            <h4><i class="fa fa-university"></i> Education</h4>
-          </div>
-          <author-education></author-education>
-        </div>
+      <div class="col-md-6">
+        <author-positions></author-positions>
       </div>
 
       <div class="col-md-6">
@@ -123,7 +111,7 @@
           <div class="pull-left">
             <h4><i class="fa fa-users"></i> Collaborators</h4>
           </div>
-          <collaborators></collaborators>
+          <author-collaborators></author-collaborators>
         </div>
       </div>
   </div>


### PR DESCRIPTION
* Updates the Angular.js apps to make use of new /authors API.

* Adds support for citations count including listing of
  publications and general statistics.

* Adds impact graphs for every listed publication.

* Updates collaborators to display authors instead of
  experiments (sorted by count of shared publications).

* Hides work/education box, when there is no data.

* Restrctures author apps.

Signed-off-by: Grzegorz Jacenków <grzegorz.jacenkow@cern.ch>