### PR TITLE
tasks: add control for duplicate notes

### DIFF
--- a/inspirehep/modules/workflows/tasks/submission.py
+++ b/inspirehep/modules/workflows/tasks/submission.py
@@ -306,13 +306,17 @@ def send_robotupload(url=None,
 
 def add_note_entry(obj, eng):
     """Add note entry to metadata on approval."""
+    def _has_note(reference_note, notes):
+        return any(reference_note == note for note in notes)
+
     entry = {'value': '*Temporary entry*'} if obj.extra_data.get("core") \
         else {'value': '*Brief entry*'}
     if obj.data.get('public_notes') is None or \
             not isinstance(obj.data.get("public_notes"), list):
         obj.data['public_notes'] = [entry]
     else:
-        obj.data['public_notes'].append(entry)
+        if not _has_note(entry, obj.data['public_notes']):
+            obj.data['public_notes'].append(entry)
 
 
 def filter_keywords(obj, eng):

--- a/tests/unit/workflows/test_workflows_tasks_submission.py
+++ b/tests/unit/workflows/test_workflows_tasks_submission.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+from inspirehep.modules.workflows.tasks.submission import add_note_entry
+
+
+class StubObj(object):
+    def __init__(self, data, extra_data):
+        self.data = data
+        self.extra_data = extra_data
+
+
+class DummyEng(object):
+    pass
+
+
+def test_add_note_entry_does_not_add_value_that_is_already_present():
+    obj = StubObj({'public_notes': [{'value': '*Temporary entry*'}]}, {'core': 'something'})
+    eng = DummyEng()
+
+    assert add_note_entry(obj, eng) is None
+    assert {'public_notes': [{'value': '*Temporary entry*'}]} == obj.data


### PR DESCRIPTION
During the accepting phase for an harvest article, the worker raise an error for a duplicate dictionary. This fix should check if the dictionary that is going to be added is already present and avoid the error.