### PR TITLE
dojson: invalid name variant sources

### DIFF
--- a/inspirehep/dojson/institutions/fields/bd1xx.py
+++ b/inspirehep/dojson/institutions/fields/bd1xx.py
@@ -139,6 +139,14 @@ def field_activity(self, key, value):
 @institutions.over('name_variants', '^410..')
 def name_variants(self, key, value):
     """Variants of the name."""
+    valid_sources = [
+        "DESY_AFF",
+        "ADS",
+        "INSPIRE"
+    ]
+    if value.get('9') and value.get('9') not in valid_sources:
+        return self.get('name_variants', [])
+
     if value.get('g'):
         self.setdefault('extra_words', [])
         self['extra_words'].extend(force_force_list(value.get('g')))

--- a/inspirehep/modules/records/jsonschemas/records/institutions.json
+++ b/inspirehep/modules/records/jsonschemas/records/institutions.json
@@ -102,7 +102,8 @@
                         "enum": [
                             "DESY",
                             "DESY_AFF",
-                            "ADS"
+                            "ADS",
+                            "INSPIRE"
                         ],
                         "title": "Name variant source",
                         "type": "string"

--- a/tests/unit/dojson/test_dojson_institutions.py
+++ b/tests/unit/dojson/test_dojson_institutions.py
@@ -450,14 +450,14 @@ def test_field_activity_from_372__a():
 def test_name_variants_from_410__a_9():
     snippet = (
         '<datafield tag="410" ind1=" " ind2=" ">'
-        '  <subfield code="9">DESY</subfield>'
+        '  <subfield code="9">INSPIRE</subfield>'
         '  <subfield code="a">Aachen Tech. Hochsch.</subfield>'
         '</datafield>'
     )  # record/902624
 
     expected = [
         {
-            'source': 'DESY',
+            'source': 'INSPIRE',
             'value': [
                 'Aachen Tech. Hochsch.',
             ],
@@ -466,6 +466,22 @@ def test_name_variants_from_410__a_9():
     result = clean_record(institutions.do(create_record(snippet)))
 
     assert expected == result['name_variants']
+
+
+def test_name_variants_from_410__9_with_invalid_source():
+    snippet = (
+        '<datafield tag="410" ind1=" " ind2=" ">'
+            '<subfield code="9">Tech</subfield>'
+            '<subfield code="a">CIIT</subfield>'
+            '<subfield code="g">Inst</subfield>'
+        '</datafield>'
+    ) #record 1338296
+
+    expected = {}
+
+    result = clean_record(institutions.do(create_record(snippet)))
+
+    assert expected == result.get('name_variants', {})
 
 
 def test_name_variants_from_410__double_a():


### PR DESCRIPTION
* Ignores name variants coming from non valid sources.
  (closes #1524)

Signed-off-by: Panos Paparrigopoulos <panos.paparrigopoulos@cern.ch>