### PR TITLE
setup: pin elasticsearch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ install_requires = [
     'iso8601>=0.1.11',
     'invenio-trends>=1.0.0a1',
     'invenio-trends-ui>=1.0.0a1',
+    'elasticsearch<3.0.0',
 ]
 
 tests_require = [


### PR DESCRIPTION
Otherwise the build fails like this: https://travis-ci.org/inspirehep/inspire-next/jobs/168969097#L716

Remove this when `elasticsearch-dsl` is updated (build might start failing again).