### PR TITLE
pidstore: request next pid from legacy

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -1149,6 +1149,10 @@ INSPIRE_RANK_TYPES = {
     }
 }
 
+# Legacy PID provider
+# ===================
+LEGACY_PID_PROVIDER = None  # e.g. "http://example.org/batchuploader/allocaterecord"
+
 # Inspire subject translation
 # ===========================
 ARXIV_TO_INSPIRE_CATEGORY_MAPPING = {

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -26,6 +26,7 @@ from __future__ import absolute_import, division, print_function
 
 from time import sleep
 
+import httpretty
 import pytest
 
 from invenio_db import db
@@ -95,3 +96,10 @@ def small_app(request):
         es.indices.refresh('records-hep')
 
         yield app
+
+
+@pytest.yield_fixture
+def httpretty_mock():
+    httpretty.enable()
+    yield
+    httpretty.disable()

--- a/tests/integration/test_pidstore.py
+++ b/tests/integration/test_pidstore.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import httpretty
+import mock
+
+from inspirehep.modules.pidstore.providers import InspireRecordIdProvider
+
+
+def test_getting_next_recid_from_legacy(httpretty_mock, app):
+    extra_config = {
+        'LEGACY_PID_PROVIDER': 'http://server/batchuploader/allocaterecord',
+    }
+
+    with app.app_context():
+        with mock.patch.dict(app.config, extra_config):
+            httpretty.register_uri(
+                httpretty.GET,
+                "http://server/batchuploader/allocaterecord",
+                content_type="application/json",
+                body=u'3141592',
+                status=200)
+
+            args = dict(
+                object_type="rec",
+                object_uuid="7753a30b-4c4b-469c-8d8d-d5020069b3ab",
+                pid_type="literature"
+            )
+            provider = InspireRecordIdProvider.create(**args)
+
+            assert str(provider.pid.pid_value) == "3141592"


### PR DESCRIPTION
* Adds a method, which reserves a new pid from legacy instance,
  so that when a new record arrives there won't be a conflict
  between legacy systems and labs.

Signed-off-by: Grzegorz Jacenków <grzegorz.jacenkow@cern.ch>