### PR TITLE
permissions: Creation of an update permission factory.

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -469,8 +469,8 @@ RECORDS_REST_ENDPOINTS = dict(
         list_route='/literature/db',
         item_route='/literature/<pid(lit):pid_value>/db',
         default_media_type='application/json',
-        search_factory_imp='inspirehep.modules.search.query:inspire_search_factory'
-
+        search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
+        update_permission_factory_imp="inspirehep.modules.records.permissions:record_update_permission_factory",
     ),
     authors=dict(
         default_endpoint_prefix=True,

--- a/inspirehep/modules/fixtures/users.py
+++ b/inspirehep/modules/fixtures/users.py
@@ -49,6 +49,12 @@ def init_users_and_permissions():
             active=True,
             roles=[superuser_role]
         )
+        ds.create_user(
+            email='cataloger@inspirehep.net',
+            password=encrypt_password("123456"),
+            active=True,
+            roles=[cataloger_role]
+        )
         db.session.add(ActionRoles(
             action='superuser-access',
             role=superuser_role

--- a/setup.py
+++ b/setup.py
@@ -209,6 +209,7 @@ setup(
             'inspire_cache = inspirehep.modules.cache.ext:INSPIRECache',
             'inspire_search = inspirehep.modules.search:INSPIRESearch',
             'inspire_workflows = inspirehep.modules.workflows:INSPIREWorkflows',
+            'invenio_collections = invenio_collections:InvenioCollections',
         ],
         'invenio_base.apps': [
             'inspire_cache = inspirehep.modules.cache.ext:INSPIRECache',

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -105,6 +105,12 @@ def small_app():
         yield app
 
 
+@pytest.yield_fixture()
+def app_client(app):
+    """Flask test client for APP app."""
+    with app.test_client() as client:
+        yield client
+
 
 @pytest.yield_fixture(scope='session')
 def api(app):

--- a/tests/integration/test_orcid.py
+++ b/tests/integration/test_orcid.py
@@ -61,11 +61,11 @@ def mock_user(app, request):
 
     def teardown(app):
         with app.app_context():
-            user = User.query.filter_by(id=2).first()
+            user = User.query.filter_by(email='test_orcid_user@inspirehep.net').first()
             token = RemoteToken.query.filter_by(access_token='123').first()
             user_identity = UserIdentity.query.filter_by(
                 id='0000-0001-9412-8627', method='orcid').first()
-            remote_account = RemoteAccount.query.filter_by(user_id=2).first()
+            remote_account = RemoteAccount.query.filter_by(user_id=user.id).first()
             with db.session.begin_nested():
                 db.session.delete(token)
                 db.session.delete(user_identity)
@@ -76,25 +76,27 @@ def mock_user(app, request):
     request.addfinalizer(lambda: teardown(app))
 
     user = User(
-        id=2,
+        email='test_orcid_user@inspirehep.net',
     )
+    db.session.add(user)
+    db.session.commit()
+
     token = RemoteToken(
         id_remote_account=1,
         access_token='123'
     )
     user_identity = UserIdentity(
         id='0000-0001-9412-8627',
-        id_user='2',
+        id_user=str(user.id),
         method='orcid')
     remote_account = RemoteAccount(
         id=1,
-        user_id=2,
+        user_id=user.id,
         extra_data={},
         client_id=1,
         user=user)
     with app.app_context():
         with db.session.begin_nested():
-            db.session.add(user)
             db.session.add(user_identity)
             db.session.add(remote_account)
             db.session.add(token)


### PR DESCRIPTION
* Adds a new record update permission factory. Change update access from `allow_all`
   to administrators and catalogers.

 * Adds invenio_collections extension in api_apps entrypoints for using the
   invenio-records-rest PUT request upon a single record.

 * Adds a new integration test for checking user update permissions.

Signed-off-by: Zacharias Zacharodimos zacharias.zacharodimos@cern.ch
