### PR TITLE
dojson: allow multiple experiments in authors

### DIFF
--- a/inspirehep/dojson/hepnames/fields/bd1xx.py
+++ b/inspirehep/dojson/hepnames/fields/bd1xx.py
@@ -393,48 +393,75 @@ def _curators_note2marc(self, key, value):
 
 
 @hepnames.over('experiments', '^693..')
-@utils.for_each_value
-def experiments(self, key, value):
+def experiments(self, key, values):
     """Information about experiments.
 
-    Currently the ``id`` subfield stores the name of the experiment. It should
-    be moved to storing id of the experiment as soon as experiments are
-    available as records.
+    FIXME: use the flatten decorator once DoJSON 1.3.0 is released.
     """
-    try:
-        start_year = int(value.get('s'))
-    except (TypeError, ValueError):
-        start_year = None
-    try:
-        end_year = int(value.get('d'))
-    except (TypeError, ValueError):
-        end_year = None
+    def _int_or_none(maybe_int):
+        try:
+            return int(maybe_int)
+        except (TypeError, ValueError):
+            return None
 
-    return {
-        'id': value.get('i'),
-        'name': value.get('e'),
-        'start_year': start_year,
-        'end_year': end_year,
-        'status': value.get('z')
-    }
+    def _get_json_experiments(marc_dict):
+        start_year = _int_or_none(marc_dict.get('s'))
+        end_year = _int_or_none(marc_dict.get('d'))
+
+        names = force_force_list(marc_dict.get('e'))
+        recids = force_force_list(marc_dict.get('0'))
+        name_recs = zip(names, recids or [None] * len(names))
+
+        for name, recid in name_recs:
+            record = get_record_ref(recid, 'experiments')
+            yield {
+                'curated_relation': record is not None,
+                'current': (
+                    True if marc_dict.get('z', '').lower() == 'current'
+                    else False
+                ),
+                'end_year': end_year,
+                'name': name,
+                'record': record,
+                'start_year': start_year,
+            }
+
+    values = force_force_list(values)
+    json_experiments = self.get('experiments', [])
+    for experiment in values:
+        if experiment:
+            json_experiments.extend(_get_json_experiments(experiment))
+
+    return json_experiments
 
 
 @hepnames2marc.over('693', '^experiments$')
-@utils.for_each_value
-def experiments2marc(self, key, value):
+def experiments2marc(self, key, values):
     """Information about experiments.
 
-    Currently the ``id`` subfield stores the name of the experiment. It should
-    be moved to storing id of the experiment as soon as experiments are
-    available as records.
+    FIXME: use the flatten decorator once DoJSON 1.3.0 is released.
     """
-    return {
-        'i': value.get('id'),
-        'e': value.get('name'),
-        's': value.get('start_year'),
-        'd': value.get('end_year'),
-        'z': value.get('status')
-    }
+    def _get_marc_experiment(json_dict):
+        marc = {
+            'e': json_dict.get('name'),
+            's': json_dict.get('start_year'),
+            'd': json_dict.get('end_year'),
+        }
+        status = 'current' if json_dict.get('current') else None
+        if status:
+            marc['z'] = status
+        recid = get_recid_from_ref(json_dict.get('record', None))
+        if recid:
+            marc['0'] = recid
+        return marc
+
+    marc_experiments = self.get('693', [])
+    values = force_force_list(values)
+    for experiment in values:
+        if experiment:
+            marc_experiments.append(_get_marc_experiment(experiment))
+
+    return marc_experiments
 
 
 @hepnames.over('advisors', '^701..')

--- a/tests/unit/dojson/fixtures/test_hepnames_record.xml
+++ b/tests/unit/dojson/fixtures/test_hepnames_record.xml
@@ -114,15 +114,6 @@
     <datafield tag="678" ind1=" " ind2=" ">
         <subfield code="a">Nobel Prize Physics 2003</subfield>
     </datafield>
-    <datafield tag="693" ind1=" " ind2=" ">
-        <subfield code="e">SDSS</subfield>
-    </datafield>
-    <datafield tag="693" ind1=" " ind2=" ">
-        <subfield code="d">2020</subfield>
-        <subfield code="e">CERN-ALPHA</subfield>
-        <subfield code="s">2014</subfield>
-        <subfield code="z">current</subfield>
-    </datafield>
     <datafield tag="701" ind1=" " ind2=" ">
         <subfield code="a">Fuller, George M.</subfield>
         <subfield code="g">PHD</subfield>

--- a/tests/unit/dojson/test_dojson_hepnames.py
+++ b/tests/unit/dojson/test_dojson_hepnames.py
@@ -25,6 +25,7 @@ from __future__ import absolute_import, division, print_function
 import os
 import pkg_resources
 
+import mock
 import pytest
 
 from dojson.contrib.marc21.utils import create_record
@@ -55,16 +56,195 @@ def test_dates(marcxml_to_json, json_to_marc):
     pass
 
 
-def test_experiments(marcxml_to_json, json_to_marc):
-    """Test if experiments is created correctly."""
-    assert (marcxml_to_json['experiments'][1]['name'] ==
-            json_to_marc['693'][1]['e'])
-    assert (marcxml_to_json['experiments'][1]['start_year'] ==
-            json_to_marc['693'][1]['s'])
-    assert (marcxml_to_json['experiments'][1]['end_year'] ==
-            json_to_marc['693'][1]['d'])
-    assert (marcxml_to_json['experiments'][1]['status'] ==
-            json_to_marc['693'][1]['z'])
+EXPERIMENTS_DATA = [
+    [
+        'current_curated',
+        '''
+        <datafield tag="693" ind1=" " ind2=" ">
+            <subfield code="d">2020</subfield>
+            <subfield code="e">CERN-ALPHA</subfield>
+            <subfield code="0">00001</subfield>
+            <subfield code="s">2014</subfield>
+            <subfield code="z">current</subfield>
+        </datafield>
+        ''',
+        [{
+            'curated_relation': True,
+            'current': True,
+            'end_year': 2020,
+            'name': 'CERN-ALPHA',
+            'record': 'mocked_recid_00001',
+            'start_year': 2014,
+        }],
+        [{
+            '0': 1,
+            'd': 2020,
+            'e': 'CERN-ALPHA',
+            's': 2014,
+            'z': 'current',
+        }],
+    ],
+    [
+        'notcurrent_curated',
+        '''
+        <datafield tag="693" ind1=" " ind2=" ">
+            <subfield code="e">SDSS</subfield>
+            <subfield code="0">00003</subfield>
+        </datafield>
+        ''',
+        [{
+            'curated_relation': True,
+            'current': False,
+            'name': 'SDSS',
+            'record': 'mocked_recid_00003',
+        }],
+        [{
+            '0': 3,
+            'd': None,
+            'e': 'SDSS',
+            's': None,
+        }],
+    ],
+    [
+        'notcurrent_notcurated',
+        '''
+        <datafield tag="693" ind1=" " ind2=" ">
+            <subfield code="e">NOTCURATED</subfield>
+        </datafield>
+        ''',
+        [{
+            'name': 'NOTCURATED',
+            'curated_relation': False,
+            'current': False,
+        }],
+        [{
+            'd': None,
+            'e': 'NOTCURATED',
+            's': None,
+        }],
+    ],
+    [
+        'repeated_experiment',
+        '''
+        <datafield tag="693" ind1=" " ind2=" ">
+            <subfield code="d">2020</subfield>
+            <subfield code="e">CERN-ALPHA</subfield>
+            <subfield code="0">00001</subfield>
+            <subfield code="s">2014</subfield>
+            <subfield code="z">current</subfield>
+        </datafield>
+        <datafield tag="693" ind1=" " ind2=" ">
+            <subfield code="d">2012</subfield>
+            <subfield code="e">CERN-ALPHA</subfield>
+            <subfield code="0">00001</subfield>
+            <subfield code="s">2010</subfield>
+        </datafield>
+        ''',
+        [
+            {
+                'curated_relation': True,
+                'current': True,
+                'end_year': 2020,
+                'name': 'CERN-ALPHA',
+                'record': 'mocked_recid_00001',
+                'start_year': 2014,
+            },
+            {
+                'curated_relation': True,
+                'current': False,
+                'end_year': 2012,
+                'name': 'CERN-ALPHA',
+                'record': 'mocked_recid_00001',
+                'start_year': 2010,
+            },
+        ],
+        [
+            {
+                '0': 1,
+                'd': 2020,
+                'e': 'CERN-ALPHA',
+                's': 2014,
+                'z': 'current',
+            },
+            {
+                '0': 1,
+                'd': 2012,
+                'e': 'CERN-ALPHA',
+                's': 2010,
+            },
+        ],
+    ],
+    [
+        'simultaneous_experiments',
+        '''
+        <datafield tag="693" ind1=" " ind2=" ">
+            <subfield code="d">2013</subfield>
+            <subfield code="e">FIRST-SIMULTANEOUS</subfield>
+            <subfield code="e">SECOND-SIMULTANEOUS</subfield>
+            <subfield code="0">00001</subfield>
+            <subfield code="0">00002</subfield>
+            <subfield code="s">2015</subfield>
+        </datafield>
+        ''',
+        [
+            {
+                'curated_relation': True,
+                'current': False,
+                'end_year': 2013,
+                'name': 'FIRST-SIMULTANEOUS',
+                'record': 'mocked_recid_00001',
+                'start_year': 2015,
+            },
+            {
+                'curated_relation': True,
+                'current': False,
+                'end_year': 2013,
+                'name': 'SECOND-SIMULTANEOUS',
+                'record': 'mocked_recid_00002',
+                'start_year': 2015
+            },
+        ],
+        [
+            {
+                '0': 1,
+                'd': 2013,
+                'e': 'FIRST-SIMULTANEOUS',
+                's': 2015,
+            },
+            {
+                '0': 2,
+                'd': 2013,
+                'e': 'SECOND-SIMULTANEOUS',
+                's': 2015,
+            },
+        ],
+    ],
+]
+
+
+@pytest.mark.parametrize(
+    'test_name,xml_snippet,expected_json,expected_marc',
+    EXPERIMENTS_DATA,
+    ids=[test_data[0] for test_data in EXPERIMENTS_DATA],
+)
+@mock.patch('inspirehep.dojson.hepnames.fields.bd1xx.get_recid_from_ref')
+@mock.patch('inspirehep.dojson.hepnames.fields.bd1xx.get_record_ref')
+def test_experiments(mock_get_record_ref, mock_get_recid_from_ref, test_name,
+                     xml_snippet, expected_json, expected_marc):
+    mock_get_record_ref.side_effect = \
+        lambda x, *_: x and 'mocked_recid_%s' % x
+    mock_get_recid_from_ref.side_effect = \
+        lambda x, *_: x and int(x.rsplit('_')[-1])
+
+    if not xml_snippet.strip().startswith('<record>'):
+        xml_snippet = '<record>%s</record>' % xml_snippet
+
+    json_data = hepnames.do(create_record(xml_snippet))
+    json_experiments = json_data['experiments']
+    marc_experiments = hepnames2marc.do(json_data)['693']
+
+    assert marc_experiments == expected_marc
+    assert json_experiments == expected_json
 
 
 def test_field_categories(marcxml_to_json, json_to_marc):


### PR DESCRIPTION
Sentry: https://sentry.cern.ch/inspire-sentry/inspire-labs-qa/group/601676/

Some minor changes, like removing the (unrelated?) modifications in `tests/unit/conftest.py` and tweaking the docstrings as suggested in https://github.com/inspirehep/inspire-next/pull/1526#r77206250.

Closes #1526