### PR TITLE
config: add sha512_crypt to password schemes

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -114,6 +114,15 @@ SECURITY_LOGIN_SALT = "CHANGE_ME"
 SECURITY_PASSWORD_SALT = "CHANGE_ME"
 SECURITY_REMEMBER_SALT = "CHANGE_ME"
 SECURITY_RESET_SALT = "CHANGE_ME"
+SECURITY_PASSWORD_SCHEMES = [
+    'pbkdf2_sha512',
+    'sha512_crypt',
+    'invenio_aes_encrypted_email'
+]
+SECURITY_DEPRECATED_PASSWORD_SCHEMES = [
+    'sha512_crypt',
+    'invenio_aes_encrypted_email'
+]
 
 REMEMBER_COOKIE_HTTPONLY = True
 """


### PR DESCRIPTION
* For compatibility with passwords created with Invenio 2.x. (closes #1755)

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>