### PR TITLE
dojson: ignore double longitudes

### DIFF
--- a/inspirehep/dojson/institutions/fields/bd1xx.py
+++ b/inspirehep/dojson/institutions/fields/bd1xx.py
@@ -34,7 +34,6 @@ from inspirehep.utils.helpers import force_force_list
 
 
 @institutions.over('location', '^034..')
-@utils.filter_values
 def location(self, key, value):
     """GPS location info."""
     def _get_float(value, c):
@@ -43,10 +42,14 @@ def location(self, key, value):
         except (TypeError, KeyError, ValueError):
             return ''
 
-    return {
-        'longitude': _get_float(value, 'd'),
-        'latitude': _get_float(value, 'f'),
-    }
+    latitude = _get_float(value, 'f')
+    longitude = _get_float(value, 'd')
+
+    if latitude and longitude:
+        return {
+            'latitude': latitude,
+            'longitude': longitude,
+        }
 
 
 @institutions.over('timezone', '^043..')

--- a/inspirehep/dojson/institutions/fields/bd1xx.py
+++ b/inspirehep/dojson/institutions/fields/bd1xx.py
@@ -40,7 +40,7 @@ def location(self, key, value):
     def _get_float(value, c):
         try:
             return float(value[c])
-        except (KeyError, ValueError):
+        except (TypeError, KeyError, ValueError):
             return ''
 
     return {

--- a/tests/unit/dojson/test_dojson_institutions.py
+++ b/tests/unit/dojson/test_dojson_institutions.py
@@ -90,6 +90,19 @@ def test_no_location_from_invalid_034__d_f():
     assert 'location' not in result
 
 
+def test_no_location_from_034__double_d():
+    snippet = (
+        '<datafield tag="034" ind1=" " ind2=" ">'
+        '   <subfield code="d">32.540776</subfield>'
+        '   <subfield code="d">15.561010</subfield>'
+        '</datafield>'
+    )  # record/1442294
+
+    result = clean_record(institutions.do(create_record(snippet)))
+
+    assert 'location' not in result
+
+
 def test_timezone_from_043__t():
     snippet = (
         '<datafield tag="043" ind1=" " ind2=" ">'

--- a/tests/unit/dojson/test_dojson_institutions.py
+++ b/tests/unit/dojson/test_dojson_institutions.py
@@ -47,34 +47,28 @@ def test_location_from_034__d_f():
     assert expected == result['location']
 
 
-def test_location_from_034__d():
+def test_no_location_from_034__d():
     snippet = (
         '<datafield tag="034" ind1=" " ind2=" ">'
         '  <subfield code="d">6.07532</subfield>'
         '</datafield>'
     )  # synthetic data
 
-    expected = {
-        'longitude': 6.07532,
-    }
     result = clean_record(institutions.do(create_record(snippet)))
 
-    assert expected == result['location']
+    assert 'location' not in result
 
 
-def test_location_from_034__f():
+def test_no_location_from_034__f():
     snippet = (
         '<datafield tag="034" ind1=" " ind2=" ">'
         '  <subfield code="f">50.7736</subfield>'
         '</datafield>'
     )  # synthetic data
 
-    expected = {
-        'latitude': 50.7736,
-    }
     result = clean_record(institutions.do(create_record(snippet)))
 
-    assert expected == result['location']
+    assert 'location' not in result
 
 
 def test_no_location_from_invalid_034__d_f():


### PR DESCRIPTION
Now that https://github.com/inspirehep/inspire/issues/170 was properly solved on Legacy data we can start ignoring this error on Nightly.