### PR TITLE
global: inspire-schemas 2.0.0 upgrade

### DIFF
--- a/inspirehep/dojson/common/base.py
+++ b/inspirehep/dojson/common/base.py
@@ -79,7 +79,7 @@ def acquisition_source2marc(self, key, value):
 def self_url(index):
     def _self_url(self, key, value):
         """Url of the record itself."""
-        self['control_number'] = value
+        self['control_number'] = int(value)
         return get_record_ref(value, index)
     return _self_url
 

--- a/inspirehep/modules/api/utils.py
+++ b/inspirehep/modules/api/utils.py
@@ -88,7 +88,7 @@ def get_document_type(record):
 
 
 def get_id(record):
-    return int(record['control_number'])
+    return record['control_number']
 
 
 def get_subject(record):

--- a/inspirehep/modules/authors/rest/citations.py
+++ b/inspirehep/modules/authors/rest/citations.py
@@ -62,7 +62,7 @@ class AuthorAPICitations(object):
         for result in search.scan():
             result_source = result.to_dict()
 
-            recid = int(result_source['control_number'])
+            recid = result_source['control_number']
             authors = set([i['recid'] for i in result_source['authors']])
             citations[recid] = {}
 

--- a/inspirehep/modules/authors/rest/stats.py
+++ b/inspirehep/modules/authors/rest/stats.py
@@ -83,7 +83,7 @@ class AuthorAPIStats(object):
             citation_count = result_source.get('citation_count', 0)
 
             statistics['citations'] += citation_count
-            statistics_citations[int(result_source['control_number'])] = \
+            statistics_citations[result_source['control_number']] = \
                 citation_count
 
             # Count how many times certain type of publication was published.

--- a/inspirehep/modules/migrator/tasks/records.py
+++ b/inspirehep/modules/migrator/tasks/records.py
@@ -309,7 +309,6 @@ def record_upsert(json):
     """Insert or update a record."""
     control_number = json.get('control_number', json.get('recid'))
     if control_number:
-        control_number = int(control_number)
         pid_type = get_pid_type_from_schema(json['$schema'])
         try:
             pid = PersistentIdentifier.get(pid_type, control_number)

--- a/inspirehep/modules/pidstore/minters.py
+++ b/inspirehep/modules/pidstore/minters.py
@@ -41,5 +41,5 @@ def inspire_recid_minter(record_uuid, data):
     if 'control_number' in data:
         args['pid_value'] = data['control_number']
     provider = InspireRecordIdProvider.create(**args)
-    data['control_number'] = str(provider.pid.pid_value)
+    data['control_number'] = provider.pid.pid_value
     return provider.pid

--- a/inspirehep/modules/records/mappings/records/hep.json
+++ b/inspirehep/modules/records/mappings/records/hep.json
@@ -146,6 +146,9 @@
                 "citation_count": {
                     "type": "integer"
                 },
+                "control_number": {
+                    "type": "integer"
+                },
                 "cnum": {
                     "index": "not_analyzed",
                     "type": "string"

--- a/inspirehep/modules/records/receivers.py
+++ b/inspirehep/modules/records/receivers.py
@@ -359,7 +359,7 @@ def check_if_record_is_going_to_be_deleted(sender, *args, **kwargs):
     If 'deleted' field exists and its value is True, before update,
     then delete all the record's pidstores.
     """
-    control_number = int(sender.get('control_number'))
+    control_number = sender.get('control_number')
     pid_type = get_pid_type_from_schema(sender.get('$schema'))
     record = get_db_record(pid_type, control_number)
 

--- a/inspirehep/modules/records/serializers/impactgraph_serializer.py
+++ b/inspirehep/modules/records/serializers/impactgraph_serializer.py
@@ -54,7 +54,7 @@ class ImpactGraphSerializer(object):
         citations = []
 
         record_citations = LiteratureSearch().query_from_iq(
-            'refersto:' + record['control_number']
+            'refersto:' + str(record['control_number'])
         ).params(
             size=9999,
             _source=[

--- a/inspirehep/modules/references/view_utils.py
+++ b/inspirehep/modules/references/view_utils.py
@@ -65,12 +65,12 @@ class Reference(object):
 
             # Create mapping to keep reference order
             recid_to_reference = {
-                str(ref['control_number']): ref for ref in resolved_references
+                ref['control_number']: ref for ref in resolved_references
             }
             for reference in references:
                 row = []
                 ref_record = recid_to_reference.get(
-                    str(reference.get('recid')), {}
+                    reference.get('recid'), {}
                 )
                 if 'reference' in reference:
                     reference.update(reference['reference'])

--- a/inspirehep/modules/theme/views.py
+++ b/inspirehep/modules/theme/views.py
@@ -365,7 +365,7 @@ def get_institution_people_datatables_rows(recid):
     ).execute()
 
     recid_map = dict(
-        [(int(result.control_number), result.name) for result in results]
+        [(result.control_number, result.name) for result in results]
     )
 
     result = []

--- a/inspirehep/utils/bibtex.py
+++ b/inspirehep/utils/bibtex.py
@@ -259,6 +259,7 @@ class Bibtex(Export):
         key = ''
         if not self._get_citation_key():
             key = self.record['control_number']
+
         return key
 
     def _get_author(self):

--- a/inspirehep/utils/citations.py
+++ b/inspirehep/utils/citations.py
@@ -40,7 +40,7 @@ class Citation(object):
 
         # Get citations
         record_citations = LiteratureSearch().query_from_iq(
-            'refersto:' + self.record['control_number']
+            'refersto:' + str(self.record['control_number'])
         ).params(
             _source=[
                 'control_number',

--- a/inspirehep/utils/latex.py
+++ b/inspirehep/utils/latex.py
@@ -283,7 +283,7 @@ class Latex(Export):
                     pages = field.get('page_start') or field['artid']
                 try:
                     if journal and (volume != '' or pages != ''):
-                        recid = self.record['control_number', '']
+                        recid = self.record['control_number']
                         record = get_es_record('jou', recid)
                         coden = ','.join(
                             [record['coden'][0], volume, pages])

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ install_requires = [
     'invenio-utils==0.2.0',  # Not fully Invenio 3 ready
     'invenio>=3.0.0a1,<3.1.0',
     'inspire-crawler~=0.2.7',
-    'inspire-schemas~=1.0',
+    'inspire-schemas~=2.0',
     'dojson==1.2.1',
     'Flask>=0.11.1',
     'Flask-Breadcrumbs>=0.3.0',

--- a/tests/integration/disambiguation/test_receivers.py
+++ b/tests/integration/disambiguation/test_receivers.py
@@ -63,7 +63,7 @@ def test_append_new_record_to_queue_method(small_app):
             {'primary': 'CORE'},
             {'primary': 'HEP'}
         ],
-        'control_number': '4328',
+        'control_number': 4328,
         'self': {'$ref': 'http://localhost:5000/api/literature/4328'},
         'titles': [{'title': 'Partial Symmetries of Weak Interactions'}]
     })
@@ -79,7 +79,7 @@ def test_append_new_record_to_queue_method_not_hep_record(small_app):
     sample_author_record = _IdDict({
         '$schema': 'http://localhost:5000/schemas/records/authors.json',
         'collections': [{'primary': 'HEPNAMES'}],
-        'control_number': '314159265',
+        'control_number': 314159265,
         'name': {'value': 'Glashow, S.L.'},
         'positions': [{'institution': {'name': 'Copenhagen U.'}}],
         'self': {'$ref': 'http://localhost:5000/api/authors/314159265'}})
@@ -125,7 +125,7 @@ def test_append_updated_record_to_queue_new_record(small_app):
             {'primary': 'CORE'},
             {'primary': 'HEP'}
         ],
-        'control_number': '4328',
+        'control_number': 4328,
         'self': {'$ref': 'http://localhost:5000/api/literature/4328'},
         'titles': [{'title': 'Partial Symmetries of Weak Interactions'}]
     })
@@ -144,7 +144,7 @@ def test_append_updated_record_to_queue_not_hep_record(small_app):
     sample_author_record = _IdDict({
         '$schema': 'http://localhost:5000/schemas/records/authors.json',
         'collections': [{'primary': 'HEPNAMES'}],
-        'control_number': '314159265',
+        'control_number': 314159265,
         'name': {'value': 'Glashow, S.L.'},
         'positions': [{'institution': {'name': 'Copenhagen U.'}}],
         'self': {'$ref': 'http://localhost:5000/api/authors/314159265'}})

--- a/tests/integration/test_orcid.py
+++ b/tests/integration/test_orcid.py
@@ -118,7 +118,7 @@ def orcid_test(mock_user, request):
             "value": "Full Name"
         },
         "$schema": "http://localhost:5000/schemas/records/authors.json",
-        "control_number": "10",
+        "control_number": 10,
         "self": {"$ref": "http://localhost:5000/api/authors/10"},
         "ids": [{
             "type": "INSPIRE",

--- a/tests/integration/test_permissions.py
+++ b/tests/integration/test_permissions.py
@@ -62,7 +62,7 @@ def _create_and_index_record(record):
 def sample_record(app):
     record = {
         "$schema": "http://localhost:5000/schemas/records/hep.json",
-        "control_number": "123",
+        "control_number": 123,
         "titles": [
             {
                 "title": "Supersymmetric gauge field theory and string theory"
@@ -105,7 +105,7 @@ def restricted_record(app):
 
     record = {
         "$schema": "http://localhost:5000/schemas/records/hep.json",
-        "control_number": "222",
+        "control_number": 222,
         "titles": [
             {
                 "title": "Supersymmetric gauge field theory and string theory"

--- a/tests/unit/api/test_api_utils.py
+++ b/tests/unit/api/test_api_utils.py
@@ -77,7 +77,7 @@ def test_get_document_type_returns_none_when_no_facet_inspire_doc_type():
 
 
 def test_get_id():
-    record = {'control_number': '4328'}
+    record = {'control_number': 4328}
 
     expected = 4328
     result = get_id(record)
@@ -89,13 +89,6 @@ def test_get_id_raises_when_no_control_number():
     record = {}
 
     with pytest.raises(KeyError):
-        assert get_id(record)
-
-
-def test_get_id_raises_when_control_number_is_malformed():
-    record = {'control_number': 'foo'}
-
-    with pytest.raises(ValueError):
         assert get_id(record)
 
 

--- a/tests/unit/orcid/test_orcid_converter.py
+++ b/tests/unit/orcid/test_orcid_converter.py
@@ -87,7 +87,7 @@ def test_successfull_conversion():
                 "year": 1961
             }
         ],
-        "control_number": "0000000",
+        "control_number": 10,
         "external_system_numbers": [
             {
                 "institute": "INSPIRETeX",
@@ -191,7 +191,7 @@ def test_arxiv_missing_conversion():
                 "primary": "HEP"
             }
         ],
-        "control_number": "0000000",
+        "control_number": 10,
         "external_system_numbers": [
             {
                 "institute": "INSPIRETeX",
@@ -255,7 +255,7 @@ def test_record():
                 "primary": "not_valid"
             }
         ],
-        "control_number": "0000000",
+        "control_number": 10,
         "imprints": [
             {
                 "date": "2008-08-14"
@@ -263,7 +263,7 @@ def test_record():
         ]
     }
 
-    excepted = {'citation': {'citation': u'@article{,\n      key            = "0000000",\n      title          = "{Title}",\n      year           = "1961",\n      doi            = "00.0000/PhysRevD.00.000000",\n      SLACcitation   = "%%CITATION = INSPIRE-0000000;%%"\n}',
+    excepted = {'citation': {'citation': u'@article{,\n      key            = "10",\n      title          = "{Title}",\n      year           = "1961",\n      doi            = "00.0000/PhysRevD.00.000000",\n      SLACcitation   = "%%CITATION = INSPIRE-10;%%"\n}',
                              'citation-type': 'BIBTEX'},
                 'external-identifiers': {'work-external-identifier': [{'external-identifier-id': '00.0000/PhysRevD.00.000000',
                                                                        'external-identifier-type': 'DOI'}]},
@@ -306,7 +306,7 @@ def test_record_with_more_than_20_authors_return_the_first_20_authors():
             "primary": "not_valid"
         }
     ],
-        "control_number": "0000000",
+        "control_number": 10,
         "imprints": [
         {
             "date": "2008-08-14"
@@ -314,7 +314,7 @@ def test_record_with_more_than_20_authors_return_the_first_20_authors():
     ]
     }
 
-    expected = {'citation': {'citation': u'@article{,\n      key            = "0000000",\n      author         = "Name, Full0 and others",\n      title          = "{Title}",\n      year           = "1961",\n      doi            = "00.0000/PhysRevD.00.000000",\n      SLACcitation   = "%%CITATION = INSPIRE-0000000;%%"\n}',
+    expected = {'citation': {'citation': u'@article{,\n      key            = "10",\n      author         = "Name, Full0 and others",\n      title          = "{Title}",\n      year           = "1961",\n      doi            = "00.0000/PhysRevD.00.000000",\n      SLACcitation   = "%%CITATION = INSPIRE-10;%%"\n}',
                              'citation-type': 'BIBTEX'},
                 'contributors': {'contributor': [{'contributor-attributes': {'contributor-role': 'AUTHOR',
                                                                              'contributor-sequence': 'FIRST'},
@@ -424,7 +424,7 @@ def test_record_without_title():
                 "primary": "book"
             }
         ],
-        "control_number": "0000000"
+        "control_number": 0
     }
 
     with pytest.raises(KeyError):
@@ -448,13 +448,13 @@ def test_record_with_invalid_date():
                 "primary": "book"
             }
         ],
-        "control_number": "0000000",
+        "control_number": 10,
         "imprints": [
             {}
         ]
     }
 
-    expected = {'citation': {'citation': u'@book{,\n      key            = "0000000",\n      title          = "{Title}",\n      doi            = "00.0000/PhysRevD.00.000000",\n      SLACcitation   = "%%CITATION = INSPIRE-0000000;%%"\n}',
+    expected = {'citation': {'citation': u'@book{,\n      key            = "10",\n      title          = "{Title}",\n      doi            = "00.0000/PhysRevD.00.000000",\n      SLACcitation   = "%%CITATION = INSPIRE-10;%%"\n}',
                              'citation-type': 'BIBTEX'},
                 'external-identifiers': {'work-external-identifier': [{'external-identifier-id': '00.0000/PhysRevD.00.000000',
                                                                        'external-identifier-type': 'DOI'}]},
@@ -479,14 +479,14 @@ def test_record_without_primary_collection():
                 "not_primary": "not_valid"
             }
         ],
-        "control_number": "0000000",
+        "control_number": 10,
         "dois": [
             {
                 "value": "00.0000/PhysRevD.00.000000"
             }
         ]
     }
-    excepted = {'citation': {'citation': u'@article{,\n      key            = "0000000",\n      title          = "{Title}",\n      doi            = "00.0000/PhysRevD.00.000000",\n      SLACcitation   = "%%CITATION = INSPIRE-0000000;%%"\n}',
+    excepted = {'citation': {'citation': u'@article{,\n      key            = "10",\n      title          = "{Title}",\n      doi            = "00.0000/PhysRevD.00.000000",\n      SLACcitation   = "%%CITATION = INSPIRE-10;%%"\n}',
                              'citation-type': 'BIBTEX'},
                 'external-identifiers': {'work-external-identifier': [{'external-identifier-id': '00.0000/PhysRevD.00.000000',
                                                                        'external-identifier-type': 'DOI'}]},

--- a/tests/unit/records/test_records_receivers.py
+++ b/tests/unit/records/test_records_receivers.py
@@ -52,14 +52,14 @@ def test_dates_validator_does_nothing_when_dates_are_valid():
 @mock.patch('inspirehep.modules.records.receivers.current_app.logger.warning')
 def test_dates_validator_warns_when_date_is_invalid(warning):
     json_dict = {
-        'control_number': 'foo',
+        'control_number': 123,
         'opening_date': 'bar',
     }
 
     dates_validator(None, json_dict)
 
     warning.assert_called_once_with(
-        'MALFORMED: %s value in %s: %s', 'opening_date', 'foo', 'bar')
+        'MALFORMED: %s value in %s: %s', 'opening_date', 123, 'bar')
 
 
 def test_match_valid_experiments_adds_facet_experiment():
@@ -719,7 +719,7 @@ def test_references_validator_does_nothing_on_numerical_recids():
 @mock.patch('inspirehep.modules.records.receivers.current_app.logger.warning')
 def test_references_validator_removes_and_warns_on_non_numerical_recids(warning):
     json_dict = {
-        'control_number': '123',
+        'control_number': 123,
         'references': [
             {'recid': 'foo'},
             {'recid': 456},
@@ -729,7 +729,7 @@ def test_references_validator_removes_and_warns_on_non_numerical_recids(warning)
     references_validator(None, json_dict)
 
     warning.assert_called_once_with(
-        'MALFORMED: recid value found in references of %s: %s', '123', 'foo')
+        'MALFORMED: recid value found in references of %s: %s', 123, 'foo')
     assert json_dict['references'] == [
         {},
         {'recid': 456},

--- a/tests/unit/utils/test_utils_bibtex.py
+++ b/tests/unit/utils/test_utils_bibtex.py
@@ -313,9 +313,9 @@ def test_get_key_empty(_g_c_k):
 def test_get_key_from_control_number(_g_c_k):
     _g_c_k.return_value = False
 
-    with_control_number = Record({'control_number': '1'})
+    with_control_number = Record({'control_number': 1})
 
-    expected = '1'
+    expected = 1
     result = Bibtex(with_control_number)._get_key()
 
     assert expected == result

--- a/tests/unit/utils/test_utils_cv_latex.py
+++ b/tests/unit/utils/test_utils_cv_latex.py
@@ -412,7 +412,7 @@ def test_get_publi_info_from_publication_info_a_list_of_two_elements():
     'inspirehep.utils.cv_latex.config',
     mock.Mock(SERVER_NAME='http://localhost:5000'))
 def test_get_url():
-    record = Record({'control_number': '1'})
+    record = Record({'control_number': 1})
 
     expected = 'http://localhost:5000/record/1'
     result = Cv_latex(record)._get_url()


### PR DESCRIPTION
* Updates inspire-schemas package to 2.0.0.

* Updates usage of control_number field to make sure it is always used
  as an integer.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>