### PR TITLE
WIP authors: extend publications with affiliations

### DIFF
--- a/inspirehep/modules/authors/static/js/authors/templates/publications.html
+++ b/inspirehep/modules/authors/static/js/authors/templates/publications.html
@@ -6,6 +6,7 @@
         <th>Journal</th>
         <th>Citations</th>
         <th>Impact Graph</th>
+        <th>Affiliation</th>
         <th>Year</th>
       </tr>
     </thead>
@@ -34,6 +35,14 @@
         <td>
           <impact-graph publication="{{ publication.id }}">
           </impact-graph>
+        </td>
+        <td ng-if="publication.affiliation.id !== undefined">
+          <a href="/institutions/{{ publication.affiliation.id }}">
+            {{ publication.affiliation.name }}
+          </a>
+        </td>
+        <td ng-if="publication.affiliation.id === undefined">
+          {{ publication.affiliation.name }}
         </td>
         <td>{{ publication.date | limitTo:4 }}</td>
       </tr>

--- a/tests/integration/test_author_api.py
+++ b/tests/integration/test_author_api.py
@@ -126,6 +126,13 @@ def test_api_authors_publications(app):
     schema = {
         'items': {
             'properties': {
+                'affiliation': {
+                    'properties': {
+                        'id': {'type': 'integer'},
+                        'name': {'type': 'string'}
+                    },
+                    'type': 'object'
+                },
                 'collaborations': {
                     'items': {'type': 'string'},
                     'type': 'array'


### PR DESCRIPTION
- Extends /authors API with affiliation field for every
  publication. Referes #1090.
- Includes affiliation in the data table of author profile.

Signed-off-by: Grzegorz Jacenków grzegorz.jacenkow@cern.ch
