### PR TITLE
WIP utils: add get_record_pid_type helper

### DIFF
--- a/inspirehep/utils/record.py
+++ b/inspirehep/utils/record.py
@@ -26,6 +26,8 @@ import re
 
 from invenio_pidstore.models import PersistentIdentifier
 
+from inspirehep.modules.pidstore.providers import InspireRecordIdProvider
+
 SPLIT_KEY_PATTERN = re.compile('\.|\[')
 
 
@@ -107,6 +109,19 @@ def get_value(record, key, default=None):
         except KeyError:
             return default
     return value
+
+
+def get_record_pid_type(record):
+    """Get the record's ``pid_type``.
+
+    Return the record's ``pid_type`` (e.g. literature or jobs)
+    from the record's ``$schema``.
+    """
+    schema = record.get('$schema')
+    if schema:
+        return InspireRecordIdProvider.schema_to_pid_type(schema)
+
+    raise TypeError('This record has no schema.')
 
 
 def is_submitted_but_not_published(record):

--- a/tests/unit/utils/test_utils_record.py
+++ b/tests/unit/utils/test_utils_record.py
@@ -21,7 +21,13 @@
 
 from __future__ import absolute_import, print_function
 
-from inspirehep.utils.record import get_abstract, get_subtitle, get_title, get_value
+from inspirehep.utils.record import (
+    get_abstract,
+    get_record_pid_type,
+    get_subtitle,
+    get_title,
+    get_value,
+)
 
 from invenio_records.api import Record
 
@@ -294,3 +300,30 @@ def test_get_value_returns_none_on_index_error():
     })
 
     assert get_value(single_title, 'titles.title[1]') is None
+
+
+def test_get_record_pid_type_returns_type_for_existing_schema():
+    record = Record({
+        '$schema': 'http://localhost:5000/schemas/records/jobs.json'
+    })
+
+    assert get_record_pid_type(record) == 'jobs'
+
+
+@pytest.mark.xfail(reason='does not know which schemas really exist.')
+def test_get_record_pid_type_raises_error_for_nonexisting_schema():
+    record = Record({
+        '$schema': 'does-not-exist.json'
+    })
+
+    with pytest.raises(ValueError) as excinfo:
+        get_record_pid_type(record)
+    assert str(excinfo.value) == 'This record has an invalid schema.'
+
+
+def test_get_record_pid_type_raises_error_when_no_schema():
+    record = Record({})
+
+    with pytest.raises(TypeError) as excinfo:
+        get_record_pid_type(record)
+    assert str(excinfo.value) == 'This record has no schema.'


### PR DESCRIPTION
Will also close #1355 and these:

```
% ag \#1355
inspirehep/modules/disambiguation/receivers.py
98:    # FIXME: Use a dedicated method when #1355 will be resolved.
113:    # FIXME: Use a dedicated method when #1355 will be resolved.

inspirehep/modules/disambiguation/records.py
49:    # FIXME: Use a dedicated method when #1355 will be resolved.
```

Closes #1570
