### PR TITLE
WIP warnings: suppress SQLAlchemy warnings

### DIFF
--- a/inspirehep/modules/warnings/__init__.py
+++ b/inspirehep/modules/warnings/__init__.py
@@ -1,21 +1,24 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of INSPIRE
+# This file is part of INSPIRE.
 # Copyright (C) 2016 CERN.
 #
-# INSPIRE is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License as
-# published by the Free Software Foundation; either version 2 of the
-# License, or (at your option) any later version.
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-# INSPIRE is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with INSPIRE; if not, write to the Free Software Foundation,
-# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
 
 """Warnings extension that removes deprecation warnings.
 
@@ -23,7 +26,9 @@ Invenio-Base enables deprecation warnings and this extension removes
 this setting unless ``DEBUG_SHOW_DEPRECATION_WARNINGS`` is set to True.
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
+
+import warnings
 
 
 class INSPIREWarnings(object):
@@ -41,7 +46,6 @@ class INSPIREWarnings(object):
                               False)
 
         if not app.config['DEBUG_SHOW_DEPRECATION_WARNINGS']:
-            import warnings
             warnings.filterwarnings(
                 'ignore',
                 category=DeprecationWarning

--- a/inspirehep/modules/warnings/ext.py
+++ b/inspirehep/modules/warnings/ext.py
@@ -20,11 +20,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-"""Extension that suppresses warnings.
-
-By default Invenio-Base enables deprecation warnings. This extension
-disables them, unless ``DEBUG_SHOW_DEPRECATION_WARNINGS`` is ``True``.
-"""
+"""Extension that suppresses warnings."""
 
 from __future__ import absolute_import, division, print_function
 
@@ -44,11 +40,7 @@ class INSPIREWarnings(object):
         """Initialize the application."""
         self.init_config(app)
 
-        if not app.config['DEBUG_SHOW_DEPRECATION_WARNINGS']:
-            warnings.filterwarnings('ignore', category=DeprecationWarning)
-
         app.extensions['inspire-warnings'] = self
 
     def init_config(self, app):
         """Initialize the configuration."""
-        app.config.setdefault('DEBUG_SHOW_DEPRECATION_WARNINGS', False)

--- a/inspirehep/modules/warnings/ext.py
+++ b/inspirehep/modules/warnings/ext.py
@@ -20,11 +20,34 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-"""INSPIREWarnings module."""
+"""Warnings extension that removes deprecation warnings.
+
+Invenio-Base enables deprecation warnings and this extension removes
+this setting unless ``DEBUG_SHOW_DEPRECATION_WARNINGS`` is set to True.
+"""
 
 from __future__ import absolute_import, division, print_function
 
-from .ext import INSPIREWarnings
+import warnings
 
 
-__all__ = ("INSPIREWarnings", )
+class INSPIREWarnings(object):
+    """INSPIREWarnings extension implementation."""
+
+    def __init__(self, app=None):
+        """Initialize extension."""
+        self.app = app
+        if app is not None:
+            self.init_app(app)
+
+    def init_app(self, app):
+        """Initialize a Flask application."""
+        app.config.setdefault("DEBUG_SHOW_DEPRECATION_WARNINGS",
+                              False)
+
+        if not app.config['DEBUG_SHOW_DEPRECATION_WARNINGS']:
+            warnings.filterwarnings(
+                'ignore',
+                category=DeprecationWarning
+            )
+        app.extensions["inspire-warnings"] = self

--- a/inspirehep/modules/warnings/ext.py
+++ b/inspirehep/modules/warnings/ext.py
@@ -20,10 +20,10 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-"""Warnings extension that removes deprecation warnings.
+"""Extension that suppresses warnings.
 
-Invenio-Base enables deprecation warnings and this extension removes
-this setting unless ``DEBUG_SHOW_DEPRECATION_WARNINGS`` is set to True.
+By default Invenio-Base enables deprecation warnings. This extension
+disables them, unless ``DEBUG_SHOW_DEPRECATION_WARNINGS`` is ``True``.
 """
 
 from __future__ import absolute_import, division, print_function
@@ -32,22 +32,23 @@ import warnings
 
 
 class INSPIREWarnings(object):
-    """INSPIREWarnings extension implementation."""
+
+    """Extension that suppresses warnings."""
 
     def __init__(self, app=None):
-        """Initialize extension."""
-        self.app = app
-        if app is not None:
+        """Initialize the extension."""
+        if app:
             self.init_app(app)
 
     def init_app(self, app):
-        """Initialize a Flask application."""
-        app.config.setdefault("DEBUG_SHOW_DEPRECATION_WARNINGS",
-                              False)
+        """Initialize the application."""
+        self.init_config(app)
 
         if not app.config['DEBUG_SHOW_DEPRECATION_WARNINGS']:
-            warnings.filterwarnings(
-                'ignore',
-                category=DeprecationWarning
-            )
-        app.extensions["inspire-warnings"] = self
+            warnings.filterwarnings('ignore', category=DeprecationWarning)
+
+        app.extensions['inspire-warnings'] = self
+
+    def init_config(self, app):
+        """Initialize the configuration."""
+        app.config.setdefault('DEBUG_SHOW_DEPRECATION_WARNINGS', False)


### PR DESCRIPTION
With this PR we go from:
```
$ inspirehep shell
/Users/jacquerie/.virtualenvs/inspire/lib/python2.7/site-packages/sqlalchemy/ext/declarative/clsregistry.py:120: SAWarning: This declarative base already contains a class with the same class name and module name as flask_sqlalchemy.RecordMetadataVersion, and will be replaced in the string-lookup table.
  item.__name__

/Users/jacquerie/.virtualenvs/inspire/lib/python2.7/site-packages/sqlalchemy/orm/properties.py:194: SAWarning: On mapper Mapper|RecordMetadataVersion|records_metadata_version, primary key column 'records_metadata_version.transaction_id' is being combined with distinct primary key column 'records_metadata_version.transaction_id' in attribute 'transaction_id'.  Use explicit properties to give each column its own mapped attribute name.
  self.columns[0], self.key))

Python 2.7.12 (default, Jun 29 2016, 14:04:44)
[GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)] on darwin
IPython: 5.1.0
App: inspirehep [debug]
Instance: /Users/jacquerie/.virtualenvs/inspire/bin/../var/inspirehep-instance

In [1]:
```
to:
```
$ inspirehep shell
Python 2.7.12 (default, Jun 29 2016, 14:04:44)
[GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)] on darwin
IPython: 5.1.0
App: inspirehep [debug]
Instance: /Users/jacquerie/.virtualenvs/inspire/bin/../var/inspirehep-instance

In [1]:
```