### PR TITLE
theme: redirect linkedaccounts view

### DIFF
--- a/inspirehep/modules/theme/views.py
+++ b/inspirehep/modules/theme/views.py
@@ -647,6 +647,12 @@ def ajax_experiments_people():
     )
 
 
+@blueprint.route('/account/settings/linkedaccounts/', methods=['GET'])
+def linkedaccounts():
+    """."""
+    return redirect('/')
+
+
 #
 # Helpers
 #


### PR DESCRIPTION
* /account/settings/linkedaccounts is the page that invenio-oauthclient
  redirects by default after a successful login. INSPIRE does not use
  that page so the user is currently shown a blank page. This commits
  makes that page redirect to the front page which was the behaviour
  in Invenio 2.x. (closes #1737)

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>