### PR TITLE
records: fix crash in get_es_record

### DIFF
--- a/inspirehep/modules/records/es_record.py
+++ b/inspirehep/modules/records/es_record.py
@@ -58,4 +58,7 @@ class ESRecord(Record):
     @property
     def updated(self):
         """Get last updated timestamp."""
-        return arrow.get(self['_updated']).naive
+        if self.get('_updated'):
+            return arrow.get(self['_updated']).naive
+        else:
+            return datetime.now()

--- a/inspirehep/modules/records/es_record.py
+++ b/inspirehep/modules/records/es_record.py
@@ -3,31 +3,30 @@
 # This file is part of INSPIRE.
 # Copyright (C) 2016 CERN.
 #
-# INSPIRE is free software; you can redistribute it
-# and/or modify it under the terms of the GNU General Public License as
-# published by the Free Software Foundation; either version 2 of the
-# License, or (at your option) any later version.
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-# INSPIRE is distributed in the hope that it will be
-# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with INSPIRE; if not, write to the
-# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
-# MA 02111-1307, USA.
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
 #
-# In applying this license, CERN does not
-# waive the privileges and immunities granted to it by virtue of its status
-# as an Intergovernmental Organization or submit itself to any jurisdiction.
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
 
 """Record subclass to fetch records from ElasticSearch."""
 
 from __future__ import absolute_import, division, print_function
 
-import arrow
+from datetime import datetime
 
+import arrow
 from elasticsearch.exceptions import NotFoundError
 
 from invenio_pidstore.errors import PIDDoesNotExistError

--- a/tests/integration/test_record.py
+++ b/tests/integration/test_record.py
@@ -101,7 +101,6 @@ def record_not_yet_deleted(app):
                 ri = RecordIndexer()
                 ri.index(record)
 
-        es.indices.refresh('records-hep')
         db.session.commit()
 
     yield

--- a/tests/integration/test_record.py
+++ b/tests/integration/test_record.py
@@ -65,18 +65,7 @@ def record_already_deleted_in_marcxml(app):
     yield
 
     with app.app_context():
-        ri = RecordIndexer()
-
-        record = get_db_record('literature', 222)
-        ri.delete(record)
-        record.delete(force=True)
-
-        pid = PersistentIdentifier.get('literature', 222)
-        PersistentIdentifier.delete(pid)
-
-        object_uuid = pid.object_uuid
-        PersistentIdentifier.query.filter(object_uuid == PersistentIdentifier.object_uuid).delete()
-        db.session.commit()
+        _delete_record_from_everywhere('literature', 222)
 
 
 @pytest.fixture(scope='function')
@@ -106,18 +95,24 @@ def record_not_yet_deleted(app):
     yield
 
     with app.app_context():
-        record = get_db_record('literature', 333)
+        _delete_record_from_everywhere('literature', 333)
 
-        ri = RecordIndexer()
-        ri.delete(record)
-        record.delete(force=True)
 
-        pid = PersistentIdentifier.get('literature', 333)
-        PersistentIdentifier.delete(pid)
+def _delete_record_from_everywhere(collection, record_control_number):
+    record = get_db_record(collection, record_control_number)
 
-        object_uuid = pid.object_uuid
-        PersistentIdentifier.query.filter(object_uuid == PersistentIdentifier.object_uuid).delete()
-        db.session.commit()
+    ri = RecordIndexer()
+    ri.delete(record)
+    record.delete(force=True)
+
+    pid = PersistentIdentifier.get(collection, record_control_number)
+    PersistentIdentifier.delete(pid)
+
+    object_uuid = pid.object_uuid
+    PersistentIdentifier.query.filter(
+        object_uuid == PersistentIdentifier.object_uuid).delete()
+
+    db.session.commit()
 
 
 def test_deleted_record_stays_deleted(app, record_already_deleted_in_marcxml):


### PR DESCRIPTION
Sentry: https://sentry.cern.ch/inspire-sentry/inspire-labs-qa/group/606029/

First commit fixes a license and rearranges some imports.
Second commit (by @spirosdelviniotis) is the meat of the PR:

> Requesting a record from Elasticsearch too soon after creation
  might result in a missing `_updated` key, which raises an
  uncaught exception in the `updated` property of the `ESRecord`
  class. This commit ensures that this doesn't happen by returning
  a fresh datetime.now() object instead (closes #1595).

Third commit (also by @spirosdelviniotis) does some minor refactoring in the same file, removing some duplicated code.

Closes #1603