### PR TITLE
WIP setup: remove theme ext from API app

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -178,7 +178,6 @@ setup(
             'hepnames2marc = inspirehep.dojson.hepnames2marc:hepnames2marc',
         ],
         'invenio_base.api_apps': [
-            'inspire_theme = inspirehep.modules.theme:INSPIRETheme',
             'inspire_search = inspirehep.modules.search:INSPIRESearch',
             'inspire_workflows = inspirehep.modules.workflows:INSPIREWorkflows',
             'inspire_warnings = inspirehep.modules.warnings:INSPIREWarnings',


### PR DESCRIPTION
Sentry: https://sentry.cern.ch/inspire-sentry/inspire-labs-qa/group/601686/

* The theme extension adds a few error handlers to the
  `error_handler_spec` of the application. These error
  handlers try to render a template with custom Jinja2
  filters, which are not loaded in the API app, causing
  another exception that masks the true source of error.
  Therefore, removes the theme extension from the API.

Signed-off-by: Jacopo Notarstefano <jacopo.notarstefano@cern.ch>