### PR TITLE
global: roles fix

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -1095,6 +1095,25 @@ CRAWLER_SETTINGS = {
 # Inspire mappings
 # ================
 
+INSPIRE_LEGACY_ROLES = {
+    'editing': [
+        'ed.',
+        'eds.',
+        'ed,,',
+        'eds',
+        'ed,',
+        'ed. et al.'
+    ],
+    'administration': [
+        'task force leader',
+        'resource manager',
+        'scientific coordinator',
+        'chairman',
+        'chair',
+        'workshop chair'
+    ]
+}
+
 INSPIRE_CATEGORIES = [
     'Accelerators',
     'Astrophysics',

--- a/inspirehep/dojson/hep/fields/bd70x75x.py
+++ b/inspirehep/dojson/hep/fields/bd70x75x.py
@@ -43,7 +43,7 @@ def thesis_supervisors(self, key, value):
             'affiliations': _get_affiliations(value),
             'contributor_roles': [
                 {
-                    'source': 'CRediT',
+                    'schema': 'CRediT',
                     'value': 'Supervision',
                 },
             ],

--- a/inspirehep/modules/disambiguation/search.py
+++ b/inspirehep/modules/disambiguation/search.py
@@ -349,7 +349,7 @@ def get_signature(uuid):
             "authors.orcid",
             "authors.profile",
             "authors.recid",
-            "authors.role",
+            "authors.contributor_roles.value",
             "authors.uuid"
         ],
         "query": {

--- a/inspirehep/modules/records/jsonschemas/records/hep.json
+++ b/inspirehep/modules/records/jsonschemas/records/hep.json
@@ -127,7 +127,7 @@
                     "contributor_roles": {
                         "items": {
                             "properties": {
-                                "source": {
+                                "schema": {
                                     "enum": [
                                         "CRediT"
                                     ],
@@ -187,11 +187,6 @@
                         "$ref": "elements/json_reference.json",
                         "description": "URI for the person record",
                         "title": "URI for the person record"
-                    },
-                    "role": {
-                        "description": "Role of the author within the paper. So far only Editor was captured.",
-                        "title": "Role of the person",
-                        "type": "string"
                     },
                     "uuid": {
                         "description": "Universally unique identifier of the author.",

--- a/tests/unit/dojson/fixtures/test_hep_record.xml
+++ b/tests/unit/dojson/fixtures/test_hep_record.xml
@@ -44,7 +44,7 @@
   <datafield tag="100" ind1=" " ind2=" ">
     <subfield code="a">Seidel, Alexander</subfield>
     <subfield code="u">Washington U., St. Louis</subfield>
-    <subfield code="e">relator_term</subfield>
+    <subfield code="e">ed.</subfield>
     <subfield code="q">alternative_name</subfield>
     <subfield code="i">Inspire_id</subfield>
     <subfield code="j">External_id</subfield>

--- a/tests/unit/dojson/test_dojson_hep.py
+++ b/tests/unit/dojson/test_dojson_hep.py
@@ -366,8 +366,8 @@ def test_authors(marcxml_to_json, json_to_marc):
     """Test if authors are created correctly."""
     assert (marcxml_to_json['authors'][0]['full_name'] ==
             json_to_marc['100']['a'])
-    assert (marcxml_to_json['authors'][0]['role'] ==
-            json_to_marc['100']['e'])
+    assert (marcxml_to_json['authors'][0]['contributor_roles'][0]['value'] ==
+            json_to_marc['100']['e'][0])
     assert (marcxml_to_json['authors'][0]['alternative_names'][0] ==
             json_to_marc['100']['q'][0])
     assert (marcxml_to_json['authors'][0]['emails'][0] ==
@@ -1334,7 +1334,7 @@ def test_authors_supervisors_from_701__a_u():
             ],
             'contributor_roles': [
                 {
-                    'source': 'CRediT',
+                    'schema': 'CRediT',
                     'value': 'Supervision',
                 },
             ],
@@ -1369,7 +1369,7 @@ def test_authors_supervisors_from_701__a_double_u():
             ],
             'contributor_roles': [
                 {
-                    'source': 'CRediT',
+                    'schema': 'CRediT',
                     'value': 'Supervision',
                 },
             ],
@@ -1410,7 +1410,7 @@ def test_authors_supervisors_from_multiple_701():
             ],
             'contributor_roles': [
                 {
-                    'source': 'CRediT',
+                    'schema': 'CRediT',
                     'value': 'Supervision',
                 },
             ],
@@ -1429,7 +1429,7 @@ def test_authors_supervisors_from_multiple_701():
             ],
             'contributor_roles': [
                 {
-                    'source': 'CRediT',
+                    'schema': 'CRediT',
                     'value': 'Supervision',
                 },
             ],
@@ -1444,7 +1444,7 @@ def test_authors_supervisors_from_multiple_701():
             ],
             'contributor_roles': [
                 {
-                    'source': 'CRediT',
+                    'schema': 'CRediT',
                     'value': 'Supervision',
                 },
             ],
@@ -1492,7 +1492,7 @@ def test_authors_supervisors_from_multiple_701_with_z():
             ],
             'contributor_roles': [
                 {
-                    'source': 'CRediT',
+                    'schema': 'CRediT',
                     'value': 'Supervision',
                 },
             ],
@@ -1517,7 +1517,7 @@ def test_authors_supervisors_from_multiple_701_with_z():
             ],
             'contributor_roles': [
                 {
-                    'source': 'CRediT',
+                    'schema': 'CRediT',
                     'value': 'Supervision',
                 },
             ],
@@ -1535,7 +1535,7 @@ def test_authors_supervisors_from_multiple_701_with_z():
             ],
             'contributor_roles': [
                 {
-                    'source': 'CRediT',
+                    'schema': 'CRediT',
                     'value': 'Supervision',
                 },
             ],
@@ -1570,7 +1570,7 @@ def test_authors_supervisors_from_701__double_a_u_z():
             ],
             'contributor_roles': [
                 {
-                    'source': 'CRediT',
+                    'schema': 'CRediT',
                     'value': 'Supervision',
                 },
             ],
@@ -1588,7 +1588,7 @@ def test_authors_supervisors_from_701__double_a_u_z():
             ],
             'contributor_roles': [
                 {
-                    'source': 'CRediT',
+                    'schema': 'CRediT',
                     'value': 'Supervision',
                 },
             ],

--- a/tests/unit/utils/test_utils_bibtex.py
+++ b/tests/unit/utils/test_utils_bibtex.py
@@ -375,7 +375,7 @@ def test_get_author_two_authors_one_a_supervisor():
             {
                 'contributor_roles': [
                     {
-                        'source': 'CRediT',
+                        'schema': 'CRediT',
                         'value': 'Supervision',
                     },
                 ],


### PR DESCRIPTION
* `roles` field has been deleted.
* `contributor_roles` is now used to store author roles.
* Solves https://sentry.cern.ch/inspire-sentry/inspire-labs-qa/group/601708/ .

Signed-off-by: Panos Paparrigopoulos <panos.paparrigopoulos@cern.ch>