### PR TITLE
dojson: mashed up 773s

### DIFF
--- a/inspirehep/dojson/hep/fields/bd76x78x.py
+++ b/inspirehep/dojson/hep/fields/bd76x78x.py
@@ -32,6 +32,7 @@ from inspirehep.utils.pubnote import split_page_artid
 
 from ..model import hep, hep2marc
 from ...utils import (
+    force_single_element,
     get_recid_from_ref,
     get_record_ref,
 )
@@ -39,7 +40,6 @@ from ...utils import (
 
 @hep.over('publication_info', '^773..')
 @utils.for_each_value
-@utils.filter_values
 def publication_info(self, key, value):
     """Publication info about record."""
     def get_int_value(val):
@@ -67,16 +67,16 @@ def publication_info(self, key, value):
         'page_start': page_start,
         'page_end': page_end,
         'artid': artid,
-        'journal_issue': value.get('n'),
-        'conf_acronym': value.get('o'),
-        'journal_title': value.get('p'),
-        'reportnumber': value.get('r'),
-        'confpaper_info': value.get('t'),
-        'journal_volume': value.get('v'),
-        'cnum': force_force_list(value.get('w')),
-        'pubinfo_freetext': value.get('x'),
+        'journal_issue': force_single_element(value.get('n')),
+        'conf_acronym': force_single_element(value.get('o')),
+        'journal_title': force_single_element(value.get('p')),
+        'reportnumber': force_single_element(value.get('r')),
+        'confpaper_info': force_single_element(value.get('t')),
+        'journal_volume': force_single_element(value.get('v')),
+        'cnum': force_single_element(value.get('w')),
+        'pubinfo_freetext': force_single_element(value.get('x')),
         'year': year,
-        'isbn': value.get('z'),
+        'isbn': force_single_element(value.get('z')),
         'notes': dedupe_list(force_force_list(value.get('m'))),
     }
 

--- a/inspirehep/modules/records/jsonschemas/records/hep.json
+++ b/inspirehep/modules/records/jsonschemas/records/hep.json
@@ -616,10 +616,7 @@
                         "type": "string"
                     },
                     "cnum": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
+                        "type": "string"
                     },
                     "conf_acronym": {
                         "type": "string"

--- a/tests/unit/dojson/test_dojson_hep.py
+++ b/tests/unit/dojson/test_dojson_hep.py
@@ -1488,6 +1488,44 @@ def test_authors_supervisors_from_701__double_a_u_z():
     assert expected == result['authors']
 
 
+def test_mashed_publication_info_from_773():
+    snippet = (
+        '<datafield tag="773" ind1=" " ind2=" ">'
+        '  <subfield code="p">IAU Symp.</subfield>'
+        '  <subfield code="w">C08-06-09</subfield>'
+        '  <subfield code="v">354</subfield>'
+        '  <subfield code="y">2008</subfield>'
+        '  <subfield code="v">254</subfield>'
+        '  <subfield code="y">2009</subfield>'
+        '  <subfield code="c">45</subfield>'
+        '  <subfield code="1">1212883</subfield>'
+        '  <subfield code="2">978924</subfield>'
+        '  <subfield code="0">1408366</subfield>'
+        '</datafield>'
+    ) # record/820763/export/xme
+
+    expected = {
+        'journal_title': 'IAU Symp.',
+        'cnum': 'C08-06-09',
+        'journal_volume': '354',
+        'year': 2008,
+        'artid': '45',
+        'page_start': '45',
+        'journal_record': {
+            '$ref': 'http://localhost:5000/api/journals/1212883',
+        },
+        'parent_record': {
+            '$ref': 'http://localhost:5000/api/literature/1408366',
+        },
+        'conference_record': {
+            '$ref': 'http://localhost:5000/api/conferences/978924',
+        },
+    }
+    result = clean_record(hep.do(create_record(snippet)))
+
+    assert expected == result['publication_info'][0]
+
+
 def test_collaboration(marcxml_to_json, json_to_marc):
     """Test if collaboration is created correctly."""
     assert (marcxml_to_json['collaboration'][0] ==


### PR DESCRIPTION
* Ignores second instances of subfields for mashed up 773s.
  (closes #1507)

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>