### PR TITLE
tools: authorlist improvements

### DIFF
--- a/inspirehep/modules/tools/templates/authorlist_form.html
+++ b/inspirehep/modules/tools/templates/authorlist_form.html
@@ -35,8 +35,9 @@
 
 {% if results %}
 <h4>{{ results_title }}</h4>
-<pre><textarea class="form-control" form="authorlist" id="resultarea">{{ results }}</textarea></pre>
 <button class="btn btn-default" id="copy-button" data-clipboard-target="resultarea">Copy to clipboard</button>
+<pre><textarea class="form-control" form="authorlist" id="resultarea" rows="10">{{ results }}</textarea></pre>
+
 
 {% else %}
 <div>

--- a/inspirehep/modules/tools/templates/authorlist_form.html
+++ b/inspirehep/modules/tools/templates/authorlist_form.html
@@ -30,13 +30,13 @@
   <dl>
     {{ render_field(form.author_string) }}
   </dl>
-  <p><input class="btn" type="submit" value="Format">
+  <p><input class="btn btn-default" type="submit" value="Format">
 </form>
 
 {% if results %}
 <h4>{{ results_title }}</h4>
 <pre><textarea class="form-control" form="authorlist" id="resultarea">{{ results }}</textarea></pre>
-<button class="btn" id="copy-button" data-clipboard-target="resultarea">Copy to clipboard</button>
+<button class="btn btn-default" id="copy-button" data-clipboard-target="resultarea">Copy to clipboard</button>
 
 {% else %}
 <div>

--- a/inspirehep/modules/tools/templates/authorlist_form.html
+++ b/inspirehep/modules/tools/templates/authorlist_form.html
@@ -51,6 +51,8 @@ F. Lastname1, F.M. Otherlastname1,2
 1 CERN
 2 Otheraffiliation
 </pre></p>
+You should make sure there is only one affiliation per line and the affiliation
+IDs in author names are separated with commas.
 </div>
 {% endif %}
 

--- a/inspirehep/modules/tools/utils.py
+++ b/inspirehep/modules/tools/utils.py
@@ -64,6 +64,11 @@ def format_name(author):
     else:
         fname, mname, lname = name.first, name.middle, name.last
 
+    if len(fname) == 1 and '.' not in fname:
+        fname += '.'
+    if len(mname) == 1 and '.' not in mname:
+        mname += '.'
+
     return u'{}{}{}'.format(
         lname,
         ', ' + fname if fname else '',

--- a/tests/unit/tools/test_tools_utils.py
+++ b/tests/unit/tools/test_tools_utils.py
@@ -74,7 +74,7 @@ def test_authorlist_with_affiliations():
     expected = (
         '100__ $$aDurães, F.$$vCERN\n'
         '700__ $$aGiannini, A.V.$$vFermilab\n'
-        '700__ $$aGonçalves, V.P.$$vLund University ' \
+        '700__ $$aGonçalves, V.P.$$vLund University '
         '$$vInstituto de Física, Universidade de São Paulo\n'
         '700__ $$aNavarra, F.S.$$vFermilab'
     )
@@ -107,8 +107,9 @@ def test_authorlist_with_missing_affid():
     """
     text = 'A. Einstein, N. Bohr2'
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(AttributeError) as excinfo:
         authorlist(text)
+    assert 'Could not find affiliations' in str(excinfo.value)
 
 
 def test_authorlist_with_affid_but_missing_affiliation():
@@ -118,8 +119,9 @@ def test_authorlist_with_affid_but_missing_affiliation():
         '2 Københavns Universitet'
     )
 
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError) as excinfo:
         authorlist(text)
+    assert 'the affiliation is missing.' in str(excinfo.value)
 
 
 def test_authorlist_with_invalid_affiliation():
@@ -130,8 +132,22 @@ def test_authorlist_with_invalid_affiliation():
         '2 Københavns Universitet'
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(AttributeError) as excinfo:
         authorlist(text)
+    assert 'Could not find affiliations' in str(excinfo.value)
+
+
+def test_authorlist_with_one_author_missing_affiliation():
+    """Test case when some author doesn't have an affiliation."""
+    text = (
+        'A. Einstein, N. Bohr1,2\n'
+        '1 ETH\n'
+        '2 Københavns Universitet'
+    )
+
+    with pytest.raises(AttributeError) as excinfo:
+        authorlist(text)
+    assert 'This author might not have an affiliation' in str(excinfo.value)
 
 
 def test_authorlist_ignores_space_between_authors_and_affiliations():
@@ -149,3 +165,257 @@ def test_authorlist_ignores_space_between_authors_and_affiliations():
     result = authorlist(text)
 
     assert expected == result
+
+
+def test_authorlist_bad_author_lines():
+    text = (
+        'A. Aduszkiewicz\n'
+        '1\n'
+        ', Y.X. Ali\n'
+        '1,20\n'
+        ', E I Andronov\n'
+        '20\n'
+        ', Einstein\n'
+        '13,15\n'
+        '\n'
+        '1 CERN\n'
+        '20 DESY\n'
+        '13 ETH ZÜRICH\n'
+        '15 PRINCETON\n'
+    )
+
+    expected = (
+        '100__ $$aAduszkiewicz, A.$$vCERN\n'
+        '700__ $$aAli, Y.X.$$vCERN $$vDESY\n'
+        '700__ $$aAndronov, E. I.$$vDESY\n'
+        '700__ $$aEinstein$$vETH ZÜRICH $$vPRINCETON'
+    )
+    result = authorlist(text)
+
+    assert expected == result.encode('utf-8')
+
+
+def test_authorlist_no_commas_between_authors():
+    text = (
+        'C. Patrignani1 K. Agashe2 G. Aielli1,2\n'
+        '1 Universit`a di Bologna and INFN, Dip. Scienze per la Qualit`a della Vita, I-47921, Rimini, Italy\n'
+        '2 University of Maryland, Department of Physics, College Park, MD 20742-4111, USA'
+    )
+
+    expected = (
+        '100__ $$aPatrignani, C.$$vUniversità di Bologna and INFN, Dip. Scienze per la Qualità della Vita, I-47921, Rimini, Italy\n'
+        '700__ $$aAgashe, K.$$vUniversity of Maryland, Department of Physics, College Park, MD 20742-4111, USA\n'
+        '700__ $$aAielli, G.$$vUniversità di Bologna and INFN, Dip. Scienze per la Qualità della Vita, I-47921, Rimini, Italy $$vUniversity of Maryland, Department of Physics, College Park, MD 20742-4111, USA'
+    )
+
+    result = authorlist(text)
+
+    assert expected == result.encode('utf-8')
+
+
+def test_authorlist_newlines_and_no_commas_between_authors():
+    text = (
+        'C. Patrignani\n'
+        '1\n'
+        'K. Agashe\n'
+        '2\n'
+        'G. Aielli\n'
+        '1,\n'
+        '2\n'
+        '1\n'
+        'Universit`a di Bologna and INFN, Dip. Scienze per la Qualit`a della Vita, I-47921, Rimini, Italy\n'
+        '2\n'
+        'University of Maryland, Department of Physics, College Park, MD 20742-4111, USA'
+    )
+
+    expected = (
+        '100__ $$aPatrignani, C.$$vUniversità di Bologna and INFN, Dip. Scienze per la Qualità della Vita, I-47921, Rimini, Italy\n'
+        '700__ $$aAgashe, K.$$vUniversity of Maryland, Department of Physics, College Park, MD 20742-4111, USA\n'
+        '700__ $$aAielli, G.$$vUniversità di Bologna and INFN, Dip. Scienze per la Qualità della Vita, I-47921, Rimini, Italy $$vUniversity of Maryland, Department of Physics, College Park, MD 20742-4111, USA'
+    )
+
+    result = authorlist(text)
+
+    assert expected == result.encode('utf-8')
+
+
+def test_authorlist_affids_with_dots():
+    text = (
+        'C. Patrignani\n'
+        '1,\n'
+        'K. Agashe\n'
+        '2,\n'
+        'G. Aielli\n'
+        '1,\n'
+        '2\n'
+        '1.\n'
+        'Universit`a di Bologna and INFN, Dip. Scienze per la Qualit`a della Vita, I-47921, Rimini, Italy\n'
+        '2.\n'
+        'University of Maryland, Department of Physics, College Park, MD 20742-4111, USA'
+    )
+
+    expected = (
+        '100__ $$aPatrignani, C.$$vUniversità di Bologna and INFN, Dip. Scienze per la Qualità della Vita, I-47921, Rimini, Italy\n'
+        '700__ $$aAgashe, K.$$vUniversity of Maryland, Department of Physics, College Park, MD 20742-4111, USA\n'
+        '700__ $$aAielli, G.$$vUniversità di Bologna and INFN, Dip. Scienze per la Qualità della Vita, I-47921, Rimini, Italy $$vUniversity of Maryland, Department of Physics, College Park, MD 20742-4111, USA'
+    )
+    result = authorlist(text)
+
+    assert expected == result.encode('utf-8')
+
+
+def test_authorlist_no_commas_between_affids():
+    text = (
+        'C. Patrignani\n'
+        '1,\n'
+        'K. Agashe\n'
+        '2,\n'
+        'G. Aielli\n'
+        '1\n'
+        '2\n'
+        '1.\n'
+        'Universit`a di Bologna and INFN, Dip. Scienze per la Qualit`a della Vita, I-47921, Rimini, Italy\n'
+        '2.\n'
+        'University of Maryland, Department of Physics, College Park, MD 20742-4111, USA'
+    )
+
+    with pytest.raises(KeyError) as excinfo:
+        authorlist(text)
+    assert 'affiliation IDs might not be separated with commas' in str(
+        excinfo.value)
+
+
+def test_authorlist_multiple_affiliations_on_single_line():
+    text = (
+        'A. Aduszkiewicz\n'
+        '1\n'
+        ', Y.X. Ali\n'
+        '1,20\n'
+        ', E I Andronov\n'
+        '20\n'
+        ', Einstein\n'
+        '13,15\n'
+        '\n'
+        '1 CERN\n'
+        '20 DESY\n'
+        '13 ETH ZÜRICH15PRINCETON\n'
+    )
+
+    with pytest.raises(KeyError) as excinfo:
+        authorlist(text)
+    assert 'There might be multiple affiliations per line' in str(
+        excinfo.value)
+
+
+def test_authorlist_space_between_affids():
+    text = (
+        'Y.X. Ali1, 20, E I Andronov20\n'
+        '1 CERN\n'
+        '20 DESY'
+    )
+
+    expected = (
+        '100__ $$aAli, Y.X.$$vCERN $$vDESY\n'
+        '700__ $$aAndronov, E. I.$$vDESY'
+    )
+    result = authorlist(text)
+
+    assert expected == result.encode('utf-8')
+
+
+def test_authorlist_affiliation_with_numbers_and_letters():
+    text = (
+        'O. Buchmueller\n'
+        '1\n'
+        'K. Agashe\n'
+        '2\n'
+        '\n'
+        '1.\n'
+        'High Energy Physics Group, Blackett Laboratory, Imperial College, Prince Consort Road, London SW7 2AZ, UK\n'
+        '2.\n'
+        'University of Maryland, Department of Physics, College Park, MD 20742-4111, USA\n'
+    )
+
+    expected = (
+        '100__ $$aBuchmueller, O.$$vHigh Energy Physics Group, Blackett Laboratory, Imperial College, Prince Consort Road, London SW7 2AZ, UK\n'
+        '700__ $$aAgashe, K.$$vUniversity of Maryland, Department of Physics, College Park, MD 20742-4111, USA'
+    )
+    result = authorlist(text)
+
+    assert expected == result.encode('utf-8')
+
+
+def test_authorlist_note_symbols():
+    """Test authors which have some footnote symbols like † and ∗"""
+    text = (
+        'Y.X. Ali†1, 20, E I Andronov20∗\n'
+        '1 CERN\n'
+        '20 DESY'
+    )
+
+    expected = (
+        '100__ $$aAli, Y.X.$$vCERN $$vDESY\n'
+        '700__ $$aAndronov, E. I.$$vDESY'
+    )
+    result = authorlist(text)
+
+    assert expected == result.encode('utf-8')
+
+
+def test_authorlist_comma_wrong_position():
+    """Test case when there is comma before affiliation id."""
+    text = (
+        'Y. Bao,\n'
+        '1\n'
+        'and A. Lambrecht,\n'
+        '1,\n'
+        '2\n'
+        '1\n'
+        'Department of Physics, University of Florida, Gainesville, Florida 32611\n'
+        '2\n'
+        'Laboratoire Kastler–Brossel, CNRS, ENS, Universit ́e Pierre et Marie Curie case 74, Campus Jussieu, F-75252 Paris Cedex 05, France\n'
+    )
+    expected = (
+        '100__ $$aBao, Y.$$vDepartment of Physics, University of Florida, Gainesville, Florida 32611\n'
+        '700__ $$aLambrecht, A.$$vDepartment of Physics, University of Florida, Gainesville, Florida 32611 $$vLaboratoire Kastler-Brossel, '
+        'CNRS, ENS, Universit ́e Pierre et Marie Curie case 74, Campus Jussieu, F-75252 Paris Cedex 05, France'
+    )
+    result = authorlist(text)
+
+    assert expected == result.encode('utf-8')
+
+
+def test_authorlist_when_aff_line_ends_in_number():
+    text = (
+        'T.M. Liss\n'
+        '91\n'
+        'L. Littenberg\n'
+        '92\n'
+        '91.\n'
+        'Division of Science, City College of New York, 160 Convent Avenue, New York, NY 10031\n'
+        '92.\n'
+        'Physics Department, Brookhaven National Laboratory, Upton, NY 11973, USA'
+    )
+
+    expected = (
+        '100__ $$aLiss, T.M.$$vDivision of Science, City College of New York, 160 Convent Avenue, New York, NY 10031\n'
+        '700__ $$aLittenberg, L.$$vPhysics Department, Brookhaven National Laboratory, Upton, NY 11973, USA'
+    )
+    result = authorlist(text)
+
+    assert expected == result.encode('utf-8')
+
+
+def test_author_with_many_affiliations():
+    text = (
+        'F. Durães1,2,3,4\n'
+        '1 CERN\n'
+        '2 Fermilab\n'
+        '3 Lund University\n'
+        '4 Instituto de Física, Universidade de São Paulo'
+    )
+    expected = (
+        '100__ $$aDurães, F.$$vCERN $$vFermilab $$vLund University $$vInstituto de Física, Universidade de São Paulo'
+    )
+
+    assert authorlist(text).encode('utf-8') == expected


### PR DESCRIPTION
* Better buttons.
* Better output box size.
* Always dots in initials.
* Works better with bad input data, e.g. ligatures or unnecessary whitespaces and newlines.

Still requires that there is only one affiliation per line, and affiliation IDs in author names be separated with commas.