### PR TITLE
dojson: skip CURATOR source in DOI

### DIFF
--- a/inspirehep/dojson/hep/fields/bd01x09x.py
+++ b/inspirehep/dojson/hep/fields/bd01x09x.py
@@ -144,17 +144,21 @@ def persistent_identifiers(self, key, value):
         if val:
             items = force_force_list(val.get('a'))
             items_type = force_single_element(val.get('2'))
+            # We don't support more than one source and 'CURATOR' is really not used.
+            sources = force_force_list(val.get('9'))
+            sources = [source for source in sources if source.upper() != 'CURATOR']
+            source = force_single_element(sources)
             if items_type and items_type.lower() == 'doi':
                 for v in items:
                     dois.append({
                         'value': v,
-                        'source': val.get('9')
+                        'source': source
                     })
             else:
                 for v in items:
                     persistent_identifiers.append({
                         'value': v,
-                        'source': val.get('9'),
+                        'source': source,
                         'type': val.get('2')
                     })
     self['dois'] = dois

--- a/tests/unit/dojson/test_dojson_hep.py
+++ b/tests/unit/dojson/test_dojson_hep.py
@@ -187,6 +187,24 @@ def test_languages_single_value():
     assert expected == result['languages']
 
 
+def test_ignore_curator_from_0247_a():
+    snippet = (
+        '<datafield tag="024" ind1="7" ind2=" ">'
+        '  <subfield code="2">DOI</subfield>'
+        '  <subfield code="9">bibcheck</subfield>'
+        '  <subfield code="9">CURATOR</subfield>'
+        '  <subfield code="a">10.1590/S1806-11172008005000006</subfield>'
+        '</datafield>'
+    )
+
+    expected = [{
+        'source': 'bibcheck',
+        'value': '10.1590/S1806-11172008005000006',
+    }]
+    result = clean_record(hep.do(create_record(snippet)))
+
+    assert expected == result['dois']
+
 
 def test_external_system_numbers_from_035__a():
     snippet = (


### PR DESCRIPTION
Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>

Fixes sentry: https://sentry.cern.ch/inspire-sentry/inspire-labs-qa/group/601710/