### PR TITLE
WIP: use recid as pid_type

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -354,9 +354,24 @@ SEARCH_ELASTIC_KEYWORD_MAPPING = {
 # Records
 # =======
 RECORDS_REST_ENDPOINTS = dict(
-    literature=dict(
+    record=dict(
         default_endpoint_prefix=True,
-        pid_type='lit',
+        pid_type='recid',
+        list_route='/record/',
+        item_route=(
+            '/record'
+            '/<pid(recid,record_class="inspirehep.modules.records.es_record:ESRecord"):pid_value>'),
+        record_serializers={
+            'application/json': ('invenio_records_rest.serializers'
+                                 ':json_v1_response'),
+        },
+        search_serializers={
+            'application/json': ('invenio_records_rest.serializers'
+                                 ':json_v1_search'),
+        }
+    ),
+    literature=dict(
+        pid_type='recid',
         pid_minter='inspire_recid_minter',
         pid_fetcher='inspire_recid_fetcher',
         search_class='inspirehep.modules.search:LiteratureSearch',
@@ -413,7 +428,7 @@ RECORDS_REST_ENDPOINTS = dict(
         list_route='/literature/',
         item_route=(
             '/literature'
-            '/<pid(lit,record_class="inspirehep.modules.records.es_record:ESRecord"):pid_value>'),
+            '/<pid(recid,record_class="inspirehep.modules.records.es_record:ESRecord"):pid_value>'),
         default_media_type='application/json',
         max_result_window=10000,
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
@@ -424,13 +439,13 @@ RECORDS_REST_ENDPOINTS = dict(
         default_media_type='application/json',
         item_route=(
             '/literature'
-            '/<pid(lit,record_class="inspirehep.modules.records.es_record:ESRecord"):pid_value>'
+            '/<pid(recid,record_class="inspirehep.modules.records.es_record:ESRecord"):pid_value>'
             '/citesummary'),
         list_route='/literature/',
         max_result_window=10000,
         pid_fetcher='inspire_recid_fetcher',
         pid_minter='inspire_recid_minter',
-        pid_type='lit',
+        pid_type='recid',
         record_serializers={
             'application/json': (
                 'inspirehep.modules.api.v1.literature:citesummary_response')
@@ -444,7 +459,7 @@ RECORDS_REST_ENDPOINTS = dict(
         },
     ),
     literature_db=dict(
-        pid_type='lit',
+        pid_type='recid',
         search_class='inspirehep.modules.search:LiteratureSearch',
         record_serializers={
             'application/json': ('invenio_records_rest.serializers'
@@ -455,14 +470,13 @@ RECORDS_REST_ENDPOINTS = dict(
                                  ':json_v1_search')
         },
         list_route='/literature/db',
-        item_route='/literature/<pid(lit):pid_value>/db',
+        item_route='/literature/<pid(recid):pid_value>/db',
         default_media_type='application/json',
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory'
 
     ),
     authors=dict(
-        default_endpoint_prefix=True,
-        pid_type='aut',
+        pid_type='recid',
         pid_minter='inspire_recid_minter',
         pid_fetcher='inspire_recid_fetcher',
         search_class='inspirehep.modules.search:AuthorsSearch',
@@ -479,13 +493,13 @@ RECORDS_REST_ENDPOINTS = dict(
             ),
         },
         list_route='/authors/',
-        item_route='/authors/<pid(aut):pid_value>',
+        item_route='/authors/<pid(recid):pid_value>',
         default_media_type='application/json',
         max_result_window=10000,
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
     ),
     authors_citations=dict(
-        pid_type='aut',
+        pid_type='recid',
         pid_minter='inspire_recid_minter',
         pid_fetcher='inspire_recid_fetcher',
         search_class='inspirehep.modules.search:AuthorsSearch',
@@ -502,7 +516,7 @@ RECORDS_REST_ENDPOINTS = dict(
             ),
         },
         list_route='/authors/',
-        item_route='/authors/<pid(aut):pid_value>/citations',
+        item_route='/authors/<pid(recid):pid_value>/citations',
         default_media_type='application/json',
         max_result_window=10000,
         search_factory_imp=('inspirehep.modules.search.query'
@@ -510,12 +524,12 @@ RECORDS_REST_ENDPOINTS = dict(
     ),
     authors_citesummary=dict(
         default_media_type='application/json',
-        item_route='/authors/<pid(aut):pid_value>/citesummary',
+        item_route='/authors/<pid(recid):pid_value>/citesummary',
         list_route='/authors/',
         max_result_window=10000,
         pid_fetcher='inspire_recid_fetcher',
         pid_minter='inspire_recid_minter',
-        pid_type='aut',
+        pid_type='recid',
         record_serializers={
             'application/json': (
                 'inspirehep.modules.api.v1.authors:citesummary_response'),
@@ -531,7 +545,7 @@ RECORDS_REST_ENDPOINTS = dict(
         },
     ),
     authors_coauthors=dict(
-        pid_type='aut',
+        pid_type='recid',
         pid_minter='inspire_recid_minter',
         pid_fetcher='inspire_recid_fetcher',
         search_class='inspirehep.modules.search:AuthorsSearch',
@@ -548,14 +562,14 @@ RECORDS_REST_ENDPOINTS = dict(
             ),
         },
         list_route='/authors/',
-        item_route='/authors/<pid(aut):pid_value>/coauthors',
+        item_route='/authors/<pid(recid):pid_value>/coauthors',
         default_media_type='application/json',
         max_result_window=10000,
         search_factory_imp=('inspirehep.modules.search.query'
                             ':inspire_search_factory'),
     ),
     authors_publications=dict(
-        pid_type='aut',
+        pid_type='recid',
         pid_minter='inspire_recid_minter',
         pid_fetcher='inspire_recid_fetcher',
         search_class='inspirehep.modules.search:AuthorsSearch',
@@ -572,14 +586,14 @@ RECORDS_REST_ENDPOINTS = dict(
             ),
         },
         list_route='/authors/',
-        item_route='/authors/<pid(aut):pid_value>/publications',
+        item_route='/authors/<pid(recid):pid_value>/publications',
         default_media_type='application/json',
         max_result_window=10000,
         search_factory_imp=('inspirehep.modules.search.query'
                             ':inspire_search_factory'),
     ),
     authors_stats=dict(
-        pid_type='aut',
+        pid_type='recid',
         pid_minter='inspire_recid_minter',
         pid_fetcher='inspire_recid_fetcher',
         search_class='inspirehep.modules.search:AuthorsSearch',
@@ -596,15 +610,14 @@ RECORDS_REST_ENDPOINTS = dict(
             ),
         },
         list_route='/authors/',
-        item_route='/authors/<pid(aut):pid_value>/stats',
+        item_route='/authors/<pid(recid):pid_value>/stats',
         default_media_type='application/json',
         max_result_window=10000,
         search_factory_imp=('inspirehep.modules.search.query'
                             ':inspire_search_factory'),
     ),
     data=dict(
-        default_endpoint_prefix=True,
-        pid_type='dat',
+        pid_type='recid',
         pid_minter='inspire_recid_minter',
         pid_fetcher='inspire_recid_fetcher',
         search_class='inspirehep.modules.search:DataSearch',
@@ -621,14 +634,13 @@ RECORDS_REST_ENDPOINTS = dict(
             ),
         },
         list_route='/data/',
-        item_route='/data/<pid(dat):pid_value>',
+        item_route='/data/<pid(recid):pid_value>',
         default_media_type='application/json',
         max_result_window=10000,
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
     ),
     conferences=dict(
-        default_endpoint_prefix=True,
-        pid_type='con',
+        pid_type='recid',
         pid_minter='inspire_recid_minter',
         pid_fetcher='inspire_recid_fetcher',
         search_class='inspirehep.modules.search:ConferencesSearch',
@@ -645,14 +657,13 @@ RECORDS_REST_ENDPOINTS = dict(
             ),
         },
         list_route='/conferences/',
-        item_route='/conferences/<pid(con):pid_value>',
+        item_route='/conferences/<pid(recid):pid_value>',
         default_media_type='application/json',
         max_result_window=10000,
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
     ),
     jobs=dict(
-        default_endpoint_prefix=True,
-        pid_type='job',
+        pid_type='recid',
         pid_minter='inspire_recid_minter',
         pid_fetcher='inspire_recid_fetcher',
         search_class='inspirehep.modules.search:JobsSearch',
@@ -669,14 +680,13 @@ RECORDS_REST_ENDPOINTS = dict(
             ),
         },
         list_route='/jobs/',
-        item_route='/jobs/<pid(job):pid_value>',
+        item_route='/jobs/<pid(recid):pid_value>',
         default_media_type='application/json',
         max_result_window=10000,
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
     ),
     institutions=dict(
-        default_endpoint_prefix=True,
-        pid_type='ins',
+        pid_type='recid',
         pid_minter='inspire_recid_minter',
         pid_fetcher='inspire_recid_fetcher',
         search_class='inspirehep.modules.search:InstitutionsSearch',
@@ -693,7 +703,7 @@ RECORDS_REST_ENDPOINTS = dict(
             ),
         },
         list_route='/institutions/',
-        item_route='/institutions/<pid(ins):pid_value>',
+        item_route='/institutions/<pid(recid):pid_value>',
         default_media_type='application/json',
         max_result_window=10000,
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
@@ -701,12 +711,12 @@ RECORDS_REST_ENDPOINTS = dict(
     institutions_citesummary=dict(
         default_media_type='application/json',
         item_route=(
-            '/institutions/<pid(ins):pid_value>/citesummary'),
+            '/institutions/<pid(recid):pid_value>/citesummary'),
         list_route='/institutions/',
         max_result_window=10000,
         pid_fetcher='inspire_recid_fetcher',
         pid_minter='inspire_recid_minter',
-        pid_type='ins',
+        pid_type='recid',
         record_serializers={
             'application/json': (
                 'inspirehep.modules.api.v1.institutions:citesummary_response'),
@@ -721,8 +731,7 @@ RECORDS_REST_ENDPOINTS = dict(
         },
     ),
     experiments=dict(
-        default_endpoint_prefix=True,
-        pid_type='exp',
+        pid_type='recid',
         pid_minter='inspire_recid_minter',
         pid_fetcher='inspire_recid_fetcher',
         search_class='inspirehep.modules.search:ExperimentsSearch',
@@ -739,7 +748,7 @@ RECORDS_REST_ENDPOINTS = dict(
             ),
         },
         list_route='/experiments/',
-        item_route='/experiments/<pid(exp):pid_value>',
+        item_route='/experiments/<pid(recid):pid_value>',
         default_media_type='application/json',
         max_result_window=10000,
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
@@ -747,12 +756,12 @@ RECORDS_REST_ENDPOINTS = dict(
     experiments_citesummary=dict(
         default_media_type='application/json',
         item_route=(
-            '/experiments/<pid(exp):pid_value>/citesummary'),
+            '/experiments/<pid(recid):pid_value>/citesummary'),
         list_route='/experiments/',
         max_result_window=10000,
         pid_fetcher='inspire_recid_fetcher',
         pid_minter='inspire_recid_minter',
-        pid_type='exp',
+        pid_type='recid',
         record_serializers={
             'application/json': (
                 'inspirehep.modules.api.v1.experiments:citesummary_response'),
@@ -767,8 +776,7 @@ RECORDS_REST_ENDPOINTS = dict(
         },
     ),
     journals=dict(
-        default_endpoint_prefix=True,
-        pid_type='jou',
+        pid_type='recid',
         pid_minter='inspire_recid_minter',
         pid_fetcher='inspire_recid_fetcher',
         search_class='inspirehep.modules.search:JournalsSearch',
@@ -785,7 +793,7 @@ RECORDS_REST_ENDPOINTS = dict(
             ),
         },
         list_route='/journals/',
-        item_route='/journals/<pid(jou):pid_value>',
+        item_route='/journals/<pid(recid):pid_value>',
         default_media_type='application/json',
         max_result_window=10000,
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
@@ -793,12 +801,12 @@ RECORDS_REST_ENDPOINTS = dict(
     journals_citesummary=dict(
         default_media_type='application/json',
         item_route=(
-            '/journals/<pid(jou):pid_value>/citesummary'),
+            '/journals/<pid(recid):pid_value>/citesummary'),
         list_route='/journals/',
         max_result_window=10000,
         pid_fetcher='inspire_recid_fetcher',
         pid_minter='inspire_recid_minter',
-        pid_type='jou',
+        pid_type='recid',
         record_serializers={
             'application/json': (
                 'inspirehep.modules.api.v1.journals:citesummary_response'),
@@ -820,50 +828,50 @@ RECORDS_UI_DEFAULT_PERMISSION_FACTORY = \
 
 RECORDS_UI_ENDPOINTS = dict(
     literature=dict(
-        pid_type='lit',
+        pid_type='recid',
         route='/literature/<pid_value>',
         template='inspirehep_theme/format/record/'
                  'Inspire_Default_HTML_detailed.tpl',
         record_class='inspirehep.modules.records.wrappers:LiteratureRecord',
     ),
     authors=dict(
-        pid_type='aut',
+        pid_type='recid',
         route='/authors/<pid_value>',
         template='inspirehep_theme/format/record/'
                  'authors/Author_HTML_detailed.html',
         record_class='inspirehep.modules.records.wrappers:AuthorsRecord',
     ),
     data=dict(
-        pid_type='dat',
+        pid_type='recid',
         route='/data/<pid_value>',
         template='inspirehep_theme/format/record/Data_HTML_detailed.tpl'
     ),
     conferences=dict(
-        pid_type='con',
+        pid_type='recid',
         route='/conferences/<pid_value>',
         template='inspirehep_theme/format/record/Conference_HTML_detailed.tpl',
         record_class='inspirehep.modules.records.wrappers:ConferencesRecord',
     ),
     jobs=dict(
-        pid_type='job',
+        pid_type='recid',
         route='/jobs/<pid_value>',
         template='inspirehep_theme/format/record/Job_HTML_detailed.tpl',
         record_class='inspirehep.modules.records.wrappers:JobsRecord',
     ),
     institutions=dict(
-        pid_type='ins',
+        pid_type='recid',
         route='/institutions/<pid_value>',
         template='inspirehep_theme/format/record/Institution_HTML_detailed.tpl',
         record_class='inspirehep.modules.records.wrappers:InstitutionsRecord',
     ),
     experiments=dict(
-        pid_type='exp',
+        pid_type='recid',
         route='/experiments/<pid_value>',
         template='inspirehep_theme/format/record/Experiment_HTML_detailed.tpl',
         record_class='inspirehep.modules.records.wrappers:ExperimentsRecord',
     ),
     journals=dict(
-        pid_type='jou',
+        pid_type='recid',
         route='/journals/<pid_value>',
         template='inspirehep_theme/format/record/Journal_HTML_detailed.tpl',
         record_class='inspirehep.modules.records.wrappers:JournalsRecord',
@@ -1313,7 +1321,7 @@ ORCID_ID_FETCHER = 'inspirehep.modules.orcid.utils:get_orcid_id'
 
 ORCID_AUTHORS_SEARCH_CLASS = 'inspirehep.modules.search:AuthorsSearch'
 
-ORCID_RECORDS_PID_TYPE = 'lit'
+ORCID_RECORDS_PID_TYPE = 'recid'
 ORCID_RECORDS_DOC_TYPE = 'hep'
 ORCID_RECORDS_PID_FETCHER = 'inspire_recid_fetcher'
 

--- a/inspirehep/modules/hal/tei.py
+++ b/inspirehep/modules/hal/tei.py
@@ -122,7 +122,7 @@ def _parse_structures(record):
                 continue
 
     try:
-        records = get_es_records('ins', recids)
+        records = get_es_records('institutions', recids)
     except RequestError:
         records = []
 

--- a/inspirehep/modules/migrator/tasks/records.py
+++ b/inspirehep/modules/migrator/tasks/records.py
@@ -324,7 +324,7 @@ def record_upsert(json):
         if json.get('deleted'):
             new_recid = get_recid_from_ref(json.get('new_record'))
             if new_recid:
-                merged_record = get_db_record(pid_type, new_recid)
+                merged_record = get_db_record(new_recid)
                 merge_pidstores_of_two_merged_records(merged_record.id, record.id)
             else:
                 soft_delete_pidstore_for_record(record.id)

--- a/inspirehep/modules/pidstore/utils.py
+++ b/inspirehep/modules/pidstore/utils.py
@@ -38,14 +38,14 @@ def _get_pid_type_endpoint_map():
     return pid_type_endpoint_map
 
 
-def get_endpoint_from_pid_type(pid_type):
+def get_endpoint_from_pid_type(pid_type='recid'):
     """Return the endpoint corresponding to a ``pid_type``."""
     PID_TYPE_TO_ENDPOINT = _get_pid_type_endpoint_map()
 
     return PID_TYPE_TO_ENDPOINT[pid_type]
 
 
-def get_pid_type_from_endpoint(endpoint):
+def get_pid_type_from_endpoint(endpoint='literature'):
     """Return the ``pid_type`` corresponding to an endpoint."""
     ENDPOINT_TO_PID_TYPE = {
         v: k for k, v in iteritems(_get_pid_type_endpoint_map())}
@@ -60,11 +60,12 @@ def get_pid_type_from_schema(schema):
     Literature records. This implementation exploits this by falling back to
     ``get_pid_type_from_endpoint``.
     """
-    def _get_schema_name_from_schema(schema):
-        return urlsplit(schema).path.split('/')[-1].split('.')[0]
+    # def _get_schema_name_from_schema(schema):
+    #     return urlsplit(schema).path.split('/')[-1].split('.')[0]
 
-    schema_name = _get_schema_name_from_schema(schema)
-    if schema_name == 'hep':  # FIXME: remove when hep.json -> literature.json
-        return 'lit'
+    # schema_name = _get_schema_name_from_schema(schema)
+    # if schema_name == 'hep':  # FIXME: remove when hep.json -> literature.json
+    #     return 'recid'
 
-    return get_pid_type_from_endpoint(schema_name)
+    # return get_pid_type_from_endpoint(schema_name)
+    return 'recid'

--- a/inspirehep/modules/records/es_record.py
+++ b/inspirehep/modules/records/es_record.py
@@ -43,10 +43,10 @@ class ESRecord(Record):
     """Record class that fetches records from ElasticSearch."""
 
     @classmethod
-    def get_record(cls, object_uuid, with_deleted=False):
+    def get_record(cls, object_uuid, with_deleted=False, endpoint='literature'):
         """Get record instance from ElasticSearch."""
         try:
-            return cls(get_es_record_by_uuid(object_uuid))
+            return cls(get_es_record_by_uuid(endpoint, object_uuid))
         except RecordGetterError as e:
             if isinstance(e.cause, NotFoundError):
                 # Raise this error so the interface will render a 404 page

--- a/inspirehep/modules/records/json_ref_loader.py
+++ b/inspirehep/modules/records/json_ref_loader.py
@@ -46,6 +46,7 @@ class AbstractRecordLoader(JsonLoader):
         raise NotImplementedError()
 
     def get_remote_json(self, uri, **kwargs):
+        # import pytest; pytest.set_trace()
         parsed_uri = url_parse(uri)
         # Add http:// protocol so uri.netloc is correctly parsed.
         server_name = current_app.config.get('SERVER_NAME')
@@ -62,27 +63,29 @@ class AbstractRecordLoader(JsonLoader):
             return None
 
         endpoint = path_parts[-2]
-        pid_type = get_pid_type_from_endpoint(endpoint)
+        # pid_type = get_pid_type_from_endpoint(endpoint)
         recid = path_parts[-1]
-        res = self.get_record(pid_type, recid)
+        res = self.get_record(endpoint, recid)
         return res
 
 
 class ESJsonLoader(AbstractRecordLoader):
     """Resolve resources by retrieving them from Elasticsearch."""
 
-    def get_record(self, pid_type, recid):
+    def get_record(self, endpoint, recid):
         try:
-            return record_getter.get_es_record(pid_type, recid)
+            # import pytest; pytest.set_trace()
+            return record_getter.get_es_record(endpoint, recid)
         except record_getter.RecordGetterError:
             return None
 
 
 class DatabaseJsonLoader(AbstractRecordLoader):
 
-    def get_record(self, pid_type, recid):
+    def get_record(self, endpoint, recid):
         try:
-            return record_getter.get_db_record(pid_type, recid)
+            # import pytest; pytest.set_trace()
+            return record_getter.get_db_record(recid)
         except record_getter.RecordGetterError:
             return None
 

--- a/inspirehep/modules/records/receivers.py
+++ b/inspirehep/modules/records/receivers.py
@@ -361,13 +361,13 @@ def check_if_record_is_going_to_be_deleted(sender, *args, **kwargs):
     """
     control_number = int(sender.get('control_number'))
     pid_type = get_pid_type_from_schema(sender.get('$schema'))
-    record = get_db_record(pid_type, control_number)
+    record = get_db_record(control_number)
 
     if sender.get('deleted'):
         new_recid = get_recid_from_ref(sender.get('new_record'))
         if new_recid:
-            merged_record = get_db_record(pid_type, new_recid)
+            merged_record = get_db_record(new_recid)
             merge_pidstores_of_two_merged_records(merged_record.id, record.id)
         else:
-            record = get_db_record(pid_type, control_number)
+            record = get_db_record(control_number)
             soft_delete_pidstore_for_record(record.id)

--- a/inspirehep/modules/records/wrappers.py
+++ b/inspirehep/modules/records/wrappers.py
@@ -31,6 +31,13 @@ from inspirehep.modules.search import JobsSearch
 class LiteratureRecord(ESRecord):
     """Record class specialized for literature records."""
 
+    @classmethod
+    def get_record(cls, object_uuid):
+        return super(LiteratureRecord, cls).get_record(
+            object_uuid,
+            endpoint='literature'
+        )
+
     @property
     def title(self):
         """Get preferred title."""
@@ -106,6 +113,13 @@ class LiteratureRecord(ESRecord):
 class AuthorsRecord(ESRecord):
     """Record class specialized for author records."""
 
+    @classmethod
+    def get_record(cls, object_uuid):
+        return super(AuthorsRecord, cls).get_record(
+            object_uuid,
+            endpoint='authors'
+        )
+
     @property
     def title(self):
         """Get preferred title."""
@@ -115,6 +129,13 @@ class AuthorsRecord(ESRecord):
 class ConferencesRecord(ESRecord):
     """Record class specialized for conference records."""
 
+    @classmethod
+    def get_record(cls, object_uuid):
+        return super(ConferencesRecord, cls).get_record(
+            object_uuid,
+            endpoint='conferences'
+        )
+
     @property
     def title(self):
         """Get preferred title."""
@@ -123,6 +144,13 @@ class ConferencesRecord(ESRecord):
 
 class JobsRecord(ESRecord):
     """Record class specialized for job records."""
+
+    @classmethod
+    def get_record(cls, object_uuid):
+        return super(JobsRecord, cls).get_record(
+            object_uuid,
+            endpoint='jobs'
+        )
 
     @property
     def title(self):
@@ -154,6 +182,13 @@ class JobsRecord(ESRecord):
 class InstitutionsRecord(ESRecord):
     """Record class specialized for institution records."""
 
+    @classmethod
+    def get_record(cls, object_uuid):
+        return super(InstitutionsRecord, cls).get_record(
+            object_uuid,
+            endpoint='institutions'
+        )
+
     @property
     def title(self):
         """Get preferred title."""
@@ -165,6 +200,13 @@ class InstitutionsRecord(ESRecord):
 class ExperimentsRecord(ESRecord):
     """Record class specialized for experiment records."""
 
+    @classmethod
+    def get_record(cls, object_uuid):
+        return super(ExperimentsRecord, cls).get_record(
+            object_uuid,
+            endpoint='experiments'
+        )
+
     @property
     def title(self):
         """Get preferred title."""
@@ -175,6 +217,13 @@ class ExperimentsRecord(ESRecord):
 
 class JournalsRecord(ESRecord):
     """Record class specialized for journal records."""
+
+    @classmethod
+    def get_record(cls, object_uuid):
+        return super(JournalsRecord, cls).get_record(
+            object_uuid,
+            endpoint='journals'
+        )
 
     @property
     def title(self):

--- a/inspirehep/modules/references/view_utils.py
+++ b/inspirehep/modules/references/view_utils.py
@@ -49,7 +49,7 @@ class Reference(object):
             ]
 
             resolved_references = get_es_records(
-                'lit',
+                'literature',
                 reference_recids,
                 _source=[
                     'control_number',

--- a/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Inspire_Default_HTML_detailed.tpl
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Inspire_Default_HTML_detailed.tpl
@@ -131,7 +131,7 @@
       ) {
         DataTables.attachTo(document, {
           'recid': "{{ record.control_number }}",
-          'collection': "literature",
+          'endpoint': "literature",
           {% if record['series'] %}
             'seriesname' : "{{ record['series'][0] }}"
           {% endif %}

--- a/inspirehep/utils/bibtex.py
+++ b/inspirehep/utils/bibtex.py
@@ -647,7 +647,7 @@ class Bibtex(Export):
                 try:
                     if journal and (volume != '' or pages != ''):
                         recid = self.record['control_number', '']
-                        record = get_es_record('jou', recid)
+                        record = get_es_record('journals', recid)
                         coden = ','.join(
                             [record['coden'][0], volume, pages])
                         return coden

--- a/inspirehep/utils/export.py
+++ b/inspirehep/utils/export.py
@@ -133,7 +133,7 @@ class Export(object):
     def _get_citation_number(self):
         """Returns how many times record was cited. If 0, returns nothing"""
         today = time.strftime("%d %b %Y")
-        record = get_es_record('lit', self.record['control_number'])
+        record = get_es_record('literature', self.record['control_number'])
         citations = ''
         try:
             times_cited = record['citation_count']

--- a/inspirehep/utils/latex.py
+++ b/inspirehep/utils/latex.py
@@ -284,7 +284,7 @@ class Latex(Export):
                 try:
                     if journal and (volume != '' or pages != ''):
                         recid = self.record['control_number', '']
-                        record = get_es_record('jou', recid)
+                        record = get_es_record('journals', recid)
                         coden = ','.join(
                             [record['coden'][0], volume, pages])
                         return coden

--- a/inspirehep/utils/record_getter.py
+++ b/inspirehep/utils/record_getter.py
@@ -64,17 +64,16 @@ def raise_record_getter_error_and_log(f):
 
 
 @raise_record_getter_error_and_log
-def get_es_record(pid_type, recid, **kwargs):
-    pid = PersistentIdentifier.get(pid_type, recid)
+def get_es_record(endpoint, recid, **kwargs):
+    pid = PersistentIdentifier.get('recid', recid)
 
-    endpoint = get_endpoint_from_pid_type(pid_type)
     search_conf = current_app.config['RECORDS_REST_ENDPOINTS'][endpoint]
     search_class = import_string(search_conf['search_class'])()
 
     return search_class.get_source(pid.object_uuid, **kwargs)
 
 
-def get_es_records(pid_type, recids, **kwargs):
+def get_es_records(endpoint, recids, **kwargs):
     """Get a list of recids from ElasticSearch.
 
     :param pid_type: pid type of recids.
@@ -85,11 +84,10 @@ def get_es_records(pid_type, recids, **kwargs):
     """
     uuids = PersistentIdentifier.query.filter(
         PersistentIdentifier.pid_value.in_(recids),
-        PersistentIdentifier.pid_type == pid_type
+        PersistentIdentifier.pid_type == 'recid'
     ).all()
     uuids = [str(uuid.object_uuid) for uuid in uuids]
 
-    endpoint = get_endpoint_from_pid_type(pid_type)
     search_conf = current_app.config['RECORDS_REST_ENDPOINTS'][endpoint]
     search_class = import_string(search_conf['search_class'])()
 
@@ -97,10 +95,7 @@ def get_es_records(pid_type, recids, **kwargs):
 
 
 @raise_record_getter_error_and_log
-def get_es_record_by_uuid(uuid):
-    pid = PersistentIdentifier.query.filter_by(object_uuid=uuid).one()
-
-    endpoint = get_endpoint_from_pid_type(pid.pid_type)
+def get_es_record_by_uuid(endpoint, uuid):
     search_conf = current_app.config['RECORDS_REST_ENDPOINTS'][endpoint]
     search_class = import_string(search_conf['search_class'])()
 
@@ -108,6 +103,6 @@ def get_es_record_by_uuid(uuid):
 
 
 @raise_record_getter_error_and_log
-def get_db_record(pid_type, recid):
-    pid = PersistentIdentifier.get(pid_type, recid)
+def get_db_record(recid):
+    pid = PersistentIdentifier.get('recid', recid)
     return Record.get_record(pid.object_uuid)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -53,23 +53,23 @@ def app():
         from inspirehep.modules.fixtures.files import init_all_storage_paths
         from inspirehep.modules.fixtures.users import init_users_and_permissions
 
-        db.drop_all()
-        db.create_all()
+        # db.drop_all()
+        # db.create_all()
 
-        sleep(10)  # Makes sure that ES is up.
-        _es = app.extensions['invenio-search']
-        list(_es.delete(ignore=[404]))
-        list(_es.create(ignore=[400]))
+        # sleep(10)  # Makes sure that ES is up.
+        # _es = app.extensions['invenio-search']
+        # list(_es.delete(ignore=[404]))
+        # list(_es.create(ignore=[400]))
 
-        init_all_storage_paths()
-        init_users_and_permissions()
-        init_collections()
+        # init_all_storage_paths()
+        # init_users_and_permissions()
+        # init_collections()
 
-        migrate('./inspirehep/demosite/data/demo-records.xml.gz', wait_for_results=True)
-        es.indices.refresh('records-hep')  # Makes sure that all HEP records were migrated.
+        # migrate('./inspirehep/demosite/data/demo-records.xml.gz', wait_for_results=True)
+        # es.indices.refresh('records-hep')  # Makes sure that all HEP records were migrated.
 
-        add_citation_counts()
-        es.indices.refresh('records-hep')  # Makes sure that all citation counts were added.
+        # add_citation_counts()
+        # es.indices.refresh('records-hep')  # Makes sure that all citation counts were added.
 
         yield app
 

--- a/tests/integration/disambiguation/test_daemon.py
+++ b/tests/integration/disambiguation/test_daemon.py
@@ -42,8 +42,8 @@ def test_count_phonetic_block_dispatched(small_app):
 
     # Signature #1.
     glashow_record_id = str(PersistentIdentifier.get(
-        "literature", 4328).object_uuid)
-    glashow_record = get_es_record_by_uuid(glashow_record_id)
+        "recid", 4328).object_uuid)
+    glashow_record = get_es_record_by_uuid("literature", glashow_record_id)
 
     # Add phonetic block to the record.
     glashow_record['authors'][0]['signature_block'] = "GLASs"
@@ -53,8 +53,8 @@ def test_count_phonetic_block_dispatched(small_app):
 
     # Signature #2.
     higgs_record_id_first = str(PersistentIdentifier.get(
-        "literature", 1358492).object_uuid)
-    higgs_record_first = get_es_record_by_uuid(higgs_record_id_first)
+        "recid", 1358492).object_uuid)
+    higgs_record_first = get_es_record_by_uuid("literature", higgs_record_id_first)
 
     # Add phonetic block to the record.
     higgs_record_first['authors'][0]['signature_block'] = "HAGp"
@@ -64,8 +64,8 @@ def test_count_phonetic_block_dispatched(small_app):
 
     # Signature #3.
     higgs_record_id_second = str(PersistentIdentifier.get(
-        "literature", 11883).object_uuid)
-    higgs_record_second = get_es_record_by_uuid(higgs_record_id_second)
+        "recid", 11883).object_uuid)
+    higgs_record_second = get_es_record_by_uuid("literature", higgs_record_id_second)
 
     # Add phonetic block to the record.
     higgs_record_second['authors'][0]['signature_block'] = "HAGp"

--- a/tests/integration/disambiguation/test_logic.py
+++ b/tests/integration/disambiguation/test_logic.py
@@ -29,7 +29,7 @@ from inspirehep.modules.disambiguation.logic import _create_distance_signature
 
 def test_create_distance_signature_method(small_app):
     """Test the method responsible for creating data in Beard format."""
-    pid = PersistentIdentifier.get('lit', 4328)
+    pid = PersistentIdentifier.get('recid', 4328)
     publication_id = str(pid.object_uuid)
 
     signatures_map = {

--- a/tests/integration/disambiguation/test_receivers.py
+++ b/tests/integration/disambiguation/test_receivers.py
@@ -92,7 +92,7 @@ def test_append_new_record_to_queue_method_not_hep_record(small_app):
 
 def test_append_updated_record_to_queue(small_app):
     """Test the receiver responsible for queuing updated HEP records."""
-    pid = PersistentIdentifier.get('lit', 4328)
+    pid = PersistentIdentifier.get('recid', 4328)
     publication_id = str(pid.object_uuid)
     record = Record.get_record(publication_id)
 
@@ -159,7 +159,7 @@ def test_append_updated_record_to_queue_not_hep_record(small_app):
 
 def test_append_updated_record_to_queue_same_data(small_app):
     """Check if for the same record, the receiver will skip the publication."""
-    pid = PersistentIdentifier.get('lit', 11883)
+    pid = PersistentIdentifier.get('recid', 11883)
     publication_id = str(pid.object_uuid)
     record = Record.get_record(publication_id)
 

--- a/tests/integration/disambiguation/test_records.py
+++ b/tests/integration/disambiguation/test_records.py
@@ -48,7 +48,7 @@ def test_create_author_method(small_app):
     }
 
     recid = create_author(signature)
-    pid = PersistentIdentifier.get('aut', recid)
+    pid = PersistentIdentifier.get('recid', recid)
     record = Record.get_record(pid.object_uuid)
 
     assert record['collections'] == [{'primary': 'HEPNAMES'}]
@@ -61,7 +61,7 @@ def test_update_authors_recid_method(small_app):
     """Test the method responsible for updating author's recid."""
     from inspirehep.modules.disambiguation.tasks import update_authors_recid
 
-    pid = PersistentIdentifier.get('lit', 4328)
+    pid = PersistentIdentifier.get('recid', 4328)
     publication_id = str(pid.object_uuid)
 
     signature = Record.get_record(publication_id)['authors'][0]['uuid']

--- a/tests/integration/disambiguation/test_workflows.py
+++ b/tests/integration/disambiguation/test_workflows.py
@@ -54,8 +54,8 @@ def test_single_signature_with_no_profile(small_app):
         update_authors_recid
     )
 
-    record_id = str(PersistentIdentifier.get('lit', 11883).object_uuid)
-    record = get_es_record_by_uuid(record_id)
+    record_id = str(PersistentIdentifier.get('recid', 11883).object_uuid)
+    record = get_es_record_by_uuid('literature', record_id)
     author_uuid = record['authors'][0]['uuid']
 
     # Add phonetic block to the record.
@@ -80,8 +80,8 @@ def test_match_signature_with_existing_profile(small_app):
         update_authors_recid
     )
 
-    old_record_id = str(PersistentIdentifier.get('lit', 11883).object_uuid)
-    old_record = get_es_record_by_uuid(old_record_id)
+    old_record_id = str(PersistentIdentifier.get('recid', 11883).object_uuid)
+    old_record = get_es_record_by_uuid('literature', old_record_id)
     old_author_uuid = old_record['authors'][0]['uuid']
 
     # Add phonetic block to the record.
@@ -90,8 +90,8 @@ def test_match_signature_with_existing_profile(small_app):
              id=old_record_id, body=old_record)
     es.indices.refresh('records-hep')
 
-    record_id = str(PersistentIdentifier.get('lit', 1358492).object_uuid)
-    record = get_es_record_by_uuid(record_id)
+    record_id = str(PersistentIdentifier.get('recid', 1358492).object_uuid)
+    record = get_es_record_by_uuid('literature', record_id)
     author_uuid = record['authors'][0]['uuid']
 
     # Add phonetic block to the record.
@@ -120,8 +120,8 @@ def test_appoint_profile_from_claimed_signature(small_app):
         update_authors_recid
     )
 
-    old_record_id = str(PersistentIdentifier.get('lit', 11883).object_uuid)
-    old_record = get_es_record_by_uuid(old_record_id)
+    old_record_id = str(PersistentIdentifier.get('recid', 11883).object_uuid)
+    old_record = get_es_record_by_uuid('literature', old_record_id)
     old_author_uuid = old_record['authors'][0]['uuid']
 
     # Add phonetic block to the record.
@@ -131,8 +131,8 @@ def test_appoint_profile_from_claimed_signature(small_app):
              id=old_record_id, body=old_record)
     es.indices.refresh('records-hep')
 
-    record_id = str(PersistentIdentifier.get('lit', 1358492).object_uuid)
-    record = get_es_record_by_uuid(record_id)
+    record_id = str(PersistentIdentifier.get('recid', 1358492).object_uuid)
+    record = get_es_record_by_uuid('literature', record_id)
     author_uuid = record['authors'][0]['uuid']
 
     # Add phonetic block to the record.
@@ -167,9 +167,9 @@ def test_solve_claim_conflicts(small_app):
 
     # Claimed signature #1.
     glashow_record_id_claimed = str(
-        PersistentIdentifier.get('lit', 4328).object_uuid)
-    glashow_record_claimed = get_es_record_by_uuid(
-        glashow_record_id_claimed)
+        PersistentIdentifier.get('recid', 4328).object_uuid)
+    glashow_record_claimed = get_es_record_by_uuid('literature',
+                                                   glashow_record_id_claimed)
     glashow_record_uuid_claimed = glashow_record_claimed[
         'authors'][0]['uuid']
 
@@ -183,9 +183,9 @@ def test_solve_claim_conflicts(small_app):
 
     # Claimed signature #2.
     higgs_record_id_claimed = str(
-        PersistentIdentifier.get('lit', 1358492).object_uuid)
-    higgs_record_claimed = get_es_record_by_uuid(
-        higgs_record_id_claimed)
+        PersistentIdentifier.get('recid', 1358492).object_uuid)
+    higgs_record_claimed = get_es_record_by_uuid('literature',
+                                                 higgs_record_id_claimed)
     higgs_record_uuid_claimed = higgs_record_claimed[
         'authors'][0]['uuid']
 
@@ -199,9 +199,9 @@ def test_solve_claim_conflicts(small_app):
 
     # Not claimed signature.
     higgs_record_id_not_claimed = str(
-        PersistentIdentifier.get('lit', 11883).object_uuid)
-    higgs_record_not_claimed = get_es_record_by_uuid(
-        higgs_record_id_not_claimed)
+        PersistentIdentifier.get('recid', 11883).object_uuid)
+    higgs_record_not_claimed = get_es_record_by_uuid('literature',
+                                                     higgs_record_id_not_claimed)
     higgs_record_uuid_not_claimed = higgs_record_not_claimed[
         'authors'][0]['uuid']
 

--- a/tests/integration/hal/test_tei_exporting.py
+++ b/tests/integration/hal/test_tei_exporting.py
@@ -37,7 +37,7 @@ def test_format_tei(app):
     expected = pkg_resources.resource_string(
         __name__, os.path.join('fixtures', 'test_tei_record.xml'))
 
-    record = get_db_record('lit', 1407506)
+    record = get_db_record(1407506)
     result = tei.tei_response(record)
 
     assert result == expected

--- a/tests/integration/test_bibtex_exporting.py
+++ b/tests/integration/test_bibtex_exporting.py
@@ -25,7 +25,7 @@ from inspirehep.utils.record_getter import get_db_record
 
 
 def test_format_article(app):
-    article = get_db_record('lit', 4328)
+    article = get_db_record(4328)
 
     expected = u'''@article{Glashow:1961tr,
       author         = "Glashow, S. L.",
@@ -43,7 +43,7 @@ def test_format_article(app):
 
 
 def test_format_inproceeding(app):
-    inproceeding = get_db_record('lit', 524480)
+    inproceeding = get_db_record(524480)
 
     expected = u'''@inproceedings{Hu:2000az,
       author         = "Hu, Wayne",
@@ -61,7 +61,7 @@ def test_format_inproceeding(app):
 
 
 def test_format_proceeding(app):
-    proceeding = get_db_record('lit', 701585)
+    proceeding = get_db_record(701585)
 
     expected = u'''@proceedings{Alekhin:2005dx,
       author         = "Alekhin, S. and others",
@@ -80,7 +80,7 @@ def test_format_proceeding(app):
 
 
 def test_format_thesis(app):
-    thesis = get_db_record('lit', 1395663)
+    thesis = get_db_record(1395663)
 
     expected = u'''@phdthesis{Mankuzhiyil:2010jpa,
       author         = "Mankuzhiyil, Nijil",
@@ -102,7 +102,7 @@ def test_format_thesis(app):
 
 
 def test_format_book(app):
-    book = get_db_record('lit', 736770)
+    book = get_db_record(736770)
 
     expected = u'''@book{Fecko:2006zy,
       author         = "Fecko, M.",
@@ -118,7 +118,7 @@ def test_format_book(app):
 
 
 def test_format_inbook(app):
-    inbook = get_db_record('lit', 1375491)
+    inbook = get_db_record(1375491)
 
     expected = u'''@inbook{Bechtle:2015nta,
       author         = "Bechtle, Philip and Plehn, Tilman and Sander, Christian",

--- a/tests/integration/test_citation_counts.py
+++ b/tests/integration/test_citation_counts.py
@@ -25,7 +25,7 @@ from inspirehep.utils.record_getter import get_es_record
 
 def test_citation_counts_are_correct(app):
     def get_citation_count(recid):
-        record = get_es_record('lit', recid)
+        record = get_es_record('literature', recid)
         citation_count = record['citation_count']
 
         return citation_count

--- a/tests/integration/test_cvlatex_exporting.py
+++ b/tests/integration/test_cvlatex_exporting.py
@@ -30,7 +30,7 @@ import pytest
 
 @pytest.mark.xfail(reason='wrong output')
 def test_format_cv_latex(app):
-    article = get_db_record('lit', 4328)
+    article = get_db_record(4328)
     today = date.today().strftime('%d %b %Y')
 
     expected = u'''%\cite{Glashow:1961tr}

--- a/tests/integration/test_cvlatex_html_exporting.py
+++ b/tests/integration/test_cvlatex_html_exporting.py
@@ -25,7 +25,7 @@ from inspirehep.utils.record_getter import get_db_record
 
 
 def test_format_cv_latex_html(app):
-    record = get_db_record('lit', 4328)
+    record = get_db_record(4328)
 
     expected = (
         '<a href="localhost:5000/record/4328">Partial Symmetries of Weak Interactions.'

--- a/tests/integration/test_latex_exporting.py
+++ b/tests/integration/test_latex_exporting.py
@@ -30,7 +30,7 @@ import pytest
 
 @pytest.mark.xfail(reason='wrong output')
 def test_format_latex_eu(app):
-    article = get_db_record('lit', 4328)
+    article = get_db_record(4328)
     today = date.today().strftime('%d %b %Y')
 
     expected = u'''%\cite{Glashow:1961tr}
@@ -48,7 +48,7 @@ def test_format_latex_eu(app):
 
 @pytest.mark.xfail(reason='wrong output')
 def test_format_latex_us(app):
-    article = get_db_record('lit', 4328)
+    article = get_db_record(4328)
     today = date.today().strftime('%d %b %Y')
 
     expected = u'''%\cite{Glashow:1961tr}

--- a/tests/integration/test_orcid.py
+++ b/tests/integration/test_orcid.py
@@ -138,7 +138,7 @@ def orcid_test(mock_user, request):
         es.index(index='records-authors',
                  doc_type='authors', id=10, body=record)
         es.indices.refresh('records-authors')
-        record = get_db_record('lit', 782466)
+        record = get_db_record(782466)
         record['authors'].append({u'affiliations': [{u'value': u'St. Petersburg, INP'}],  u'curated_relation': True,  u'full_name': u'Full, Name',  u'profile': {
                                  u'__url__': u'http://inspirehep.net/record/00000000'},  u'record': {u'$ref': u'http://localhost:5000/api/authors/10'}})
         mock_orcid_api = OrcidApiMock(1)

--- a/tests/integration/test_permissions.py
+++ b/tests/integration/test_permissions.py
@@ -81,7 +81,7 @@ def sample_record(app):
     record = _create_and_index_record(record)
     yield record
 
-    pid = PersistentIdentifier.get('lit', '123')
+    pid = PersistentIdentifier.get('recid', '123')
     db.session.delete(pid)
     record.delete(force=True)
     current_app.extensions['invenio-db'].versioning_manager.transaction_cls.query.delete()
@@ -139,7 +139,7 @@ def restricted_record(app):
         another_collection = Collection.query.filter_by(
             name='Another Restricted Collection'
         ).one()
-        pid = PersistentIdentifier.get('lit', '222')
+        pid = PersistentIdentifier.get('recid', '222')
         es.delete(index='records-hep', doc_type='hep', id=pid.object_uuid)
         db.session.delete(collection)
         db.session.delete(another_collection)

--- a/tests/integration/test_pidstore.py
+++ b/tests/integration/test_pidstore.py
@@ -45,7 +45,7 @@ def test_getting_next_recid_from_legacy(httpretty_mock, app):
             args = dict(
                 object_type="rec",
                 object_uuid="7753a30b-4c4b-469c-8d8d-d5020069b3ab",
-                pid_type="lit"
+                pid_type="recid"
             )
             provider = InspireRecordIdProvider.create(**args)
 

--- a/tests/integration/test_record.py
+++ b/tests/integration/test_record.py
@@ -66,7 +66,7 @@ def record_already_deleted_in_marcxml(app):
     yield
 
     with app.app_context():
-        _delete_record_from_everywhere('lit', 222)
+        _delete_record_from_everywhere('recid', 222)
 
 
 @pytest.fixture(scope='function')
@@ -96,7 +96,7 @@ def record_not_yet_deleted(app):
     yield
 
     with app.app_context():
-        _delete_record_from_everywhere('lit', 333)
+        _delete_record_from_everywhere('recid', 333)
 
 
 @pytest.fixture(scope='function')
@@ -174,7 +174,7 @@ def records_already_merged_in_marcxml(app):
     yield
 
     with app.app_context():
-        _delete_merged_records_from_everywhere('lit', 111, 222)
+        _delete_merged_records_from_everywhere('recid', 111, 222)
 
 
 @pytest.fixture(scope='function')
@@ -259,11 +259,11 @@ def records_not_merged_in_marcxml(app):
     yield
 
     with app.app_context():
-        _delete_merged_records_from_everywhere('lit', 111, 222)
+        _delete_merged_records_from_everywhere('recid', 111, 222)
 
 
 def _delete_record_from_everywhere(pid_type, record_control_number):
-    record = get_db_record(pid_type, record_control_number)
+    record = get_db_record(record_control_number)
 
     ri = RecordIndexer()
     ri.delete(record)
@@ -312,7 +312,7 @@ def test_record_can_be_deleted(app, record_not_yet_deleted):
     with app.test_client() as client:
         assert client.get('/api/literature/333').status_code == 200
 
-    record = get_db_record('lit', 333)
+    record = get_db_record(333)
     record['deleted'] = True
     record.commit()
     if record:
@@ -335,7 +335,7 @@ def test_records_can_be_merged(app, records_not_merged_in_marcxml):
         assert client.get('/api/literature/111').status_code == 200
         assert client.get('/api/literature/222').status_code == 200
 
-    record = get_db_record('lit', 222)
+    record = get_db_record(222)
     record['deleted'] = True
     record['new_record'] = {'$ref': 'http://localhost:5000/api/record/111'}
     record.commit()

--- a/tests/unit/pidstore/test_pidstore_utils.py
+++ b/tests/unit/pidstore/test_pidstore_utils.py
@@ -31,27 +31,27 @@ from inspirehep.modules.pidstore.utils import (
 
 def test_get_endpoint_from_pid_type():
     expected = 'literature'
-    result = get_endpoint_from_pid_type('lit')
+    result = get_endpoint_from_pid_type('recid')
 
     assert expected == result
 
 
 def test_get_pid_type_from_endpoint():
-    expected = 'lit'
+    expected = 'recid'
     result = get_pid_type_from_endpoint('literature')
 
     assert expected == result
 
 
 def test_get_pid_type_from_schema():
-    expected = 'lit'
+    expected = 'recid'
     result = get_pid_type_from_schema('http://localhost:5000/schemas/record/hep.json')
 
     assert expected == result
 
 
 def test_get_pid_from_schema_supports_relative_urls():
-    expected = 'aut'
+    expected = 'recid'
     result = get_pid_type_from_schema('schemas/record/authors.json')
 
     assert expected == result

--- a/tests/unit/records/test_records_json_ref_loader.py
+++ b/tests/unit/records/test_records_json_ref_loader.py
@@ -115,29 +115,22 @@ def test_abstract_loader_url_fallbacks(get_record, super_get_r_j, g_p_t_f_e, cur
 
 
 @mock.patch('inspirehep.modules.records.json_ref_loader.current_app')
-@mock.patch('inspirehep.modules.records.json_ref_loader.get_pid_type_from_endpoint')
 @mock.patch('inspirehep.modules.records.json_ref_loader.AbstractRecordLoader.get_record')
-def test_abstract_loader_recid_parsing(get_record, g_p_t_f_e, current_app):
+def test_abstract_loader_recid_parsing(get_record, current_app):
     current_app.config = {'SERVER_NAME': 'http://inspirehep.net'}
     with_actual = {'ACTUAL': 'ACTUAL'}
-    g_p_t_f_e.side_effect = ['pt1', 'pt2', 'pt3']
     get_record.return_value = with_actual
 
     expect_actual = JsonRef({'$ref': 'http://inspirehep.net/api/e1/1'},
                             loader=AbstractRecordLoader())
     # Force evaluation of get_record by this assertion.
     assert expect_actual == with_actual
-    get_record.assert_called_with('pt1', '1')
-
     expect_actual = JsonRef({'$ref': '/api/e2/2'},
                             loader=AbstractRecordLoader())
     assert expect_actual == with_actual
-    get_record.assert_called_with('pt2', '2')
-
     expect_actual = JsonRef({'$ref': '/e3/3/'},
                             loader=AbstractRecordLoader())
     assert expect_actual == with_actual
-    get_record.assert_called_with('pt3', '3')
 
 
 @mock.patch('inspirehep.modules.records.json_ref_loader.current_app')


### PR DESCRIPTION
Giving a try if it is possible to have a single `pid_type` called `recid` shared by all our endpoints.

Tests are supposed to fail for the moment.