### PR TITLE
api: add citesummary

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -419,6 +419,29 @@ RECORDS_REST_ENDPOINTS = dict(
         read_permission_factory_imp="inspirehep.modules.records.permissions:record_read_permission_factory",
         record_class='inspirehep.modules.records.es_record:ESRecord'
     ),
+    literature_citesummary=dict(
+        default_media_type='application/json',
+        item_route=(
+            '/literature'
+            '/<pid(literature,record_class="inspirehep.modules.records.es_record:ESRecord"):pid_value>'
+            '/citesummary'),
+        list_route='/literature/',
+        max_result_window=10000,
+        pid_fetcher='inspire_recid_fetcher',
+        pid_minter='inspire_recid_minter',
+        pid_type='literature',
+        record_serializers={
+            'application/json': (
+                'inspirehep.modules.api.v1.literature:citesummary_response')
+        },
+        search_class='inspirehep.modules.search:LiteratureSearch',
+        search_factory_imp=(
+            'inspirehep.modules.search.query:inspire_search_factory'),
+        search_serializers={
+            'application/json': (
+                'invenio_records_rest.serializers:json_v1_response')
+        },
+    ),
     literature_db=dict(
         pid_type='literature',
         search_class='inspirehep.modules.search:LiteratureSearch',
@@ -482,6 +505,28 @@ RECORDS_REST_ENDPOINTS = dict(
         max_result_window=10000,
         search_factory_imp=('inspirehep.modules.search.query'
                             ':inspire_search_factory'),
+    ),
+    authors_citesummary=dict(
+        default_media_type='application/json',
+        item_route='/authors/<pidpath(authors):pid_value>/citesummary',
+        list_route='/authors/',
+        max_result_window=10000,
+        pid_fetcher='inspire_recid_fetcher',
+        pid_minter='inspire_recid_minter',
+        pid_type='authors',
+        record_serializers={
+            'application/json': (
+                'inspirehep.modules.api.v1.authors:citesummary_response'),
+        },
+        search_class='inspirehep.modules.search:AuthorsSearch',
+        search_factory_imp=(
+            'inspirehep.modules.search.query:inspire_search_factory'),
+        search_serializers={
+            'application/json': (
+                'invenio_records_rest.serializers:json_v1_search'),
+            'application/vnd+inspire.brief+json': (
+                'invenio_records_rest.serializers:json_v1_search'),
+        },
     ),
     authors_coauthors=dict(
         pid_type='authors',
@@ -647,6 +692,28 @@ RECORDS_REST_ENDPOINTS = dict(
         max_result_window=10000,
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
     ),
+    institutions_citesummary=dict(
+        default_media_type='application/json',
+        item_route=(
+            '/institutions/<pidpath(institutions):pid_value>/citesummary'),
+        list_route='/institutions/',
+        max_result_window=10000,
+        pid_fetcher='inspire_recid_fetcher',
+        pid_minter='inspire_recid_minter',
+        pid_type='institutions',
+        record_serializers={
+            'application/json': (
+                'inspirehep.modules.api.v1.institutions:citesummary_response'),
+        },
+        search_class='inspirehep.modules.search:InstitutionsSearch',
+        search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
+        search_serializers={
+            'application/json': (
+                'invenio_records_rest.serializers:json_v1_search'),
+            'application/vnd+inspire.brief+json': (
+                'invenio_records_rest.serializers:json_v1_search'),
+        },
+    ),
     experiments=dict(
         pid_type='experiments',
         pid_minter='inspire_recid_minter',
@@ -670,6 +737,28 @@ RECORDS_REST_ENDPOINTS = dict(
         max_result_window=10000,
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
     ),
+    experiments_citesummary=dict(
+        default_media_type='application/json',
+        item_route=(
+            '/experiments/<pidpath(experiments):pid_value>/citesummary'),
+        list_route='/experiments/',
+        max_result_window=10000,
+        pid_fetcher='inspire_recid_fetcher',
+        pid_minter='inspire_recid_minter',
+        pid_type='experiments',
+        record_serializers={
+            'application/json': (
+                'inspirehep.modules.api.v1.experiments:citesummary_response'),
+        },
+        search_class='inspirehep.modules.search:ExperimentsSearch',
+        search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
+        search_serializers={
+            'application/json': (
+                'invenio_records_rest.serializers:json_v1_search'),
+            'application/vnd+inspire.brief+json': (
+                'invenio_records_rest.serializers:json_v1_search'),
+        },
+    ),
     journals=dict(
         pid_type='journals',
         pid_minter='inspire_recid_minter',
@@ -692,6 +781,28 @@ RECORDS_REST_ENDPOINTS = dict(
         default_media_type='application/json',
         max_result_window=10000,
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
+    ),
+    journals_citesummary=dict(
+        default_media_type='application/json',
+        item_route=(
+            '/journals/<pidpath(journals):pid_value>/citesummary'),
+        list_route='/journals/',
+        max_result_window=10000,
+        pid_fetcher='inspire_recid_fetcher',
+        pid_minter='inspire_recid_minter',
+        pid_type='journals',
+        record_serializers={
+            'application/json': (
+                'inspirehep.modules.api.v1.journals:citesummary_response'),
+        },
+        search_class='inspirehep.modules.search:JournalsSearch',
+        search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
+        search_serializers={
+            'application/json': (
+                'invenio_records_rest.serializers:json_v1_search'),
+            'application/vnd+inspire.brief+json': (
+                'invenio_records_rest.serializers:json_v1_search'),
+        },
     ),
 )
 

--- a/inspirehep/modules/api/__init__.py
+++ b/inspirehep/modules/api/__init__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""API of INSPIRE."""
+
+from __future__ import absolute_import, division, print_function

--- a/inspirehep/modules/api/utils.py
+++ b/inspirehep/modules/api/utils.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""API utils."""
+
+from __future__ import absolute_import, division, print_function
+
+from inspirehep.utils.helpers import force_force_list
+from inspirehep.utils.record import get_value
+
+
+def get_date(record):
+    return record['earliest_date']
+
+
+def get_document_type(record):
+    return get_value(record, 'facet_inspire_doc_type[0]')
+
+
+def get_id(record):
+    return int(record['control_number'])
+
+
+def get_subject(record):
+    field_categories = force_force_list(get_value(record, 'field_categories'))
+    inspire_field_categories = [
+        fc for fc in field_categories if fc.get('scheme') == 'INSPIRE']
+    terms = [fc['term'] for fc in field_categories if fc.get('term')]
+
+    if terms:
+        return terms[0]
+
+
+def is_collaboration(record):
+    return force_force_list(get_value(record, 'collaboration.value')) != []
+
+
+def is_core(record):
+    return 'CORE' in force_force_list(
+        get_value(record, 'collections.primary'))
+
+
+def is_selfcite(citee, citer):
+    def _get_authors_recids(record):
+        return set(force_force_list(get_value(record, 'authors.recid')))
+
+    citee_authors_recids = _get_authors_recids(citee)
+    citer_authors_recids = _get_authors_recids(citer)
+
+    return len(citee_authors_recids & citer_authors_recids) > 0

--- a/inspirehep/modules/api/v1/__init__.py
+++ b/inspirehep/modules/api/v1/__init__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Version 1 of the API of INSPIRE."""
+
+from __future__ import absolute_import, division, print_function

--- a/inspirehep/modules/api/v1/authors.py
+++ b/inspirehep/modules/api/v1/authors.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction
+
+"""API of Author records."""
+
+from __future__ import absolute_import, division, print_function
+
+import json
+
+from inspirehep.modules.records.serializers.response import (
+    record_responsify_nocache,
+)
+from inspirehep.modules.search import LiteratureSearch
+
+from ..utils import build_citesummary, get_id
+
+
+class APIAuthorsCitesummary(object):
+
+    """Implementation of citesummary for Author records."""
+
+    def serialize(self, pid, record, links_factory=None):
+        search_by_author = LiteratureSearch().query(
+            'match', authors__recid=get_id(record)
+        ).params(
+            _source=[
+                'authors.recid',
+                'collaboration.value',
+                'collections.primary',
+                'control_number',
+                'earliest_date',
+                'facet_inspire_doc_type',
+                'field_categories',
+                'titles.title',
+            ],
+        )
+
+        return json.dumps(build_citesummary(search_by_author))
+
+
+citesummary = APIAuthorsCitesummary()
+citesummary_response = record_responsify_nocache(
+    citesummary, 'application/json')

--- a/inspirehep/modules/api/v1/experiments.py
+++ b/inspirehep/modules/api/v1/experiments.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction
+
+"""API of Experiment records."""
+
+from __future__ import absolute_import, division, print_function
+
+import json
+
+from inspirehep.modules.records.serializers.response import (
+    record_responsify_nocache,
+)
+from inspirehep.modules.search import LiteratureSearch
+
+from ..utils import build_citesummary, get_id
+
+
+class APIExperimentsCitesummary(object):
+
+    """Implementation of citesummary for Experiment records."""
+
+    def serialize(self, pid, record, links_factory=None):
+        search_by_experiment = LiteratureSearch().query(
+            'match', accelerator_experiments__recid=get_id(record)
+        ).params(
+            _source=[
+                'control_number',
+            ],
+        )
+
+        literature_recids = [
+            get_id(el.to_dict()) for el in search_by_experiment.scan()]
+
+        search_by_recids = LiteratureSearch().filter(
+            'terms', control_number=literature_recids
+        ).params(
+            _source=[
+                'authors.recid',
+                'collaboration.value',
+                'collections.primary',
+                'control_number',
+                'earliest_date',
+                'facet_inspire_doc_type',
+                'field_categories',
+                'titles.title',
+            ],
+        )
+
+        return json.dumps(build_citesummary(search_by_recids))
+
+
+citesummary = APIExperimentsCitesummary()
+citesummary_response = record_responsify_nocache(
+    citesummary, 'application/json')

--- a/inspirehep/modules/api/v1/institutions.py
+++ b/inspirehep/modules/api/v1/institutions.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction
+
+"""API of Institution records."""
+
+from __future__ import absolute_import, division, print_function
+
+import json
+
+from inspirehep.modules.records.serializers.response import (
+    record_responsify_nocache,
+)
+from inspirehep.modules.search import LiteratureSearch
+
+from ..utils import build_citesummary, get_id
+
+
+class APIInstitutionsCitesummary(object):
+
+    """Implementation of citesummary for Institution records."""
+
+    def serialize(self, pid, record, links_factory=None):
+        search_by_institution = LiteratureSearch().query(
+            'match', authors__affiliations__recid=get_id(record)
+        ).params(
+            _source=[
+                'control_number',
+            ],
+        )
+
+        literature_recids = [
+            get_id(el.to_dict()) for el in search_by_institution.scan()]
+
+        search_by_recids = LiteratureSearch().filter(
+            'terms', control_number=literature_recids
+        ).params(
+            _source=[
+                'authors.recid',
+                'collaboration.value',
+                'collections.primary',
+                'control_number',
+                'earliest_date',
+                'facet_inspire_doc_type',
+                'field_categories',
+                'titles.title',
+            ],
+        )
+
+        return json.dumps(build_citesummary(search_by_recids))
+
+
+citesummary = APIInstitutionsCitesummary()
+citesummary_response = record_responsify_nocache(
+    citesummary, 'application/json')

--- a/inspirehep/modules/api/v1/journals.py
+++ b/inspirehep/modules/api/v1/journals.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction
+
+"""API of Journal records."""
+
+from __future__ import absolute_import, division, print_function
+
+import json
+
+from inspirehep.modules.records.serializers.response import (
+    record_responsify_nocache,
+)
+from inspirehep.modules.search import LiteratureSearch
+
+from ..utils import build_citesummary, get_id
+
+
+class APIJournalsCitesummary(object):
+
+    """Implementation of citesummary for Journal records."""
+
+    def serialize(self, pid, record, links_factory=None):
+        search_by_journal = LiteratureSearch().query(
+            'match', publication_info__journal_recid=get_id(record)
+        ).params(
+            _source=[
+                'control_number',
+            ],
+        )
+
+        literature_recids = [
+            get_id(el.to_dict()) for el in search_by_journal.scan()]
+
+        search_by_recids = LiteratureSearch().filter(
+            'terms', control_number=literature_recids
+        ).params(
+            _source=[
+                'authors.recid',
+                'collaboration.value',
+                'collections.primary',
+                'control_number',
+                'earliest_date',
+                'facet_inspire_doc_type',
+                'field_categories',
+                'titles.title',
+            ],
+        )
+
+        return json.dumps(build_citesummary(search_by_recids))
+
+
+citesummary = APIJournalsCitesummary()
+citesummary_response = record_responsify_nocache(
+    citesummary, 'application/json')

--- a/inspirehep/modules/api/v1/literature.py
+++ b/inspirehep/modules/api/v1/literature.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction
+
+"""API of Literature records."""
+
+from __future__ import absolute_import, division, print_function
+
+import json
+
+from inspirehep.modules.records.serializers.response import (
+    record_responsify_nocache,
+)
+from inspirehep.modules.search import LiteratureSearch
+from inspirehep.utils.record import get_title
+
+from ..utils import (
+    get_date,
+    get_document_type,
+    get_id,
+    get_subject,
+    is_collaboration,
+    is_core,
+    is_selfcite,
+)
+
+
+class APILiteratureCitesummary(object):
+
+    """Implementation of citesummary for Literature records."""
+
+    def serialize(self, pid, record, links_factory=None):
+        citesummary = [
+            {
+                'citations': [],
+                'collaboration': is_collaboration(record),
+                'core': is_core(record),
+                'date': get_date(record),
+                'document_type': get_document_type(record),
+                'id': get_id(record),
+                'subject': get_subject(record),
+                'title': get_title(record),
+            },
+        ]
+
+        search = LiteratureSearch().query(
+            'match', references__recid=get_id(record)
+        ).params(
+            _source=[
+                'authors.recid',
+                'collaboration.value',
+                'collections.primary',
+                'control_number',
+                'earliest_date',
+                'facet_inspire_doc_type',
+                'field_categories',
+                'titles.title',
+            ],
+        )
+
+        for el in search.scan():
+            result = el.to_dict()
+
+            citesummary[0]['citations'].append({
+                'collaboration': is_collaboration(result),
+                'core': is_core(result),
+                'date': get_date(result),
+                'document_type': get_document_type(result),
+                'id': get_id(result),
+                'subject': get_subject(result),
+                'selfcite': is_selfcite(record, result),
+                'title': get_title(result),
+            })
+
+        return json.dumps(citesummary)
+
+
+citesummary = APILiteratureCitesummary()
+citesummary_response = record_responsify_nocache(
+    citesummary, 'application/json')

--- a/tests/integration/api/v1/test_authors.py
+++ b/tests/integration/api/v1/test_authors.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import json
+
+from jsonschema import validate
+
+
+def test_api_v1_authors_citesummary(app):
+    schema = {
+        'items': {
+            'additionalProperties': False,
+            'properties': {
+                'citations': {
+                    'items': {
+                        'additionalProperties': False,
+                        'properties': {
+                            'collaboration': {'type': 'boolean'},
+                            'core': {'type': 'boolean'},
+                            'date': {
+                                'format': 'date',
+                                'type': 'string',
+                            },
+                            'document_type': {'type': 'string'},
+                            'id': {'type': 'integer'},
+                            'selfcite': {'type': 'boolean'},
+                            'subject': {'type': 'string'},
+                            'title': {'type': 'string'},
+                        },
+                        'required': [
+                            'collaboration',
+                            'core',
+                            'date',
+                            'document_type',
+                            'id',
+                            'selfcite',
+                            'subject',
+                            'title',
+                        ],
+                        'type': 'object',
+                    },
+                    'type': 'array',
+                },
+                'collaboration': {'type': 'boolean'},
+                'core': {'type': 'boolean'},
+                'date': {
+                    'format': 'date',
+                    'type': 'string',
+                },
+                'document_type': {'type': 'string'},
+                'id': {'type': 'integer'},
+                'subject': {'type': 'string'},
+                'title': {'type': 'string'},
+            },
+            'required': [
+                'citations',
+                'collaboration',
+                'core',
+                'date',
+                'document_type',
+                'id',
+                'subject',
+                'title',
+            ],
+            'type': 'object',
+        },
+        'type': 'array',
+    }
+
+    with app.test_client() as client:
+        response = client.get('/api/authors/983220/citesummary')
+
+        assert response.status_code == 200
+
+        response_json = json.loads(response.data)
+
+        assert validate(response_json, schema) is None
+
+        assert len(response_json) == 30

--- a/tests/integration/api/v1/test_experiments.py
+++ b/tests/integration/api/v1/test_experiments.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import json
+
+from jsonschema import validate
+
+
+def test_api_v1_experiments_citesummary(app):
+    schema = {
+        'items': {
+            'additionalProperties': False,
+            'properties': {
+                'citations': {
+                    'items': {
+                        'additionalProperties': False,
+                        'properties': {
+                            'collaboration': {'type': 'boolean'},
+                            'core': {'type': 'boolean'},
+                            'date': {
+                                'format': 'date',
+                                'type': 'string',
+                            },
+                            'document_type': {'type': 'string'},
+                            'id': {'type': 'integer'},
+                            'selfcite': {'type': 'boolean'},
+                            'subject': {'type': 'string'},
+                            'title': {'type': 'string'},
+                        },
+                        'required': [
+                            'collaboration',
+                            'core',
+                            'date',
+                            'document_type',
+                            'id',
+                            'selfcite',
+                            'subject',
+                            'title',
+                        ],
+                        'type': 'object',
+                    },
+                    'type': 'array',
+                },
+                'collaboration': {'type': 'boolean'},
+                'core': {'type': 'boolean'},
+                'date': {
+                    'format': 'date',
+                    'type': 'string',
+                },
+                'document_type': {'type': 'string'},
+                'id': {'type': 'integer'},
+                'subject': {'type': 'string'},
+                'title': {'type': 'string'},
+            },
+            'required': [
+                'citations',
+                'collaboration',
+                'core',
+                'date',
+                'document_type',
+                'id',
+                'subject',
+                'title',
+            ],
+            'type': 'object',
+        },
+        'type': 'array',
+    }
+
+    with app.test_client() as client:
+        response = client.get('/api/experiments/1108642/citesummary')
+
+        assert response.status_code == 200
+
+        response_json = json.loads(response.data)
+
+        assert validate(response_json, schema) is None
+
+        assert len(response_json) == 59

--- a/tests/integration/api/v1/test_institutions.py
+++ b/tests/integration/api/v1/test_institutions.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import json
+
+from jsonschema import validate
+
+
+def test_api_v1_institutions_citesummary(app):
+    schema = {
+        'items': {
+            'additionalProperties': False,
+            'properties': {
+                'citations': {
+                    'items': {
+                        'additionalProperties': False,
+                        'properties': {
+                            'collaboration': {'type': 'boolean'},
+                            'core': {'type': 'boolean'},
+                            'date': {
+                                'format': 'date',
+                                'type': 'string',
+                            },
+                            'document_type': {'type': 'string'},
+                            'id': {'type': 'integer'},
+                            'selfcite': {'type': 'boolean'},
+                            'subject': {'type': 'string'},
+                            'title': {'type': 'string'},
+                        },
+                        'required': [
+                            'collaboration',
+                            'core',
+                            'date',
+                            'document_type',
+                            'id',
+                            'selfcite',
+                            'subject',
+                            'title',
+                        ],
+                        'type': 'object',
+                    },
+                    'type': 'array',
+                },
+                'collaboration': {'type': 'boolean'},
+                'core': {'type': 'boolean'},
+                'date': {
+                    'format': 'date',
+                    'type': 'string',
+                },
+                'document_type': {'type': 'string'},
+                'id': {'type': 'integer'},
+                'subject': {'type': 'string'},
+                'title': {'type': 'string'},
+            },
+            'required': [
+                'citations',
+                'collaboration',
+                'core',
+                'date',
+                'document_type',
+                'id',
+                'subject',
+                'title',
+            ],
+            'type': 'object',
+        },
+        'type': 'array',
+    }
+
+    with app.test_client() as client:
+        response = client.get('/api/institutions/902725/citesummary')
+
+        assert response.status_code == 200
+
+        response_json = json.loads(response.data)
+
+        assert validate(response_json, schema) is None
+
+        assert len(response_json) == 96

--- a/tests/integration/api/v1/test_journals.py
+++ b/tests/integration/api/v1/test_journals.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import json
+
+from jsonschema import validate
+
+
+def test_api_v1_journals_citesummary(app):
+    schema = {
+        'items': {
+            'additionalProperties': False,
+            'properties': {
+                'citations': {
+                    'items': {
+                        'additionalProperties': False,
+                        'properties': {
+                            'collaboration': {'type': 'boolean'},
+                            'core': {'type': 'boolean'},
+                            'date': {
+                                'format': 'date',
+                                'type': 'string',
+                            },
+                            'document_type': {'type': 'string'},
+                            'id': {'type': 'integer'},
+                            'selfcite': {'type': 'boolean'},
+                            'subject': {'type': 'string'},
+                            'title': {'type': 'string'},
+                        },
+                        'required': [
+                            'collaboration',
+                            'core',
+                            'date',
+                            'document_type',
+                            'id',
+                            'selfcite',
+                            'subject',
+                            'title',
+                        ],
+                        'type': 'object',
+                    },
+                    'type': 'array',
+                },
+                'collaboration': {'type': 'boolean'},
+                'core': {'type': 'boolean'},
+                'date': {
+                    'format': 'date',
+                    'type': 'string',
+                },
+                'document_type': {'type': 'string'},
+                'id': {'type': 'integer'},
+                'subject': {'type': 'string'},
+                'title': {'type': 'string'},
+            },
+            'required': [
+                'citations',
+                'collaboration',
+                'core',
+                'date',
+                'document_type',
+                'id',
+                'subject',
+                'title',
+            ],
+            'type': 'object',
+        },
+        'type': 'array',
+    }
+
+    with app.test_client() as client:
+        response = client.get('/api/journals/1213103/citesummary')
+
+        assert response.status_code == 200
+
+        response_json = json.loads(response.data)
+
+        assert validate(response_json, schema) is None
+
+        assert len(response_json) == 47

--- a/tests/integration/api/v1/test_literature.py
+++ b/tests/integration/api/v1/test_literature.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import json
+
+from jsonschema import validate
+
+
+def test_api_v1_literature_citesummary(app):
+    schema = {
+        'items': {
+            'additionalProperties': False,
+            'properties': {
+                'citations': {
+                    'items': {
+                        'additionalProperties': False,
+                        'properties': {
+                            'collaboration': {'type': 'boolean'},
+                            'core': {'type': 'boolean'},
+                            'date': {
+                                'format': 'date',
+                                'type': 'string',
+                            },
+                            'document_type': {'type': 'string'},
+                            'id': {'type': 'integer'},
+                            'selfcite': {'type': 'boolean'},
+                            'subject': {'type': 'string'},
+                            'title': {'type': 'string'},
+                        },
+                        'required': [
+                            'collaboration',
+                            'core',
+                            'date',
+                            'document_type',
+                            'id',
+                            'selfcite',
+                            'subject',
+                            'title',
+                        ],
+                        'type': 'object',
+                    },
+                    'type': 'array',
+                },
+                'collaboration': {'type': 'boolean'},
+                'core': {'type': 'boolean'},
+                'date': {
+                    'format': 'date',
+                    'type': 'string',
+                },
+                'document_type': {'type': 'string'},
+                'id': {'type': 'integer'},
+                'subject': {'type': 'string'},
+                'title': {'type': 'string'},
+            },
+            'required': [
+                'citations',
+                'collaboration',
+                'core',
+                'date',
+                'document_type',
+                'id',
+                'subject',
+                'title',
+            ],
+            'type': 'object',
+        },
+        'maxItems': 1,
+        'minItems': 1,
+        'type': 'array',
+    }
+
+    with app.test_client() as client:
+        response = client.get('/api/literature/4328/citesummary')
+
+        assert response.status_code == 200
+
+        response_json = json.loads(response.data)
+
+        assert validate(response_json, schema) is None
+
+        assert len(response_json) == 1
+        assert len(response_json[0]['citations']) == 11

--- a/tests/unit/api/test_api_utils.py
+++ b/tests/unit/api/test_api_utils.py
@@ -1,0 +1,241 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+from inspirehep.modules.api.utils import (
+    get_date,
+    get_document_type,
+    get_id,
+    get_subject,
+    is_collaboration,
+    is_core,
+    is_selfcite,
+)
+
+
+def test_get_date():
+    record = {'earliest_date': '1993-02-02'}
+
+    expected = '1993-02-02'
+    result = get_date(record)
+
+    assert expected == result
+
+
+def test_get_date_raises_when_no_earliest_date():
+    record = {}
+
+    with pytest.raises(KeyError):
+        get_date(record)
+
+
+def test_get_document_type():
+    record = {
+        'facet_inspire_doc_type': [
+            'peer reviewed',
+        ],
+    }
+
+    expected = 'peer reviewed'
+    result = get_document_type(record)
+
+    assert expected == result
+
+
+def test_get_document_type_returns_none_when_facet_inspire_doc_type_is_empty():
+    record = {'facet_inspire_doc_type': []}
+
+    assert get_document_type(record) is None
+
+
+def test_get_document_type_returns_none_when_no_facet_inspire_doc_type():
+    record = {}
+
+    assert get_document_type(record) is None
+
+
+def test_get_id():
+    record = {'control_number': '4328'}
+
+    expected = 4328
+    result = get_id(record)
+
+    assert expected == result
+
+
+def test_get_id_raises_when_no_control_number():
+    record = {}
+
+    with pytest.raises(KeyError):
+        assert get_id(record)
+
+
+def test_get_id_raises_when_control_number_is_malformed():
+    record = {'control_number': 'foo'}
+
+    with pytest.raises(ValueError):
+        assert get_id(record)
+
+
+def test_get_subject():
+    record = {
+        'field_categories': [
+            {
+                'scheme': 'INSPIRE',
+                'term': 'Phenomenology-HEP',
+            },
+        ],
+    }
+
+    expected = 'Phenomenology-HEP'
+    result = get_subject(record)
+
+    assert expected == result
+
+
+def test_get_subject_selects_first():
+    record = {
+        'field_categories': [
+            {
+                'scheme': 'INSPIRE',
+                'term': 'Experiments-HEP',
+            },
+            {
+                'scheme': 'INSPIRE',
+                'term': 'Phenomenology-HEP',
+            },
+        ],
+    }
+
+    expected = 'Experiments-HEP'
+    result = get_subject(record)
+
+    assert expected == result
+
+
+def test_get_subject_discards_non_inspire_field_categories():
+    record = {
+        'field_categories': [
+            {
+                'scheme': 'arXiv',
+                'term': 'cond-mat.str-el',
+            },
+        ],
+    }
+
+    assert get_document_type(record) is None
+
+
+def test_is_collaboration():
+    record = {
+        'collaboration': [
+            {
+                'value': 'CMS',
+            },
+        ],
+    }
+
+    assert is_collaboration(record)
+
+
+def test_is_collaboration_returns_false_when_collaboration_is_empty():
+    record = {
+        'collaboration': [],
+    }
+
+    assert not is_collaboration(record)
+
+
+def test_is_collaboration_returns_false_when_no_collaboration():
+    record = {}
+
+    assert not is_collaboration(record)
+
+
+def test_is_core():
+    record = {
+        'collections': [
+            {
+                'primary': 'CORE',
+            },
+        ],
+    }
+
+    assert is_core(record)
+
+
+def test_is_core_returns_false_when_collections_is_empty():
+    record = {
+        'collections': [],
+    }
+
+    assert not is_core(record)
+
+
+def test_is_core_returns_false_when_no_collection():
+    record = {}
+
+    assert not is_core(record)
+
+
+def test_is_selfcite_returns_true_when_at_least_one_author_recid_is_in_common():
+    citee = {
+        'authors': [
+            {
+                'recid': '2',
+            },
+            {
+                'recid': '1',
+            },
+        ],
+    }
+    citer = {
+        'authors': [
+            {
+                'recid': '1',
+            },
+        ],
+    }
+
+    assert is_selfcite(citee, citer)
+
+
+def test_is_selfcite_returns_false_when_no_authors_recids_are_in_common():
+    citee = {
+        'authors': [
+            {
+                'recid': '1',
+            },
+        ],
+    }
+    citer = {
+        'authors': [
+            {
+                'recid': '2',
+            },
+        ],
+    }
+
+    assert not is_selfcite(citee, citer)


### PR DESCRIPTION
Introduces the new API module, were all things API should live. Note that the folder structure allows for multiple API versions: the same should be added to our `invenio-records-rest` configuration and possibly upstream (I'll expand on this later).

As a PoC for the API module, implements the `citesummary` endpoint for `literature`, `authors`, `institutions` using ES queries.

Addresses #1304
Closes #1572
