### PR TITLE
global: theme extension removal from API

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -292,7 +292,7 @@ RECORDS_REST_ENDPOINTS = dict(
                                  ':json_v1_search'),
             'application/vnd+inspire.brief+json': (
                 'inspirehep.modules.records.serializers'
-                ':json_brief_v1_search'
+                ':json_literature_brief_v1_search'
             ),
             'application/x-bibtex': ('inspirehep.modules.records.serializers'
                                      ':bibtex_v1_search'),
@@ -351,8 +351,8 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_search'),
             'application/vnd+inspire.brief+json': (
-                'inspirehep.modules.records.serializers'
-                ':json_brief_v1_search'
+                'invenio_records_rest.serializers'
+                ':json_v1_search'
             ),
         },
         list_route='/authors/',
@@ -374,8 +374,8 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_search'),
             'application/vnd+inspire.brief+json': (
-                'inspirehep.modules.records.serializers'
-                ':json_brief_v1_search'
+                'invenio_records_rest.serializers'
+                ':json_v1_search'
             ),
         },
         list_route='/authors/',
@@ -398,8 +398,8 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_search'),
             'application/vnd+inspire.brief+json': (
-                'inspirehep.modules.records.serializers'
-                ':json_brief_v1_search'
+                'invenio_records_rest.serializers'
+                ':json_v1_search'
             ),
         },
         list_route='/authors/',
@@ -422,8 +422,8 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_search'),
             'application/vnd+inspire.brief+json': (
-                'inspirehep.modules.records.serializers'
-                ':json_brief_v1_search'
+                'invenio_records_rest.serializers'
+                ':json_v1_search'
             ),
         },
         list_route='/authors/',
@@ -446,8 +446,8 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_search'),
             'application/vnd+inspire.brief+json': (
-                'inspirehep.modules.records.serializers'
-                ':json_brief_v1_search'
+                'invenio_records_rest.serializers'
+                ':json_v1_search'
             ),
         },
         list_route='/authors/',
@@ -470,8 +470,8 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_search'),
             'application/vnd+inspire.brief+json': (
-                'inspirehep.modules.records.serializers'
-                ':json_brief_v1_search'
+                'invenio_records_rest.serializers'
+                ':json_v1_search'
             ),
         },
         list_route='/data/',
@@ -493,8 +493,8 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_search'),
             'application/vnd+inspire.brief+json': (
-                'inspirehep.modules.records.serializers'
-                ':json_brief_v1_search'
+                'invenio_records_rest.serializers'
+                ':json_v1_search'
             ),
         },
         list_route='/conferences/',
@@ -516,8 +516,8 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_search'),
             'application/vnd+inspire.brief+json': (
-                'inspirehep.modules.records.serializers'
-                ':json_brief_v1_search'
+                'invenio_records_rest.serializers'
+                ':json_v1_search'
             ),
         },
         list_route='/jobs/',
@@ -539,8 +539,8 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_search'),
             'application/vnd+inspire.brief+json': (
-                'inspirehep.modules.records.serializers'
-                ':json_brief_v1_search'
+                'invenio_records_rest.serializers'
+                ':json_v1_search'
             ),
         },
         list_route='/institutions/',
@@ -562,8 +562,8 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_search'),
             'application/vnd+inspire.brief+json': (
-                'inspirehep.modules.records.serializers'
-                ':json_brief_v1_search'
+                'invenio_records_rest.serializers'
+                ':json_v1_search'
             ),
         },
         list_route='/experiments/',
@@ -585,8 +585,8 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_search'),
             'application/vnd+inspire.brief+json': (
-                'inspirehep.modules.records.serializers'
-                ':json_brief_v1_search'
+                'invenio_records_rest.serializers'
+                ':json_v1_search'
             ),
         },
         list_route='/journals/',

--- a/inspirehep/modules/records/serializers/__init__.py
+++ b/inspirehep/modules/records/serializers/__init__.py
@@ -29,7 +29,7 @@ from __future__ import absolute_import, print_function
 from invenio_records_rest.serializers.response import search_responsify
 
 from .impactgraph_serializer import ImpactGraphSerializer
-from .json import JSONBriefSerializer
+from .json_literature import LiteratureJSONBriefSerializer
 from .bibtex_serializer import BIBTEXSerializer
 from .latexeu_serializer import LATEXEUSerializer
 from .latexus_serializer import LATEXUSSerializer
@@ -41,9 +41,14 @@ from .schemas.json import RecordSchemaJSONBRIEFV1
 
 from .response import record_responsify_nocache
 
-json_brief_v1 = JSONBriefSerializer(RecordSchemaJSONBRIEFV1)
-json_brief_v1_search = search_responsify(json_brief_v1,
-                                         'application/vnd+inspire.brief+json')
+json_literature_brief_v1 = LiteratureJSONBriefSerializer(
+    RecordSchemaJSONBRIEFV1
+)
+json_literature_brief_v1_search = search_responsify(
+    json_literature_brief_v1,
+    'application/vnd+inspire.brief+json'
+)
+
 
 bibtex_v1 = BIBTEXSerializer()
 latexeu_v1 = LATEXEUSerializer()

--- a/inspirehep/modules/records/serializers/json_literature.py
+++ b/inspirehep/modules/records/serializers/json_literature.py
@@ -28,9 +28,8 @@ from __future__ import absolute_import, print_function
 
 from invenio_records_rest.serializers.json import JSONSerializer
 
-from inspirehep.modules.theme.jinja2filters import (
-    format_date, publication_info
-)
+from inspirehep.modules.records.wrappers import LiteratureRecord
+from inspirehep.modules.theme.jinja2filters import format_date
 
 
 def process_es_hit(record):
@@ -55,19 +54,21 @@ def get_display_fields(record):
     Jinja2 filters can be applied here to format certain fields.
     """
     display = {}
+    record = LiteratureRecord(record)
     if 'references' in record:
         display['number_of_references'] = len(record['references'])
     if 'earliest_date' in record:
         display['date'] = format_date(record['earliest_date'])
     if 'publication_info' in record:
-        display['publication_info_line'] = publication_info(record)
+        display['publication_info'] = record.publication_information
+        display['conference_info'] = record.conference_information
     if 'authors' in record:
         display['number_of_authors'] = len(record['authors'])
 
     return display
 
 
-class JSONBriefSerializer(JSONSerializer):
+class LiteratureJSONBriefSerializer(JSONSerializer):
     """JSON brief format serializer."""
 
     @staticmethod

--- a/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Publication_info.tpl
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Publication_info.tpl
@@ -1,0 +1,23 @@
+{%- macro pub_info(journal_title, journal_volume, year, journal_issue, page_start, page_end, artid, pubinfo_freetext) -%}
+  {%- if journal_title -%}
+    <i>{{journal_title}}</i>
+    {%- if journal_volume -%}
+      {{ " " + journal_volume }}
+    {%- endif -%}
+    {%- if year -%}
+      {{ " " + "(" + year + ")" }}
+    {%- endif -%}
+    {%- if journal_issue -%}
+      {{ " " + journal_issue + ", " }}
+    {%- endif -%}
+    {%- if page_start and page_end -%}
+      {{" " + page_start}}-{{page_end}}
+    {%- elif page_start -%}
+      {{" " + page_start}}
+    {%- elif artid -%}
+      {{" " + artid}}
+    {%- endif -%}
+  {%- elif pubinfo_freetext -%}
+    {{pubinfo_freetext}}
+  {%- endif -%}
+{%- endmacro -%}

--- a/setup.py
+++ b/setup.py
@@ -180,7 +180,6 @@ setup(
             'hepnames2marc = inspirehep.dojson.hepnames2marc:hepnames2marc',
         ],
         'invenio_base.api_apps': [
-            'inspire_theme = inspirehep.modules.theme:INSPIRETheme',
             'inspire_search = inspirehep.modules.search:INSPIRESearch',
             'inspire_workflows = inspirehep.modules.workflows:INSPIREWorkflows',
             'inspire_warnings = inspirehep.modules.warnings:INSPIREWarnings',

--- a/tests/unit/theme/test_theme_jinja2filters.py
+++ b/tests/unit/theme/test_theme_jinja2filters.py
@@ -31,6 +31,7 @@ from elasticsearch_dsl import result
 
 from invenio_records.api import Record
 
+from inspirehep.modules.records.wrappers import LiteratureRecord
 from inspirehep.modules.theme.jinja2filters import *
 
 
@@ -811,7 +812,7 @@ def test_publication_info_returns_empty_dict_when_no_publication_info():
 
 
 def test_publication_info_an_empty_list():
-    an_empty_list = Record({'publication_info': []})
+    an_empty_list = LiteratureRecord({'publication_info': []})
 
     expected = {}
     result = publication_info(an_empty_list)
@@ -820,7 +821,7 @@ def test_publication_info_an_empty_list():
 
 
 def test_publication_info_a_list_of_one_element():
-    a_list_of_one_element = Record({
+    a_list_of_one_element = LiteratureRecord({
         'publication_info': [
             {'journal_title': 'Int.J.Mod.Phys.'}
         ]
@@ -833,7 +834,7 @@ def test_publication_info_a_list_of_one_element():
 
 
 def test_publication_info_a_list_of_two_elements():
-    a_list_of_two_elements = Record({
+    a_list_of_two_elements = LiteratureRecord({
         'publication_info': [
             {
                 'journal_volume': '8',
@@ -862,7 +863,7 @@ def test_publication_info_a_list_of_two_elements():
 
 
 def test_publication_info_from_journal_title_and_journal_volume():
-    with_journal_title_and_journal_volume = Record({
+    with_journal_title_and_journal_volume = LiteratureRecord({
         'publication_info': [
             {
                 'journal_title': 'JHEP',
@@ -882,7 +883,7 @@ def test_publication_info_from_journal_title_and_journal_volume():
 
 
 def test_publication_info_from_journal_title_and_year():
-    with_journal_title_and_year = Record({
+    with_journal_title_and_year = LiteratureRecord({
         'publication_info': [
             {
                 'journal_title': 'Eur.Phys.J.',
@@ -902,7 +903,7 @@ def test_publication_info_from_journal_title_and_year():
 
 
 def test_publication_info_from_journal_title_and_journal_issue():
-    with_journal_title_and_journal_issue = Record({
+    with_journal_title_and_journal_issue = LiteratureRecord({
         'publication_info': [
             {
                 'journal_title': 'JINST',
@@ -922,7 +923,7 @@ def test_publication_info_from_journal_title_and_journal_issue():
 
 
 def test_publication_info_from_journal_title_and_pages_artid():
-    with_journal_title_and_pages_artid = Record({
+    with_journal_title_and_pages_artid = LiteratureRecord({
         'publication_info': [
             {
                 'journal_title': 'Astrophys.J.',
@@ -942,7 +943,7 @@ def test_publication_info_from_journal_title_and_pages_artid():
 
 
 def test_publication_info_from_pubinfo_freetext():
-    with_pubinfo_freetext = Record({
+    with_pubinfo_freetext = LiteratureRecord({
         'publication_info': [
             {'pubinfo_freetext': 'Phys. Rev. 127 (1962) 965-970'}
         ]
@@ -958,7 +959,7 @@ def test_publication_info_from_pubinfo_freetext():
     assert expected == result
 
 
-@mock.patch('inspirehep.modules.theme.jinja2filters.replace_refs')
+@mock.patch('inspirehep.modules.records.wrappers.replace_refs')
 def test_publication_info_from_conference_recid_and_parent_recid(r_r, mock_replace_refs):
     conf_rec = {'$ref': 'http://x/y/976391'}
     parent_rec = {'$ref': 'http://x/y/1402672'}
@@ -967,7 +968,7 @@ def test_publication_info_from_conference_recid_and_parent_recid(r_r, mock_repla
     r_r.side_effect = mock_replace_refs(with_title, [(conf_rec, 976391),
                                                      (parent_rec, 1402672)])
 
-    with_conference_recid_and_parent_recid = Record({
+    with_conference_recid_and_parent_recid = LiteratureRecord({
         'publication_info': [
             {
                 'conference_record': conf_rec,
@@ -986,7 +987,7 @@ def test_publication_info_from_conference_recid_and_parent_recid(r_r, mock_repla
     assert expected == result
 
 
-@mock.patch('inspirehep.modules.theme.jinja2filters.replace_refs')
+@mock.patch('inspirehep.modules.records.wrappers.replace_refs')
 def test_publication_info_from_conference_recid_and_parent_recid_with_pages(r_r, mock_replace_refs):
     with_title = '50th Rencontres de Moriond on EW Interactions and Unified Theories'
     conf_rec = {'$ref': 'http://x/y/1331207'}
@@ -995,7 +996,7 @@ def test_publication_info_from_conference_recid_and_parent_recid_with_pages(r_r,
     r_r.side_effect = mock_replace_refs(with_title, [(conf_rec, 1331207),
                                                      (parent_rec, 1402672)])
 
-    with_conference_recid_and_parent_recid_and_pages = Record({
+    with_conference_recid_and_parent_recid_and_pages = LiteratureRecord({
         'publication_info': [
             {
                 'conference_record': conf_rec,
@@ -1017,7 +1018,7 @@ def test_publication_info_from_conference_recid_and_parent_recid_with_pages(r_r,
     assert expected == result
 
 
-@mock.patch('inspirehep.modules.theme.jinja2filters.replace_refs')
+@mock.patch('inspirehep.modules.records.wrappers.replace_refs')
 def test_publication_info_with_pub_info_and_conf_info(r_r, mock_replace_refs):
     with_title = '2005 International Linear Collider Workshop (LCWS 2005)'
     conf_rec = {'$ref': 'http://x/y/976391'}
@@ -1026,7 +1027,7 @@ def test_publication_info_with_pub_info_and_conf_info(r_r, mock_replace_refs):
     r_r.side_effect = mock_replace_refs(with_title, [(conf_rec, 976391),
                                                      (parent_rec, 706120)])
 
-    with_pub_info_and_conf_info = Record({
+    with_pub_info_and_conf_info = LiteratureRecord({
         'publication_info': [
             {
                 'journal_title': 'eConf',
@@ -1050,14 +1051,14 @@ def test_publication_info_with_pub_info_and_conf_info(r_r, mock_replace_refs):
     assert expected == result
 
 
-@mock.patch('inspirehep.modules.theme.jinja2filters.replace_refs')
+@mock.patch('inspirehep.modules.records.wrappers.replace_refs')
 def test_publication_info_with_pub_info_and_conf_info_not_found(r_r):
     conf_rec = {'$ref': 'http://x/y/976391'}
     parent_rec = {'$ref': 'http://x/y/706120'}
 
     r_r.return_value = None
 
-    with_pub_info_and_conf_info = Record({
+    with_pub_info_and_conf_info = LiteratureRecord({
         'publication_info': [
             {
                 'journal_title': 'eConf',
@@ -1078,14 +1079,14 @@ def test_publication_info_with_pub_info_and_conf_info_not_found(r_r):
     assert expected == result
 
 
-@mock.patch('inspirehep.modules.theme.jinja2filters.replace_refs')
+@mock.patch('inspirehep.modules.records.wrappers.replace_refs')
 def test_publication_info_from_conference_recid_and_not_parent_recid(r_r, mock_replace_refs):
     with_title = '20th International Workshop on Deep-Inelastic Scattering and Related Subjects'
     conf_rec = {'$ref': 'http://x/y/1086512'}
 
     r_r.side_effect = mock_replace_refs(with_title, [(conf_rec, 1086512)])
 
-    with_conference_recid_without_parent_recid = Record({
+    with_conference_recid_without_parent_recid = LiteratureRecord({
         'publication_info': [
             {'conference_record': conf_rec}
         ]
@@ -1103,7 +1104,7 @@ def test_publication_info_from_conference_recid_and_not_parent_recid(r_r, mock_r
 
 @pytest.mark.xfail(reason='pid searched in the wrong collection')
 def test_publication_info_from_not_conference_recid_and_parent_recid():
-    without_conference_recid_with_parent_recid = Record({
+    without_conference_recid_with_parent_recid = LiteratureRecord({
         'publication_info': [
             {'parent_record': {'$ref': 'http://x/y/720114'}}
         ]


### PR DESCRIPTION
* Removes the theme extension that should not be present in the API app.
  (closes #1508)

* Refactors publication_info jinja2 filter to separate the data generation
  from the template rendering.

* Makes use of LiteratureRecord in search serializer instead of jinja2
  filter to avoid dependency on templates. The dependency on the templates
  is the reason why theme is loaded into API at the moment.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>