### PR TITLE
setup: use pytest-httpretty

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ tests_require = [
     'pep257>=0.7.0',
     'pytest-cache>=1.0',
     'pytest-cov>=1.8.0',
+    'pytest-httpretty>=0.2.0',
     'pytest-pep8>=1.0.6',
     'pytest-selenium>=1.3.1',
     'pytest>=2.8.0',

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -117,10 +117,3 @@ def api_client(api):
     """Flask test client for API app."""
     with api.test_client() as client:
         yield client
-
-
-@pytest.fixture
-def httpretty_mock():
-    httpretty.enable()
-    yield
-    httpretty.disable()

--- a/tests/integration/test_pidstore.py
+++ b/tests/integration/test_pidstore.py
@@ -24,11 +24,13 @@ from __future__ import absolute_import, division, print_function
 
 import httpretty
 import mock
+import pytest
 
 from inspirehep.modules.pidstore.providers import InspireRecordIdProvider
 
 
-def test_getting_next_recid_from_legacy(httpretty_mock, app):
+@pytest.mark.httpretty
+def test_getting_next_recid_from_legacy(app):
     extra_config = {
         'LEGACY_PID_PROVIDER': 'http://server/batchuploader/allocaterecord',
     }

--- a/tests/unit/authors/test_authors_receivers.py
+++ b/tests/unit/authors/test_authors_receivers.py
@@ -24,6 +24,7 @@ from __future__ import absolute_import, division, print_function
 
 import httpretty
 import mock
+import pytest
 
 from inspirehep.modules.authors import receivers
 
@@ -66,7 +67,8 @@ def test_name_variations():
             'Richard Ellis'])
 
 
-def test_phonetic_block_generation_ascii(httppretty_mock, app):
+@pytest.mark.httpretty
+def test_phonetic_block_generation_ascii(app):
     extra_config = {
         "BEARD_API_URL": "http://example.com/beard",
     }
@@ -92,7 +94,8 @@ def test_phonetic_block_generation_ascii(httppretty_mock, app):
             assert json_dict['authors'][0]['signature_block'] == "ELj"
 
 
-def test_phonetic_block_generation_broken(httppretty_mock, app):
+@pytest.mark.httpretty
+def test_phonetic_block_generation_broken(app):
     extra_config = {
         "BEARD_API_URL": "http://example.com/beard",
     }
@@ -118,7 +121,8 @@ def test_phonetic_block_generation_broken(httppretty_mock, app):
             assert json_dict['authors'][0]['signature_block'] is None
 
 
-def test_phonetic_block_generation_unicode(httppretty_mock, app):
+@pytest.mark.httpretty
+def test_phonetic_block_generation_unicode(app):
     extra_config = {
         "BEARD_API_URL": "http://example.com/beard",
     }

--- a/tests/unit/authors/test_authors_receivers.py
+++ b/tests/unit/authors/test_authors_receivers.py
@@ -3,29 +3,27 @@
 # This file is part of INSPIRE.
 # Copyright (C) 2016 CERN.
 #
-# INSPIRE is free software; you can redistribute it
-# and/or modify it under the terms of the GNU General Public License as
-# published by the Free Software Foundation; either version 2 of the
-# License, or (at your option) any later version.
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-# INSPIRE is distributed in the hope that it will be
-# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with INSPIRE; if not, write to the
-# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
-# MA 02111-1307, USA.
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
 #
-# In applying this license, CERN does not
-# waive the privileges and immunities granted to it by virtue of its status
-# as an Intergovernmental Organization or submit itself to any jurisdiction.
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
 
 from __future__ import absolute_import, division, print_function
 
-import mock
 import httpretty
+import mock
 
 from inspirehep.modules.authors import receivers
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -240,10 +240,3 @@ def dummy_empty_response():
             "hits": []
         }
     }
-
-
-@pytest.fixture
-def httppretty_mock():
-    httpretty.enable()
-    yield
-    httpretty.disable()


### PR DESCRIPTION
* Uses `pytest-httpretty` instead of `httpretty_mock` and `httppretty_mock`.
* Fixes some licenses and imports.

Spin off of #1748 