### PR TITLE
disambiguation: detach receivers

### DIFF
--- a/inspirehep/modules/disambiguation/__init__.py
+++ b/inspirehep/modules/disambiguation/__init__.py
@@ -22,13 +22,10 @@
 
 """Inspire wrapper for Beard author disambiguation service."""
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-)
+from __future__ import absolute_import, division, print_function
 
 from .ext import InspireDisambiguation
 from .tasks import disambiguation_daemon
+
 
 __all__ = ('InspireDisambiguation', 'disambiguation_daemon')

--- a/inspirehep/modules/disambiguation/beard.py
+++ b/inspirehep/modules/disambiguation/beard.py
@@ -22,11 +22,7 @@
 
 """Communication handler with Beard Celery service."""
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-)
+from __future__ import absolute_import, division, print_function
 
 import celery
 from flask import current_app

--- a/inspirehep/modules/disambiguation/config.py
+++ b/inspirehep/modules/disambiguation/config.py
@@ -22,11 +22,7 @@
 
 """Configuration of Disambiguation module."""
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-)
+from __future__ import absolute_import, division, print_function
 
 # Celery.
 DISAMBIGUATION_QUEUE = "celery"

--- a/inspirehep/modules/disambiguation/ext.py
+++ b/inspirehep/modules/disambiguation/ext.py
@@ -22,11 +22,7 @@
 
 """Inspire wrapper for Beard author disambiguation service."""
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-)
+from __future__ import absolute_import, division, print_function
 
 from inspirehep.modules.disambiguation import config
 

--- a/inspirehep/modules/disambiguation/logic.py
+++ b/inspirehep/modules/disambiguation/logic.py
@@ -22,11 +22,7 @@
 
 """Logic of Disambiguation module."""
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-)
+from __future__ import absolute_import, division, print_function
 
 from operator import add
 

--- a/inspirehep/modules/disambiguation/models.py
+++ b/inspirehep/modules/disambiguation/models.py
@@ -22,11 +22,7 @@
 
 """Model of the database table."""
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-)
+from __future__ import absolute_import, division, print_function
 
 from datetime import datetime
 

--- a/inspirehep/modules/disambiguation/receivers.py
+++ b/inspirehep/modules/disambiguation/receivers.py
@@ -22,11 +22,7 @@
 
 """Receivers to catch new publications and record updates."""
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-)
+from __future__ import absolute_import, division, print_function
 
 from invenio_indexer.signals import before_record_index
 from invenio_records.signals import after_record_insert

--- a/inspirehep/modules/disambiguation/receivers.py
+++ b/inspirehep/modules/disambiguation/receivers.py
@@ -88,7 +88,6 @@ def _needs_beard_reprocessing(authors_before, authors_after):
         return True
 
 
-@after_record_insert.connect
 def append_new_record_to_queue(sender, *args, **kwargs):
     """Append a new record to the queue.
 
@@ -104,7 +103,6 @@ def append_new_record_to_queue(sender, *args, **kwargs):
         beard_record.save()
 
 
-@before_record_index.connect
 def append_updated_record_to_queue(sender, json, record, index, doc_type):
     """Append record after an update to the queue.
 

--- a/inspirehep/modules/disambiguation/records.py
+++ b/inspirehep/modules/disambiguation/records.py
@@ -22,11 +22,7 @@
 
 """Set of methods to create and update records."""
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-)
+from __future__ import absolute_import, division, print_function
 
 from celery.utils.log import get_task_logger
 from flask import current_app, url_for

--- a/inspirehep/modules/disambiguation/search.py
+++ b/inspirehep/modules/disambiguation/search.py
@@ -22,11 +22,7 @@
 
 """Set of methods to query Elasticsearch instance."""
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-)
+from __future__ import absolute_import, division, print_function
 
 from dateutil.parser import parse
 

--- a/inspirehep/modules/disambiguation/tasks.py
+++ b/inspirehep/modules/disambiguation/tasks.py
@@ -22,11 +22,7 @@
 
 """Celery tasks provided by Disambiguation module."""
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-)
+from __future__ import absolute_import, division, print_function
 
 from celery import current_app, shared_task
 from celery.utils.log import get_task_logger
@@ -41,14 +37,14 @@ from invenio_records import Record
 from inspirehep.modules.disambiguation.beard import make_beard_clusters
 from inspirehep.modules.disambiguation.logic import process_clusters
 from inspirehep.modules.disambiguation.models import DisambiguationRecord
+from inspirehep.modules.disambiguation.receivers import (
+    append_updated_record_to_queue,
+)
 from inspirehep.modules.disambiguation.search import (
     create_beard_record,
     create_beard_signatures,
     get_blocks_from_record,
     get_records_from_block,
-)
-from inspirehep.modules.disambiguation.receivers import (
-    append_updated_record_to_queue,
 )
 
 logger = get_task_logger(__name__)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -77,8 +77,7 @@ def small_app():
         # Imports must be local, otherwise tasks default to pickle serializer.
         from inspirehep.modules.migrator.tasks import migrate
         from inspirehep.modules.fixtures.files import init_all_storage_paths
-        from inspirehep.modules.fixtures.users import \
-            init_users_and_permissions
+        from inspirehep.modules.fixtures.users import init_users_and_permissions
 
         db.drop_all()
         db.create_all()
@@ -91,8 +90,7 @@ def small_app():
         init_all_storage_paths()
         init_users_and_permissions()
 
-        migrate('./inspirehep/demosite/data/demo-records-small.xml',
-                wait_for_results=True)
+        migrate('./inspirehep/demosite/data/demo-records-small.xml', wait_for_results=True)
         es.indices.refresh('records-hep')
 
         yield app

--- a/tests/integration/disambiguation/test_daemon.py
+++ b/tests/integration/disambiguation/test_daemon.py
@@ -22,6 +22,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import pytest
 from mock import patch
 
 from invenio_pidstore.models import PersistentIdentifier
@@ -31,6 +32,7 @@ from inspirehep.modules.disambiguation.models import DisambiguationRecord
 from inspirehep.utils.record_getter import get_es_record_by_uuid
 
 
+@pytest.mark.xfail(reason='receivers were detached from signals')
 def test_count_phonetic_block_dispatched(small_app):
     """Count if two phonetic blocks were dispatched."""
     from inspirehep.modules.disambiguation.tasks import disambiguation_daemon

--- a/tests/integration/disambiguation/test_daemon.py
+++ b/tests/integration/disambiguation/test_daemon.py
@@ -20,28 +20,20 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-)
+from __future__ import absolute_import, division, print_function
 
 from mock import patch
 
 from invenio_pidstore.models import PersistentIdentifier
 from invenio_search import current_search_client as es
 
-from inspirehep.modules.disambiguation.models import (
-    DisambiguationRecord,
-)
+from inspirehep.modules.disambiguation.models import DisambiguationRecord
 from inspirehep.utils.record_getter import get_es_record_by_uuid
 
 
 def test_count_phonetic_block_dispatched(small_app):
     """Count if two phonetic blocks were dispatched."""
-    from inspirehep.modules.disambiguation.tasks import (
-        disambiguation_daemon,
-    )
+    from inspirehep.modules.disambiguation.tasks import disambiguation_daemon
 
     # Check if the queue has three records.
     assert DisambiguationRecord.query.count() == 3
@@ -87,9 +79,7 @@ def test_count_phonetic_block_dispatched(small_app):
 
 def test_check_if_daemon_has_cleaned_the_queue(small_app):
     """Check if the daemon has cleaned up the queue."""
-    from inspirehep.modules.disambiguation.tasks import (
-        disambiguation_daemon,
-    )
+    from inspirehep.modules.disambiguation.tasks import disambiguation_daemon
 
     disambiguation_daemon()
 

--- a/tests/integration/disambiguation/test_logic.py
+++ b/tests/integration/disambiguation/test_logic.py
@@ -20,17 +20,11 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-)
+from __future__ import absolute_import, division, print_function
 
 from invenio_pidstore.models import PersistentIdentifier
 
-from inspirehep.modules.disambiguation.logic import (
-    _create_distance_signature,
-)
+from inspirehep.modules.disambiguation.logic import _create_distance_signature
 
 
 def test_create_distance_signature_method(small_app):

--- a/tests/integration/disambiguation/test_receivers.py
+++ b/tests/integration/disambiguation/test_receivers.py
@@ -20,11 +20,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-)
+from __future__ import absolute_import, division, print_function
 
 from copy import deepcopy
 from uuid import uuid4

--- a/tests/integration/disambiguation/test_records.py
+++ b/tests/integration/disambiguation/test_records.py
@@ -20,11 +20,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-)
+from __future__ import absolute_import, division, print_function
 
 from invenio_pidstore.models import PersistentIdentifier
 from invenio_records.api import Record

--- a/tests/unit/disambiguation/test_disambiguation_logic.py
+++ b/tests/unit/disambiguation/test_disambiguation_logic.py
@@ -22,11 +22,7 @@
 
 """Test *helpers* (_method_name(foo, bar):) from logic.py"""
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-)
+from __future__ import absolute_import, division, print_function
 
 from inspirehep.modules.disambiguation.logic import (
     _check_if_claimed,

--- a/tests/unit/disambiguation/test_disambiguation_receivers.py
+++ b/tests/unit/disambiguation/test_disambiguation_receivers.py
@@ -22,11 +22,7 @@
 
 """Test *helpers* (_method_name(foo, bar):) from receivers.py"""
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-)
+from __future__ import absolute_import, division, print_function
 
 from inspirehep.modules.disambiguation.receivers import (
     _needs_beard_reprocessing,


### PR DESCRIPTION
* First commit retouches some imports in the `disambiguation` module.
* Second commit detaches the receivers from the signals. The rationale is in the commit message:

    > On record migration the `append_new_record_to_queue` receiver fires,
  which adds the record to the `DisambiguationRecord` queue. Then, when
  the same record is indexed, `append_updated_record_to_queue` fires,
  which will try adding the same record to the queue. In doing so, it
  will shoot back a query at ES to try to get a previous version of the
  record, which will probably return a 404 because this is the first
  time we're inserting the record. This generates undue pressure on ES
  and achieves nothing, therefore this PR disable these signals.