### PR TITLE
 packaging: fix pidstore package name 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@
 -e git+https://github.com/inspirehep/invenio-query-parser.git@invenio3-inspire#egg=invenio-query-parser==0.6.0
 
 # INSPIRE forks of Invenio packages
--e git+https://github.com/inspirehep/invenio-pidstore.git#egg=invenio-pidstore
+-e git+https://github.com/inspirehep/invenio-pidstore.git#egg=invenio_pidstore
 
 # Workflows and Holding Pen related dependencies
 -e git+https://github.com/inveniosoftware/invenio-classifier.git#egg=invenio-classifier


### PR DESCRIPTION
~~* There was a leftover statement using logging module directly instead
  of the logger object.~~

* This might lead to installing both, upstream as invenio_pidstore and
  another as invenio-pidstore generating strange conflicts.

Signed-off-by: David Caro <david@dcaro.es>