### PR TITLE
authors: fix key error in workflow comments field

### DIFF
--- a/inspirehep/modules/authors/views/holdingpen.py
+++ b/inspirehep/modules/authors/views/holdingpen.py
@@ -319,7 +319,7 @@ def newreview():
 
     # Converting json to populate form
     convert_for_form(workflow_metadata)
-    workflow_metadata['comments'] = workflow_metadata['_private_note']
+    workflow_metadata['comments'] = workflow_metadata.get('_private_note')
     research_fields = workflow_metadata.pop('research_field')
     final_research_fields = []
     for field in research_fields:


### PR DESCRIPTION
Sometimes the _private_note field is not there. We should use the get method to avoid the key error. 