### PR TITLE
general: upstream invenio-pidstore

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -355,7 +355,8 @@ SEARCH_ELASTIC_KEYWORD_MAPPING = {
 # =======
 RECORDS_REST_ENDPOINTS = dict(
     literature=dict(
-        pid_type='literature',
+        pid_type='lit',
+        default_endpoint_prefix=True,
         pid_minter='inspire_recid_minter',
         pid_fetcher='inspire_recid_fetcher',
         search_class='inspirehep.modules.search:LiteratureSearch',
@@ -420,7 +421,7 @@ RECORDS_REST_ENDPOINTS = dict(
         record_class='inspirehep.modules.records.es_record:ESRecord'
     ),
     literature_db=dict(
-        pid_type='literature',
+        pid_type='lit',
         search_class='inspirehep.modules.search:LiteratureSearch',
         record_serializers={
             'application/json': ('invenio_records_rest.serializers'
@@ -437,7 +438,8 @@ RECORDS_REST_ENDPOINTS = dict(
 
     ),
     authors=dict(
-        pid_type='authors',
+        pid_type='aut',
+        default_endpoint_prefix=True,
         pid_minter='inspire_recid_minter',
         pid_fetcher='inspire_recid_fetcher',
         search_class='inspirehep.modules.search:AuthorsSearch',
@@ -460,7 +462,7 @@ RECORDS_REST_ENDPOINTS = dict(
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
     ),
     authors_citations=dict(
-        pid_type='authors',
+        pid_type='aut',
         pid_minter='inspire_recid_minter',
         pid_fetcher='inspire_recid_fetcher',
         search_class='inspirehep.modules.search:AuthorsSearch',
@@ -484,7 +486,7 @@ RECORDS_REST_ENDPOINTS = dict(
                             ':inspire_search_factory'),
     ),
     authors_coauthors=dict(
-        pid_type='authors',
+        pid_type='aut',
         pid_minter='inspire_recid_minter',
         pid_fetcher='inspire_recid_fetcher',
         search_class='inspirehep.modules.search:AuthorsSearch',
@@ -508,7 +510,7 @@ RECORDS_REST_ENDPOINTS = dict(
                             ':inspire_search_factory'),
     ),
     authors_publications=dict(
-        pid_type='authors',
+        pid_type='aut',
         pid_minter='inspire_recid_minter',
         pid_fetcher='inspire_recid_fetcher',
         search_class='inspirehep.modules.search:AuthorsSearch',
@@ -532,7 +534,7 @@ RECORDS_REST_ENDPOINTS = dict(
                             ':inspire_search_factory'),
     ),
     authors_stats=dict(
-        pid_type='authors',
+        pid_type='aut',
         pid_minter='inspire_recid_minter',
         pid_fetcher='inspire_recid_fetcher',
         search_class='inspirehep.modules.search:AuthorsSearch',
@@ -556,7 +558,8 @@ RECORDS_REST_ENDPOINTS = dict(
                             ':inspire_search_factory'),
     ),
     data=dict(
-        pid_type='data',
+        pid_type='dat',
+        default_endpoint_prefix=True,
         pid_minter='inspire_recid_minter',
         pid_fetcher='inspire_recid_fetcher',
         search_class='inspirehep.modules.search:DataSearch',
@@ -579,7 +582,8 @@ RECORDS_REST_ENDPOINTS = dict(
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
     ),
     conferences=dict(
-        pid_type='conferences',
+        pid_type='con',
+        default_endpoint_prefix=True,
         pid_minter='inspire_recid_minter',
         pid_fetcher='inspire_recid_fetcher',
         search_class='inspirehep.modules.search:ConferencesSearch',
@@ -602,7 +606,8 @@ RECORDS_REST_ENDPOINTS = dict(
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
     ),
     jobs=dict(
-        pid_type='jobs',
+        pid_type='job',
+        default_endpoint_prefix=True,
         pid_minter='inspire_recid_minter',
         pid_fetcher='inspire_recid_fetcher',
         search_class='inspirehep.modules.search:JobsSearch',
@@ -625,7 +630,8 @@ RECORDS_REST_ENDPOINTS = dict(
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
     ),
     institutions=dict(
-        pid_type='institutions',
+        pid_type='ins',
+        default_endpoint_prefix=True,
         pid_minter='inspire_recid_minter',
         pid_fetcher='inspire_recid_fetcher',
         search_class='inspirehep.modules.search:InstitutionsSearch',
@@ -648,7 +654,8 @@ RECORDS_REST_ENDPOINTS = dict(
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
     ),
     experiments=dict(
-        pid_type='experiments',
+        pid_type='exp',
+        default_endpoint_prefix=True,
         pid_minter='inspire_recid_minter',
         pid_fetcher='inspire_recid_fetcher',
         search_class='inspirehep.modules.search:ExperimentsSearch',
@@ -671,7 +678,8 @@ RECORDS_REST_ENDPOINTS = dict(
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
     ),
     journals=dict(
-        pid_type='journals',
+        pid_type='jou',
+        default_endpoint_prefix=True,
         pid_minter='inspire_recid_minter',
         pid_fetcher='inspire_recid_fetcher',
         search_class='inspirehep.modules.search:JournalsSearch',
@@ -701,50 +709,50 @@ RECORDS_UI_DEFAULT_PERMISSION_FACTORY = \
 
 RECORDS_UI_ENDPOINTS = dict(
     literature=dict(
-        pid_type='literature',
+        pid_type='lit',
         route='/literature/<pid_value>',
         template='inspirehep_theme/format/record/'
                  'Inspire_Default_HTML_detailed.tpl',
         record_class='inspirehep.modules.records.wrappers:LiteratureRecord',
     ),
     authors=dict(
-        pid_type='authors',
+        pid_type='aut',
         route='/authors/<pid_value>',
         template='inspirehep_theme/format/record/'
                  'authors/Author_HTML_detailed.html',
         record_class='inspirehep.modules.records.wrappers:AuthorsRecord',
     ),
     data=dict(
-        pid_type='data',
+        pid_type='dat',
         route='/data/<pid_value>',
         template='inspirehep_theme/format/record/Data_HTML_detailed.tpl'
     ),
     conferences=dict(
-        pid_type='conferences',
+        pid_type='con',
         route='/conferences/<pid_value>',
         template='inspirehep_theme/format/record/Conference_HTML_detailed.tpl',
         record_class='inspirehep.modules.records.wrappers:ConferencesRecord',
     ),
     jobs=dict(
-        pid_type='jobs',
+        pid_type='job',
         route='/jobs/<pid_value>',
         template='inspirehep_theme/format/record/Job_HTML_detailed.tpl',
         record_class='inspirehep.modules.records.wrappers:JobsRecord',
     ),
     institutions=dict(
-        pid_type='institutions',
+        pid_type='ins',
         route='/institutions/<pid_value>',
         template='inspirehep_theme/format/record/Institution_HTML_detailed.tpl',
         record_class='inspirehep.modules.records.wrappers:InstitutionsRecord',
     ),
     experiments=dict(
-        pid_type='experiments',
+        pid_type='exp',
         route='/experiments/<pid_value>',
         template='inspirehep_theme/format/record/Experiment_HTML_detailed.tpl',
         record_class='inspirehep.modules.records.wrappers:ExperimentsRecord',
     ),
     journals=dict(
-        pid_type='journals',
+        pid_type='jou',
         route='/journals/<pid_value>',
         template='inspirehep_theme/format/record/Journal_HTML_detailed.tpl',
         record_class='inspirehep.modules.records.wrappers:JournalsRecord',

--- a/inspirehep/modules/theme/views.py
+++ b/inspirehep/modules/theme/views.py
@@ -45,6 +45,7 @@ from invenio_mail.tasks import send_email
 from invenio_pidstore.models import PersistentIdentifier
 from invenio_search import current_search_client
 
+from inspirehep.modules.pidstore.providers import get_pid_type_for, get_endpoint_from_pid_type
 from inspirehep.modules.records.conference_series import (
     CONFERENCE_CATEGORIES_TO_SERIES,
 )
@@ -226,7 +227,7 @@ def ajax_references():
     recid = request.args.get('recid', '')
     collection = request.args.get('collection', '')
 
-    pid = PersistentIdentifier.get(collection, recid)
+    pid = PersistentIdentifier.get(get_pid_type_for(collection), recid)
 
     record = LiteratureSearch().get_source(pid.object_uuid)
 
@@ -244,7 +245,7 @@ def ajax_citations():
     recid = request.args.get('recid', '')
     collection = request.args.get('collection', '')
 
-    pid = PersistentIdentifier.get(collection, recid)
+    pid = PersistentIdentifier.get(get_pid_type_for(collection), recid)
 
     record = LiteratureSearch().get_source(pid.object_uuid)
 
@@ -471,7 +472,7 @@ def ajax_institutions_experiments():
     """Datatable handler to get experiments in an institution."""
     recid = request.args.get('recid', '')
 
-    pid = PersistentIdentifier.get('institutions', recid)
+    pid = PersistentIdentifier.get(get_pid_type_for('institutions'), recid)
 
     record = InstitutionsSearch().get_source(pid.object_uuid)
     try:
@@ -570,7 +571,9 @@ def record(control_number):
         abort(404)
 
     return redirect('/{collection}/{control_number}'.format(
-        collection=pid.pid_type, control_number=control_number)), 301
+        collection=get_endpoint_from_pid_type(pid.pid_type),
+        control_number=control_number
+    )), 301
 
 
 #

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,9 +22,7 @@
 
 # FIXME temporary branch for testing
 -e git+https://github.com/inspirehep/invenio-query-parser.git@invenio3-inspire#egg=invenio-query-parser==0.6.0
-
-# INSPIRE forks of Invenio packages
--e git+https://github.com/inspirehep/invenio-pidstore.git#egg=invenio-pidstore
+-e git+https://github.com/inveniosoftware/invenio-records-rest.git#egg=invenio-records-rest
 
 # Workflows and Holding Pen related dependencies
 -e git+https://github.com/inveniosoftware/invenio-classifier.git#egg=invenio-classifier

--- a/setup.py
+++ b/setup.py
@@ -60,10 +60,12 @@ install_requires = [
     'invenio-mail>=1.0.0a4',
     'invenio-oauthclient>=1.0.0a8',
     'invenio-orcid>=1.0.0a1',
+    'invenio-pidstore>=1.0.0a9',
     'invenio-records>=1.0.0a16',  # Add [versioning] in the future
+    'invenio-records-rest>=1.0.0a16',
     'invenio-rest[cors]>=1.0.0a7',
     'invenio-search>=1.0.0a7',
-    'invenio-records-rest>=1.0.0a15',
+    'invenio-records-rest>=1.0.0a16',
     'invenio-records-ui>=1.0.0a6',
     'invenio-files-rest>=1.0.0a3',
     'invenio-records-files>=1.0.0a5',
@@ -215,6 +217,7 @@ setup(
             'crossref = inspirehep.modules.crossref:CrossRef',
             'inspire_orcid = inspirehep.modules.orcid:INSPIREOrcid',
             'inspire_disambiguation = inspirehep.modules.disambiguation:InspireDisambiguation',
+            'invenio_records_rest = invenio_records_rest:InvenioRecordsREST',
         ],
         'invenio_assets.bundles': [
             'inspirehep_theme_css = inspirehep.modules.theme.bundles:css',

--- a/tests/integration/disambiguation/test_daemon.py
+++ b/tests/integration/disambiguation/test_daemon.py
@@ -29,6 +29,7 @@ from invenio_pidstore.models import PersistentIdentifier
 from invenio_search import current_search_client as es
 
 from inspirehep.modules.disambiguation.models import DisambiguationRecord
+from inspirehep.modules.pidstore.providers import get_pid_type_for
 from inspirehep.utils.record_getter import get_es_record_by_uuid
 
 
@@ -42,7 +43,7 @@ def test_count_phonetic_block_dispatched(small_app):
 
     # Signature #1.
     glashow_record_id = str(PersistentIdentifier.get(
-        "literature", 4328).object_uuid)
+        get_pid_type_for("literature"), 4328).object_uuid)
     glashow_record = get_es_record_by_uuid(glashow_record_id)
 
     # Add phonetic block to the record.
@@ -53,7 +54,7 @@ def test_count_phonetic_block_dispatched(small_app):
 
     # Signature #2.
     higgs_record_id_first = str(PersistentIdentifier.get(
-        "literature", 1358492).object_uuid)
+        get_pid_type_for("literature"), 1358492).object_uuid)
     higgs_record_first = get_es_record_by_uuid(higgs_record_id_first)
 
     # Add phonetic block to the record.
@@ -64,7 +65,7 @@ def test_count_phonetic_block_dispatched(small_app):
 
     # Signature #3.
     higgs_record_id_second = str(PersistentIdentifier.get(
-        "literature", 11883).object_uuid)
+        get_pid_type_for("literature"), 11883).object_uuid)
     higgs_record_second = get_es_record_by_uuid(higgs_record_id_second)
 
     # Add phonetic block to the record.

--- a/tests/integration/disambiguation/test_logic.py
+++ b/tests/integration/disambiguation/test_logic.py
@@ -25,11 +25,12 @@ from __future__ import absolute_import, division, print_function
 from invenio_pidstore.models import PersistentIdentifier
 
 from inspirehep.modules.disambiguation.logic import _create_distance_signature
+from inspirehep.modules.pidstore.providers import get_pid_type_for
 
 
 def test_create_distance_signature_method(small_app):
     """Test the method responsible for creating data in Beard format."""
-    pid = PersistentIdentifier.get("literature", 4328)
+    pid = PersistentIdentifier.get(get_pid_type_for("literature"), 4328)
     publication_id = str(pid.object_uuid)
 
     signatures_map = {

--- a/tests/integration/disambiguation/test_receivers.py
+++ b/tests/integration/disambiguation/test_receivers.py
@@ -35,6 +35,7 @@ from inspirehep.modules.disambiguation.receivers import (
     append_new_record_to_queue,
     append_updated_record_to_queue,
 )
+from inspirehep.modules.pidstore.providers import get_pid_type_for
 
 
 class _IdDict(dict):
@@ -92,7 +93,7 @@ def test_append_new_record_to_queue_method_not_hep_record(small_app):
 
 def test_append_updated_record_to_queue(small_app):
     """Test the receiver responsible for queuing updated HEP records."""
-    pid = PersistentIdentifier.get("literature", 4328)
+    pid = PersistentIdentifier.get(get_pid_type_for("literature"), 4328)
     publication_id = str(pid.object_uuid)
     record = Record.get_record(publication_id)
 
@@ -159,7 +160,7 @@ def test_append_updated_record_to_queue_not_hep_record(small_app):
 
 def test_append_updated_record_to_queue_same_data(small_app):
     """Check if for the same record, the receiver will skip the publication."""
-    pid = PersistentIdentifier.get("literature", 11883)
+    pid = PersistentIdentifier.get(get_pid_type_for("literature"), 11883)
     publication_id = str(pid.object_uuid)
     record = Record.get_record(publication_id)
 

--- a/tests/integration/disambiguation/test_records.py
+++ b/tests/integration/disambiguation/test_records.py
@@ -29,6 +29,7 @@ from inspirehep.modules.disambiguation.records import (
     _get_author_schema,
     create_author,
 )
+from inspirehep.modules.pidstore.providers import get_pid_type_for
 
 
 def test_get_author_schema_method(small_app):
@@ -48,7 +49,7 @@ def test_create_author_method(small_app):
     }
 
     recid = create_author(signature)
-    pid = PersistentIdentifier.get("authors", recid)
+    pid = PersistentIdentifier.get(get_pid_type_for("authors"), recid)
     record = Record.get_record(pid.object_uuid)
 
     assert record['collections'] == [{'primary': 'HEPNAMES'}]
@@ -61,7 +62,7 @@ def test_update_authors_recid_method(small_app):
     """Test the method responsible for updating author's recid."""
     from inspirehep.modules.disambiguation.tasks import update_authors_recid
 
-    pid = PersistentIdentifier.get("literature", 4328)
+    pid = PersistentIdentifier.get(get_pid_type_for("literature"), 4328)
     publication_id = str(pid.object_uuid)
 
     signature = Record.get_record(publication_id)['authors'][0]['uuid']

--- a/tests/integration/disambiguation/test_workflows.py
+++ b/tests/integration/disambiguation/test_workflows.py
@@ -32,6 +32,7 @@ from invenio_pidstore.models import PersistentIdentifier
 from invenio_records.api import Record
 from invenio_search import current_search_client as es
 
+from inspirehep.modules.pidstore.providers import get_pid_type_for
 from inspirehep.utils.record_getter import get_es_record_by_uuid
 
 
@@ -54,7 +55,7 @@ def test_single_signature_with_no_profile(small_app):
         update_authors_recid
     )
 
-    record_id = str(PersistentIdentifier.get("literature", 11883).object_uuid)
+    record_id = str(PersistentIdentifier.get(get_pid_type_for("literature"), 11883).object_uuid)
     record = get_es_record_by_uuid(record_id)
     author_uuid = record['authors'][0]['uuid']
 
@@ -81,7 +82,7 @@ def test_match_signature_with_existing_profile(small_app):
     )
 
     old_record_id = str(PersistentIdentifier.get(
-        "literature", 11883).object_uuid)
+        get_pid_type_for("literature"), 11883).object_uuid)
     old_record = get_es_record_by_uuid(old_record_id)
     old_author_uuid = old_record['authors'][0]['uuid']
 
@@ -92,7 +93,7 @@ def test_match_signature_with_existing_profile(small_app):
     es.indices.refresh('records-hep')
 
     record_id = str(PersistentIdentifier.get(
-        "literature", 1358492).object_uuid)
+        get_pid_type_for("literature"), 1358492).object_uuid)
     record = get_es_record_by_uuid(record_id)
     author_uuid = record['authors'][0]['uuid']
 
@@ -123,7 +124,7 @@ def test_appoint_profile_from_claimed_signature(small_app):
     )
 
     old_record_id = str(PersistentIdentifier.get(
-        "literature", 11883).object_uuid)
+        get_pid_type_for("literature"), 11883).object_uuid)
     old_record = get_es_record_by_uuid(old_record_id)
     old_author_uuid = old_record['authors'][0]['uuid']
 
@@ -135,7 +136,7 @@ def test_appoint_profile_from_claimed_signature(small_app):
     es.indices.refresh('records-hep')
 
     record_id = str(PersistentIdentifier.get(
-        "literature", 1358492).object_uuid)
+        get_pid_type_for("literature"), 1358492).object_uuid)
     record = get_es_record_by_uuid(record_id)
     author_uuid = record['authors'][0]['uuid']
 
@@ -171,7 +172,7 @@ def test_solve_claim_conflicts(small_app):
 
     # Claimed signature #1.
     glashow_record_id_claimed = str(PersistentIdentifier.get(
-        "literature", 4328).object_uuid)
+        get_pid_type_for("literature"), 4328).object_uuid)
     glashow_record_claimed = get_es_record_by_uuid(
         glashow_record_id_claimed)
     glashow_record_uuid_claimed = glashow_record_claimed[
@@ -187,7 +188,7 @@ def test_solve_claim_conflicts(small_app):
 
     # Claimed signature #2.
     higgs_record_id_claimed = str(PersistentIdentifier.get(
-        "literature", 1358492).object_uuid)
+        get_pid_type_for("literature"), 1358492).object_uuid)
     higgs_record_claimed = get_es_record_by_uuid(
         higgs_record_id_claimed)
     higgs_record_uuid_claimed = higgs_record_claimed[
@@ -203,7 +204,7 @@ def test_solve_claim_conflicts(small_app):
 
     # Not claimed signature.
     higgs_record_id_not_claimed = str(PersistentIdentifier.get(
-        "literature", 11883).object_uuid)
+        get_pid_type_for("literature"), 11883).object_uuid)
     higgs_record_not_claimed = get_es_record_by_uuid(
         higgs_record_id_not_claimed)
     higgs_record_uuid_not_claimed = higgs_record_not_claimed[

--- a/tests/integration/test_pidstore.py
+++ b/tests/integration/test_pidstore.py
@@ -25,7 +25,7 @@ from __future__ import absolute_import, division, print_function
 import httpretty
 import mock
 
-from inspirehep.modules.pidstore.providers import InspireRecordIdProvider
+from inspirehep.modules.pidstore.providers import InspireRecordIdProvider, get_pid_type_for
 
 
 def test_getting_next_recid_from_legacy(httpretty_mock, app):
@@ -45,7 +45,7 @@ def test_getting_next_recid_from_legacy(httpretty_mock, app):
             args = dict(
                 object_type="rec",
                 object_uuid="7753a30b-4c4b-469c-8d8d-d5020069b3ab",
-                pid_type="literature"
+                pid_type=get_pid_type_for("literature")
             )
             provider = InspireRecordIdProvider.create(**args)
 

--- a/tests/integration/test_record.py
+++ b/tests/integration/test_record.py
@@ -32,6 +32,7 @@ from invenio_search import current_search_client as es
 
 from inspirehep.dojson.hep import hep
 from inspirehep.modules.migrator.tasks.records import record_upsert
+from inspirehep.modules.pidstore.providers import get_pid_type_for
 from inspirehep.utils.record_getter import get_db_record
 
 
@@ -105,7 +106,7 @@ def _delete_record_from_everywhere(collection, record_control_number):
     ri.delete(record)
     record.delete(force=True)
 
-    pid = PersistentIdentifier.get(collection, record_control_number)
+    pid = PersistentIdentifier.get(get_pid_type_for(collection), record_control_number)
     PersistentIdentifier.delete(pid)
 
     object_uuid = pid.object_uuid


### PR DESCRIPTION
- No longer uses INSPIRE fork of invenio-pidstore.
- Introduces new get_pid_type_for() helper to map from endpoints
  to corresponding pid_types, now that pid_types are constrained in
  length.
  (closes #1579)

Signed-off-by: Samuele Kaplun samuele.kaplun@cern.ch
