### PR TITLE
schema: allow list as publication info notes

### DIFF
--- a/inspirehep/dojson/hep/fields/bd76x78x.py
+++ b/inspirehep/dojson/hep/fields/bd76x78x.py
@@ -26,14 +26,15 @@ from __future__ import absolute_import, division, print_function
 
 from dojson import utils
 
+from inspirehep.utils.dedupers import dedupe_list
+from inspirehep.utils.helpers import force_force_list
+from inspirehep.utils.pubnote import split_page_artid
+
 from ..model import hep, hep2marc
 from ...utils import (
     get_recid_from_ref,
     get_record_ref,
 )
-
-from inspirehep.utils.helpers import force_force_list
-from inspirehep.utils.pubnote import split_page_artid
 
 
 @hep.over('publication_info', '^773..')
@@ -76,7 +77,7 @@ def publication_info(self, key, value):
         'pubinfo_freetext': value.get('x'),
         'year': year,
         'isbn': value.get('z'),
-        'note': value.get('m'),
+        'notes': dedupe_list(force_force_list(value.get('m'))),
     }
 
     return res
@@ -108,7 +109,7 @@ def publication_info2marc(self, key, value):
         'x': value.get('pubinfo_freetext'),
         'y': value.get('year'),
         'z': value.get('isbn'),
-        'm': value.get('note')
+        'm': value.get('notes')
     }
 
 

--- a/inspirehep/modules/records/jsonschemas/records/hep.json
+++ b/inspirehep/modules/records/jsonschemas/records/hep.json
@@ -650,8 +650,12 @@
                     "journal_volume": {
                         "type": "string"
                     },
-                    "note": {
-                        "type": "string"
+                    "notes": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "uniqueItems": true
                     },
                     "page_end": {
                         "description": "Last page",

--- a/tests/unit/dojson/fixtures/test_hep_record.xml
+++ b/tests/unit/dojson/fixtures/test_hep_record.xml
@@ -189,6 +189,9 @@
     <subfield code="v">105</subfield>
     <subfield code="y">2010</subfield>
     <subfield code="m">note</subfield>
+    <!-- repeated note value should be automatically removed on parsing -->
+    <subfield code="m">note</subfield>
+    <subfield code="m">extranote</subfield>
     <subfield code="z">isbn</subfield>
     <subfield code="x">pubinfo_freetext</subfield>
     <subfield code="w">cnum</subfield>

--- a/tests/unit/dojson/test_dojson_hep.py
+++ b/tests/unit/dojson/test_dojson_hep.py
@@ -1524,7 +1524,9 @@ def test_publication_info(marcxml_to_json, json_to_marc):
             json_to_marc['773'][0]['x'])
     assert (marcxml_to_json['publication_info'][0]['isbn'] ==
             json_to_marc['773'][0]['z'])
-    assert (marcxml_to_json['publication_info'][0]['note'] ==
+    assert (marcxml_to_json['publication_info'][0]['notes'] ==
+            ['note', 'extranote'])
+    assert (marcxml_to_json['publication_info'][0]['notes'] ==
             json_to_marc['773'][0]['m'])
 
 


### PR DESCRIPTION
* Model pulication info notes as a list with unique values (if not
  unique, duplicates will be ignored on parsing)

Signed-off-by: David Caro <david@dcaro.es>