### PR TITLE
packaging: remove scrapyd dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,6 @@ extras_require = {
         'invenio-migrator>=1.0.0a6',
     ],
     'crawler': [
-        'scrapyd',
         'hepcrawl>=0.2.42',
     ],
     'tests': tests_require,


### PR DESCRIPTION
It will be pulled in by hepcrawl if needed.

Signed-off-by: David Caro <david@dcaro.es>