### PR TITLE
migrator: import access

### DIFF
--- a/inspirehep/modules/migrator/cli.py
+++ b/inspirehep/modules/migrator/cli.py
@@ -36,6 +36,7 @@ from flask_cli import with_appcontext
 
 from invenio_db import db
 
+from .tasks.access import import_access, import_userrole
 from .tasks.records import (
     add_citation_counts,
     migrate,
@@ -101,6 +102,30 @@ def loadaudits():
     """Load workflow Audit logs for workflows.models.Audit."""
     # TODO implement
     pass
+
+
+@migrator.command()
+@click.argument('source', type=click.File('r'), default=sys.stdin)
+@with_appcontext
+def loadaccess(source):
+    click.echo('Loading dump...')
+    data = json.load(source)
+    click.echo('Sending tasks to queue...')
+    with click.progressbar(data) as records:
+        for item in records:
+            import_access.delay(item)
+
+
+@migrator.command()
+@click.argument('source', type=click.File('r'), default=sys.stdin)
+@with_appcontext
+def loaduserroles(source):
+    click.echo('Loading dump...')
+    data = json.load(source)
+    click.echo('Sending tasks to queue...')
+    with click.progressbar(data) as records:
+        for item in records:
+            import_userrole.delay(item)
 
 
 @migrator.command()

--- a/inspirehep/modules/migrator/tasks/access.py
+++ b/inspirehep/modules/migrator/tasks/access.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+
+"""Manage migration from INSPIRE legacy instance."""
+
+from __future__ import absolute_import, division, print_function
+
+from celery import shared_task
+
+
+@shared_task()
+def import_access(obj):
+    from invenio_accounts.models import Role
+    from invenio_db import db
+    role = Role(
+        id=obj.get('id'),
+        name=obj.get('name'),
+        description=obj.get('description')
+    )
+
+    db.session.merge(role)
+    db.session.commit()
+
+    from invenio_access.models import ActionRoles
+    for acc in obj['actions']:
+        action = ActionRoles(
+            id=acc.get('id'),
+            action=acc.get('name'),
+            exclude=False,
+            role_id=obj.get('id')
+        )
+
+        db.session.merge(action)
+    db.session.commit()
+
+
+@shared_task()
+def import_userrole(obj):
+    from invenio_accounts.models import userrole
+    from invenio_db import db
+    urole = userrole(
+        user_id=obj.get('user_id'),
+        role_id=obj.get('role_id')
+    )
+
+    db.session.merge(urole)
+    db.session.commit


### PR DESCRIPTION
- Adds migrator command to import roles, actions and user_roles tables.

Signed-off-by: Panos Paparrigopoulos panos.paparrigopoulos@cern.ch
