### PR TITLE
tests: unit tests for workflows/tasks/submission

### DIFF
--- a/tests/unit/workflows/test_workflows_tasks_submission.py
+++ b/tests/unit/workflows/test_workflows_tasks_submission.py
@@ -31,6 +31,7 @@ from inspirehep.modules.workflows.tasks.submission import (
     add_note_entry,
     filter_keywords,
     prepare_keywords,
+    user_pdf_get,
 )
 
 from six import StringIO
@@ -306,3 +307,43 @@ def test_prepare_keywords_magpie():
         ]
     }
 
+
+def test_user_pdf_get_with_file():
+    obj = MockObj(
+        1,
+        {'fft': [{'url': 'pdf_file_0', 'docfile_type': 'INSPIRE-PUBLIC'}]},
+        {
+            'pdf_upload': True,
+            'submission_data': {
+                'pdf': 'pdf_file_1'
+            }
+        }
+    )
+    user_pdf_get(obj, {})
+
+    assert obj.data == {
+        'fft': [
+            {'url': 'pdf_file_0', 'docfile_type': 'INSPIRE-PUBLIC'},
+            {'url': 'pdf_file_1', 'docfile_type': 'INSPIRE-PUBLIC'}
+        ]
+    }
+
+
+def test_user_pdf_get():
+    obj = MockObj(
+        1,
+        {},
+        {
+            'pdf_upload': True,
+            'submission_data': {
+                'pdf': 'pdf_file_0'
+            }
+        }
+    )
+    user_pdf_get(obj, {})
+
+    assert obj.data == {
+        'fft': [
+            {'url': 'pdf_file_0', 'docfile_type': 'INSPIRE-PUBLIC'}
+        ]
+    }

--- a/tests/unit/workflows/test_workflows_tasks_submission.py
+++ b/tests/unit/workflows/test_workflows_tasks_submission.py
@@ -30,6 +30,7 @@ from inspirehep.modules.workflows.tasks.submission import (
     send_robotupload,
     add_note_entry,
     filter_keywords,
+    prepare_keywords,
 )
 
 from six import StringIO
@@ -245,4 +246,63 @@ def test_filter_keywords():
     filter_keywords(obj, {})
 
     assert obj.extra_data == {'keywords_prediction': {'keywords': [{'accept': True, 'keyword': 'Physics'}]}}
+
+
+def test_prepare_keywords():
+    obj = MockObj(
+        1,
+        {},
+        {
+            'keywords_prediction': {
+                'keywords': [
+                    {
+                        'accept': True,
+                        'keyword': 'Physics',
+                        'label': 'Physics_mock_label',
+                        'curated': True
+                    }
+                ]
+            }
+        }
+    )
+    prepare_keywords(obj, {})
+    assert obj.data == {
+        'keywords': [
+            {
+                'keyword': 'Physics_mock_label',
+                'classification_scheme': '',
+                'source': 'curator',
+            },
+        ]
+    }
+
+
+def test_prepare_keywords_magpie():
+    obj = MockObj(
+        1,
+        {},
+        {
+            'keywords_prediction': {
+                'keywords': [
+                    {
+                        'accept': True,
+                        'keyword': 'Physics',
+                        'label': 'Physics_mock_label',
+                        'curated': False,
+                    },
+                ]
+            }
+        }
+    )
+    prepare_keywords(obj, {})
+
+    assert obj.data == {
+        'keywords': [
+            {
+                'keyword': 'Physics_mock_label',
+                'classification_scheme': '',
+                'source': 'magpie',
+            },
+        ]
+    }
 

--- a/tests/unit/workflows/test_workflows_tasks_submission.py
+++ b/tests/unit/workflows/test_workflows_tasks_submission.py
@@ -33,6 +33,7 @@ from inspirehep.modules.workflows.tasks.submission import (
     prepare_keywords,
     user_pdf_get,
     prepare_files,
+    remove_references,
 )
 
 from six import StringIO
@@ -390,3 +391,11 @@ def test_prepare_files():
             }
         ]
     }
+
+
+def test_remove_references():
+    obj = MockObj(1, {'references': 'fake value'}, {})
+
+    remove_references(obj, {})
+
+    assert obj.data == {}

--- a/tests/unit/workflows/test_workflows_tasks_submission.py
+++ b/tests/unit/workflows/test_workflows_tasks_submission.py
@@ -27,6 +27,7 @@ from inspirehep.modules.workflows.tasks.submission import (
     add_note_entry,
     create_ticket,
     reply_ticket,
+    close_ticket,
 )
 
 from six import StringIO
@@ -136,4 +137,16 @@ def test_reply_ticket_with_template(mock_render_template, mock_user_query, mock_
 
     mock_rt.edit_ticket.assert_called_with(ticket_id=1, Status='new')
     mock_rt.reply.assert_called_with(ticket_id=1, text='Reason\n description')
+
+
+@mock.patch('inspirehep.utils.tickets.get_instance')
+def test_close_ticket(mock_get_instance):
+    mock_rt = MagicMock()
+    mock_get_instance.return_value = mock_rt
+    close_ticket_function = close_ticket(ticket_id_key='ticket_id')
+
+    obj = MockObj(1, {}, {'ticket_id': 1})
+    close_ticket_function(obj, {})
+
+    mock_rt.edit_ticket.assert_called_with(ticket_id=1, Status='resolved')
 

--- a/tests/unit/workflows/test_workflows_tasks_submission.py
+++ b/tests/unit/workflows/test_workflows_tasks_submission.py
@@ -29,6 +29,7 @@ from inspirehep.modules.workflows.tasks.submission import (
     close_ticket,
     send_robotupload,
     add_note_entry,
+    filter_keywords,
 )
 
 from six import StringIO
@@ -46,6 +47,9 @@ class MockObj(object):
 
         def error(self, *args, **kwargs):
             self.info(args[0])
+
+        def debug(self, message, format=None):
+            self.info(message)
 
     log = MockLog()
 
@@ -223,3 +227,22 @@ def test_add_note_entry_empty_notes():
     add_note_entry(obj, {})
 
     assert obj.data['public_notes'] == [{'value': '*Temporary entry*'}]
+
+
+def test_filter_keywords():
+    obj = MockObj(
+        1,
+        {},
+        {
+            'keywords_prediction': {
+                'keywords': [
+                    {'accept': True, 'keyword': 'Physics'},
+                    {'accept': False, 'keyword': 'Biology'}
+                ]
+            }
+        }
+    )
+    filter_keywords(obj, {})
+
+    assert obj.extra_data == {'keywords_prediction': {'keywords': [{'accept': True, 'keyword': 'Physics'}]}}
+


### PR DESCRIPTION
Addresses #1773

- [x] `submit_rt_ticket`
- [x] `create_ticket`
- [x] `reply_ticket`
- [x] `close_ticket`
- [x] `send_robotupload`
- [x] `add_note_entry`
- [x] `filter_keywords`
- [x] `prepare_keywords`
- [x] `user_pdf_get`
- [x] `prepare_files`
- [x] `remove_references`