### PR TITLE
utils: refactor arxiv utils

### DIFF
--- a/inspirehep/utils/arxiv.py
+++ b/inspirehep/utils/arxiv.py
@@ -24,17 +24,11 @@
 
 from __future__ import absolute_import, division, print_function
 
+from .record import get_value
+
 
 def get_clean_arXiv_id(record):
     """Return the arXiv identifier from given record."""
-    arxiv_id = record.get("arxiv_id")
-    if not arxiv_id:
-        arxiv_eprints = record.get('arxiv_eprints', [])
-        for element in arxiv_eprints:
-            if element.get("value", ""):
-                arxiv_id = element.get("value", "")
-
+    arxiv_id = get_value(record, 'arxiv_eprints.value[-1]')
     if arxiv_id:
         return arxiv_id.split(':')[-1]
-    else:
-        return None

--- a/inspirehep/utils/arxiv.py
+++ b/inspirehep/utils/arxiv.py
@@ -29,6 +29,6 @@ from .record import get_value
 
 def get_clean_arXiv_id(record):
     """Return the arXiv identifier from given record."""
-    arxiv_id = get_value(record, 'arxiv_eprints.value[-1]')
+    arxiv_id = get_value(record, 'arxiv_eprints.value[0]')
     if arxiv_id:
         return arxiv_id.split(':')[-1]

--- a/tests/unit/utils/test_utils_arxiv.py
+++ b/tests/unit/utils/test_utils_arxiv.py
@@ -3,21 +3,24 @@
 # This file is part of INSPIRE.
 # Copyright (C) 2016 CERN.
 #
-# INSPIRE is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License as
-# published by the Free Software Foundation; either version 2 of the
-# License, or (at your option) any later version.
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-# INSPIRE is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with INSPIRE; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
 
-"""Tests for arXiv utilities."""
+from __future__ import absolute_import, division, print_function
 
 import pytest
 
@@ -58,7 +61,6 @@ def arxiv_record_oai():
 
 
 def test_arxiv_id_getter(arxiv_record, arxiv_record_old, arxiv_record_oai):
-    """Test retrieval of arXiv ID."""
     assert "1002.2647" == get_clean_arXiv_id(arxiv_record)
     assert "physics/0112006" == get_clean_arXiv_id(arxiv_record_old)
     assert "physics/0112006" == get_clean_arXiv_id(arxiv_record_oai)

--- a/tests/unit/utils/test_utils_arxiv.py
+++ b/tests/unit/utils/test_utils_arxiv.py
@@ -68,7 +68,7 @@ def test_get_clean_arXiv_id_from_arxiv_eprints_with_oai_prefix():
     assert expected == result
 
 
-def test_get_clean_arXiv_id_from_arxiv_eprints_selects_last():
+def test_get_clean_arXiv_id_from_arxiv_eprints_selects_first():
     record = {
         'arxiv_eprints': [
             {'value': 'oai:arXiv.org:0801.4782'},
@@ -76,7 +76,7 @@ def test_get_clean_arXiv_id_from_arxiv_eprints_selects_last():
         ],
     }
 
-    expected = '0805.1410'
+    expected = '0801.4782'
     result = get_clean_arXiv_id(record)
 
     assert expected == result

--- a/tests/unit/utils/test_utils_arxiv.py
+++ b/tests/unit/utils/test_utils_arxiv.py
@@ -22,46 +22,61 @@
 
 from __future__ import absolute_import, division, print_function
 
-import pytest
-
 from inspirehep.utils.arxiv import get_clean_arXiv_id
 
 
-@pytest.fixture
-def arxiv_record():
-    return {
-        "arxiv_eprints": [
-            {
-                "value": "arXiv:1002.2647",
-            }
-        ]
-    }
-
-
-@pytest.fixture
-def arxiv_record_old():
-    return {
-        "arxiv_eprints": [
-            {
-                "value": "physics/0112006",
-            }
-        ]
-    }
-
-
-@pytest.fixture
-def arxiv_record_oai():
-    return {
-        "arxiv_eprints": [
-            {
-                "value": "oai:arXiv.org:physics/0112006",
-            }
-        ]
-    }
-
-
-def test_arxiv_id_getter(arxiv_record, arxiv_record_old, arxiv_record_oai):
-    assert "1002.2647" == get_clean_arXiv_id(arxiv_record)
-    assert "physics/0112006" == get_clean_arXiv_id(arxiv_record_old)
-    assert "physics/0112006" == get_clean_arXiv_id(arxiv_record_oai)
+def test_get_clean_arXiv_id_returns_none_when_no_arxiv_eprints():
     assert get_clean_arXiv_id({}) is None
+
+
+def test_get_clean_arXiv_id_from_arxiv_eprints_using_new_style():
+    record = {
+        'arxiv_eprints': [
+            {'value': 'arxiv:1002.2647'},
+        ],
+    }
+
+    expected = '1002.2647'
+    result = get_clean_arXiv_id(record)
+
+    assert expected == result
+
+
+def test_get_clean_arXiv_id_from_arxiv_eprints_using_old_style():
+    record = {
+        'arxiv_eprints': [
+            {'value': 'physics/0112006'},
+        ],
+    }
+
+    expected = 'physics/0112006'
+    result = get_clean_arXiv_id(record)
+
+    assert expected == result
+
+
+def test_get_clean_arXiv_id_from_arxiv_eprints_with_oai_prefix():
+    record = {
+        'arxiv_eprints': [
+            {'value': 'oai:arXiv.org:physics/0112006'},
+        ],
+    }
+
+    expected = 'physics/0112006'
+    result = get_clean_arXiv_id(record)
+
+    assert expected == result
+
+
+def test_get_clean_arXiv_id_from_arxiv_eprints_selects_last():
+    record = {
+        'arxiv_eprints': [
+            {'value': 'oai:arXiv.org:0801.4782'},
+            {'value': 'oai:arXiv.org:0805.1410'},
+        ],
+    }
+
+    expected = '0805.1410'
+    result = get_clean_arXiv_id(record)
+
+    assert expected == result


### PR DESCRIPTION
* Simplifies `get_clean_arXiv_id`
* Removes data-only fixtures in tests
* Cleans up licenses and imports

Spin off of #1748