### PR TITLE
config: disable SQLALCHEMY_TRACK_MODIFICATIONS

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -63,6 +63,7 @@ BASE_TEMPLATE = "inspirehep_theme/page.html"
 # ========
 SQLALCHEMY_DATABASE_URI = "postgresql+psycopg2://inspirehep:dbpass123@localhost:5432/inspirehep"
 SQLALCHEMY_ECHO = False
+SQLALCHEMY_TRACK_MODIFICATIONS = False  # We do not use (before_)models_committed anywhere
 
 # Celery
 # ======


### PR DESCRIPTION
* Forces SQLALCHEMY_TRACK_MODIFICATIONS to False, since this feature
  just adds overhead and we are not currently using it anywhere.

* Bonus point: remove the corresponding infamous warning.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>