### PR TITLE
dojson: keep old_emails in positions

### DIFF
--- a/inspirehep/dojson/hepnames/fields/bd1xx.py
+++ b/inspirehep/dojson/hepnames/fields/bd1xx.py
@@ -289,7 +289,7 @@ def positions2marc(self, key, value):
         't': value.get('end_date'),
         'm': value.get('emails'),
         'o': value.get('old_emails'),
-        'z': value.get('current'),
+        'z': 'Current' if value.get('current') else None,
     }
 
 

--- a/inspirehep/dojson/hepnames/fields/bd1xx.py
+++ b/inspirehep/dojson/hepnames/fields/bd1xx.py
@@ -261,7 +261,7 @@ def positions(self, key, value):
     }
 
     emails = [el for el in force_force_list(value.get('m'))]
-    emails.extend([el for el in force_force_list(value.get('o'))])
+    old_emails = [el for el in force_force_list(value.get('o'))]
 
     _rank = value.get('r')
     rank = classify_rank(_rank)
@@ -269,6 +269,7 @@ def positions(self, key, value):
     return {
         'institution': institution if institution['name'] else None,
         'emails': emails,
+        'old_emails': old_emails,
         '_rank': _rank,
         'rank': rank,
         'start_date': value.get('s'),
@@ -281,15 +282,13 @@ def positions(self, key, value):
 @utils.for_each_value
 def positions2marc(self, key, value):
     """Positions that an author held during their career."""
-    emails = value.get('emails')
-
     return {
         'a': value.get('institution', {}).get('name'),
         'r': value.get('_rank'),
         's': value.get('start_date'),
         't': value.get('end_date'),
-        'm': emails[0] if emails else None,
-        'o': emails[1:] if emails else None,
+        'm': value.get('emails'),
+        'o': value.get('old_emails'),
         'z': value.get('current'),
     }
 

--- a/inspirehep/modules/authors/forms.py
+++ b/inspirehep/modules/authors/forms.py
@@ -104,7 +104,7 @@ class InstitutionInlineForm(INSPIREForm):
         ("JUNIOR", _("Junior (leads to Senior)")),
         ("STAFF", _("Staff (non-research)")),
         ("VISITOR", _("Visitor")),
-        ("POSTDOC", _("PostDoc")),
+        ("PD", _("PostDoc")),
         ("PHD", _("PhD")),
         ("MASTER", _("Master")),
         ("UNDERGRADUATE", _("Undergrad")),
@@ -158,9 +158,26 @@ class InstitutionInlineForm(INSPIREForm):
         widget=currentCheckboxWidget
     )
 
-    email = fields.HiddenField()
+    emails = fields.FieldList(
+        fields.HiddenField(label=''),
+        widget_classes='hidden-list'
+    )
 
-    old_email = fields.HiddenField()
+    old_emails = fields.FieldList(
+        fields.HiddenField(label=''),
+        widget_classes='hidden-list'
+    )
+
+
+class EmailInlineForm(INSPIREForm):
+
+    """Public emails inline form."""
+
+    email = fields.StringField(
+        widget_classes="form-control"
+    )
+
+    original_email = fields.HiddenField()
 
 
 class ExperimentsInlineForm(INSPIREForm):
@@ -264,6 +281,23 @@ class DynamicUnsortedWidget(DynamicListWidget):
         super(DynamicUnsortedWidget, self).__init__(**kwargs)
 
 
+class DynamicUnsortedNonRemoveItemWidget(DynamicItemWidget):
+
+    def _sort_button(self):
+        return ""
+
+    def _remove_button(self):
+        return ""
+
+
+class DynamicUnsortedNonRemoveWidget(DynamicListWidget):
+
+    def __init__(self, **kwargs):
+        """Initialize dynamic list widget."""
+        self.item_widget = DynamicUnsortedNonRemoveItemWidget()
+        super(DynamicUnsortedNonRemoveWidget, self).__init__(**kwargs)
+
+
 class AuthorUpdateForm(INSPIREForm):
 
     """Author update form."""
@@ -324,11 +358,21 @@ class AuthorUpdateForm(INSPIREForm):
         widget_classes="form-control"
     )
 
-    public_email = fields.StringField(
-        label=_('Public Email'),
-        description=u"This email will be displayed online in the INSPIRE Author Profile.",
-        widget_classes="form-control",
-        validators=[validators.Optional(), validators.Email()],
+    public_emails = fields.DynamicFieldList(
+        fields.FormField(
+            EmailInlineForm,
+            widget=ExtendedListWidget(
+                item_widget=ItemWidget(),
+                html_tag='div',
+            ),
+            widget_classes="col-xs-10"
+        ),
+        description=u"This emails will be displayed online in the INSPIRE Author Profile.",
+        label='Public emails',
+        add_label='Add another email',
+        min_entries=1,
+        widget=DynamicUnsortedNonRemoveWidget(),
+        widget_classes="ui-disable-sort"
     )
 
     orcid = fields.StringField(
@@ -499,7 +543,7 @@ class AuthorUpdateForm(INSPIREForm):
     groups = [
         ('Personal Information',
             ['given_names', 'family_name', 'display_name', 'native_name', 'email',
-             'public_email', 'status', 'orcid', 'bai', 'inspireid'],
+             'public_emails', 'status', 'orcid', 'bai', 'inspireid'],
             {"icon": "fa fa-user"}
          ),
         ('Personal Websites',

--- a/inspirehep/modules/authors/static/scss/authors/authors-update-form.scss
+++ b/inspirehep/modules/authors/static/scss/authors/authors-update-form.scss
@@ -41,3 +41,9 @@ div[id^="experiments-"] .form-control {
 #field-institution_history .fa-times {
   margin-top: 30%;
 }
+
+.hidden-list {
+    li {
+        list-style-type: none;
+    }
+}

--- a/inspirehep/modules/theme/templates/inspirehep_theme/format/record/authors/Author_HTML_detailed.html
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/format/record/authors/Author_HTML_detailed.html
@@ -47,7 +47,7 @@
           <div class="col-md-2 hidden-xs hidden-sm">
             {% set email = '' %}
             {% if record.positions | length %}
-              {% set email = record['positions'][0].get('email', [''])[0] %}
+              {% set email = record['positions'][0].get('emails', [''])[0] %}
             {% endif %}
             <img class="profile-image img-circle" src="{{ email | gravatar(size=90, default='identicon') }}" data-toggle='tooltip' data-placement='left' title='Your profile picture can be set at gravatar.com' width="100%">
           </div>

--- a/tests/unit/authors/test_authors_dojson.py
+++ b/tests/unit/authors/test_authors_dojson.py
@@ -323,16 +323,45 @@ def test_ids_from_inspireid_appends():
     assert expected == result['ids']
 
 
-def test_positions_from_public_email():
-    form = GroupableOrderedDict([
-        ('public_email', 'foo'),
-    ])
+def test_positions_from_public_email_unchanged():
+    form = {
+        'public_emails': [{'email': 'foo', 'original_email': 'foo'}]
+    }
+
+    expected = []
+    result = updateform.do(form)
+
+    assert expected == result['positions']
+
+
+def test_positions_from_public_email_changed():
+    form = {
+        'public_emails': [{'email': 'bar', 'original_email': 'foo'}]
+    }
 
     expected = [
         {
-            'current': 'Current',
-            'email': 'foo',
-        },
+            'emails': ['bar'],
+            'old_emails': ['foo'],
+
+        }
+    ]
+    result = updateform.do(form)
+
+    assert expected == result['positions']
+
+
+def test_positions_from_public_email_removed():
+    form = {
+        'public_emails': [{'email': '', 'original_email': 'foo'}]
+    }
+
+    expected = [
+        {
+            'emails': [''],
+            'old_emails': ['foo'],
+
+        }
     ]
     result = updateform.do(form)
 
@@ -340,20 +369,24 @@ def test_positions_from_public_email():
 
 
 def test_positions_from_public_email_appends():
-    form = GroupableOrderedDict([
-        ('public_email', 'foo'),
-        ('public_email', 'bar'),
-    ])
+    form = {
+        'public_emails': [
+            {'email': 'foo1', 'original_email': 'foo'},
+            {'email': 'bar1', 'original_email': 'bar'}
+        ]
+    }
 
     expected = [
         {
-            'current': 'Current',
-            'email': 'foo',
+            'emails': ['foo1'],
+            'old_emails': ['foo'],
+
         },
         {
-            'current': 'Current',
-            'email': 'bar',
-        },
+            'emails': ['bar1'],
+            'old_emails': ['bar'],
+
+        }
     ]
     result = updateform.do(form)
 
@@ -383,8 +416,8 @@ def test_positions_from_institutions_history():
                 'start_year': 2009,
                 'end_year': 2010,
                 'name': 'foo',
-                'email': 'bar',
-                'old_email': 'baz',
+                'emails': ['bar'],
+                'old_emails': ['baz'],
                 'current': 'qux',
                 'rank': 'quux',
             },
@@ -392,8 +425,8 @@ def test_positions_from_institutions_history():
                 'start_year': 2010,
                 'end_year': 2012,
                 'name': 'oof',
-                'email': 'rab',
-                'old_email': 'zab',
+                'emails': ['rab'],
+                'old_emails': ['zab'],
                 'current': '',
                 'rank': 'rank',
             },
@@ -403,21 +436,21 @@ def test_positions_from_institutions_history():
     expected = [
         {
             'institution': {'name': 'oof'},
-            'status': '',
+            'current': None,
             'start_date': 2010,
             'end_date': 2012,
-            'email': 'rab',
-            'old_email': 'zab',
-            'rank': '',
+            'emails': ['rab'],
+            'old_emails': ['zab'],
+            '_rank': '',
         },
         {
             'institution': {'name': 'foo'},
-            'status': 'current',
+            'current': 'Current',
             'start_date': 2009,
             'end_date': 2010,
-            'email': 'bar',
-            'old_email': 'baz',
-            'rank': 'quux',
+            'emails': ['bar'],
+            'old_emails': ['baz'],
+            '_rank': 'quux',
         },
     ]
     result = updateform.do(form)
@@ -471,7 +504,7 @@ def test_experiments_from_experiments():
         },
         {
             'start_year': 2009,
-            'status': 'current',
+            'status': 'Current',
         },
     ]
     result = updateform.do(form)

--- a/tests/unit/authors/test_authors_views.py
+++ b/tests/unit/authors/test_authors_views.py
@@ -37,6 +37,42 @@ def test_convert_for_form_without_name_urls_fc_positions_advisors_and_ids():
     assert Record({}) == without_name_urls_fc_positions_advisors_and_ids
 
 
+def test_convert_for_form_public_emails():
+    current_and_old_emails = {
+        'positions': [
+            {
+                "emails": [
+                    "michael.abbott@uct.ac.za"
+                ]
+            },
+            {
+                "emails": [
+                    "abbott@theory.tifr.res.in"
+                ]
+            },
+            {
+                "old_emails": [
+                    "abbott@het.brown.edu"
+                ]
+            }
+        ]
+    }
+    convert_for_form(current_and_old_emails)
+
+    expected = [
+        {
+          "email": "michael.abbott@uct.ac.za",
+          "original_email": "michael.abbott@uct.ac.za"
+        },
+        {
+          "email": "abbott@theory.tifr.res.in",
+          "original_email": "abbott@theory.tifr.res.in"
+        }
+    ]
+
+    assert expected == current_and_old_emails['public_emails']
+
+
 # TODO: test convert_for_form
 
 

--- a/tests/unit/dojson/test_dojson_hepnames.py
+++ b/tests/unit/dojson/test_dojson_hepnames.py
@@ -675,8 +675,8 @@ def test_positions(marcxml_to_json, json_to_marc):
             json_to_marc['371'][0]['s'])
     assert (marcxml_to_json['positions'][0]['emails'] ==
             json_to_marc['371'][0]['m'])
-    assert (marcxml_to_json['positions'][0]['current'] ==
-            json_to_marc['371'][0]['z'])
+    assert marcxml_to_json['positions'][0]['current'] is True
+    assert json_to_marc['371'][0]['z'] == 'Current'
     assert (marcxml_to_json['positions'][1]['end_date'] ==
             json_to_marc['371'][1]['t'])
 
@@ -720,8 +720,7 @@ def test_old_single_email_from_371__a():
           ],
           "s": "2012",
           "r": "PD",
-          "t": "2013",
-          "z": False
+          "t": "2013"
         }
     ]
 
@@ -782,7 +781,7 @@ def test_positions_from_371__a_double_m_z():
         {
             'a': 'Argonne',
             'm': ['rcyoung@anl.gov', 'rcyoung@hep.anl.gov'],
-            'z': True
+            'z': 'Current'
         }
     ]
 

--- a/tests/unit/dojson/test_dojson_hepnames.py
+++ b/tests/unit/dojson/test_dojson_hepnames.py
@@ -673,10 +673,61 @@ def test_positions(marcxml_to_json, json_to_marc):
             json_to_marc['371'][0]['r'])
     assert (marcxml_to_json['positions'][0]['start_date'] ==
             json_to_marc['371'][0]['s'])
+    assert (marcxml_to_json['positions'][0]['emails'] ==
+            json_to_marc['371'][0]['m'])
     assert (marcxml_to_json['positions'][0]['current'] ==
             json_to_marc['371'][0]['z'])
     assert (marcxml_to_json['positions'][1]['end_date'] ==
             json_to_marc['371'][1]['t'])
+
+
+def test_old_single_email_from_371__a():
+    snippet = (
+        '<datafield tag="371" ind1=" " ind2=" ">'
+        '   <subfield code="a">IMSc, Chennai</subfield>'
+        '   <subfield code="o">test@imsc.res.in</subfield>'
+        '   <subfield code="r">PD</subfield>'
+        '   <subfield code="s">2012</subfield>'
+        '   <subfield code="t">2013</subfield>'
+        '</datafield>'
+    )  # record/1060782
+
+    expected = [
+        {
+          "current": False,
+          "old_emails": [
+            "test@imsc.res.in"
+          ],
+          "end_date": "2013",
+          "rank": "POSTDOC",
+          "institution": {
+            "name": "IMSc, Chennai",
+            "curated_relation": False
+          },
+          "_rank": "PD",
+          "start_date": "2012"
+        }
+    ]
+    result = hepnames.do(create_record(snippet))
+
+    assert expected == result['positions']
+
+    expected = [
+        {
+          "a": "IMSc, Chennai",
+          "o": [
+            "test@imsc.res.in"
+          ],
+          "s": "2012",
+          "r": "PD",
+          "t": "2013",
+          "z": False
+        }
+    ]
+
+    marc = hepnames2marc.do(result)
+
+    assert expected == marc['371']
 
 
 def test_positions_from_371__a():
@@ -726,6 +777,19 @@ def test_positions_from_371__a_double_m_z():
     result = hepnames.do(create_record(snippet))
 
     assert expected == result['positions']
+
+    expected = [
+        {
+            'a': 'Argonne',
+            'm': ['rcyoung@anl.gov', 'rcyoung@hep.anl.gov'],
+            'z': True
+        }
+    ]
+
+    result = hepnames2marc.do(result)
+
+    assert expected == result['371']
+
 
 
 def test_positions_from_371__a_m_r_z():


### PR DESCRIPTION
* To avoid losing information when converting from/to legacy marcxml
  keep for the moment the old and new emails on different fields.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>