### PR TITLE
editor: experiment suggester

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -738,6 +738,11 @@ RECORDS_REST_ENDPOINTS = dict(
                 ':json_v1_search'
             ),
         },
+        suggesters=dict(
+            experiment=dict(completion=dict(
+                field='experiment_suggest'
+            ))
+        ),
         list_route='/experiments/',
         item_route='/experiments/<pid(exp):pid_value>',
         default_media_type='application/json',

--- a/inspirehep/modules/records/mappings/records/experiments.json
+++ b/inspirehep/modules/records/mappings/records/experiments.json
@@ -105,6 +105,12 @@
                     },
                     "type": "object"
                 },
+                "experiment_suggest": {
+                    "analyzer": "simple",
+                    "payloads": true,
+                    "search_analyzer": "simple",
+                    "type": "completion"
+                },
                 "experimentautocomplete": {
                     "type": "string"
                 },

--- a/inspirehep/modules/records/mappings/records/hep.json
+++ b/inspirehep/modules/records/mappings/records/hep.json
@@ -146,9 +146,6 @@
                 "citation_count": {
                     "type": "integer"
                 },
-                "control_number": {
-                    "type": "integer"
-                },
                 "cnum": {
                     "index": "not_analyzed",
                     "type": "string"
@@ -187,6 +184,9 @@
                         }
                     },
                     "type": "object"
+                },
+                "control_number": {
+                    "type": "integer"
                 },
                 "date": {
                     "format": "yyyy||yyyy-MM||yyyy-MM-dd",

--- a/inspirehep/modules/records/mappings/records/journals.json
+++ b/inspirehep/modules/records/mappings/records/journals.json
@@ -176,12 +176,6 @@
                     ],
                     "type": "string"
                 },
-                "title": {
-                    "copy_to": [
-                        "journalautocomplete"
-                    ],
-                    "type": "string"
-                },
                 "short_titles": {
                     "properties": {
                         "title": {
@@ -192,6 +186,12 @@
                         }
                     },
                     "type": "object"
+                },
+                "title": {
+                    "copy_to": [
+                        "journalautocomplete"
+                    ],
+                    "type": "string"
                 }
             }
         }

--- a/inspirehep/modules/records/receivers.py
+++ b/inspirehep/modules/records/receivers.py
@@ -54,6 +54,7 @@ def enhance_record(sender, json, *args, **kwargs):
     match_valid_experiments(sender, json, *args, **kwargs)
     dates_validator(sender, json, *args, **kwargs)
     add_recids_and_validate(sender, json, *args, **kwargs)
+    populate_experiment_suggest(sender, json, *args, **kwargs)
     after_record_enhanced.send(json)
 
 
@@ -371,3 +372,19 @@ def check_if_record_is_going_to_be_deleted(sender, *args, **kwargs):
         else:
             record = get_db_record(pid_type, control_number)
             soft_delete_pidstore_for_record(record.id)
+
+
+def populate_experiment_suggest(sender, json, *args, **kwargs):
+    """Populates experiment_suggest field if record is an experiment record"""
+
+    # FIXME: Use a dedicated method when #1355 will be resolved.
+    if "experiments.json" in json.get("$schema"):
+        experiment_names = get_value(json, "experiment_names.title")
+        title_variants = force_force_list(
+            get_value(json, "title_variants.title")
+        )
+        json.update({"experiment_suggest": {
+            "input": experiment_names + title_variants,
+            "output": experiment_names[0],
+            "payload": {"$ref": get_value(json, "self.$ref")},
+        }})

--- a/tests/unit/records/test_records_receivers.py
+++ b/tests/unit/records/test_records_receivers.py
@@ -32,6 +32,7 @@ from inspirehep.modules.records.receivers import (
     populate_inspire_subjects,
     populate_recid_from_ref,
     references_validator,
+    populate_experiment_suggest,
 )
 
 
@@ -734,3 +735,35 @@ def test_references_validator_removes_and_warns_on_non_numerical_recids(warning)
         {},
         {'recid': 456},
     ]
+
+
+def test_populate_experiment_suggest_populates_if_record_is_experiment():
+    json_dict = {
+        '$schema': 'http://foo/experiments.json',
+        'self': {'$ref': 'http://foo/$ref'},
+        'experiment_names': [
+            {'title': 'foo'},
+            {'title': 'bar'},
+        ],
+        'title_variants': [
+            {'title': 'foo_var'},
+            {'title': 'bar_var'},
+        ],
+    }
+
+    populate_experiment_suggest(None, json_dict)
+
+    assert json_dict['experiment_suggest']['input'] == \
+        ['foo', 'bar', 'foo_var', 'bar_var']
+    assert json_dict['experiment_suggest']['output'] == 'foo'
+    assert json_dict['experiment_suggest']['payload']['$ref'] == 'http://foo/$ref'
+
+
+def test_populate_experiment_suggest_does_nothing_if_record_is_not_experiment():
+    json_dict = {
+        '$schema': 'http://foo/bar.json',
+    }
+
+    populate_experiment_suggest(None, json_dict)
+
+    assert 'experiment_suggest' not in json_dict


### PR DESCRIPTION
* Adds a suggester for accelerator_experiments which suggest experiments
and returns results with payload that is populated with $ref of the
accelerator_experiment.

Signed-off-by: harunurhan <harunurhan17@gmail.com>

I am not sure if I need to add tests for this.