### PR TITLE
tests: add unit tests for utils/helpers

### DIFF
--- a/tests/unit/utils/fixtures/foo-bar-baz
+++ b/tests/unit/utils/fixtures/foo-bar-baz
@@ -1,0 +1,3 @@
+foo
+bar
+baz

--- a/tests/unit/utils/test_utils_helpers.py
+++ b/tests/unit/utils/test_utils_helpers.py
@@ -22,7 +22,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-from inspirehep.dojson.utils import force_force_list
+from inspirehep.utils.helpers import force_force_list
 
 
 def test_force_force_list_returns_empty_list_on_none():


### PR DESCRIPTION
* Adds unit tests for methods in `inspirehep/utils/helpers.py`.

~~Depends on #1752~~
Spin off of #1748