### PR TITLE
jsonschema: correct obsolete_institutions

### DIFF
--- a/inspirehep/dojson/institutions/fields/bd1xx.py
+++ b/inspirehep/dojson/institutions/fields/bd1xx.py
@@ -72,8 +72,27 @@ def name(self, key, value):
     set_value('institution', value.get('a'))
     set_value('department', value.get('b'))
     set_value('ICN', value.get('u'))
-    set_value('obsolete_ICN', value.get('x'))
     set_value('new_ICN', value.get('t'))
+
+    superseded_icns = force_force_list(value.get('x'))
+    superseded_recids = force_force_list(value.get('z'))
+    related_institutes = []
+    if len(superseded_icns) == len(superseded_recids):
+        for icn, recid in zip(superseded_icns, superseded_recids):
+            related_institutes.append({
+                'curated_relation': True,
+                'name': icn,
+                'record': get_record_ref(recid, record_type='institutions'),
+                'relation_type': 'superseded',
+            })
+    else:
+        for icn in superseded_icns:
+            related_institutes.append({
+                'curated_relation': False,
+                'name': icn,
+                'relation_type': 'superseded',
+            })
+    set_value('related_institutes', related_institutes)
 
     names = force_force_list(value.get('a'))
     names.extend(force_force_list(value.get('u')))

--- a/inspirehep/modules/records/jsonschemas/records/institutions.json
+++ b/inspirehep/modules/records/jsonschemas/records/institutions.json
@@ -131,21 +131,6 @@
             "type": "array",
             "uniqueItems": true
         },
-        "obsolete_ICN": {
-            "description": "ICN of obsolete inst for which this inst should be used instead",
-            "title": "Obsolete ICN",
-            "type": "string"
-        },
-        "obsolete_record": {
-            "$ref": "elements/json_reference.json",
-            "description": "record URI of obsolete inst for which this inst should be used instead",
-            "title": "Obsolete record URI"
-        },
-        "old_ICN": {
-            "description": "HEP affiliation (spires name)",
-            "title": "Old SPIRES control number",
-            "type": "string"
-        },
         "public_notes": {
             "items": {
                 "title": "Public note",
@@ -157,7 +142,6 @@
         },
         "related_institutes": {
             "items": {
-                "description": "FIXME: Shall we rather separate in two fields? predecessors and parents?",
                 "properties": {
                     "curated_relation": {
                         "title": "Is the relation curated?",
@@ -172,11 +156,11 @@
                         "title": "URI for the related institute record"
                     },
                     "relation_type": {
-                        "description": "FIXME: do we actually need 'successor' at all? Can't we derive it from predecessor?",
                         "enum": [
                             "predecessor",
                             "successor",
                             "parent",
+                            "superseded",
                             "other"
                         ],
                         "title": "Relation type",

--- a/tests/unit/dojson/test_dojson_institutions.py
+++ b/tests/unit/dojson/test_dojson_institutions.py
@@ -110,6 +110,41 @@ def test_timezone_from_043__t():
     assert expected == result['timezone']
 
 
+def test_superseded_institutions_from_110__x_z():
+    snippet = (
+        '<datafield tag="110" ind1=" " ind2=" ">'
+        '  <subfield code="a">University of Pittsburgh</subfield>'
+        '  <subfield code="t">U. Pittsburgh</subfield>'
+        '  <subfield code="u">U. Pittsburgh (main)</subfield>'
+        '  <subfield code="x">Pittsburgh U., Dept. Phil.</subfield>'
+        '  <subfield code="x">Pittsburgh U., Med. School</subfield>'
+        '  <subfield code="z">908047</subfield>'
+        '  <subfield code="z">905042</subfield>'
+        '</datafield>'
+    ) # record/1272953
+    expected = [
+        {
+            'curated_relation': True,
+            'name': 'Pittsburgh U., Dept. Phil.',
+            'record': {
+                '$ref': 'http://localhost:5000/api/institutions/908047',
+            },
+            'relation_type': 'superseded',
+        },
+        {
+            'curated_relation': True,
+            'name': 'Pittsburgh U., Med. School',
+            'record': {
+                '$ref': 'http://localhost:5000/api/institutions/905042',
+            },
+            'relation_type': 'superseded',
+        },
+    ]
+    result = clean_record(institutions.do(create_record(snippet)))
+
+    assert expected == result['related_institutes']
+
+
 def test_name_from_110__a():
     snippet = (
         '<datafield tag="110" ind1=" " ind2=" ">'


### PR DESCRIPTION
Sentry: https://sentry.cern.ch/inspire-sentry/inspire-labs-qa/group/601660/

* Merges obsolete_institutions into related_institutes.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>