### PR TITLE
authors: form output schema compliant

### DIFF
--- a/inspirehep/modules/authors/dojson/fields/updateform.py
+++ b/inspirehep/modules/authors/dojson/fields/updateform.py
@@ -186,7 +186,7 @@ def institution_history(self, key, value):
             continue
         positions.append({
             "institution": {'name': position["name"]},
-            "current": 'Current' if position["current"] else None,
+            "current": True if position.get("current") else False,
             "start_date": position["start_year"],
             "end_date": position["end_year"],
             "emails": position.get("emails", ""),
@@ -208,7 +208,7 @@ def advisors(self, key, value):
             continue
         advisors.append({
             "name": advisor["full_name"],
-            "degree_type": advisor["degree_type"]
+            "_degree_type": advisor["degree_type"]
         })
 
     return advisors
@@ -221,9 +221,10 @@ def experiments(self, key, value):
                    key=lambda k: k["start_year"],
                    reverse=True)
     for experiment in value:
-        experiment["status"] = "Current" if experiment["status"] else ""
+        experiment["current"] = True if experiment["status"] else False
         _set_int_or_del(experiment, "start_year", experiment.get("start_year"))
         _set_int_or_del(experiment, "end_year", experiment.get("end_year"))
+        del experiment["status"]
         experiments.append(experiment)
 
     return experiments

--- a/inspirehep/modules/authors/views/holdingpen.py
+++ b/inspirehep/modules/authors/views/holdingpen.py
@@ -149,7 +149,7 @@ def convert_for_form(data):
         for advisor in advisors:
             adv = {}
             adv["name"] = advisor.get("name", "")
-            adv["degree_type"] = advisor.get("degree_type", "")
+            adv["degree_type"] = advisor.get("_degree_type", "")
             data["advisors"].append(adv)
     if "ids" in data:
         for id in data["ids"]:

--- a/tests/unit/authors/test_authors_dojson.py
+++ b/tests/unit/authors/test_authors_dojson.py
@@ -436,7 +436,7 @@ def test_positions_from_institutions_history():
     expected = [
         {
             'institution': {'name': 'oof'},
-            'current': None,
+            'current': False,
             'start_date': 2010,
             'end_date': 2012,
             'emails': ['rab'],
@@ -445,7 +445,7 @@ def test_positions_from_institutions_history():
         },
         {
             'institution': {'name': 'foo'},
-            'current': 'Current',
+            'current': True,
             'start_date': 2009,
             'end_date': 2010,
             'emails': ['bar'],
@@ -474,7 +474,7 @@ def test_advisors_from_advisors():
 
     expected = [
         {
-            'degree_type': 'PhD',
+            '_degree_type': 'PhD',
             'name': 'foo',
         },
     ]
@@ -500,11 +500,11 @@ def test_experiments_from_experiments():
     expected = [
         {
             'start_year': 2010,
-            'status': ''
+            'current': False
         },
         {
             'start_year': 2009,
-            'status': 'Current',
+            'current': True,
         },
     ]
     result = updateform.do(form)


### PR DESCRIPTION
* Makes sure the output of the author creation form is compliant with
  the json schema, to be able to save the author locally.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>