### PR TITLE
forms: fix authors autocomplete

### DIFF
--- a/inspirehep/modules/forms/static/js/forms/affiliations_typeahead.js
+++ b/inspirehep/modules/forms/static/js/forms/affiliations_typeahead.js
@@ -39,18 +39,13 @@ define([
             if (index != 0) {
               pattern = pattern + " AND ";
             }
-            pattern = pattern + "affautocomplete:" + "/" + this + ".*/";
+            pattern = pattern + "affautocomplete:" + "/" + encodeURIComponent(this) + ".*/";
           })
 
-          return '/search?cc=Institutions&p=' + pattern + '&of=recjson&rg=100'
+          return '/api/institutions?q=' + pattern
         },
         filter: function(response) {
-
-          return response.sort(function(a, b) {
-            if (a.ICN < b.ICN) return -1;
-            if (a.ICN > b.ICN) return 1;
-            return 0;
-          })
+          return $.map(response.hits.hits, function(el) { return el });
         }
       },
       datumTokenizer: function() {},
@@ -84,7 +79,9 @@ define([
           callback(suggestions);
         }.bind(this));
       }.bind(this),
-      displayKey: 'ICN',
+      displayKey: function(data) {
+        return data.metadata.ICN[0];
+      },
       templates: {
         empty: function(data) {
           return 'Cannot find this affiliation in our database.';
@@ -93,7 +90,7 @@ define([
           if (data.new_ICN != data.ICN) {
             data.show_future_name = true;
           }
-          return suggestionTemplate.render.call(suggestionTemplate, data);
+          return suggestionTemplate.render.call(suggestionTemplate, data.metadata);
         }.bind(this)
       }
     });

--- a/inspirehep/modules/forms/static/js/forms/authors_typeahead.js
+++ b/inspirehep/modules/forms/static/js/forms/authors_typeahead.js
@@ -38,17 +38,13 @@ define([
             if (index != 0) {
               pattern = pattern + " AND ";
             }
-            pattern = pattern + "authorautocomplete:" + "/" + this + ".*/";
+            pattern = pattern + "authorautocomplete:" + "/" + encodeURIComponent(this) + ".*/";
           })
 
-          return '/search?cc=HepNames&p=' + pattern + '&of=recjson&rg=100'
+          return '/api/authors?q=' + pattern
         },
         filter: function(response) {
-          return response.sort(function(a, b) {
-            if (a.name.value < b.name.value) return -1;
-            if (a.name.value > b.name.value) return 1;
-            return 0;
-          })
+          return $.map(response.hits.hits, function(el) { return el });
         }
       },
       datumTokenizer: function() {},
@@ -81,24 +77,24 @@ define([
         }.bind(this));
       }.bind(this),
       displayKey: function(data) {
-        return data.name.value;
+        return data.metadata.name.value;
       },
       templates: {
         empty: function(data) {
           return 'Cannot find this author in our database.';
         },
         suggestion: function(data) {
-          data.affiliation = null;
-          if (data.positions) {
-            var currentPosition = $.map(data.positions, function(item, idx) {
+          data.metadata.affiliation = null;
+          if (data.metadata.positions) {
+            var currentPosition = $.map(data.metadata.positions, function(item, idx) {
               if ('status' in item && 'institution' in item) {
                 if (item.status.toLowerCase() === "current") {
-                  data.affiliation = item.institution.name;
+                  data.metadata.affiliation = item.institution.name;
                 }
               }
             });
           }
-          return suggestionTemplate.render.call(suggestionTemplate, data);
+          return suggestionTemplate.render.call(suggestionTemplate, data.metadata);
         }.bind(this)
       }
     });

--- a/inspirehep/modules/forms/static/js/forms/experiments_typeahead.js
+++ b/inspirehep/modules/forms/static/js/forms/experiments_typeahead.js
@@ -41,17 +41,13 @@ define([
             if (index != 0) {
               pattern = pattern + " AND ";
             }
-            pattern = pattern + "experimentautocomplete:" + "/" + this + ".*/";
+            pattern = pattern + "experimentautocomplete:" + "/" + encodeURIComponent(this) + ".*/";
           })
 
-          return '/search?cc=Experiments&p=' + pattern + '&of=recjson&rg=100'
+          return '/api/experiments?q=' + pattern
         },
         filter: function(response) {
-          return response.sort(function(a, b) {
-            if (a.experiment_name.experiment[0] < b.experiment_name.experiment[0]) return -1;
-            if (a.experiment_name.experiment[0] > b.experiment_name.experiment[0]) return 1;
-            return 0;
-          })
+          return $.map(response.hits.hits, function(el) { return el });
         }
       },
       datumTokenizer: function() {},
@@ -81,15 +77,15 @@ define([
         }.bind(this));
       }.bind(this),
       displayKey: function(data) {
-        return data.experiment_name.experiment[0];
+        return data.metadata.experiment_names[0].title;
       },
       templates: {
         empty: function(data) {
           return 'Cannot find this experiment in our database.';
         },
         suggestion: function(data) {
-          data.display_name = data.experiment_name.experiment[0];
-          return suggestionTemplate.render.call(suggestionTemplate, data);
+          data.metadata.display_name = data.metadata.experiment_names[0].title;
+          return suggestionTemplate.render.call(suggestionTemplate, data.metadata);
         }.bind(this)
       }
     });

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -37,8 +37,8 @@ from inspirehep.config import SERVER_NAME
 from inspirehep.factory import create_app
 
 
-@pytest.fixture(scope='module')
-def small_app(request):
+@pytest.fixture(scope='session')
+def app(request):
     """Flask application fixture."""
     app = create_app()
     app.config.update({'DEBUG': True})
@@ -60,7 +60,7 @@ def small_app(request):
         init_all_storage_paths()
         init_users_and_permissions()
 
-        migrate('./inspirehep/demosite/data/demo-records-small.xml',
+        migrate('./inspirehep/demosite/data/demo-records.xml.gz',
                 wait_for_results=True)
         es.indices.refresh('records-hep')
 
@@ -68,7 +68,7 @@ def small_app(request):
 
 
 @pytest.fixture
-def selenium(selenium, small_app):
+def selenium(selenium, app):
     selenium.implicitly_wait(10)
     selenium.maximize_window()
     selenium.get(environ['SERVER_NAME'])

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -73,3 +73,17 @@ def selenium(selenium, app):
     selenium.maximize_window()
     selenium.get(environ['SERVER_NAME'])
     return selenium
+
+
+@pytest.fixture
+def login(selenium):
+    selenium.find_element_by_link_text('Sign in').click()
+    selenium.get(environ['SERVER_NAME'] + '/login/?local=1')
+    selenium.find_element_by_id('email').send_keys('admin@inspirehep.net')
+    selenium.find_element_by_id('password').send_keys('123456')
+    selenium.find_element_by_xpath("//button[@type='submit']").click()
+
+    yield
+
+    selenium.find_element_by_id('user-info').click()
+    selenium.find_element_by_xpath("(//button[@type='button'])[2]").click()

--- a/tests/acceptance/test_author_create_typehead.py
+++ b/tests/acceptance/test_author_create_typehead.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import os
+from time import sleep
+
+from selenium.webdriver.common.keys import Keys
+
+
+def test_institutions_typehead(selenium, login):
+    selenium.get(os.environ['SERVER_NAME'] + '/submit/author/create')
+
+    institution_field = selenium.find_element_by_id('institution_history-0-name')
+    _force_autocomplete_event(institution_field, 'CER')
+
+    assert 'CERN' in institution_field.get_attribute('value')
+
+
+def test_experiments_typehead(selenium, login):
+    selenium.get(os.environ['SERVER_NAME'] + '/submit/author/create')
+
+    experiment_field = selenium.find_element_by_id('experiments-0-name')
+    _force_autocomplete_event(experiment_field, 'ATL')
+
+    assert 'ATLAS' in experiment_field.get_attribute('value')
+
+
+def test_advisors_typehead(selenium, login):
+    selenium.get(os.environ['SERVER_NAME'] + '/submit/author/create')
+
+    advisor_field = selenium.find_element_by_id('advisors-0-name')
+    _force_autocomplete_event(advisor_field, 'alexe')
+
+    assert 'Vorobyev, Alexey' in advisor_field.get_attribute('value')
+
+
+def _force_autocomplete_event(field, chunk_text):
+    field.send_keys(chunk_text)
+    sleep(2)
+    field.send_keys(Keys.DOWN)
+    field.send_keys(Keys.ENTER)


### PR DESCRIPTION
@rikirenz, some things changed from the integrated PR:

* I squashed the first two commits  because they implement the same idea: switching from using a `small_app` in the acceptance tests to a `full_app`, or, as we call it, `app`.
* I squashed together the three commits that fix the suggestions parsers and the three tests commit since they basically do the same thing, except for different fields. Note here that this signals a refactoring opportunity: the fact that you had to something three times means that the code is not DRY (https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).
* I put the commit that implements the feature first, so that `git bisect` won't break when driven by the acceptance test suite.

Then, some style comments:

* People usually write commit titles in the imperative mode, as if they are instructing the code base to do something: not `changed foo` but `change foo`.
* We cargo cult (https://en.wikipedia.org/wiki/Cargo_cult_programming) from Invenio the signoff of commits (eg: `Signed-off-by: Riccardo Candido <riccardocandido@gmail.com>`). There's absolutely no reason to do this except aesthetic consistency (I think that only the Linux kernel uses this Git feature). 

CC: @spirosdelviniotis, you might want to read this as well.

Closes #1554