### PR TITLE
theme: typeahead fixes

### DIFF
--- a/inspirehep/modules/authors/receivers.py
+++ b/inspirehep/modules/authors/receivers.py
@@ -127,8 +127,12 @@ def generate_name_variations(recid, json, *args, **kwargs):
             if name:
                 name_variations = author_tokenize(name)
                 author.update({"name_variations": name_variations})
+                bai = [
+                    item['value'] for item in author.get('ids', [])
+                    if item['type'] == 'INSPIRE BAI'
+                ]
                 author.update({"name_suggest": {
                     "input": name_variations,
                     "output": name,
-                    "payload": {"bai": author.get("inspire_bai")}
+                    "payload": {"bai": bai[0] if bai else None}
                 }})

--- a/inspirehep/modules/theme/templates/inspirehep_theme/typeahead.html
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/typeahead.html
@@ -73,7 +73,9 @@ require(
         .directive('invenioSearchAutocompleteBar', function() {
             function link(scope, element, attrs, vm) {
               function updateQuery() {
-                vm.invenioSearchArgs.q = vm.userQuery;
+                var e = document.getElementById("search");
+                var $e = angular.element(e);
+                vm.invenioSearchArgs.q = $e.val();
               }
               scope.placeholder = attrs.placeholder;
               scope.updateQuery = updateQuery;


### PR DESCRIPTION
* Fixes receiver that populates payload used by typeahead to adapt to
  data model change for ids.

* Fixes typeahead angular directive so that it works nicely with the jQuery
  plugin. (closes #1432)

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>