### PR TITLE
authors: fix key error in workflow comments field

### DIFF
--- a/inspirehep/modules/authors/views/holdingpen.py
+++ b/inspirehep/modules/authors/views/holdingpen.py
@@ -323,7 +323,7 @@ def newreview():
 
     # Converting json to populate form
     convert_for_form(workflow_metadata)
-    workflow_metadata['comments'] = workflow_metadata['_private_note']
+    workflow_metadata['comments'] = workflow_metadata.get('_private_note')
     research_fields = workflow_metadata.pop('field_categories')
     final_research_fields = []
     for field in research_fields:


### PR DESCRIPTION
it should work as before but avoid the key error in the field _private_node