### PR TITLE
pidstore: fix pid type, cast from string to int

### DIFF
--- a/inspirehep/modules/pidstore/providers.py
+++ b/inspirehep/modules/pidstore/providers.py
@@ -49,7 +49,7 @@ def _get_next_pid_from_legacy():
     url = current_app.config.get('LEGACY_PID_PROVIDER')
     next_pid = requests.get(url, headers=headers).json()
 
-    return str(next_pid)
+    return next_pid
 
 
 class InspireRecordIdProvider(BaseProvider):
@@ -75,7 +75,7 @@ class InspireRecordIdProvider(BaseProvider):
             if current_app.config.get('LEGACY_PID_PROVIDER'):
                 kwargs['pid_value'] = _get_next_pid_from_legacy()
             else:
-                kwargs['pid_value'] = str(RecordIdentifier.next())
+                kwargs['pid_value'] = RecordIdentifier.next()
         kwargs.setdefault('status', cls.default_status)
         if object_type and object_uuid:
             kwargs['status'] = PIDStatus.REGISTERED


### PR DESCRIPTION
cast `pidstore` value, because when we accept an article in the holdingpen the validation process is complaining about the type of this value. It requires an int but a we were passing a string.