### PR TITLE
theme: fix invalid HTML in header

### DIFF
--- a/inspirehep/modules/theme/templates/inspirehep_theme/header.html
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/header.html
@@ -47,7 +47,7 @@
             {% include 'inspirehep_theme/labs-logo.svg' %}
           </span>
         </a>
-        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#topnav-right" data-toggle="modal">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#topnav-right">
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
@@ -208,7 +208,7 @@
       <a href="/data" id="data-collection" class="{{collection_name | collection_select_current("Data") }}">
         Data
       </a>
-      <a href="/conferences"id="conferences-collection" class="{{collection_name | collection_select_current("Conferences") }}">
+      <a href="/conferences" id="conferences-collection" class="{{collection_name | collection_select_current("Conferences") }}">
         Conferences
       </a>
       <a href="/jobs" id="jobs-collection" class="{{collection_name | collection_select_current("Jobs") }}">


### PR DESCRIPTION
Removed a duplicate HTML attribute (ignored by the browser) and added a space betwen the URL attributes.

Signed-off-by: Liam Kirsh <liam.kirsh@cern.ch>