### PR TITLE
setup: pin Flask-Login

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ install_requires = [
     'invenio-trends>=1.0.0a1',
     'invenio-trends-ui>=1.0.0a1',
     'elasticsearch<3.0.0',
+    'Flask-Login<0.4.0',
 ]
 
 tests_require = [


### PR DESCRIPTION
`Flask-Login==0.4.0` was [just released](https://github.com/maxcountryman/flask-login/releases/tag/0.4.0), but it is [incompatible](https://github.com/mattupstate/flask-security/blob/9e5865d9735b0b292360f63588ed4725c376757e/requirements.txt#L2) with `Flask-Security==1.7.5` (just spotted this on Nightly).

Failure: https://travis-ci.org/inspirehep/inspire-next/jobs/170856603#L709.