### PR TITLE
tests: remove deprecated yield_fixture uses

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -35,8 +35,8 @@ from invenio_search import current_search_client as es
 from inspirehep.factory import create_app
 
 
-@pytest.yield_fixture(scope='session')
-def app(request):
+@pytest.fixture(scope='session')
+def app():
     """Flask application fixture."""
     app = create_app()
     app.config.update({'DEBUG': True})
@@ -67,8 +67,8 @@ def app(request):
         yield app
 
 
-@pytest.yield_fixture(scope='module')
-def small_app(request):
+@pytest.fixture(scope='module')
+def small_app():
     """Flask application fixture."""
     app = create_app()
     app.config.update({'DEBUG': True})
@@ -98,7 +98,7 @@ def small_app(request):
         yield app
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def httpretty_mock():
     httpretty.enable()
     yield

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -37,8 +37,8 @@ else:
     from io import StringIO
 
 
-@pytest.yield_fixture(scope='session', autouse=True)
-def email_app(request):
+@pytest.fixture(scope='session', autouse=True)
+def email_app():
     """Email-aware Flask application fixture."""
     app = create_app(
         CFG_SITE_SUPPORT_EMAIL='admin@inspirehep.net',
@@ -57,8 +57,8 @@ def email_app(request):
         yield app
 
 
-@pytest.yield_fixture(scope='session', autouse=True)
-def app(request):
+@pytest.fixture(scope='session', autouse=True)
+def app():
     """Flask application fixture."""
     instance_path = tempfile.mkdtemp()
 
@@ -74,13 +74,10 @@ def app(request):
         TESTING=True,
     )
 
-    def teardown():
-        shutil.rmtree(instance_path)
-
-    request.addfinalizer(teardown)
-
     with app.app_context():
         yield app
+
+    shutil.rmtree(instance_path)
 
 
 @pytest.fixture
@@ -245,7 +242,7 @@ def dummy_empty_response():
     }
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def httppretty_mock():
     httpretty.enable()
     yield


### PR DESCRIPTION
* Since py.test>2.10 the yield_fixture construct is deprecated, and
  the request.addfinalizer mechanism was replaced by using just yield
  instead of return in the fixture, see:
      http://doc.pytest.org/en/latest/fixture.html#fixture-finalization-executing-teardown-code

Signed-off-by: David Caro <david@dcaro.es>