### PR TITLE
travis: bump docker version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
   global:
     - DOCKER_DATA="$HOME/docker_data"
     - DOCKER_VERSION=1.12.3-0~trusty
-    - DOCKER_COMPOSE_VERSION=1.8.0
+    - DOCKER_COMPOSE_VERSION=1.9.0
   matrix:
     - SUITE=workflows
     - SUITE=integration

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ services:
 env:
   global:
     - DOCKER_DATA="$HOME/docker_data"
-    - DOCKER_VERSION=1.12.0-0~trusty
+    - DOCKER_VERSION=1.12.3-0~trusty
     - DOCKER_COMPOSE_VERSION=1.8.0
   matrix:
     - SUITE=workflows


### PR DESCRIPTION
As you can see from the branch name, I started with the idea of removing [these lines](https://github.com/inspirehep/inspire-next/blob/9a9a4b4add6738d889251f8352510711a793eb9a/.travis.yml#L54-L57) and the variable above, but then I decided against it, because I believe there's value in specifying exactly which version of Docker/Docker-Compose we know are working.