### PR TITLE
migrator: import audit

### DIFF
--- a/inspirehep/modules/migrator/cli.py
+++ b/inspirehep/modules/migrator/cli.py
@@ -28,6 +28,7 @@ import json
 import logging
 import os
 import sys
+import json
 
 import click
 import requests
@@ -44,6 +45,8 @@ from .tasks.records import (
     split_blob,
 )
 from .tasks.workflows import import_holdingpen_record
+
+from .tasks.workflows import import_audit_record
 
 
 @click.group()
@@ -97,10 +100,15 @@ def count_citations():
 @migrator.command()
 @click.argument('source', type=click.File('r'), default=sys.stdin)
 @with_appcontext
-def loadaudits():
+def loadaudits(source):
     """Load workflow Audit logs for workflows.models.Audit."""
-    # TODO implement
-    pass
+    click.echo('Loading dump...')
+    data = json.load(source)
+
+    click.echo('Sending tasks to queue...')
+    with click.progressbar(data) as records:
+        for item in records:
+            import_audit_record.delay(item)
 
 
 @migrator.command()

--- a/inspirehep/modules/migrator/tasks/__init__.py
+++ b/inspirehep/modules/migrator/tasks/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.

--- a/inspirehep/modules/migrator/tasks/workflows.py
+++ b/inspirehep/modules/migrator/tasks/workflows.py
@@ -159,4 +159,24 @@ def import_holdingpen_record(parent_objs, obj, eng):
     fix_object_model(eng, object_model)
     object_model.save()
 
+
+@shared_task()
+def import_audit_record(obj):
+    """Import an audit record."""
+    from invenio_db import db
+    from inspirehep.modules.workflows.models import WorkflowsAudit
+
+    audit = WorkflowsAudit(
+        id=obj.get('id'),
+        created=obj.get('created'),
+        user_id=obj.get('user_id'),
+        object_id=obj.get('object_id'),
+        score=obj.get('score'),
+        user_action=obj.get('user_action'),
+        decision=obj.get('decision'),
+        source=obj.get('source'),
+        action=obj.get('action')
+    )
+
+    db.session.add(audit)
     db.session.commit()


### PR DESCRIPTION
- Adds a migrator command to load dumps of audit records.

Signed-off-by: Panos Paparrigopoulos panos.paparrigopoulos@cern.ch
