### PR TITLE
packaging: unpin html5lib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,6 @@ install_requires = [
     'jsmin',
     'pytest-runner>=2.7.0',
     'workflow>=2.0.0',
-    'html5lib<1.0b9',
     'SQLAlchemy>=1.0.14,<1.1',
     'nameparser>=0.4.0',
     'iso8601>=0.1.11',


### PR DESCRIPTION
* The fix for the issue we were seeing was already pushed upstream on
  the latest version (1.0b10/0.99999999).

Signed-off-by: David Caro <david@dcaro.es>