### PR TITLE
records: sync modifications in database and ElasticSearch

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -63,7 +63,7 @@ BASE_TEMPLATE = "inspirehep_theme/page.html"
 # ========
 SQLALCHEMY_DATABASE_URI = "postgresql+psycopg2://inspirehep:dbpass123@localhost:5432/inspirehep"
 SQLALCHEMY_ECHO = False
-SQLALCHEMY_TRACK_MODIFICATIONS = False  # We do not use (before_)models_committed anywhere
+SQLALCHEMY_TRACK_MODIFICATIONS = True
 
 # Celery
 # ======

--- a/inspirehep/modules/disambiguation/records.py
+++ b/inspirehep/modules/disambiguation/records.py
@@ -29,8 +29,6 @@ from flask import current_app, url_for
 
 from invenio_db import db
 
-from invenio_indexer.api import RecordIndexer
-
 from invenio_records import Record
 from invenio_records.signals import after_record_insert
 
@@ -140,10 +138,6 @@ def create_author(profile):
     # Apply the changes.
     record.commit()
     db.session.commit()
-
-    # Add the record to Elasticsearch.
-    indexer = RecordIndexer()
-    indexer.index_by_id(record_pid.object_uuid)
 
     # Reconnect the disconnected signal.
     after_record_insert.connect(append_new_record_to_queue)

--- a/inspirehep/modules/disambiguation/tasks.py
+++ b/inspirehep/modules/disambiguation/tasks.py
@@ -30,7 +30,6 @@ from sqlalchemy import distinct
 from sqlalchemy.orm.exc import StaleDataError
 
 from invenio_db import db
-from invenio_indexer.api import RecordIndexer
 from invenio_indexer.signals import before_record_index
 from invenio_records import Record
 
@@ -175,10 +174,6 @@ def update_authors_recid(record_id, uuid, profile_recid):
             # Update the record in the database.
             record.commit()
             db.session.commit()
-
-            # Update the record in Elasticsearch.
-            indexer = RecordIndexer()
-            indexer.index_by_id(record.id)
     except StaleDataError as exc:
         raise update_authors_recid.retry(exc=exc)
     finally:

--- a/inspirehep/modules/workflows/tasks/upload.py
+++ b/inspirehep/modules/workflows/tasks/upload.py
@@ -29,7 +29,6 @@ from pprint import pformat
 from flask import url_for
 
 from invenio_db import db
-from invenio_indexer.api import RecordIndexer
 from invenio_records import Record
 
 from inspirehep.modules.pidstore.minters import inspire_recid_minter
@@ -48,7 +47,7 @@ def store_record(obj, *args, **kwargs):
     record = Record.create(obj.data, id_=None)
 
     # Create persistent identifier.
-    pid = inspire_recid_minter(str(record.id), record)
+    inspire_recid_minter(str(record.id), record)
 
     # Commit any changes to record
     record.commit()
@@ -58,10 +57,6 @@ def store_record(obj, *args, **kwargs):
 
     # Commit to DB before indexing
     db.session.commit()
-
-    # Index record
-    indexer = RecordIndexer()
-    indexer.index_by_id(pid.object_uuid)
 
 
 def set_schema(obj, eng):

--- a/tests/integration/test_model_receiver.py
+++ b/tests/integration/test_model_receiver.py
@@ -1,0 +1,57 @@
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+from elasticsearch import NotFoundError
+
+from invenio_records.api import Record
+from invenio_records.signals import before_record_update
+
+from inspirehep.modules.records.receivers import (
+    check_if_record_is_going_to_be_deleted
+)
+from inspirehep.modules.search import LiteratureSearch
+
+
+def test_receive_after_model_commit(app):
+    """Test if records are correctly synced with ElasticSearch."""
+    before_record_update.disconnect(check_if_record_is_going_to_be_deleted)
+    json = {
+        "$schema": "http://localhost:5000/schemas/records/hep.json",
+        "Hello": "World"
+    }
+    record = Record.create(json)
+    search = LiteratureSearch()
+    es_record = search.get_source(record.id)
+    assert es_record["Hello"] == "World"
+
+    record["Hello"] = "INSPIRE"
+    record.commit()
+    es_record = search.get_source(record.id)
+    assert es_record["Hello"] == "INSPIRE"
+
+    record.delete(force=True)
+    with pytest.raises(NotFoundError):
+        es_record = search.get_source(record.id)
+    before_record_update.connect(check_if_record_is_going_to_be_deleted)


### PR DESCRIPTION
* Adds models_committed receiver that sends to ElasticSearch the changes
  made in the RecordsMetadata table.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>