### PR TITLE
records: add Inspire record class

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -432,18 +432,18 @@ RECORDS_REST_ENDPOINTS = dict(
         list_route='/literature/',
         item_route=(
             '/literature'
-            '/<pid(lit,record_class="inspirehep.modules.records.es_record:ESRecord"):pid_value>'),
+            '/<pid(lit,record_class="inspirehep.modules.records.api:ESRecord"):pid_value>'),
         default_media_type='application/json',
         max_result_window=10000,
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
         read_permission_factory_imp="inspirehep.modules.records.permissions:record_read_permission_factory",
-        record_class='inspirehep.modules.records.es_record:ESRecord'
+        record_class='inspirehep.modules.records.api:ESRecord'
     ),
     literature_citesummary=dict(
         default_media_type='application/json',
         item_route=(
             '/literature'
-            '/<pid(lit,record_class="inspirehep.modules.records.es_record:ESRecord"):pid_value>'
+            '/<pid(lit,record_class="inspirehep.modules.records.api:ESRecord"):pid_value>'
             '/citesummary'),
         list_route='/literature/',
         max_result_window=10000,
@@ -454,6 +454,7 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': (
                 'inspirehep.modules.api.v1.literature:citesummary_response')
         },
+        record_class='inspirehep.modules.records.api:InspireRecord',
         search_class='inspirehep.modules.search:LiteratureSearch',
         search_factory_imp=(
             'inspirehep.modules.search.query:inspire_search_factory'),
@@ -469,12 +470,13 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_response')
         },
+        record_class='inspirehep.modules.records.api:InspireRecord',
         search_serializers={
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_search')
         },
         list_route='/literature/db',
-        item_route='/literature/<pid(lit):pid_value>/db',
+        item_route='/literature/<pid(lit,record_class="inspirehep.modules.records.api:InspireRecord"):pid_value>/db',
         default_media_type='application/json',
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
         update_permission_factory_imp="inspirehep.modules.records.permissions:record_update_permission_factory",
@@ -489,6 +491,7 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_response'),
         },
+        record_class='inspirehep.modules.records.api:InspireRecord',
         search_serializers={
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_search'),
@@ -498,7 +501,7 @@ RECORDS_REST_ENDPOINTS = dict(
             ),
         },
         list_route='/authors/',
-        item_route='/authors/<pid(aut):pid_value>',
+        item_route='/authors/<pid(aut,record_class="inspirehep.modules.records.api:InspireRecord"):pid_value>',
         default_media_type='application/json',
         max_result_window=10000,
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
@@ -512,6 +515,7 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': ('inspirehep.modules.authors.rest'
                                  ':citations_v1_response'),
         },
+        record_class='inspirehep.modules.records.api:InspireRecord',
         search_serializers={
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_search'),
@@ -521,7 +525,7 @@ RECORDS_REST_ENDPOINTS = dict(
             ),
         },
         list_route='/authors/',
-        item_route='/authors/<pid(aut):pid_value>/citations',
+        item_route='/authors/<pid(aut,record_class="inspirehep.modules.records.api:InspireRecord"):pid_value>/citations',
         default_media_type='application/json',
         max_result_window=10000,
         search_factory_imp=('inspirehep.modules.search.query'
@@ -529,7 +533,7 @@ RECORDS_REST_ENDPOINTS = dict(
     ),
     authors_citesummary=dict(
         default_media_type='application/json',
-        item_route='/authors/<pid(aut):pid_value>/citesummary',
+        item_route='/authors/<pid(aut,record_class="inspirehep.modules.records.api:InspireRecord"):pid_value>/citesummary',
         list_route='/authors/',
         max_result_window=10000,
         pid_fetcher='inspire_recid_fetcher',
@@ -539,6 +543,7 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': (
                 'inspirehep.modules.api.v1.authors:citesummary_response'),
         },
+        record_class='inspirehep.modules.records.api:InspireRecord',
         search_class='inspirehep.modules.search:AuthorsSearch',
         search_factory_imp=(
             'inspirehep.modules.search.query:inspire_search_factory'),
@@ -558,6 +563,7 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': ('inspirehep.modules.authors.rest'
                                  ':coauthors_v1_response'),
         },
+        record_class='inspirehep.modules.records.api:InspireRecord',
         search_serializers={
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_search'),
@@ -567,7 +573,7 @@ RECORDS_REST_ENDPOINTS = dict(
             ),
         },
         list_route='/authors/',
-        item_route='/authors/<pid(aut):pid_value>/coauthors',
+        item_route='/authors/<pid(aut,record_class="inspirehep.modules.records.api:InspireRecord"):pid_value>/coauthors',
         default_media_type='application/json',
         max_result_window=10000,
         search_factory_imp=('inspirehep.modules.search.query'
@@ -582,6 +588,7 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': ('inspirehep.modules.authors.rest'
                                  ':publications_v1_response'),
         },
+        record_class='inspirehep.modules.records.api:InspireRecord',
         search_serializers={
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_search'),
@@ -591,7 +598,7 @@ RECORDS_REST_ENDPOINTS = dict(
             ),
         },
         list_route='/authors/',
-        item_route='/authors/<pid(aut):pid_value>/publications',
+        item_route='/authors/<pid(aut,record_class="inspirehep.modules.records.api:InspireRecord"):pid_value>/publications',
         default_media_type='application/json',
         max_result_window=10000,
         search_factory_imp=('inspirehep.modules.search.query'
@@ -606,6 +613,7 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': ('inspirehep.modules.authors.rest'
                                  ':stats_v1_response'),
         },
+        record_class='inspirehep.modules.records.api:InspireRecord',
         search_serializers={
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_search'),
@@ -615,7 +623,7 @@ RECORDS_REST_ENDPOINTS = dict(
             ),
         },
         list_route='/authors/',
-        item_route='/authors/<pid(aut):pid_value>/stats',
+        item_route='/authors/<pid(aut,record_class="inspirehep.modules.records.api:InspireRecord"):pid_value>/stats',
         default_media_type='application/json',
         max_result_window=10000,
         search_factory_imp=('inspirehep.modules.search.query'
@@ -631,6 +639,7 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_response'),
         },
+        record_class='inspirehep.modules.records.api:InspireRecord',
         search_serializers={
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_search'),
@@ -640,7 +649,7 @@ RECORDS_REST_ENDPOINTS = dict(
             ),
         },
         list_route='/data/',
-        item_route='/data/<pid(dat):pid_value>',
+        item_route='/data/<pid(dat,record_class="inspirehep.modules.records.api:InspireRecord"):pid_value>',
         default_media_type='application/json',
         max_result_window=10000,
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
@@ -655,6 +664,7 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_response'),
         },
+        record_class='inspirehep.modules.records.api:InspireRecord',
         search_serializers={
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_search'),
@@ -664,7 +674,7 @@ RECORDS_REST_ENDPOINTS = dict(
             ),
         },
         list_route='/conferences/',
-        item_route='/conferences/<pid(con):pid_value>',
+        item_route='/conferences/<pid(con,record_class="inspirehep.modules.records.api:InspireRecord"):pid_value>',
         default_media_type='application/json',
         max_result_window=10000,
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
@@ -679,6 +689,7 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_response'),
         },
+        record_class='inspirehep.modules.records.api:InspireRecord',
         search_serializers={
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_search'),
@@ -688,7 +699,7 @@ RECORDS_REST_ENDPOINTS = dict(
             ),
         },
         list_route='/jobs/',
-        item_route='/jobs/<pid(job):pid_value>',
+        item_route='/jobs/<pid(job,record_class="inspirehep.modules.records.api:InspireRecord"):pid_value>',
         default_media_type='application/json',
         max_result_window=10000,
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
@@ -703,6 +714,7 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_response'),
         },
+        record_class='inspirehep.modules.records.api:InspireRecord',
         search_serializers={
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_search'),
@@ -712,7 +724,7 @@ RECORDS_REST_ENDPOINTS = dict(
             ),
         },
         list_route='/institutions/',
-        item_route='/institutions/<pid(ins):pid_value>',
+        item_route='/institutions/<pid(ins,record_class="inspirehep.modules.records.api:InspireRecord"):pid_value>',
         default_media_type='application/json',
         max_result_window=10000,
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
@@ -720,7 +732,7 @@ RECORDS_REST_ENDPOINTS = dict(
     institutions_citesummary=dict(
         default_media_type='application/json',
         item_route=(
-            '/institutions/<pid(ins):pid_value>/citesummary'),
+            '/institutions/<pid(ins,record_class="inspirehep.modules.records.api:InspireRecord"):pid_value>/citesummary'),
         list_route='/institutions/',
         max_result_window=10000,
         pid_fetcher='inspire_recid_fetcher',
@@ -730,6 +742,7 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': (
                 'inspirehep.modules.api.v1.institutions:citesummary_response'),
         },
+        record_class='inspirehep.modules.records.api:InspireRecord',
         search_class='inspirehep.modules.search:InstitutionsSearch',
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
         search_serializers={
@@ -749,6 +762,7 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_response'),
         },
+        record_class='inspirehep.modules.records.api:InspireRecord',
         search_serializers={
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_search'),
@@ -763,7 +777,7 @@ RECORDS_REST_ENDPOINTS = dict(
             ))
         ),
         list_route='/experiments/',
-        item_route='/experiments/<pid(exp):pid_value>',
+        item_route='/experiments/<pid(exp,record_class="inspirehep.modules.records.api:InspireRecord"):pid_value>',
         default_media_type='application/json',
         max_result_window=10000,
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
@@ -771,7 +785,7 @@ RECORDS_REST_ENDPOINTS = dict(
     experiments_citesummary=dict(
         default_media_type='application/json',
         item_route=(
-            '/experiments/<pid(exp):pid_value>/citesummary'),
+            '/experiments/<pid(exp,record_class="inspirehep.modules.records.api:InspireRecord"):pid_value>/citesummary'),
         list_route='/experiments/',
         max_result_window=10000,
         pid_fetcher='inspire_recid_fetcher',
@@ -781,6 +795,7 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': (
                 'inspirehep.modules.api.v1.experiments:citesummary_response'),
         },
+        record_class='inspirehep.modules.records.api:InspireRecord',
         search_class='inspirehep.modules.search:ExperimentsSearch',
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
         search_serializers={
@@ -800,6 +815,7 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_response'),
         },
+        record_class='inspirehep.modules.records.api:InspireRecord',
         search_serializers={
             'application/json': ('invenio_records_rest.serializers'
                                  ':json_v1_search'),
@@ -809,7 +825,7 @@ RECORDS_REST_ENDPOINTS = dict(
             ),
         },
         list_route='/journals/',
-        item_route='/journals/<pid(jou):pid_value>',
+        item_route='/journals/<pid(jou,record_class="inspirehep.modules.records.api:InspireRecord"):pid_value>',
         default_media_type='application/json',
         max_result_window=10000,
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
@@ -817,7 +833,7 @@ RECORDS_REST_ENDPOINTS = dict(
     journals_citesummary=dict(
         default_media_type='application/json',
         item_route=(
-            '/journals/<pid(jou):pid_value>/citesummary'),
+            '/journals/<pid(jou,record_class="inspirehep.modules.records.api:InspireRecord"):pid_value>/citesummary'),
         list_route='/journals/',
         max_result_window=10000,
         pid_fetcher='inspire_recid_fetcher',
@@ -827,6 +843,7 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/json': (
                 'inspirehep.modules.api.v1.journals:citesummary_response'),
         },
+        record_class='inspirehep.modules.records.api:InspireRecord',
         search_class='inspirehep.modules.search:JournalsSearch',
         search_factory_imp='inspirehep.modules.search.query:inspire_search_factory',
         search_serializers={

--- a/inspirehep/modules/disambiguation/records.py
+++ b/inspirehep/modules/disambiguation/records.py
@@ -29,12 +29,11 @@ from flask import current_app, url_for
 
 from invenio_db import db
 
-from invenio_records import Record
 from invenio_records.signals import after_record_insert
 
 from inspirehep.dojson import utils as inspire_dojson_utils
 from inspirehep.modules.pidstore.minters import inspire_recid_minter
-
+from inspirehep.modules.records.api import InspireRecord
 from inspirehep.modules.disambiguation.receivers import (
     append_new_record_to_queue,
 )
@@ -125,7 +124,7 @@ def create_author(profile):
     after_record_insert.disconnect(append_new_record_to_queue)
 
     # Create a new author profile.
-    record = Record.create(record, id_=None)
+    record = InspireRecord.create(record, id_=None)
 
     # Create Inspire recid.
     record_pid = inspire_recid_minter(record.id, record)

--- a/inspirehep/modules/disambiguation/tasks.py
+++ b/inspirehep/modules/disambiguation/tasks.py
@@ -31,7 +31,6 @@ from sqlalchemy.orm.exc import StaleDataError
 
 from invenio_db import db
 from invenio_indexer.signals import before_record_index
-from invenio_records import Record
 
 from inspirehep.modules.disambiguation.beard import make_beard_clusters
 from inspirehep.modules.disambiguation.logic import process_clusters
@@ -45,6 +44,7 @@ from inspirehep.modules.disambiguation.search import (
     get_blocks_from_record,
     get_records_from_block,
 )
+from inspirehep.modules.records.api import InspireRecord
 
 logger = get_task_logger(__name__)
 
@@ -159,7 +159,7 @@ def update_authors_recid(record_id, uuid, profile_recid):
             profile_recid = "1"
     """
     try:
-        record = Record.get_record(record_id)
+        record = InspireRecord.get_record(record_id)
         update_flag = False
 
         for author in record['authors']:

--- a/inspirehep/modules/migrator/tasks/records.py
+++ b/inspirehep/modules/migrator/tasks/records.py
@@ -46,7 +46,6 @@ from invenio_db import db
 from invenio_indexer.api import RecordIndexer, current_record_to_index
 from invenio_pidstore.errors import PIDDoesNotExistError
 from invenio_pidstore.models import PersistentIdentifier
-from invenio_records import Record
 from invenio_search import current_search_client
 from invenio_search.utils import schema_to_index
 
@@ -54,13 +53,10 @@ from inspirehep.dojson.processors import overdo_marc_dict
 from inspirehep.dojson.utils import get_recid_from_ref
 from inspirehep.modules.pidstore.minters import inspire_recid_minter
 from inspirehep.modules.pidstore.utils import get_pid_type_from_schema
+from inspirehep.modules.records.api import InspireRecord
 from inspirehep.utils.dedupers import dedupe_list
 from inspirehep.utils.helpers import force_force_list
-from inspirehep.utils.record import (
-    get_value,
-    merge_pidstores_of_two_merged_records,
-    soft_delete_pidstore_for_record,
-)
+from inspirehep.utils.record import get_value
 from inspirehep.utils.record_getter import get_db_record
 
 from ..models import InspireProdRecords
@@ -312,11 +308,11 @@ def record_upsert(json):
         pid_type = get_pid_type_from_schema(json['$schema'])
         try:
             pid = PersistentIdentifier.get(pid_type, control_number)
-            record = Record.get_record(pid.object_uuid)
+            record = InspireRecord.get_record(pid.object_uuid)
             record.update(json)
             record.commit()
         except PIDDoesNotExistError:
-            record = Record.create(json, id_=None)
+            record = InspireRecord.create(json, id_=None)
             # Create persistent identifier.
             inspire_recid_minter(str(record.id), json)
 
@@ -324,9 +320,9 @@ def record_upsert(json):
             new_recid = get_recid_from_ref(json.get('new_record'))
             if new_recid:
                 merged_record = get_db_record(pid_type, new_recid)
-                merge_pidstores_of_two_merged_records(merged_record.id, record.id)
+                record.merge(merged_record)
             else:
-                soft_delete_pidstore_for_record(record.id)
+                record.delete()
 
         return record
 

--- a/inspirehep/modules/records/wrappers.py
+++ b/inspirehep/modules/records/wrappers.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import, division, print_function
 
 from inspirehep.utils.record import get_title
 from inspirehep.modules.records.json_ref_loader import replace_refs
-from inspirehep.modules.records.es_record import ESRecord
+from inspirehep.modules.records.api import ESRecord
 from inspirehep.modules.search import JobsSearch
 
 

--- a/inspirehep/modules/workflows/tasks/upload.py
+++ b/inspirehep/modules/workflows/tasks/upload.py
@@ -29,9 +29,9 @@ from pprint import pformat
 from flask import url_for
 
 from invenio_db import db
-from invenio_records import Record
 
 from inspirehep.modules.pidstore.minters import inspire_recid_minter
+from inspirehep.modules.records.api import InspireRecord
 
 
 def store_record(obj, *args, **kwargs):
@@ -44,7 +44,7 @@ def store_record(obj, *args, **kwargs):
     # FIXME: Do some preprocessing of obj.data before creating a record so that
     # we're sure that the schema will be validated without touching the full
     # holdingpen stack.
-    record = Record.create(obj.data, id_=None)
+    record = InspireRecord.create(obj.data, id_=None)
 
     # Create persistent identifier.
     inspire_recid_minter(str(record.id), record)

--- a/inspirehep/utils/record.py
+++ b/inspirehep/utils/record.py
@@ -24,8 +24,6 @@
 
 import re
 
-from invenio_pidstore.models import PersistentIdentifier
-
 
 SPLIT_KEY_PATTERN = re.compile('\.|\[')
 
@@ -137,20 +135,3 @@ def is_submitted_but_not_published(record):
                 if is_complete(publication_info):
                     return False
     return had_at_least_one_journal_title
-
-
-def soft_delete_pidstore_for_record(record_id):
-    """Mark as deleted all pidstores for a specific record."""
-    pids = PersistentIdentifier.query.filter(PersistentIdentifier.object_uuid == record_id).all()
-
-    for pid in pids:
-        pid.delete()
-
-
-def merge_pidstores_of_two_merged_records(record_merged_uuid, record_deleted_uuid):
-    """Merge all pidstores of deleted record to the merged record."""
-    pids_deleted = PersistentIdentifier.query.filter(PersistentIdentifier.object_uuid == record_deleted_uuid).all()
-    pids_merged = PersistentIdentifier.query.filter(PersistentIdentifier.object_uuid == record_merged_uuid).one()
-
-    for pid in pids_deleted:
-        pid.redirect(pids_merged)

--- a/inspirehep/utils/record_getter.py
+++ b/inspirehep/utils/record_getter.py
@@ -30,7 +30,6 @@ from flask import current_app
 from werkzeug.utils import import_string
 
 from invenio_pidstore.models import PersistentIdentifier
-from invenio_records.api import Record
 
 from inspirehep.modules.pidstore.utils import get_endpoint_from_pid_type
 
@@ -109,5 +108,6 @@ def get_es_record_by_uuid(uuid):
 
 @raise_record_getter_error_and_log
 def get_db_record(pid_type, recid):
+    from inspirehep.modules.records.api import InspireRecord
     pid = PersistentIdentifier.get(pid_type, recid)
-    return Record.get_record(pid.object_uuid)
+    return InspireRecord.get_record(pid.object_uuid)

--- a/tests/integration/disambiguation/test_receivers.py
+++ b/tests/integration/disambiguation/test_receivers.py
@@ -28,13 +28,13 @@ from uuid import uuid4
 from sqlalchemy import desc
 
 from invenio_pidstore.models import PersistentIdentifier
-from invenio_records.api import Record
 
 from inspirehep.modules.disambiguation.models import DisambiguationRecord
 from inspirehep.modules.disambiguation.receivers import (
     append_new_record_to_queue,
     append_updated_record_to_queue,
 )
+from inspirehep.modules.records.api import InspireRecord
 
 
 class _IdDict(dict):
@@ -94,7 +94,7 @@ def test_append_updated_record_to_queue(small_app):
     """Test the receiver responsible for queuing updated HEP records."""
     pid = PersistentIdentifier.get('lit', 4328)
     publication_id = str(pid.object_uuid)
-    record = Record.get_record(publication_id)
+    record = InspireRecord.get_record(publication_id)
 
     record_to_update = deepcopy(record)
     record_to_update['authors'][0]['full_name'] = "John Smith"
@@ -161,7 +161,7 @@ def test_append_updated_record_to_queue_same_data(small_app):
     """Check if for the same record, the receiver will skip the publication."""
     pid = PersistentIdentifier.get('lit', 11883)
     publication_id = str(pid.object_uuid)
-    record = Record.get_record(publication_id)
+    record = InspireRecord.get_record(publication_id)
 
     append_updated_record_to_queue(None, record, record, "records-hep", "hep")
 

--- a/tests/integration/disambiguation/test_records.py
+++ b/tests/integration/disambiguation/test_records.py
@@ -23,12 +23,12 @@
 from __future__ import absolute_import, division, print_function
 
 from invenio_pidstore.models import PersistentIdentifier
-from invenio_records.api import Record
 
 from inspirehep.modules.disambiguation.records import (
     _get_author_schema,
     create_author,
 )
+from inspirehep.modules.records.api import InspireRecord
 
 
 def test_get_author_schema_method(small_app):
@@ -49,7 +49,7 @@ def test_create_author_method(small_app):
 
     recid = create_author(signature)
     pid = PersistentIdentifier.get('aut', recid)
-    record = Record.get_record(pid.object_uuid)
+    record = InspireRecord.get_record(pid.object_uuid)
 
     assert record['collections'] == [{'primary': 'HEPNAMES'}]
     assert record['name'] == {'value': 'Glashow, S.L.'}
@@ -64,10 +64,10 @@ def test_update_authors_recid_method(small_app):
     pid = PersistentIdentifier.get('lit', 4328)
     publication_id = str(pid.object_uuid)
 
-    signature = Record.get_record(publication_id)['authors'][0]['uuid']
+    signature = InspireRecord.get_record(publication_id)['authors'][0]['uuid']
     profile_recid = "314159265"
 
     update_authors_recid(publication_id, signature, profile_recid)
 
-    assert Record.get_record(publication_id)['authors'][0]['recid'] == \
+    assert InspireRecord.get_record(publication_id)['authors'][0]['recid'] == \
         profile_recid

--- a/tests/integration/disambiguation/test_workflows.py
+++ b/tests/integration/disambiguation/test_workflows.py
@@ -29,9 +29,9 @@ from __future__ import (
 from mock import patch
 
 from invenio_pidstore.models import PersistentIdentifier
-from invenio_records.api import Record
 from invenio_search import current_search_client as es
 
+from inspirehep.modules.records.api import InspireRecord
 from inspirehep.utils.record_getter import get_es_record_by_uuid
 
 
@@ -70,7 +70,7 @@ def test_single_signature_with_no_profile(small_app):
                    side_effect=update_authors_recid):
             disambiguation_clustering("HAGp")
 
-    assert Record.get_record(record_id)['authors'][0]['recid'] == "1"
+    assert InspireRecord.get_record(record_id)['authors'][0]['recid'] == "1"
 
 
 def test_match_signature_with_existing_profile(small_app):
@@ -107,8 +107,8 @@ def test_match_signature_with_existing_profile(small_app):
                    side_effect=update_authors_recid):
             disambiguation_clustering("HAGp")
 
-    assert Record.get_record(old_record_id)['authors'][0]['recid'] == "1"
-    assert Record.get_record(record_id)['authors'][0]['recid'] == "1"
+    assert InspireRecord.get_record(old_record_id)['authors'][0]['recid'] == "1"
+    assert InspireRecord.get_record(record_id)['authors'][0]['recid'] == "1"
 
 
 def test_appoint_profile_from_claimed_signature(small_app):
@@ -150,9 +150,9 @@ def test_appoint_profile_from_claimed_signature(small_app):
                    side_effect=update_authors_recid):
             disambiguation_clustering("HAGp")
 
-    assert Record.get_record(old_record_id)['authors'][0]['recid'] == \
+    assert InspireRecord.get_record(old_record_id)['authors'][0]['recid'] == \
         "314159265"
-    assert Record.get_record(record_id)['authors'][0]['recid'] == \
+    assert InspireRecord.get_record(record_id)['authors'][0]['recid'] == \
         "314159265"
 
 
@@ -224,5 +224,5 @@ def test_solve_claim_conflicts(small_app):
             with patch("inspirehep.modules.disambiguation.tasks.update_authors_recid.delay", side_effect=update_authors_recid):
                 disambiguation_clustering("HAGp")
 
-    assert Record.get_record(
+    assert InspireRecord.get_record(
         higgs_record_id_not_claimed)['authors'][0]['recid'] == "4"

--- a/tests/integration/test_permissions.py
+++ b/tests/integration/test_permissions.py
@@ -35,16 +35,16 @@ from invenio_accounts.testutils import login_user_via_view
 from invenio_collections.models import Collection
 from invenio_db import db
 from invenio_pidstore.models import PersistentIdentifier
-from invenio_records.api import Record
 from invenio_search import current_search_client as es
 
 from inspirehep.modules.pidstore.minters import inspire_recid_minter
+from inspirehep.modules.records.api import InspireRecord
 from inspirehep.modules.search.api import LiteratureSearch
 from inspirehep.modules.cache import current_cache
 
 
 def _create_and_index_record(record):
-    record = Record.create(record)
+    record = InspireRecord.create(record)
     inspire_recid_minter(record.id, record)
     # invenio-collections will populate _collections field in record upon
     # commit
@@ -80,8 +80,8 @@ def sample_record(app):
 
     pid = PersistentIdentifier.get('lit', '123')
     db.session.delete(pid)
-    record = Record.get_record(record_id)
-    record.delete(force=True)
+    record = InspireRecord.get_record(record_id)
+    record._delete(force=True)
     current_app.extensions[
         'invenio-db'].versioning_manager.transaction_cls.query.delete()
     db.session.commit()
@@ -138,7 +138,7 @@ def restricted_record(app):
     db.session.delete(collection)
     db.session.delete(another_collection)
     db.session.delete(pid)
-    record.delete(force=True)
+    record._delete(force=True)
     current_app.extensions[
         'invenio-db'].versioning_manager.transaction_cls.query.delete()
     db.session.commit()

--- a/tests/unit/authors/test_authors_views.py
+++ b/tests/unit/authors/test_authors_views.py
@@ -22,19 +22,18 @@
 
 from __future__ import absolute_import, division, print_function
 
-from invenio_records.api import Record
-
 from inspirehep.modules.authors.views.holdingpen import (
     convert_for_form,
     get_inspire_url,
 )
+from inspirehep.modules.records.api import InspireRecord
 
 
 def test_convert_for_form_without_name_urls_fc_positions_advisors_and_ids():
-    without_name_urls_fc_positions_advisors_and_ids = Record({})
+    without_name_urls_fc_positions_advisors_and_ids = InspireRecord({})
     convert_for_form(without_name_urls_fc_positions_advisors_and_ids)
 
-    assert Record({}) == without_name_urls_fc_positions_advisors_and_ids
+    assert InspireRecord({}) == without_name_urls_fc_positions_advisors_and_ids
 
 
 def test_convert_for_form_public_emails():
@@ -77,7 +76,7 @@ def test_convert_for_form_public_emails():
 
 
 def test_get_inspire_url_with_bai():
-    with_bai = Record({'bai': 'TODO'})
+    with_bai = InspireRecord({'bai': 'TODO'})
 
     expected = 'http://inspirehep.net/author/profile/TODO'
     result = get_inspire_url(with_bai)
@@ -86,7 +85,7 @@ def test_get_inspire_url_with_bai():
 
 
 def test_get_inspire_url_with_control_number():
-    with_recid = Record({'control_number': 'TODO'})
+    with_recid = InspireRecord({'control_number': 'TODO'})
 
     expected = 'http://inspirehep.net/record/TODO'
     result = get_inspire_url(with_recid)
@@ -95,7 +94,7 @@ def test_get_inspire_url_with_control_number():
 
 
 def test_get_inspire_url_without_recid_or_bai():
-    without_recid_or_bai = Record({})
+    without_recid_or_bai = InspireRecord({})
 
     expected = 'http://inspirehep.net/hepnames'
     result = get_inspire_url(without_recid_or_bai)

--- a/tests/unit/dojson/test_dojson_hep_receivers.py
+++ b/tests/unit/dojson/test_dojson_hep_receivers.py
@@ -22,13 +22,12 @@
 
 from __future__ import absolute_import, division, print_function
 
-from invenio_records.api import Record
-
+from inspirehep.modules.records.api import InspireRecord
 from inspirehep.dojson.hep.receivers import earliest_date
 
 
 def test_earliest_date_from_preprint_date():
-    with_preprint_date = Record({'preprint_date': '2014-05-29'})
+    with_preprint_date = InspireRecord({'preprint_date': '2014-05-29'})
     earliest_date(None, with_preprint_date)
 
     expected = '2014-05-29'
@@ -38,7 +37,7 @@ def test_earliest_date_from_preprint_date():
 
 
 def test_earliest_date_from_thesis_date():
-    with_thesis_date = Record({
+    with_thesis_date = InspireRecord({
         'thesis': {'date': '2008'}
     })
     earliest_date(None, with_thesis_date)
@@ -50,7 +49,7 @@ def test_earliest_date_from_thesis_date():
 
 
 def test_earliest_date_from_thesis_defense_date():
-    with_thesis_defense_date = Record({
+    with_thesis_defense_date = InspireRecord({
         'thesis': {'defense_date': '2012-06-01'}
     })
     earliest_date(None, with_thesis_defense_date)
@@ -62,7 +61,7 @@ def test_earliest_date_from_thesis_defense_date():
 
 
 def test_earliest_date_from_publication_info_year():
-    with_publication_info_year = Record({
+    with_publication_info_year = InspireRecord({
         'publication_info': [
             {'year': '2014'}
         ]
@@ -76,7 +75,7 @@ def test_earliest_date_from_publication_info_year():
 
 
 def test_earliest_date_from_creation_modification_date_creation_date():
-    with_creation_modification_date_creation_date = Record({
+    with_creation_modification_date_creation_date = InspireRecord({
         'creation_modification_date': [
             {'creation_date': '2015-11-04'}
         ]
@@ -90,7 +89,7 @@ def test_earliest_date_from_creation_modification_date_creation_date():
 
 
 def test_earliest_date_from_imprints_date():
-    with_imprints_date = Record({
+    with_imprints_date = InspireRecord({
         'imprints': [
             {'date': '2014-09-26'}
         ]

--- a/tests/unit/hal/test_tei.py
+++ b/tests/unit/hal/test_tei.py
@@ -25,16 +25,15 @@
 import mock
 import pytest
 
-from invenio_records.api import Record
-
 from inspirehep.modules.hal import tei
+from inspirehep.modules.records.api import InspireRecord
 
 
 @mock.patch('inspirehep.modules.hal.tei.get_es_records')
 def test_parse_structures_no_authors(g_e_r):
     g_e_r.return_value = []
 
-    no_authors = Record({})
+    no_authors = InspireRecord({})
 
     expected = []
     result = tei._parse_structures(no_authors)
@@ -46,7 +45,7 @@ def test_parse_structures_no_authors(g_e_r):
 def test_parse_structures_one_author_no_affiliations(g_e_r):
     g_e_r.return_value = []
 
-    one_author_no_affiliations = Record({
+    one_author_no_affiliations = InspireRecord({
         'authors': [{}]
     })
 
@@ -60,7 +59,7 @@ def test_parse_structures_one_author_no_affiliations(g_e_r):
 def test_parse_structures_one_author_invalid_affiliation_record(g_e_r):
     g_e_r.return_value = []
 
-    one_author_invalid_affiliation_record = Record({
+    one_author_invalid_affiliation_record = InspireRecord({
         'authors': [
             {'affiliations':
                 [{'record':
@@ -96,7 +95,7 @@ def test_parse_structures_one_author_one_affiliation_record(g_e_r):
         'self': {'$ref': "http://localhost:5000/api/institutions/902780"},
     }]
 
-    one_author_one_affiliation_record = Record({
+    one_author_one_affiliation_record = InspireRecord({
         'authors': [
             {'affiliations':
                 [
@@ -123,7 +122,7 @@ def test_parse_structures_one_author_one_affiliation_record(g_e_r):
 
 
 def test_parse_pub_info_not_journal_or_conference():
-    not_journal_or_conference = Record({
+    not_journal_or_conference = InspireRecord({
         'publication_info': [None]
     })
 
@@ -133,7 +132,7 @@ def test_parse_pub_info_not_journal_or_conference():
 
 
 def test_parse_pub_info_journal():
-    journal = Record({
+    journal = InspireRecord({
         'publication_info': [
             {'journal_title': "JHEP",
              'journal_volume': "1603",

--- a/tests/unit/theme/test_theme_jinja2filters.py
+++ b/tests/unit/theme/test_theme_jinja2filters.py
@@ -29,8 +29,7 @@ import mock
 import pytest
 from elasticsearch_dsl import result
 
-from invenio_records.api import Record
-
+from inspirehep.modules.records.api import InspireRecord
 from inspirehep.modules.records.wrappers import LiteratureRecord
 from inspirehep.modules.theme.jinja2filters import *
 
@@ -285,7 +284,7 @@ def test_email_link_returns_email_link_on_element(app):
 
 
 def test_url_links_returns_url_link_on_list_of_one_element():
-    record_with_urls = Record({'urls': [{'value': 'http://www.example.com'}]})
+    record_with_urls = InspireRecord({'urls': [{'value': 'http://www.example.com'}]})
 
     expected = ['\n\n<a href="http://www.example.com">http://www.example.com</a>']
     result = url_links(record_with_urls)
@@ -294,7 +293,7 @@ def test_url_links_returns_url_link_on_list_of_one_element():
 
 
 def test_institutes_links():
-    record_with_institute = Record({'institute': ['foo']})
+    record_with_institute = InspireRecord({'institute': ['foo']})
 
     expected = ['\n\n<a href="search/?cc=Institutions&p=110_u%3Afoo&of=hd">foo</a>']
     result = institutes_links(record_with_institute)
@@ -303,7 +302,7 @@ def test_institutes_links():
 
 
 def test_author_profile():
-    record_with_profile = Record({'profile': ['foo']})
+    record_with_profile = InspireRecord({'profile': ['foo']})
 
     expected = ['\n\n<a href="/author/search?q=foo">foo</a>']
     result = author_profile(record_with_profile)
@@ -348,7 +347,7 @@ def test_remove_duplicates__from_list_removes_duplicates_from_non_empty_list():
 
 
 def test_conference_date_returns_date_when_record_has_a_date():
-    with_a_date = Record({'date': '26-30 Mar 2012'})
+    with_a_date = InspireRecord({'date': '26-30 Mar 2012'})
 
     expected = '26-30 Mar 2012'
     result = conference_date(with_a_date)
@@ -357,7 +356,7 @@ def test_conference_date_returns_date_when_record_has_a_date():
 
 
 def test_conference_date_returns_empty_string_when_no_opening_date():
-    no_opening_date = Record({'closing_date': '2015-03-21'})
+    no_opening_date = InspireRecord({'closing_date': '2015-03-21'})
 
     expected = ''
     result = conference_date(no_opening_date)
@@ -366,7 +365,7 @@ def test_conference_date_returns_empty_string_when_no_opening_date():
 
 
 def test_conference_date_returns_empty_string_when_no_closing_date():
-    no_closing_date = Record({'opening_date': '2015-03-14'})
+    no_closing_date = InspireRecord({'opening_date': '2015-03-14'})
 
     expected = ''
     result = conference_date(no_closing_date)
@@ -375,7 +374,7 @@ def test_conference_date_returns_empty_string_when_no_closing_date():
 
 
 def test_conference_date_formats_date_when_same_year_same_month():
-    same_year_same_month = Record({
+    same_year_same_month = InspireRecord({
         'opening_date': '2015-03-14',
         'closing_date': '2015-03-21'
     })
@@ -387,7 +386,7 @@ def test_conference_date_formats_date_when_same_year_same_month():
 
 
 def test_conference_date_formats_date_when_same_year_different_month():
-    same_year_different_month = Record({
+    same_year_different_month = InspireRecord({
         'opening_date': '2012-05-28',
         'closing_date': '2012-06-01'
     })
@@ -399,7 +398,7 @@ def test_conference_date_formats_date_when_same_year_different_month():
 
 
 def test_conference_date_formats_date_when_different_year():
-    different_year = Record({
+    different_year = InspireRecord({
         'opening_date': '2012-12-31',
         'closing_date': '2013-01-01'
     })
@@ -435,13 +434,13 @@ def test_search_for_experiments_joins_with_a_comma_and_a_space():
 
 
 def test_experiment_date_returns_none_with_no_dates():
-    with_no_dates = Record({})
+    with_no_dates = InspireRecord({})
 
     assert experiment_date(with_no_dates) is None
 
 
 def test_experiment_date_returns_started_with_date_started():
-    with_date_started = Record({'date_started': '1993'})
+    with_date_started = InspireRecord({'date_started': '1993'})
 
     expected = 'Started: 1993'
     result = experiment_date(with_date_started)
@@ -449,7 +448,7 @@ def test_experiment_date_returns_started_with_date_started():
     assert expected == result
 
 def test_experiment_date_returns_proposed_with_date_started():
-    with_date_started = Record({'date_proposed': '1993'})
+    with_date_started = InspireRecord({'date_proposed': '1993'})
 
     expected = 'Proposed: 1993'
     result = experiment_date(with_date_started)
@@ -457,7 +456,7 @@ def test_experiment_date_returns_proposed_with_date_started():
     assert expected == result
 
 def test_experiment_date_returns_approved_with_date_started():
-    with_date_started = Record({'date_approved': '1993'})
+    with_date_started = InspireRecord({'date_approved': '1993'})
 
     expected = 'Approved: 1993'
     result = experiment_date(with_date_started)
@@ -466,7 +465,7 @@ def test_experiment_date_returns_approved_with_date_started():
 
 
 def test_experiment_date_returns_still_running_with_date_completed_9999():
-    with_date_completed_9999 = Record({'date_completed': '9999'})
+    with_date_completed_9999 = InspireRecord({'date_completed': '9999'})
 
     expected = 'Still Running'
     result = experiment_date(with_date_completed_9999)
@@ -475,7 +474,7 @@ def test_experiment_date_returns_still_running_with_date_completed_9999():
 
 
 def test_experiment_date_returns_completed_with_date_completed():
-    with_date_completed = Record({'date_completed': '1993'})
+    with_date_completed = InspireRecord({'date_completed': '1993'})
 
     expected = 'Completed: 1993'
     result = experiment_date(with_date_completed)
@@ -484,7 +483,7 @@ def test_experiment_date_returns_completed_with_date_completed():
 
 
 def test_proceedings_link_returns_empty_string_without_cnum():
-    without_cnum = Record({})
+    without_cnum = InspireRecord({})
 
     expected = ''
     result = proceedings_link(without_cnum)
@@ -496,7 +495,7 @@ def test_proceedings_link_returns_empty_string_without_cnum():
 def test_proceedings_link_returns_empty_string_with_zero_search_results(c, mock_perform_es_search_empty):
     c.return_value = mock_perform_es_search_empty
 
-    with_cnum = Record({'cnum': 'banana'})
+    with_cnum = InspireRecord({'cnum': 'banana'})
 
     expected = ''
     result = proceedings_link(with_cnum)
@@ -508,7 +507,7 @@ def test_proceedings_link_returns_empty_string_with_zero_search_results(c, mock_
 def test_proceedings_link_returns_a_link_with_one_search_result(c, mock_perform_es_search_onerecord):
     c.return_value = mock_perform_es_search_onerecord
 
-    with_cnum = Record({'cnum': 'banana'})
+    with_cnum = InspireRecord({'cnum': 'banana'})
 
     expected = '<a href="/record/1410174">Proceedings</a>'
     result = proceedings_link(with_cnum)
@@ -520,7 +519,7 @@ def test_proceedings_link_returns_a_link_with_one_search_result(c, mock_perform_
 def test_proceedings_link_joins_with_a_comma_and_a_space(s, mock_perform_es_search_tworecord):
     s.return_value = mock_perform_es_search_tworecord
 
-    with_cnum = Record({'cnum': 'banana'})
+    with_cnum = InspireRecord({'cnum': 'banana'})
 
     expected = ('Proceedings: <a href="/record/1407068">#1</a> (DOI: <a '
                 'href="http://dx.doi.org/10.1016/j.ppnp.2015.10.002">'
@@ -532,7 +531,7 @@ def test_proceedings_link_joins_with_a_comma_and_a_space(s, mock_perform_es_sear
 
 
 def test_experiment_link_returns_empty_list_without_related_experiments():
-    without_related_experiment = Record({})
+    without_related_experiment = InspireRecord({})
 
     expected = []
     result = experiment_link(without_related_experiment)
@@ -541,7 +540,7 @@ def test_experiment_link_returns_empty_list_without_related_experiments():
 
 
 def test_experiment_link_returns_link_for_a_list_of_one_element():
-    related_experiments_a_list_of_one_element = Record({
+    related_experiments_a_list_of_one_element = InspireRecord({
         'related_experiments': [
             {'name': 'foo'}
         ]
@@ -568,7 +567,7 @@ def test_format_cnum_with_hyphons():
 
 
 def test_link_to_hep_affiliation_returns_empty_string_when_record_has_no_ICN():
-    without_ICN = Record({})
+    without_ICN = InspireRecord({})
 
     expected = ''
     result = link_to_hep_affiliation(without_ICN)
@@ -580,7 +579,7 @@ def test_link_to_hep_affiliation_returns_empty_string_when_record_has_no_ICN():
 def test_link_to_hep_affiliation_returns_empty_string_when_empty_results(s, mock_perform_es_search_empty):
     s.return_value = mock_perform_es_search_empty
 
-    with_ICN = Record({'ICN': 'CERN'})
+    with_ICN = InspireRecord({'ICN': 'CERN'})
 
     expected = ''
     result = link_to_hep_affiliation(with_ICN)
@@ -592,7 +591,7 @@ def test_link_to_hep_affiliation_returns_empty_string_when_empty_results(s, mock
 def test_link_to_hep_affiliation_singular_when_one_result(s, mock_perform_es_search_onerecord):
     s.return_value = mock_perform_es_search_onerecord
 
-    with_ICN = Record({'ICN': 'DESY'})
+    with_ICN = InspireRecord({'ICN': 'DESY'})
 
     expected = '1 Paper from DESY'
     result = link_to_hep_affiliation(with_ICN)
@@ -604,7 +603,7 @@ def test_link_to_hep_affiliation_singular_when_one_result(s, mock_perform_es_sea
 def test_link_to_hep_affiliation_plural_when_more_results(s, mock_perform_es_search_tworecord):
     s.return_value = mock_perform_es_search_tworecord
 
-    with_ICN = Record({'ICN': 'Fermilab'})
+    with_ICN = InspireRecord({'ICN': 'Fermilab'})
 
     expected = '2 Papers from Fermilab'
     result = link_to_hep_affiliation(with_ICN)
@@ -719,7 +718,7 @@ def test_author_urls_joins_with_the_separator():
 
 
 def test_ads_links_returns_empty_string_when_record_has_no_name():
-    without_name = Record({})
+    without_name = InspireRecord({})
 
     expected = ''
     result = ads_links(without_name)
@@ -728,7 +727,7 @@ def test_ads_links_returns_empty_string_when_record_has_no_name():
 
 
 def test_ads_links_builds_link_from_full_name():
-    with_full_name = Record({
+    with_full_name = InspireRecord({
         'name': {'value': 'Ellis, John R.'}
     })
 
@@ -739,7 +738,7 @@ def test_ads_links_builds_link_from_full_name():
 
 
 def test_ads_links_uses_preferred_name_when_name_has_no_lastname():
-    without_last_name = Record({
+    without_last_name = InspireRecord({
         'name': {
             'value': ', John R.',
             'preferred_name': 'Ellis, John R.'
@@ -803,7 +802,7 @@ def test_json_dumps():
 
 
 def test_publication_info_returns_empty_dict_when_no_publication_info():
-    without_publication_info = Record({})
+    without_publication_info = InspireRecord({})
 
     expected = {}
     result = publication_info(without_publication_info)

--- a/tests/unit/utils/test_utils_bibtex.py
+++ b/tests/unit/utils/test_utils_bibtex.py
@@ -23,11 +23,12 @@ import mock
 import pytest
 
 from inspirehep.utils.bibtex import Bibtex
-from invenio_records.api import Record
+
+from inspirehep.modules.records.api import InspireRecord
 
 
 def test_get_entry_type_no_collections_no_pubinfo():
-    no_collections_no_pubinfo = Record({})
+    no_collections_no_pubinfo = InspireRecord({})
 
     expected = ('article', 'article')
     result = Bibtex(no_collections_no_pubinfo)._get_entry_type()
@@ -36,7 +37,7 @@ def test_get_entry_type_no_collections_no_pubinfo():
 
 
 def test_get_entry_type_no_primary_collections_no_pubinfo():
-    no_primary_collections_no_pubinfo = Record({
+    no_primary_collections_no_pubinfo = InspireRecord({
         'collections': [
             {'not-primary': 'foo'}
         ]
@@ -49,7 +50,7 @@ def test_get_entry_type_no_primary_collections_no_pubinfo():
 
 
 def test_get_entry_type_conferencepaper_no_pubinfo():
-    conferencepaper_no_pubinfo = Record({
+    conferencepaper_no_pubinfo = InspireRecord({
         'collections': [
             {'primary': 'conferencepaper'}
         ]
@@ -62,7 +63,7 @@ def test_get_entry_type_conferencepaper_no_pubinfo():
 
 
 def test_get_entry_type_thesis_no_pubinfo():
-    thesis_no_pubinfo = Record({
+    thesis_no_pubinfo = InspireRecord({
         'collections': [
             {'primary': 'thesis'}
         ]
@@ -75,7 +76,7 @@ def test_get_entry_type_thesis_no_pubinfo():
 
 
 def test_get_entry_type_proceedings_no_pubinfo():
-    proceedings_no_pubinfo = Record({
+    proceedings_no_pubinfo = InspireRecord({
         'collections': [
             {'primary': 'proceedings'}
         ]
@@ -88,7 +89,7 @@ def test_get_entry_type_proceedings_no_pubinfo():
 
 
 def test_get_entry_type_book_no_pubinfo():
-    book_no_pubinfo = Record({
+    book_no_pubinfo = InspireRecord({
         'collections': [
             {'primary': 'book'}
         ]
@@ -101,7 +102,7 @@ def test_get_entry_type_book_no_pubinfo():
 
 
 def test_get_entry_type_bookchapter_no_pubinfo():
-    bookchapter_no_pubinfo = Record({
+    bookchapter_no_pubinfo = InspireRecord({
         'collections': [
             {'primary': 'bookchapter'}
         ]
@@ -114,7 +115,7 @@ def test_get_entry_type_bookchapter_no_pubinfo():
 
 
 def test_get_entry_type_arxiv_no_pubinfo():
-    arxiv_no_pubinfo = Record({
+    arxiv_no_pubinfo = InspireRecord({
         'collections': [
             {'primary': 'arxiv'}
         ]
@@ -127,7 +128,7 @@ def test_get_entry_type_arxiv_no_pubinfo():
 
 
 def test_get_entry_type_published_no_pubinfo():
-    published_no_pubinfo = Record({
+    published_no_pubinfo = InspireRecord({
         'collections': [
             {'primary': 'published'}
         ]
@@ -140,7 +141,7 @@ def test_get_entry_type_published_no_pubinfo():
 
 
 def test_get_entry_type_no_collections_one_valid_pubinfo():
-    no_collections_one_valid_pubinfo = Record({
+    no_collections_one_valid_pubinfo = InspireRecord({
         'publication_info': {
             'journal_title': 'foo',
             'journal_volume': 'bar',
@@ -156,7 +157,7 @@ def test_get_entry_type_no_collections_one_valid_pubinfo():
 
 
 def test_get_entry_type_no_collections_one_invalid_pubinfo():
-    no_collections_one_invalid_pubinfo = Record({
+    no_collections_one_invalid_pubinfo = InspireRecord({
         'publication_info': {}
     })
 
@@ -167,7 +168,7 @@ def test_get_entry_type_no_collections_one_invalid_pubinfo():
 
 
 def test_get_entry_type_no_collections_second_pubinfo_valid():
-    no_collections_second_pubinfo_valid = Record({
+    no_collections_second_pubinfo_valid = InspireRecord({
         'publication_info': [
             {},
             {
@@ -186,7 +187,7 @@ def test_get_entry_type_no_collections_second_pubinfo_valid():
 
 
 def test_get_entry_type_one_collection_one_pubinfo():
-    one_collection_one_pubinfo = Record({
+    one_collection_one_pubinfo = InspireRecord({
         'collections': [{'primary': 'conferencepaper'}],
         'publication_info': [
             {
@@ -211,7 +212,7 @@ def test_fetch_fields_missing_required_key(self, _get_key):
 
     from inspirehep.utils.export import MissingRequiredFieldError
 
-    dummy = Record({})
+    dummy = InspireRecord({})
 
     with pytest.raises(MissingRequiredFieldError) as excinfo:
         Bibtex(dummy)._fetch_fields(['key'], [])
@@ -219,7 +220,7 @@ def test_fetch_fields_missing_required_key(self, _get_key):
 
 
 def test_format_output_row_single_author():
-    dummy = Record({})
+    dummy = InspireRecord({})
 
     expected = u'      author         = "0",\n'
     result = Bibtex(dummy)._format_output_row('author', [0])
@@ -228,7 +229,7 @@ def test_format_output_row_single_author():
 
 
 def test_format_output_row_between_one_and_ten_authors():
-    dummy = Record({})
+    dummy = InspireRecord({})
 
     expected = u'      author         = "0 and 1 and 2",\n'
     result = Bibtex(dummy)._format_output_row('author', list(range(3)))
@@ -237,7 +238,7 @@ def test_format_output_row_between_one_and_ten_authors():
 
 
 def test_format_output_row_more_than_ten_authors():
-    dummy = Record({})
+    dummy = InspireRecord({})
 
     expected = u'      author         = "0 and others",\n'
     result = Bibtex(dummy)._format_output_row('author', list(range(11)))
@@ -246,7 +247,7 @@ def test_format_output_row_more_than_ten_authors():
 
 
 def test_format_output_row_title():
-    dummy = Record({})
+    dummy = InspireRecord({})
 
     expected = u'      title          = "{bar}",\n'
     result = Bibtex(dummy)._format_output_row('title', 'bar')
@@ -255,7 +256,7 @@ def test_format_output_row_title():
 
 
 def test_format_output_row_doi():
-    dummy = Record({})
+    dummy = InspireRecord({})
 
     expected = u'      doi            = "bar",\n'
     result = Bibtex(dummy)._format_output_row('doi', 'bar')
@@ -264,7 +265,7 @@ def test_format_output_row_doi():
 
 
 def test_format_output_row_slaccitation():
-    dummy = Record({})
+    dummy = InspireRecord({})
 
     expected = u'      SLACcitation   = "bar"'
     result = Bibtex(dummy)._format_output_row('SLACcitation', 'bar')
@@ -273,7 +274,7 @@ def test_format_output_row_slaccitation():
 
 
 def test_format_output_row_number_value():
-    dummy = Record({})
+    dummy = InspireRecord({})
 
     expected = u'      foo            = "0",\n'
     result = Bibtex(dummy)._format_output_row('foo', 0)
@@ -282,7 +283,7 @@ def test_format_output_row_number_value():
 
 
 def test_format_output_row_not_number_value():
-    dummy = Record({})
+    dummy = InspireRecord({})
 
     expected = u'      foo            = "bar",\n'
     result = Bibtex(dummy)._format_output_row('foo', 'bar')
@@ -291,7 +292,7 @@ def test_format_output_row_not_number_value():
 
 
 def test_is_number():
-    dummy = Record({})
+    dummy = InspireRecord({})
 
     assert Bibtex(dummy)._is_number(0)
     assert not Bibtex(dummy)._is_number('foo')
@@ -301,7 +302,7 @@ def test_is_number():
 def test_get_key_empty(_g_c_k):
     _g_c_k.return_value = True
 
-    dummy = Record({})
+    dummy = InspireRecord({})
 
     expected = ''
     result = Bibtex(dummy)._get_key()
@@ -313,7 +314,7 @@ def test_get_key_empty(_g_c_k):
 def test_get_key_from_control_number(_g_c_k):
     _g_c_k.return_value = False
 
-    with_control_number = Record({'control_number': 1})
+    with_control_number = InspireRecord({'control_number': 1})
 
     expected = 1
     result = Bibtex(with_control_number)._get_key()
@@ -322,7 +323,7 @@ def test_get_key_from_control_number(_g_c_k):
 
 
 def test_get_author_no_authors_no_corporate_author():
-    no_authors_no_corporate_author = Record({})
+    no_authors_no_corporate_author = InspireRecord({})
 
     expected = []
     result = Bibtex(no_authors_no_corporate_author)._get_author()
@@ -331,7 +332,7 @@ def test_get_author_no_authors_no_corporate_author():
 
 
 def test_get_author_one_author_without_full_name():
-    one_author_without_full_name = Record({
+    one_author_without_full_name = InspireRecord({
         'authors': [{}]
     })
 
@@ -342,7 +343,7 @@ def test_get_author_one_author_without_full_name():
 
 
 def test_get_author_one_author_with_one_fullname():
-    one_author_with_one_fullname = Record({
+    one_author_with_one_fullname = InspireRecord({
         'authors': [
             {'full_name': 'Higgs, Peter W.'}
         ]
@@ -355,7 +356,7 @@ def test_get_author_one_author_with_one_fullname():
 
 
 def test_get_author_two_authors_with_fullnames():
-    two_authors_with_fullnames = Record({
+    two_authors_with_fullnames = InspireRecord({
         'authors': [
             {'full_name': 'Englert, F.'},
             {'full_name': 'Brout, R.'}
@@ -369,7 +370,7 @@ def test_get_author_two_authors_with_fullnames():
 
 
 def test_get_author_two_authors_one_a_supervisor():
-    two_authors_one_a_supervisor = Record({
+    two_authors_one_a_supervisor = InspireRecord({
         'authors': [
             {'full_name': 'Mankuzhiyil, Nijil'},
             {
@@ -391,7 +392,7 @@ def test_get_author_two_authors_one_a_supervisor():
 
 
 def test_get_author_corporate_author():
-    corporate_author = Record({
+    corporate_author = InspireRecord({
         'corporate_author': [
             'CMS Collaboration'
         ]
@@ -404,13 +405,13 @@ def test_get_author_corporate_author():
 
 
 def test_get_editor_no_authors():
-    no_authors = Record({})
+    no_authors = InspireRecord({})
 
     assert Bibtex(no_authors)._get_editor() is None
 
 
 def test_get_editor_no_author_has_editor_role():
-    no_author_has_editor_role = Record({
+    no_author_has_editor_role = InspireRecord({
         'authors': [
             {'full_name': 'Englert, F.'},
             {'full_name': 'Brout, R.'}
@@ -421,7 +422,7 @@ def test_get_editor_no_author_has_editor_role():
 
 
 def test_get_editor_first_author_has_editor_role():
-    first_author_has_editor_role = Record({
+    first_author_has_editor_role = InspireRecord({
         'authors': [
             {
                 'full_name': 'Englert, F.',
@@ -438,7 +439,7 @@ def test_get_editor_first_author_has_editor_role():
 
 
 def test_get_editor_non_first_author_has_editor_role():
-    non_first_author_has_editor_role = Record({
+    non_first_author_has_editor_role = InspireRecord({
         'authors': [
             {'full_name': 'Englert, F.'},
             {
@@ -452,7 +453,7 @@ def test_get_editor_non_first_author_has_editor_role():
 
 
 def test_get_title_no_titles():
-    no_titles = Record({})
+    no_titles = InspireRecord({})
 
     expected = ''
     result = Bibtex(no_titles)._get_title()
@@ -461,7 +462,7 @@ def test_get_title_no_titles():
 
 
 def test_get_title_one_title():
-    one_title = Record({
+    one_title = InspireRecord({
         'titles': {
             'title': 'Partial Symmetries of Weak Interactions'
         }
@@ -474,7 +475,7 @@ def test_get_title_one_title():
 
 
 def test_get_title_with_a_list_of_titles_selectes_first():
-    a_list_of_titles = Record({
+    a_list_of_titles = InspireRecord({
         'titles': [
             {'title': 'Broken Symmetries and the Masses of Gauge Bosons'},
             {'title': 'BROKEN SYMMETRIES AND THE MASSES OF GAUGE BOSONS.'}
@@ -488,7 +489,7 @@ def test_get_title_with_a_list_of_titles_selectes_first():
 
 
 def test_get_collaboration_no_collaboration():
-    no_collaboration = Record({})
+    no_collaboration = InspireRecord({})
 
     expected = ''
     result = Bibtex(no_collaboration)._get_collaboration()
@@ -497,7 +498,7 @@ def test_get_collaboration_no_collaboration():
 
 
 def test_get_collaboration_with_a_list_of_collaboration_selects_first():
-    a_list_of_collaboration = Record({
+    a_list_of_collaboration = InspireRecord({
         'collaboration': [
             {'value': 'ATLAS'},
             {'value': 'CMS'}
@@ -511,7 +512,7 @@ def test_get_collaboration_with_a_list_of_collaboration_selects_first():
 
 
 def test_get_collaboration_malformed_collaboration():
-    malformed_collaboration = Record({
+    malformed_collaboration = InspireRecord({
         'collaboration': [
             {'notvalue': 'ATLAS'}
         ]
@@ -524,7 +525,7 @@ def test_get_collaboration_malformed_collaboration():
 
 
 def test_get_organization_no_imprints():
-    no_imprints = Record({})
+    no_imprints = InspireRecord({})
 
     expected = ''
     result = Bibtex(no_imprints)._get_organization()
@@ -533,7 +534,7 @@ def test_get_organization_no_imprints():
 
 
 def test_get_organization_with_a_list_of_imprints_selects_first_with_a_publisher():
-    a_list_of_imprints_with_a_publisher = Record({
+    a_list_of_imprints_with_a_publisher = InspireRecord({
         'imprints': [
             {},
             {'publisher': 'Cambridge University Press'}
@@ -547,7 +548,7 @@ def test_get_organization_with_a_list_of_imprints_selects_first_with_a_publisher
 
 
 def test_get_address_no_imprints():
-    no_imprints = Record({})
+    no_imprints = InspireRecord({})
 
     expected = []
     result = Bibtex(no_imprints)._get_address()
@@ -556,7 +557,7 @@ def test_get_address_no_imprints():
 
 
 def test_get_address_a_list_of_imprints_with_no_places():
-    a_list_of_imprints_with_no_places = Record({
+    a_list_of_imprints_with_no_places = InspireRecord({
         'imprints': [
             {'notplace': 'Piscataway, USA'}
         ]
@@ -566,7 +567,7 @@ def test_get_address_a_list_of_imprints_with_no_places():
 
 
 def test_get_address_a_list_of_imprints_with_one_place_not_a_list():
-    a_list_of_imprints_with_one_place_not_a_list = Record({
+    a_list_of_imprints_with_one_place_not_a_list = InspireRecord({
         'imprints': [
             {'place': 'Piscataway, USA'}
         ]
@@ -579,7 +580,7 @@ def test_get_address_a_list_of_imprints_with_one_place_not_a_list():
 
 
 def test_get_address_a_list_of_imprints_with_one_place_a_list():
-    a_list_of_imprints_with_one_place_a_list = Record({
+    a_list_of_imprints_with_one_place_a_list = InspireRecord({
         'imprints': [
             {
                 'place': [
@@ -597,7 +598,7 @@ def test_get_address_a_list_of_imprints_with_one_place_a_list():
 
 
 def test_get_address_a_list_of_imprints_with_two_places():
-    a_list_of_imprints_with_two_places = Record({
+    a_list_of_imprints_with_two_places = InspireRecord({
         'imprints': [
             {'place': 'Moscow'},
             {'place': 'Russia'}
@@ -611,7 +612,7 @@ def test_get_address_a_list_of_imprints_with_two_places():
 
 
 def test_get_school_no_authors():
-    no_authors = Record({})
+    no_authors = InspireRecord({})
 
     expected = ''
     result = Bibtex(no_authors)._get_school()
@@ -620,7 +621,7 @@ def test_get_school_no_authors():
 
 
 def test_get_school_a_list_of_authors_with_no_affiliations():
-    a_list_of_authors_with_no_affiliations = Record({'authors': []})
+    a_list_of_authors_with_no_affiliations = InspireRecord({'authors': []})
 
     expected = ''
     result = Bibtex(a_list_of_authors_with_no_affiliations)._get_school()
@@ -629,7 +630,7 @@ def test_get_school_a_list_of_authors_with_no_affiliations():
 
 
 def test_get_school_a_list_of_authors_with_one_affiliation_each():
-    a_list_of_authors_with_one_affiliation_each = Record({
+    a_list_of_authors_with_one_affiliation_each = InspireRecord({
         'authors': [
             {
                 'affiliations': [
@@ -651,7 +652,7 @@ def test_get_school_a_list_of_authors_with_one_affiliation_each():
 
 
 def test_get_school_a_list_of_authors_with_more_than_one_affiliation_each():
-    a_list_of_authors_with_more_than_one_affiliation_each = Record({
+    a_list_of_authors_with_more_than_one_affiliation_each = InspireRecord({
         'authors': [
             {
                 'affiliations': [
@@ -675,7 +676,7 @@ def test_get_school_a_list_of_authors_with_more_than_one_affiliation_each():
 
 
 def test_get_booktitle_not_in_proceedings():
-    record = Record({})
+    record = InspireRecord({})
 
     not_in_proceedings = Bibtex(record)
     not_in_proceedings.entry_type = 'not-inproceedings'
@@ -689,7 +690,7 @@ def test_get_booktitle_from_generate_booktitle(g_b):
     # TODO: mock the actual generate_booktitle output.
     g_b.return_value = 'foo bar baz'
 
-    record = Record({})
+    record = InspireRecord({})
 
     in_proceedings = Bibtex(record)
     in_proceedings.entry_type = 'inproceedings'
@@ -701,7 +702,7 @@ def test_get_booktitle_from_generate_booktitle(g_b):
 
 
 def test_get_year_no_publication_info_no_thesis_no_imprints_no_preprint_date():
-    no_publication_info_no_thesis_no_imprints_no_preprint_date = Record({})
+    no_publication_info_no_thesis_no_imprints_no_preprint_date = InspireRecord({})
 
     expected = ''
     result = Bibtex(no_publication_info_no_thesis_no_imprints_no_preprint_date)._get_year()
@@ -710,7 +711,7 @@ def test_get_year_no_publication_info_no_thesis_no_imprints_no_preprint_date():
 
 
 def test_get_year_from_publication_info_an_empty_list():
-    publication_info_an_empty_list = Record({
+    publication_info_an_empty_list = InspireRecord({
         'publication_info': []
     })
 
@@ -721,7 +722,7 @@ def test_get_year_from_publication_info_an_empty_list():
 
 
 def test_get_year_from_publication_info_a_list_one_year():
-    publication_info_a_list_one_year = Record({
+    publication_info_a_list_one_year = InspireRecord({
         'publication_info': [
             {'year': '2015'}
         ]
@@ -734,7 +735,7 @@ def test_get_year_from_publication_info_a_list_one_year():
 
 
 def test_get_year_from_publication_info_a_list_from_imprints():
-    publication_info_a_list_from_imprints = Record({
+    publication_info_a_list_from_imprints = InspireRecord({
         'publication_info': [],
         'imprints': [
             {'date': '2015-12-04'}
@@ -748,7 +749,7 @@ def test_get_year_from_publication_info_a_list_from_imprints():
 
 
 def test_get_year_from_publication_info_a_list_from_preprint_date():
-    publication_info_a_list_from_preprint_date = Record({
+    publication_info_a_list_from_preprint_date = InspireRecord({
         'publication_info': [],
         'preprint_date': [
             '2015-12-04'
@@ -762,7 +763,7 @@ def test_get_year_from_publication_info_a_list_from_preprint_date():
 
 
 def test_get_year_from_thesis_an_empty_obj():
-    record = Record({
+    record = InspireRecord({
         'thesis': {}
     })
 
@@ -776,7 +777,7 @@ def test_get_year_from_thesis_an_empty_obj():
 
 
 def test_get_year_from_thesis_an_empty_obj_but_preprint_date():
-    record = Record({
+    record = InspireRecord({
         'preprint_date': '1998-04-30',
         'thesis': {}
     })
@@ -791,7 +792,7 @@ def test_get_year_from_thesis_an_empty_obj_but_preprint_date():
 
 
 def test_get_year_from_thesis_an_empty_obj_but_imprints():
-    record = Record({
+    record = InspireRecord({
         'imprints': [{'date': '2015-12-04'}],
         'thesis': {}
     })
@@ -806,7 +807,7 @@ def test_get_year_from_thesis_an_empty_obj_but_imprints():
 
 
 def test_get_year_from_thesis_one_date():
-    record = Record({
+    record = InspireRecord({
         'thesis': {'date': '2008'}
     })
 
@@ -820,7 +821,7 @@ def test_get_year_from_thesis_one_date():
 
 
 def test_get_year_from_imprints_an_empty_list():
-    imprints_an_empty_list = Record({
+    imprints_an_empty_list = InspireRecord({
         'imprints': []
     })
 
@@ -831,7 +832,7 @@ def test_get_year_from_imprints_an_empty_list():
 
 
 def test_get_year_from_imprints_one_date():
-    imprints_one_date = Record({
+    imprints_one_date = InspireRecord({
         'imprints': [
             {'date': '1998-04-30'}
         ]
@@ -844,7 +845,7 @@ def test_get_year_from_imprints_one_date():
 
 
 def test_get_year_from_imprints_two_dates():
-    imprints_two_dates = Record({
+    imprints_two_dates = InspireRecord({
         'imprints': [
             {'date': '1998-04-30'},
             {'date': '2015-12-04'}
@@ -858,7 +859,7 @@ def test_get_year_from_imprints_two_dates():
 
 
 def test_get_year_from_preprint_date_an_empty_list():
-    preprint_date_an_empty_list = Record({
+    preprint_date_an_empty_list = InspireRecord({
         'preprint_date': []
     })
 
@@ -869,7 +870,7 @@ def test_get_year_from_preprint_date_an_empty_list():
 
 
 def test_get_year_from_preprint_date_one_date():
-    preprint_date_one_date = Record({
+    preprint_date_one_date = InspireRecord({
         'preprint_date': [
             '2015-12-04'
         ]
@@ -882,7 +883,7 @@ def test_get_year_from_preprint_date_one_date():
 
 
 def test_get_year_from_preprint_date_two_dates():
-    preprint_date_two_dates = Record({
+    preprint_date_two_dates = InspireRecord({
         'preprint_date': [
             '1998-04-30',
             '2015-12-04'
@@ -896,7 +897,7 @@ def test_get_year_from_preprint_date_two_dates():
 
 
 def test_get_journal_no_publication_info():
-    no_publication_info = Record({})
+    no_publication_info = InspireRecord({})
 
     expected = ''
     result = Bibtex(no_publication_info)._get_journal()
@@ -905,7 +906,7 @@ def test_get_journal_no_publication_info():
 
 
 def test_get_journal_publication_info_a_list_no_journal_title():
-    publication_info_a_list_no_journal_title = Record({
+    publication_info_a_list_no_journal_title = InspireRecord({
         'publication_info': []
     })
 
@@ -916,7 +917,7 @@ def test_get_journal_publication_info_a_list_no_journal_title():
 
 
 def test_get_journal_publication_info_a_list_one_journal_title():
-    publication_info_a_list_one_journal_title = Record({
+    publication_info_a_list_one_journal_title = InspireRecord({
         'publication_info': [
             {'journal_title': 'Nucl.Phys.'}
         ]
@@ -929,7 +930,7 @@ def test_get_journal_publication_info_a_list_one_journal_title():
 
 
 def test_get_journal_publication_info_a_list_one_journal_title_a_list():
-    publication_info_a_list_one_journal_title_a_list = Record({
+    publication_info_a_list_one_journal_title_a_list = InspireRecord({
         'publication_info': [
             {
                 'journal_title': [
@@ -947,7 +948,7 @@ def test_get_journal_publication_info_a_list_one_journal_title_a_list():
 
 
 def test_get_volume_no_publication_info_no_book_series():
-    no_publication_info_no_book_series = Record({})
+    no_publication_info_no_book_series = InspireRecord({})
 
     expected = ''
     result = Bibtex(no_publication_info_no_book_series)._get_volume()
@@ -956,7 +957,7 @@ def test_get_volume_no_publication_info_no_book_series():
 
 
 def test_get_volume_from_publication_info_an_empty_list():
-    publication_info_an_empty_list = Record({
+    publication_info_an_empty_list = InspireRecord({
         'publication_info': []
     })
 
@@ -967,7 +968,7 @@ def test_get_volume_from_publication_info_an_empty_list():
 
 
 def test_get_volume_from_publication_info_a_list_one_with_volume():
-    publication_info_a_list_one_with_volume = Record({
+    publication_info_a_list_one_with_volume = InspireRecord({
         'publication_info': [
             {'journal_volume': 'D89'}
         ]
@@ -980,7 +981,7 @@ def test_get_volume_from_publication_info_a_list_one_with_volume():
 
 
 def test_get_volume_from_publication_info_one_with_volume_JHEP():
-    publication_info_a_list_one_with_volume_JHEP = Record({
+    publication_info_a_list_one_with_volume_JHEP = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'JHEP',
@@ -996,7 +997,7 @@ def test_get_volume_from_publication_info_one_with_volume_JHEP():
 
 
 def test_get_volume_from_publication_info_a_list_two_with_volume():
-    publication_info_a_list_two_with_volume = Record({
+    publication_info_a_list_two_with_volume = InspireRecord({
         'publication_info': [
             {'journal_volume': 'D89'},
             {'journal_volume': 'D91'}
@@ -1010,7 +1011,7 @@ def test_get_volume_from_publication_info_a_list_two_with_volume():
 
 
 def test_get_volume_from_publication_info_actually_from_book_series():
-    publication_info_actually_from_book_series = Record({
+    publication_info_actually_from_book_series = InspireRecord({
         'publication_info': [],
         'book_series': [
             {'volume': '11'}
@@ -1024,7 +1025,7 @@ def test_get_volume_from_publication_info_actually_from_book_series():
 
 
 def test_get_volume_from_book_series_an_empty_list():
-    book_series_an_empty_list = Record({
+    book_series_an_empty_list = InspireRecord({
         'book_series': []
     })
 
@@ -1035,7 +1036,7 @@ def test_get_volume_from_book_series_an_empty_list():
 
 
 def test_get_volume_from_book_series_one_volume():
-    book_series_one_volume = Record({
+    book_series_one_volume = InspireRecord({
         'book_series': [
             {'volume': '11'}
         ]
@@ -1048,7 +1049,7 @@ def test_get_volume_from_book_series_one_volume():
 
 
 def test_get_volume_from_book_series_two_volumes():
-    book_series_two_volumes = Record({
+    book_series_two_volumes = InspireRecord({
         'book_series': [
             {'volume': '11'},
             {'volume': '5'}
@@ -1062,7 +1063,7 @@ def test_get_volume_from_book_series_two_volumes():
 
 
 def test_get_number_no_publication_info():
-    no_publication_info = Record({})
+    no_publication_info = InspireRecord({})
 
     expected = ''
     result = Bibtex(no_publication_info)._get_number()
@@ -1071,7 +1072,7 @@ def test_get_number_no_publication_info():
 
 
 def test_get_number_publication_info_an_empty_list():
-    publication_info_an_empty_list = Record({
+    publication_info_an_empty_list = InspireRecord({
         'publication_info': []
     })
 
@@ -1082,7 +1083,7 @@ def test_get_number_publication_info_an_empty_list():
 
 
 def test_get_number_publication_info_a_list_one_issue():
-    publication_info_a_list_one_issue = Record({
+    publication_info_a_list_one_issue = InspireRecord({
         'publication_info': [
             {'journal_issue': '5'}
         ]
@@ -1095,7 +1096,7 @@ def test_get_number_publication_info_a_list_one_issue():
 
 
 def test_get_number_publication_info_a_list_two_issues():
-    publication_info_a_list_two_issues = Record({
+    publication_info_a_list_two_issues = InspireRecord({
         'publication_info': [
             {'journal_issue': '11'},
             {'journal_issue': '5'}
@@ -1109,7 +1110,7 @@ def test_get_number_publication_info_a_list_two_issues():
 
 
 def test_get_pages_no_publication_info():
-    no_publication_info = Record({})
+    no_publication_info = InspireRecord({})
 
     expected = ''
     result = Bibtex(no_publication_info)._get_pages()
@@ -1118,7 +1119,7 @@ def test_get_pages_no_publication_info():
 
 
 def test_get_pages_publication_info_an_empty_list():
-    publication_info_an_empty_list = Record({
+    publication_info_an_empty_list = InspireRecord({
         'publication_info': []
     })
 
@@ -1129,7 +1130,7 @@ def test_get_pages_publication_info_an_empty_list():
 
 
 def test_get_pages_publication_info_one_page():
-    publication_info_one_page = Record({
+    publication_info_one_page = InspireRecord({
         'publication_info': [
             {'page_start': '585',
              'page_end': '587'}
@@ -1143,7 +1144,7 @@ def test_get_pages_publication_info_one_page():
 
 
 def test_get_pages_publication_info_two_pages():
-    publication_info_two_pages = Record({
+    publication_info_two_pages = InspireRecord({
         'publication_info': [
             {'page_start': '585',
              'page_end': '587'},
@@ -1159,7 +1160,7 @@ def test_get_pages_publication_info_two_pages():
 
 
 def test_get_note_not_article_not_in_proceedings():
-    record = Record({})
+    record = InspireRecord({})
 
     not_article_not_in_proceedings = Bibtex(record)
     not_article_not_in_proceedings.entry_type = 'not-article'
@@ -1168,13 +1169,13 @@ def test_get_note_not_article_not_in_proceedings():
 
 
 def test_get_note_no_publication_info():
-    no_publication_info = Record({})
+    no_publication_info = InspireRecord({})
 
     assert Bibtex(no_publication_info)._get_note() is None
 
 
 def test_get_note_publication_info_an_empty_list():
-    publication_info_an_empty_list = Record({
+    publication_info_an_empty_list = InspireRecord({
         'publication_info': []
     })
 
@@ -1185,7 +1186,7 @@ def test_get_note_publication_info_an_empty_list():
 
 
 def test_get_note_publication_info_a_list_one_el():
-    publication_info_a_list_one_el = Record({
+    publication_info_a_list_one_el = InspireRecord({
         'publication_info': [
             {
                 'note': 'Erratum',
@@ -1201,7 +1202,7 @@ def test_get_note_publication_info_a_list_one_el():
 
 
 def test_get_note_publication_info_a_list_two_els():
-    publication_info_a_list_two_els = Record({
+    publication_info_a_list_two_els = InspireRecord({
         'publication_info': [
             {
                 'note': 'Erratum',
@@ -1221,7 +1222,7 @@ def test_get_note_publication_info_a_list_two_els():
 
 
 def test_get_note_publication_info_a_list_not_a_note_with_title():
-    publication_info_a_list_not_a_note_with_title = Record({
+    publication_info_a_list_not_a_note_with_title = InspireRecord({
         'publication_info': [
             {'journal_title': 'Phys.Rev.'},
             {'journal_title': 'Phys.Rev.'}
@@ -1235,7 +1236,7 @@ def test_get_note_publication_info_a_list_not_a_note_with_title():
 
 
 def test_get_note_publication_info_a_list_not_a_note_with_volume():
-    publication_info_a_list_not_a_note_with_volume = Record({
+    publication_info_a_list_not_a_note_with_volume = InspireRecord({
         'publication_info': [
             {'journal_volume': 'D69'},
             {'journal_volume': 'D69'}
@@ -1249,7 +1250,7 @@ def test_get_note_publication_info_a_list_not_a_note_with_volume():
 
 
 def test_get_note_publication_info_a_list_not_a_note_with_volume_JHEP():
-    publication_info_a_list_not_a_note_with_volume_JHEP = Record({
+    publication_info_a_list_not_a_note_with_volume_JHEP = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'JHEP',
@@ -1269,7 +1270,7 @@ def test_get_note_publication_info_a_list_not_a_note_with_volume_JHEP():
 
 
 def test_get_note_publication_info_a_list_not_a_note_with_issue():
-    publication_info_a_list_not_a_note_with_issue = Record({
+    publication_info_a_list_not_a_note_with_issue = InspireRecord({
         'publication_info': [
             {'journal_issue': '11'},
             {'journal_issue': '11'}
@@ -1283,7 +1284,7 @@ def test_get_note_publication_info_a_list_not_a_note_with_issue():
 
 
 def test_get_note_publication_info_a_list_not_a_note_with_pages():
-    publication_info_a_list_not_a_note_with_pages = Record({
+    publication_info_a_list_not_a_note_with_pages = InspireRecord({
         'publication_info': [
             {'page_start': 'pp.2067',
              'page_end': '2414'},
@@ -1299,7 +1300,7 @@ def test_get_note_publication_info_a_list_not_a_note_with_pages():
 
 
 def test_get_note_publication_info_a_list_not_a_note_with_year():
-    publication_info_a_list_not_a_note_with_year = Record({
+    publication_info_a_list_not_a_note_with_year = InspireRecord({
         'publication_info': [
             {'year': '2015'},
             {'year': '2015'}
@@ -1313,7 +1314,7 @@ def test_get_note_publication_info_a_list_not_a_note_with_year():
 
 
 def test_get_note_publication_info_a_list_not_a_note_with_preprint():
-    publication_info_a_list_not_a_note_with_preprint = Record({
+    publication_info_a_list_not_a_note_with_preprint = InspireRecord({
         'preprint_date': '2015-12-04',
         'publication_info': [
             {'journal_title': 'Acta Phys.Polon.'},
@@ -1328,7 +1329,7 @@ def test_get_note_publication_info_a_list_not_a_note_with_preprint():
 
 
 def test_get_note_publication_info_a_list_not_a_note_with_everything():
-    publication_info_a_list_not_a_note_with_everything = Record({
+    publication_info_a_list_not_a_note_with_everything = InspireRecord({
         'doi': 'something',
         'publication_info': [
             {
@@ -1355,7 +1356,7 @@ def test_get_note_publication_info_a_list_not_a_note_with_everything():
 
 
 def test_get_note_publication_info_a_list_a_note_with_title():
-    publication_info_a_list_a_note_with_title = Record({
+    publication_info_a_list_a_note_with_title = InspireRecord({
         'publication_info': [
             {
                 'note': 'Erratum',
@@ -1375,7 +1376,7 @@ def test_get_note_publication_info_a_list_a_note_with_title():
 
 
 def test_get_note_publication_info_a_list_a_note_with_volume():
-    publication_info_a_list_a_note_with_volume = Record({
+    publication_info_a_list_a_note_with_volume = InspireRecord({
         'publication_info': [
             {
                 'note': 'Addendum',
@@ -1395,7 +1396,7 @@ def test_get_note_publication_info_a_list_a_note_with_volume():
 
 
 def test_get_note_publication_info_a_list_a_note_with_volume_JHEP():
-    publication_info_a_list_a_note_with_volume_JHEP = Record({
+    publication_info_a_list_a_note_with_volume_JHEP = InspireRecord({
         'publication_info': [
             {
                 'note': 'Erratum',
@@ -1417,7 +1418,7 @@ def test_get_note_publication_info_a_list_a_note_with_volume_JHEP():
 
 
 def test_get_note_publication_info_a_list_a_note_with_issue():
-    publication_info_a_list_a_note_with_issue = Record({
+    publication_info_a_list_a_note_with_issue = InspireRecord({
         'publication_info': [
             {
                 'note': 'Corrigendum',
@@ -1437,7 +1438,7 @@ def test_get_note_publication_info_a_list_a_note_with_issue():
 
 
 def test_get_note_publication_info_a_list_a_note_with_pages():
-    publication_info_a_list_a_note_with_pages = Record({
+    publication_info_a_list_a_note_with_pages = InspireRecord({
         'publication_info': [
             {
                 'note': 'Reprint',
@@ -1457,7 +1458,7 @@ def test_get_note_publication_info_a_list_a_note_with_pages():
 
 
 def test_get_note_publication_info_a_list_a_note_with_year():
-    publication_info_a_list_a_note_with_year = Record({
+    publication_info_a_list_a_note_with_year = InspireRecord({
         'publication_info': [
             {
                 'note': 'Erratum',
@@ -1477,7 +1478,7 @@ def test_get_note_publication_info_a_list_a_note_with_year():
 
 
 def test_get_url_no_urls():
-    no_urls = Record({})
+    no_urls = InspireRecord({})
 
     expected = ''
     result = Bibtex(no_urls)._get_url()
@@ -1486,7 +1487,7 @@ def test_get_url_no_urls():
 
 
 def test_get_url_empty_urls():
-    empty_urls = Record({
+    empty_urls = InspireRecord({
         'urls': []
     })
 
@@ -1497,7 +1498,7 @@ def test_get_url_empty_urls():
 
 
 def test_get_url_urls_without_value():
-    urls_without_url = Record({
+    urls_without_url = InspireRecord({
         'urls': [
             {'not-value': 'foo'}
         ]
@@ -1510,7 +1511,7 @@ def test_get_url_urls_without_value():
 
 
 def test_get_url_one_url_to_an_image():
-    one_url_to_an_image = Record({
+    one_url_to_an_image = InspireRecord({
         'urls': [
             {'value': 'foo.jpg'}
         ]
@@ -1523,7 +1524,7 @@ def test_get_url_one_url_to_an_image():
 
 
 def test_get_url_one_url_not_to_an_image():
-    one_url_not_to_an_image = Record({
+    one_url_not_to_an_image = InspireRecord({
         'urls': [
             {'value': 'http://link.aps.org/abstract/PRL/V19/P1264'}
         ]
@@ -1536,7 +1537,7 @@ def test_get_url_one_url_not_to_an_image():
 
 
 def test_get_url_more_urls_selects_first():
-    more_urls = Record({
+    more_urls = InspireRecord({
         'urls': [
             {'value': 'http://link.aps.org/abstract/PRL/V19/P1264'},
             {'value': 'http://example.com'}
@@ -1550,7 +1551,7 @@ def test_get_url_more_urls_selects_first():
 
 
 def test_get_eprint_no_arxiv_field():
-    no_arxiv_field = Record({})
+    no_arxiv_field = InspireRecord({})
 
     expected = []
     result = Bibtex(no_arxiv_field)._get_eprint()
@@ -1559,7 +1560,7 @@ def test_get_eprint_no_arxiv_field():
 
 
 def test_get_eprint_arxiv_field_starts_with_arxiv():
-    starts_with_arxiv = Record({
+    starts_with_arxiv = InspireRecord({
         'arxiv_eprints': [
             {'value': 'arXiv:1512.01381'}
         ]
@@ -1572,7 +1573,7 @@ def test_get_eprint_arxiv_field_starts_with_arxiv():
 
 
 def test_get_eprint_arxiv_field_does_not_start_with_arxiv():
-    does_not_start_with_arxiv = Record({
+    does_not_start_with_arxiv = InspireRecord({
         'arxiv_eprints': [
             {'value': '1512.01381'}
         ]
@@ -1585,7 +1586,7 @@ def test_get_eprint_arxiv_field_does_not_start_with_arxiv():
 
 
 def test_get_archive_prefix_no_arxiv_eprints():
-    no_arxiv_eprints = Record({})
+    no_arxiv_eprints = InspireRecord({})
 
     expected = ''
     result = Bibtex(no_arxiv_eprints)._get_archive_prefix()
@@ -1594,7 +1595,7 @@ def test_get_archive_prefix_no_arxiv_eprints():
 
 
 def test_get_archive_prefix_empty_arxiv_eprints():
-    empty_arxiv_eprints = Record({
+    empty_arxiv_eprints = InspireRecord({
         'arxiv_eprints': []
     })
 
@@ -1605,7 +1606,7 @@ def test_get_archive_prefix_empty_arxiv_eprints():
 
 
 def test_get_archive_prefix_some_arxiv_eprints():
-    some_arxiv_eprints = Record({
+    some_arxiv_eprints = InspireRecord({
         'arxiv_eprints': [
             {
                 u'categories': [u'hep-th'],
@@ -1621,7 +1622,7 @@ def test_get_archive_prefix_some_arxiv_eprints():
 
 
 def test_get_primary_class_no_arxiv_eprints():
-    no_arxiv_eprints = Record({})
+    no_arxiv_eprints = InspireRecord({})
 
     expected = ''
     result = Bibtex(no_arxiv_eprints)._get_primary_class()
@@ -1630,7 +1631,7 @@ def test_get_primary_class_no_arxiv_eprints():
 
 
 def test_get_primary_class_empty_arxiv_eprints():
-    empty_arxiv_eprints = Record({
+    empty_arxiv_eprints = InspireRecord({
         'arxiv_eprints': []
     })
 
@@ -1638,7 +1639,7 @@ def test_get_primary_class_empty_arxiv_eprints():
 
 
 def test_get_primary_class_one_arxiv_eprint_one_category():
-    one_arxiv_eprint_one_category = Record({
+    one_arxiv_eprint_one_category = InspireRecord({
         'arxiv_eprints': [
             {'categories': ['hep-th']}
         ]
@@ -1651,7 +1652,7 @@ def test_get_primary_class_one_arxiv_eprint_one_category():
 
 
 def test_get_primary_class_one_arxiv_eprint_more_categories():
-    one_arxiv_eprint_more_categories = Record({
+    one_arxiv_eprint_more_categories = InspireRecord({
         'arxiv_eprints': [
             {'categories': ['hep-th', 'hep-ph']}
         ]
@@ -1664,7 +1665,7 @@ def test_get_primary_class_one_arxiv_eprint_more_categories():
 
 
 def test_get_primary_class_more_arxiv_eprints_more_categories():
-    more_arxiv_eprints_more_categories = Record({
+    more_arxiv_eprints_more_categories = InspireRecord({
         'arxiv_eprints': [
             {'categories': ['hep-th', 'hep-ph']},
             {'categories': ['hep-ex']}
@@ -1678,7 +1679,7 @@ def test_get_primary_class_more_arxiv_eprints_more_categories():
 
 
 def test_get_series_no_book_series():
-    no_book_series = Record({})
+    no_book_series = InspireRecord({})
 
     expected = ''
     result = Bibtex(no_book_series)._get_series()
@@ -1687,7 +1688,7 @@ def test_get_series_no_book_series():
 
 
 def test_get_series_empty_book_series():
-    empty_book_series = Record({
+    empty_book_series = InspireRecord({
         'book_series': []
     })
 
@@ -1698,7 +1699,7 @@ def test_get_series_empty_book_series():
 
 
 def test_get_series_one_book_series():
-    one_book_series = Record({
+    one_book_series = InspireRecord({
         'book_series': [
             {'value': 'Mathematical Physics Studies'}
         ]
@@ -1711,7 +1712,7 @@ def test_get_series_one_book_series():
 
 
 def test_get_series_more_book_series():
-    more_book_series = Record({
+    more_book_series = InspireRecord({
         'book_series': [
             {'value': 'High Energy Physics'},
             {'value': 'Mathematical Physics Studies'}
@@ -1725,7 +1726,7 @@ def test_get_series_more_book_series():
 
 
 def test_get_isbn_no_isbns():
-    no_isbns = Record({})
+    no_isbns = InspireRecord({})
 
     expected = ''
     result = Bibtex(no_isbns)._get_isbn()
@@ -1735,7 +1736,7 @@ def test_get_isbn_no_isbns():
 
 @pytest.mark.xfail
 def test_get_isbn_empty_isbns():
-    empty_isbns = Record({
+    empty_isbns = InspireRecord({
         'isbns': []
     })
 
@@ -1744,7 +1745,7 @@ def test_get_isbn_empty_isbns():
 
 @pytest.mark.xfail
 def test_get_isbn_one_isbn_not_a_list():
-    one_isbn_not_a_list = Record({
+    one_isbn_not_a_list = InspireRecord({
         'isbns': [
             {'value': '978-1-4244-0922-8'}
         ]
@@ -1757,7 +1758,7 @@ def test_get_isbn_one_isbn_not_a_list():
 
 
 def test_get_isbn_two_isbns_not_a_list():
-    two_isbns_not_a_list = Record({
+    two_isbns_not_a_list = InspireRecord({
         'isbns': [
             {'value': '978-3-319-17544-7'},
             {'value': '978-3-319-17545-4'}
@@ -1771,7 +1772,7 @@ def test_get_isbn_two_isbns_not_a_list():
 
 
 def test_get_isbn_two_isbns_one_a_list():
-    two_isbns_one_a_list = Record({
+    two_isbns_one_a_list = InspireRecord({
         'isbns': [
             {'value': ['978-3-319-17544-7', '978-3-319-17545-4']},
             {'value': '978-94-010-2276-7'}
@@ -1785,7 +1786,7 @@ def test_get_isbn_two_isbns_one_a_list():
 
 
 def test_get_pubnote_no_publication_info():
-    no_publication_info = Record({})
+    no_publication_info = InspireRecord({})
 
     expected = ''
     result = Bibtex(no_publication_info)._get_pubnote()
@@ -1794,7 +1795,7 @@ def test_get_pubnote_no_publication_info():
 
 
 def test_get_pubnote_publication_info_an_empty_list():
-    publication_info_an_empty_list = Record({
+    publication_info_an_empty_list = InspireRecord({
         'publication_info': []
     })
 
@@ -1802,7 +1803,7 @@ def test_get_pubnote_publication_info_an_empty_list():
 
 
 def test_get_pubnote_publication_info_a_list_one_with_title():
-    publication_info_a_list_one_with_title = Record({
+    publication_info_a_list_one_with_title = InspireRecord({
         'publication_info': [
             {'journal_title': 'Nucl.Phys.'}
         ]
@@ -1817,7 +1818,7 @@ def test_get_pubnote_publication_info_a_list_one_with_title_and_volume(self, g_k
     # TODO: mock the actual invenio_knowledge API.
     g_k_k.return_value = [['Nucl. Phys.']]
 
-    publication_info_a_list_one_with_title_and_volume = Record({
+    publication_info_a_list_one_with_title_and_volume = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'Nucl.Phys.',
@@ -1838,7 +1839,7 @@ def test_get_pubnote_publication_info_a_list_one_with_title_and_pages_not_a_list
     # TODO: mock the actual invenio_knowledge API.
     g_k_k.return_value = [['Nucl. Phys.']]
 
-    publication_info_a_list_one_with_title_and_pages_not_a_list = Record({
+    publication_info_a_list_one_with_title_and_pages_not_a_list = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'Nucl.Phys.',
@@ -1860,7 +1861,7 @@ def test_get_pubnote_publication_info_a_list_one_with_everything(self, g_k_k):
     # TODO: mock the actual invenio_knowledge API.
     g_k_k.return_value = [['Nucl. Phys.']]
 
-    publication_info_a_list_one_with_everything = Record({
+    publication_info_a_list_one_with_everything = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'Nucl.Phys.',
@@ -1883,7 +1884,7 @@ def test_get_pubnote_publication_info_a_list_get_kbr_keys_raises(self, g_k_k):
     # TODO: mock the actual invenio_knowledge API.
     g_k_k.side_effect = RuntimeError
 
-    publication_info_a_list_one_with_everything = Record({
+    publication_info_a_list_one_with_everything = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'Nucl.Phys.',

--- a/tests/unit/utils/test_utils_bibtex_booktitle.py
+++ b/tests/unit/utils/test_utils_bibtex_booktitle.py
@@ -24,13 +24,12 @@
 
 import pytest
 
-from invenio_records.api import Record
-
+from inspirehep.modules.records.api import InspireRecord
 from inspirehep.utils.bibtex_booktitle import generate_booktitle, traverse
 
 
 def test_generate_booktitle_no_publication_info():
-    no_publication_info = Record({})
+    no_publication_info = InspireRecord({})
 
     expected = ''
     result = generate_booktitle(no_publication_info)
@@ -39,7 +38,7 @@ def test_generate_booktitle_no_publication_info():
 
 
 def test_generate_booktitle_publication_info_an_empty_list():
-    publication_info_an_empty_list = Record({
+    publication_info_an_empty_list = InspireRecord({
         'publication_info': []
     })
 
@@ -50,7 +49,7 @@ def test_generate_booktitle_publication_info_an_empty_list():
 
 
 def test_generate_booktitle_no_reportnumber():
-    no_reportnumber = Record({
+    no_reportnumber = InspireRecord({
         'publication_info': [
             {}
         ]
@@ -63,7 +62,7 @@ def test_generate_booktitle_no_reportnumber():
 
 
 def test_generate_booktitle_empty_reportnumber():
-    empty_reportnumber = Record({
+    empty_reportnumber = InspireRecord({
         'publication_info': [
             {
                 'reportnumber': ''
@@ -79,7 +78,7 @@ def test_generate_booktitle_empty_reportnumber():
 
 @pytest.mark.xfail(reason='KeyError when looking for acronym')
 def test_generate_booktitle_reportnumber_and_conf_acronym():
-    recordnumber_and_conf_acronym = Record({
+    recordnumber_and_conf_acronym = InspireRecord({
         'publication_info': [
             {
                 'reportnumber': 'CERN-Proceedings-2010-001',
@@ -96,7 +95,7 @@ def test_generate_booktitle_reportnumber_and_conf_acronym():
 
 @pytest.mark.xfail(reason='KeyError when looking for acronym')
 def test_generate_booktitle_reportnumber_but_no_conf_acronym():
-    no_conf_acronym = Record({
+    no_conf_acronym = InspireRecord({
         'publication_info': [
             {
                 'reportnumber': 'CERN-Proceedings-2014-001'
@@ -111,7 +110,7 @@ def test_generate_booktitle_reportnumber_but_no_conf_acronym():
 
 
 def test_generate_booktitle_from_one_pubinfo_freetext():
-    one_pubinfo_freetext = Record({
+    one_pubinfo_freetext = InspireRecord({
         'publication_info': [
             {
                 'pubinfo_freetext': 'Adv. Theor. Math. Phys. 2 (1998) 51-59'
@@ -126,7 +125,7 @@ def test_generate_booktitle_from_one_pubinfo_freetext():
 
 
 def test_generate_booktitle_from_two_pubinfo_freetext():
-    two_pubinfo_freetext = Record({
+    two_pubinfo_freetext = InspireRecord({
         'publication_info': [
             {
                 'pubinfo_freetext': 'Prog. Theor. Phys. 49 (1973) 652-657'

--- a/tests/unit/utils/test_utils_cv_latex.py
+++ b/tests/unit/utils/test_utils_cv_latex.py
@@ -23,8 +23,7 @@
 import mock
 import pytest
 
-from invenio_records.api import Record
-
+from inspirehep.modules.records.api import InspireRecord
 from inspirehep.utils.cv_latex import Cv_latex
 
 
@@ -32,7 +31,7 @@ from inspirehep.utils.cv_latex import Cv_latex
 
 
 def test_get_author_from_authors_a_list_with_one_element():
-    authors_a_list_with_one_element = Record({
+    authors_a_list_with_one_element = InspireRecord({
         'authors': [
             {'full_name': 'Glashow, S.L.'}
         ]
@@ -45,7 +44,7 @@ def test_get_author_from_authors_a_list_with_one_element():
 
 
 def test_get_author_from_authors_a_list_with_two_elements():
-    authors_a_list_with_two_elements = Record({
+    authors_a_list_with_two_elements = InspireRecord({
         'authors': [
             {'full_name': 'Englert, F.'},
             {'full_name': 'Brout, R.'}
@@ -59,7 +58,7 @@ def test_get_author_from_authors_a_list_with_two_elements():
 
 
 def test_get_author_from_authors_one_author_with_an_empty_list_of_full_names():
-    one_author_with_an_empty_list_of_full_names = Record({
+    one_author_with_an_empty_list_of_full_names = InspireRecord({
         'authors': [
             {'full_name': []}
         ]
@@ -72,7 +71,7 @@ def test_get_author_from_authors_one_author_with_an_empty_list_of_full_names():
 
 
 def test_get_author_from_authors_one_author_with_a_list_of_one_full_name():
-    one_author_with_a_list_of_one_full_name = Record({
+    one_author_with_a_list_of_one_full_name = InspireRecord({
         'authors': [
             {'full_name': ['Glashow, S.L.']}
         ]
@@ -85,7 +84,7 @@ def test_get_author_from_authors_one_author_with_a_list_of_one_full_name():
 
 
 def test_get_author_from_authors_one_author_with_a_list_of_two_full_names():
-    one_author_with_a_list_of_two_full_names = Record({
+    one_author_with_a_list_of_two_full_names = InspireRecord({
         'authors': [
             {
                 'full_name': [
@@ -103,7 +102,7 @@ def test_get_author_from_authors_one_author_with_a_list_of_two_full_names():
 
 
 def test_get_author_from_corporate_author_an_empty_list():
-    corporate_author_an_empty_list = Record({'corporate_author': []})
+    corporate_author_an_empty_list = InspireRecord({'corporate_author': []})
 
     expected = []
     result = Cv_latex(corporate_author_an_empty_list)._get_author()
@@ -113,7 +112,7 @@ def test_get_author_from_corporate_author_an_empty_list():
 
 @pytest.mark.xfail(reason='corporate_author is parsed as a real name')
 def test_get_author_from_corporate_author_a_list_with_one_element():
-    corporate_author_a_list_of_one_element = Record({
+    corporate_author_a_list_of_one_element = InspireRecord({
         'corporate_author': [
             'CMS Collaboration'
         ]
@@ -127,7 +126,7 @@ def test_get_author_from_corporate_author_a_list_with_one_element():
 
 @pytest.mark.xfail(reason='corporate_author is parsed as a real name')
 def test_get_author_from_corporate_author_a_list_with_two_elements():
-    corporate_author_a_list_of_two_elements = Record({
+    corporate_author_a_list_of_two_elements = InspireRecord({
         'corporate_author': [
             'CMS Collaboration',
             'The ATLAS Collaboration'
@@ -141,7 +140,7 @@ def test_get_author_from_corporate_author_a_list_with_two_elements():
 
 
 def test_get_title_returns_empty_string_when_no_titles():
-    without_titles = Record({})
+    without_titles = InspireRecord({})
 
     expected = ''
     result = Cv_latex(without_titles)._get_title()
@@ -150,7 +149,7 @@ def test_get_title_returns_empty_string_when_no_titles():
 
 
 def test_get_title_returns_first_title_found_when_titles_is_a_list():
-    a_list_of_titles = Record({
+    a_list_of_titles = InspireRecord({
         'titles': [
             {'title': ('Effective relational dynamics of a '
                        'nonintegrable cosmological model')},
@@ -170,13 +169,13 @@ def test_get_title_returns_first_title_found_when_titles_is_a_list():
 
 
 def test_get_publi_info_no_publication_info():
-    no_publication_info = Record({})
+    no_publication_info = InspireRecord({})
 
     assert Cv_latex(no_publication_info)._get_publi_info() is None
 
 
 def test_get_publi_info_from_publication_info_an_empty_list():
-    publication_info_an_empty_list = Record({'publication_info': []})
+    publication_info_an_empty_list = InspireRecord({'publication_info': []})
 
     expected = []
     result = Cv_latex(publication_info_an_empty_list)._get_publi_info()
@@ -185,7 +184,7 @@ def test_get_publi_info_from_publication_info_an_empty_list():
 
 
 def test_get_publi_info_from_publication_info_with_journal_title_not_a_list():
-    journal_title_not_a_list = Record({
+    journal_title_not_a_list = InspireRecord({
         'publication_info': [
             {'journal_title': 'Nucl.Phys.'}
         ]
@@ -199,7 +198,7 @@ def test_get_publi_info_from_publication_info_with_journal_title_not_a_list():
 
 @pytest.mark.xfail(reason='IndexError when accessing last element')
 def test_get_publi_info_from_publication_info_with_journal_title_an_empty_list():
-    journal_title_an_empty_list = Record({
+    journal_title_an_empty_list = InspireRecord({
         'publication_info': [
             {'journal_title': []}
         ]
@@ -212,7 +211,7 @@ def test_get_publi_info_from_publication_info_with_journal_title_an_empty_list()
 
 
 def test_get_publi_info_from_publication_info_with_journal_title_a_list_of_one_element():
-    journal_title_a_list_of_one_element = Record({
+    journal_title_a_list_of_one_element = InspireRecord({
         'publication_info': [
             {'journal_title': ['foo']}
         ]
@@ -225,7 +224,7 @@ def test_get_publi_info_from_publication_info_with_journal_title_a_list_of_one_e
 
 
 def test_get_publi_info_from_publication_info_with_journal_title_a_list_of_two_elements():
-    journal_title_a_list_of_two_elements = Record({
+    journal_title_a_list_of_two_elements = InspireRecord({
         'publication_info': [
             {'journal_title': ['foo', 'bar']}
         ]
@@ -238,7 +237,7 @@ def test_get_publi_info_from_publication_info_with_journal_title_a_list_of_two_e
 
 
 def test_get_publi_info_from_publication_info_with_journal_volume():
-    journal_volume = Record({
+    journal_volume = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'eConf',
@@ -254,7 +253,7 @@ def test_get_publi_info_from_publication_info_with_journal_volume():
 
 
 def test_get_publi_info_from_publication_info_with_journal_volume_with_letter():
-    journal_volume_with_letter = Record({
+    journal_volume_with_letter = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'Eur.Phys.J.',
@@ -270,7 +269,7 @@ def test_get_publi_info_from_publication_info_with_journal_volume_with_letter():
 
 
 def test_get_publi_info_from_publication_info_with_year_not_a_list():
-    year_not_a_list = Record({
+    year_not_a_list = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'Phys.Lett.',
@@ -287,7 +286,7 @@ def test_get_publi_info_from_publication_info_with_year_not_a_list():
 
 @pytest.mark.xfail(reason='IndexError when accessing last element')
 def test_get_publi_info_from_publication_info_with_year_an_empty_list():
-    year_an_empty_list = Record({
+    year_an_empty_list = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'Phys.Rev.',
@@ -303,7 +302,7 @@ def test_get_publi_info_from_publication_info_with_year_an_empty_list():
 
 
 def test_get_publi_info_from_publication_info_with_year_a_list_of_one_element():
-    year_a_list_of_one_element = Record({
+    year_a_list_of_one_element = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'JHEP',
@@ -319,7 +318,7 @@ def test_get_publi_info_from_publication_info_with_year_a_list_of_one_element():
 
 
 def test_get_publi_info_from_publication_info_with_year_a_list_of_two_elements():
-    year_a_list_of_two_elements = Record({
+    year_a_list_of_two_elements = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'Phys.Rev.Lett.',
@@ -335,7 +334,7 @@ def test_get_publi_info_from_publication_info_with_year_a_list_of_two_elements()
 
 
 def test_get_publi_info_from_publication_info_with_journal_issue():
-    journal_issue = Record({
+    journal_issue = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'Class.Quant.Grav.',
@@ -351,7 +350,7 @@ def test_get_publi_info_from_publication_info_with_journal_issue():
 
 
 def test_get_publi_info_from_publication_info_with_page_start():
-    page_start = Record({
+    page_start = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'JHEP',
@@ -367,7 +366,7 @@ def test_get_publi_info_from_publication_info_with_page_start():
 
 
 def test_get_publi_info_from_pubinfo_freetext():
-    pubinfo_freetext = Record({
+    pubinfo_freetext = InspireRecord({
         'publication_info': [
             {'pubinfo_freetext': 'Phys. Lett. 12 (1964) 132-133'}
         ]
@@ -380,7 +379,7 @@ def test_get_publi_info_from_pubinfo_freetext():
 
 
 def test_get_publi_info_from_publication_info_a_list_of_two_elements():
-    publication_info_a_list_of_two_elements = Record({
+    publication_info_a_list_of_two_elements = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'Int.J.Theor.Phys.',
@@ -412,7 +411,7 @@ def test_get_publi_info_from_publication_info_a_list_of_two_elements():
     'inspirehep.utils.cv_latex.config',
     mock.Mock(SERVER_NAME='http://localhost:5000'))
 def test_get_url():
-    record = Record({'control_number': 1})
+    record = InspireRecord({'control_number': 1})
 
     expected = 'http://localhost:5000/record/1'
     result = Cv_latex(record)._get_url()
@@ -421,13 +420,13 @@ def test_get_url():
 
 
 def test_get_date_without_any_date_returns_none():
-    without_any_date = Record({})
+    without_any_date = InspireRecord({})
 
     assert Cv_latex(without_any_date)._get_date() is None
 
 
 def test_get_date_from_preprint_date():
-    preprint_date = Record({'preprint_date': '2015-11-25'})
+    preprint_date = InspireRecord({'preprint_date': '2015-11-25'})
 
     expected = 'Nov 25, 2015'
     result = Cv_latex(preprint_date)._get_date()
@@ -437,7 +436,7 @@ def test_get_date_from_preprint_date():
 
 @pytest.mark.xfail(reason='zero is not added to the day')
 def test_get_date_from_preprint_date_adds_zero_to_day():
-    preprint_date = Record({'preprint_date': '2014-10-1'})
+    preprint_date = InspireRecord({'preprint_date': '2014-10-1'})
 
     expected = 'Oct 01, 2014'
     result = Cv_latex(preprint_date)._get_date()
@@ -455,7 +454,7 @@ def test_get_date_from_preprint_date_adds_zero_to_day():
 
 
 def test_get_date_from_publication_info():
-    publication_info = Record({
+    publication_info = InspireRecord({
         'publication_info': [
             {'year': '2011'}
         ]
@@ -468,7 +467,7 @@ def test_get_date_from_publication_info():
 
 
 def test_get_date_from_publication_info_returns_none_when_no_year():
-    publication_info_without_a_year = Record({
+    publication_info_without_a_year = InspireRecord({
         'publication_info': []
     })
 
@@ -476,7 +475,7 @@ def test_get_date_from_publication_info_returns_none_when_no_year():
 
 
 def test_get_date_from_publication_info_uses_first_year_found():
-    publication_info = Record({
+    publication_info = InspireRecord({
         'publication_info': [
             {},
             {'year': '2012'}
@@ -490,7 +489,7 @@ def test_get_date_from_publication_info_uses_first_year_found():
 
 
 def test_get_date_from_creation_modification_date():
-    creation_modification_date = Record({
+    creation_modification_date = InspireRecord({
         'creation_modification_date': [
             {'creation_date': '2012'}
         ]
@@ -503,7 +502,7 @@ def test_get_date_from_creation_modification_date():
 
 
 def test_get_date_from_creation_modification_date_returns_none_when_no_creation_date():
-    creation_modification_date_without_a_creation_date = Record({
+    creation_modification_date_without_a_creation_date = InspireRecord({
         'creation_modification_date': []
     })
 
@@ -512,7 +511,7 @@ def test_get_date_from_creation_modification_date_returns_none_when_no_creation_
 
 @pytest.mark.xfail(reason='creation_date might not be there')
 def test_get_date_from_creation_modification_date_uses_first_creation_date_found():
-    creation_modification_date = Record({
+    creation_modification_date = InspireRecord({
         'creation_modification_date': [
             {},
             {'creation_date': '2014-03-07'}
@@ -526,7 +525,7 @@ def test_get_date_from_creation_modification_date_uses_first_creation_date_found
 
 
 def test_get_date_from_imprints_returns_none_when_no_date():
-    imprints_without_a_date = Record({
+    imprints_without_a_date = InspireRecord({
         'imprints': []
     })
 
@@ -534,7 +533,7 @@ def test_get_date_from_imprints_returns_none_when_no_date():
 
 
 def test_get_date_from_imprints_uses_first_date_found():
-    imprints = Record({
+    imprints = InspireRecord({
         'imprints': [
             {},
             {'date': '2011-03-29'}
@@ -548,7 +547,7 @@ def test_get_date_from_imprints_uses_first_date_found():
 
 
 def test_get_date_from_thesis_returns_none_when_no_date():
-    thesis_without_a_date = Record({
+    thesis_without_a_date = InspireRecord({
         'thesis': {}
     })
 
@@ -556,7 +555,7 @@ def test_get_date_from_thesis_returns_none_when_no_date():
 
 
 def test_get_date_from_thesis_uses_first_date_found():
-    thesis = Record({
+    thesis = InspireRecord({
         'thesis': {'date': '1966'}
     })
 
@@ -567,7 +566,7 @@ def test_get_date_from_thesis_uses_first_date_found():
 
 
 def test_format_date_when_datestruct_has_one_element():
-    record = Record({})
+    record = InspireRecord({})
     cv_latex = Cv_latex(record)
 
     expected = 1993
@@ -577,7 +576,7 @@ def test_format_date_when_datestruct_has_one_element():
 
 
 def test_format_date_when_datestruct_has_two_elements():
-    record = Record({})
+    record = InspireRecord({})
     cv_latex = Cv_latex(record)
 
     expected = 'Feb 1993'
@@ -587,7 +586,7 @@ def test_format_date_when_datestruct_has_two_elements():
 
 
 def test_format_date_when_datestruct_has_three_elements():
-    record = Record({})
+    record = InspireRecord({})
     cv_latex = Cv_latex(record)
 
     expected = 'Feb 2, 1993'
@@ -597,28 +596,28 @@ def test_format_date_when_datestruct_has_three_elements():
 
 
 def test_format_date_returns_none_when_datestruct_has_four_elements():
-    record = Record({})
+    record = InspireRecord({})
     cv_latex = Cv_latex(record)
 
     assert cv_latex._format_date((1993, 2, 2, 1)) is None
 
 
 def test_parse_date_returns_none_when_datetext_is_none():
-    record = Record({})
+    record = InspireRecord({})
     cv_latex = Cv_latex(record)
 
     assert cv_latex.parse_date(None) is None
 
 
 def test_parse_date_returns_none_when_datetext_is_an_empty_string():
-    record = Record({})
+    record = InspireRecord({})
     cv_latex = Cv_latex(record)
 
     assert cv_latex.parse_date('') is None
 
 
 def test_parse_date_returns_none_when_datetext_is_not_of_type_str():
-    record = Record({})
+    record = InspireRecord({})
     cv_latex = Cv_latex(record)
 
     assert cv_latex.parse_date(0) is None
@@ -626,7 +625,7 @@ def test_parse_date_returns_none_when_datetext_is_not_of_type_str():
 
 @pytest.mark.xfail(reason='too strict check against str type')
 def test_parse_date_supports_unicode_strings():
-    record = Record({})
+    record = InspireRecord({})
     cv_latex = Cv_latex(record)
 
     expected = (1993, 2, 2)
@@ -636,7 +635,7 @@ def test_parse_date_supports_unicode_strings():
 
 
 def test_parse_date_partial_spires_format_year_only():
-    record = Record({})
+    record = InspireRecord({})
     cv_latex = Cv_latex(record)
 
     expected = (1993,)
@@ -646,7 +645,7 @@ def test_parse_date_partial_spires_format_year_only():
 
 
 def test_parse_date_partial_spires_format_year_and_month():
-    record = Record({})
+    record = InspireRecord({})
     cv_latex = Cv_latex(record)
 
     expected = (1993, 2)
@@ -656,7 +655,7 @@ def test_parse_date_partial_spires_format_year_and_month():
 
 
 def test_parse_date_full_spires_format():
-    record = Record({})
+    record = InspireRecord({})
     cv_latex = Cv_latex(record)
 
     expected = (1993, 2, 2)
@@ -666,7 +665,7 @@ def test_parse_date_full_spires_format():
 
 
 def test_parse_date_invalid_spires_format():
-    record = Record({})
+    record = InspireRecord({})
     cv_latex = Cv_latex(record)
 
     expected = (1993, 2)
@@ -676,7 +675,7 @@ def test_parse_date_invalid_spires_format():
 
 
 def test_parse_date_full_invenio_format():
-    record = Record({})
+    record = InspireRecord({})
     cv_latex = Cv_latex(record)
 
     expected = (1993, 2, 2)
@@ -686,7 +685,7 @@ def test_parse_date_full_invenio_format():
 
 
 def test_parse_date_invalid_invenio_format():
-    record = Record({})
+    record = InspireRecord({})
     cv_latex = Cv_latex(record)
 
     expected = (1993, 2)

--- a/tests/unit/utils/test_utils_cv_latex_html_text.py
+++ b/tests/unit/utils/test_utils_cv_latex_html_text.py
@@ -22,8 +22,7 @@
 
 import pytest
 
-from invenio_records.api import Record
-
+from inspirehep.modules.records.api import InspireRecord
 from inspirehep.utils.cv_latex_html_text import Cv_latex_html_text
 
 
@@ -31,7 +30,7 @@ from inspirehep.utils.cv_latex_html_text import Cv_latex_html_text
 
 
 def test_get_author_from_authors_a_list_with_one_element():
-    authors_a_list_with_one_element = Record({
+    authors_a_list_with_one_element = InspireRecord({
         'authors': [
             {'full_name': 'Glashow, S.L.'}
         ]
@@ -46,7 +45,7 @@ def test_get_author_from_authors_a_list_with_one_element():
 
 
 def test_get_author_from_authors_a_list_with_two_elements():
-    authors_a_list_with_two_elements = Record({
+    authors_a_list_with_two_elements = InspireRecord({
         'authors': [
             {'full_name': 'Englert, F.'},
             {'full_name': 'Brout, R.'}
@@ -62,7 +61,7 @@ def test_get_author_from_authors_a_list_with_two_elements():
 
 
 def test_get_author_from_authors_one_author_with_an_empty_list_of_full_names():
-    one_author_with_an_empty_list_of_full_names = Record({
+    one_author_with_an_empty_list_of_full_names = InspireRecord({
         'authors': [
             {'full_name': []}
         ]
@@ -77,7 +76,7 @@ def test_get_author_from_authors_one_author_with_an_empty_list_of_full_names():
 
 
 def test_get_author_from_authors_one_author_with_a_list_of_one_full_name():
-    one_author_with_a_list_of_one_full_name = Record({
+    one_author_with_a_list_of_one_full_name = InspireRecord({
         'authors': [
             {'full_name': ['Glashow, S.L.']}
         ]
@@ -92,7 +91,7 @@ def test_get_author_from_authors_one_author_with_a_list_of_one_full_name():
 
 
 def test_get_author_from_authors_one_author_with_a_list_of_two_full_names():
-    one_author_with_a_list_of_two_full_names = Record({
+    one_author_with_a_list_of_two_full_names = InspireRecord({
         'authors': [
             {
                 'full_name': [
@@ -112,7 +111,7 @@ def test_get_author_from_authors_one_author_with_a_list_of_two_full_names():
 
 
 def test_get_author_from_corporate_author_an_empty_list():
-    corporate_author_an_empty_list = Record({'corporate_author': []})
+    corporate_author_an_empty_list = InspireRecord({'corporate_author': []})
     cv_latex_html_text = Cv_latex_html_text(
         corporate_author_an_empty_list, 'cv_latex_html_text', ',')
 
@@ -123,7 +122,7 @@ def test_get_author_from_corporate_author_an_empty_list():
 
 
 def test_get_author_from_corporate_author_a_list_with_one_element():
-    corporate_author_a_list_of_one_element = Record({
+    corporate_author_a_list_of_one_element = InspireRecord({
         'corporate_author': [
             'CMS Collaboration'
         ]
@@ -138,7 +137,7 @@ def test_get_author_from_corporate_author_a_list_with_one_element():
 
 
 def test_get_author_from_corporate_author_a_list_with_two_elements():
-    corporate_author_a_list_of_two_elements = Record({
+    corporate_author_a_list_of_two_elements = InspireRecord({
         'corporate_author': [
             'CMS Collaboration',
             'The ATLAS Collaboration'
@@ -154,7 +153,7 @@ def test_get_author_from_corporate_author_a_list_with_two_elements():
 
 
 def test_get_title_returns_empty_string_when_no_titles():
-    no_titles = Record({})
+    no_titles = InspireRecord({})
     cv_latex_html_text = Cv_latex_html_text(
         no_titles, 'cv_latex_html_text', ',')
 
@@ -165,7 +164,7 @@ def test_get_title_returns_empty_string_when_no_titles():
 
 
 def test_get_title_returns_empty_string_when_titles_is_an_empty_list():
-    titles_an_empty_list = Record({
+    titles_an_empty_list = InspireRecord({
         'titles': []
     })
     cv_latex_html_text = Cv_latex_html_text(
@@ -178,7 +177,7 @@ def test_get_title_returns_empty_string_when_titles_is_an_empty_list():
 
 
 def test_get_title_when_titles_is_a_list_of_one_element_without_subtitles():
-    titles_a_list_of_one_element_without_subtitles = Record({
+    titles_a_list_of_one_element_without_subtitles = InspireRecord({
         'titles': [
             {'title': 'foo'}
         ]
@@ -193,7 +192,7 @@ def test_get_title_when_titles_is_a_list_of_one_element_without_subtitles():
 
 
 def test_get_titles_when_titles_is_a_list_of_two_elements_without_subtitles():
-    titles_a_list_of_two_elements_without_subtitles = Record({
+    titles_a_list_of_two_elements_without_subtitles = InspireRecord({
         'titles': [
             {'title': 'foo'},
             {'title': 'bar'}
@@ -209,7 +208,7 @@ def test_get_titles_when_titles_is_a_list_of_two_elements_without_subtitles():
 
 
 def test_get_title_when_titles_is_a_list_of_one_element_with_subtitle():
-    titles_a_list_of_one_element_with_subtitle = Record({
+    titles_a_list_of_one_element_with_subtitle = InspireRecord({
         'titles': [
             {
                 'title': 'foo',
@@ -227,7 +226,7 @@ def test_get_title_when_titles_is_a_list_of_one_element_with_subtitle():
 
 
 def test_get_title_when_titles_is_a_list_of_two_elements_with_subtitles():
-    titles_a_list_of_two_elements_with_subtitles = Record({
+    titles_a_list_of_two_elements_with_subtitles = InspireRecord({
         'titles': [
             {
                 'title': 'foo',
@@ -249,7 +248,7 @@ def test_get_title_when_titles_is_a_list_of_two_elements_with_subtitles():
 
 
 def test_get_title_when_titles_is_not_a_list_without_subtitles():
-    titles_not_a_list_without_subtitles = Record({
+    titles_not_a_list_without_subtitles = InspireRecord({
         'titles': {
             'title': 'foo'
         }
@@ -264,7 +263,7 @@ def test_get_title_when_titles_is_not_a_list_without_subtitles():
 
 
 def test_get_title_when_titles_is_not_a_list_with_subtitle():
-    titles_not_a_list_with_subtitle = Record({
+    titles_not_a_list_with_subtitle = InspireRecord({
         'titles': {
             'title': 'foo',
             'subtitle': 'bar'
@@ -280,7 +279,7 @@ def test_get_title_when_titles_is_not_a_list_with_subtitle():
 
 
 def test_get_title_capitalizes_when_title_is_uppercase():
-    title_is_uppercase = Record({
+    title_is_uppercase = InspireRecord({
         'titles': [
             {'title': 'FOO'}
         ]
@@ -295,7 +294,7 @@ def test_get_title_capitalizes_when_title_is_uppercase():
 
 
 def test_get_title_capitalizes_when_title_contains_uppercase_the():
-    title_contains_uppercase_the = Record({
+    title_contains_uppercase_the = InspireRecord({
         'titles': [
             {'title': 'foo THE bar'}
         ]
@@ -310,7 +309,7 @@ def test_get_title_capitalizes_when_title_contains_uppercase_the():
 
 
 def test_get_publi_info_no_publication_info():
-    no_publication_info = Record({})
+    no_publication_info = InspireRecord({})
     cv_latex_html_text = Cv_latex_html_text(
         no_publication_info, 'cv_latex_html_text', ',')
 
@@ -318,7 +317,7 @@ def test_get_publi_info_no_publication_info():
 
 
 def test_get_publi_info_from_publication_info_an_empty_list():
-    publication_info_an_empty_list = Record({'publication_info': []})
+    publication_info_an_empty_list = InspireRecord({'publication_info': []})
     cv_latex_html_text = Cv_latex_html_text(
         publication_info_an_empty_list, 'cv_latex_html_text', ',')
 
@@ -329,7 +328,7 @@ def test_get_publi_info_from_publication_info_an_empty_list():
 
 
 def test_get_publi_info_from_publication_info_with_journal_title():
-    journal_title = Record({
+    journal_title = InspireRecord({
         'publication_info': [
             {'journal_title': 'Nucl.Phys.'}
         ]
@@ -344,7 +343,7 @@ def test_get_publi_info_from_publication_info_with_journal_title():
 
 
 def test_get_publi_info_from_publication_info_with_journal_volume():
-    journal_volume = Record({
+    journal_volume = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'eConf',
@@ -362,7 +361,7 @@ def test_get_publi_info_from_publication_info_with_journal_volume():
 
 
 def test_get_publi_info_from_publication_info_with_journal_volume_with_letter():
-    journal_volume_with_letter = Record({
+    journal_volume_with_letter = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'Eur.Phys.J.',
@@ -380,7 +379,7 @@ def test_get_publi_info_from_publication_info_with_journal_volume_with_letter():
 
 
 def test_get_publi_info_from_publication_info_with_year():
-    year_not_a_list = Record({
+    year_not_a_list = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'Phys.Lett.',
@@ -398,7 +397,7 @@ def test_get_publi_info_from_publication_info_with_year():
 
 
 def test_get_publi_info_from_publication_info_with_journal_issue():
-    journal_issue = Record({
+    journal_issue = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'Class.Quant.Grav.',
@@ -416,7 +415,7 @@ def test_get_publi_info_from_publication_info_with_journal_issue():
 
 
 def test_get_publi_info_from_publication_info_with_page_start():
-    page_start = Record({
+    page_start = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'JHEP',
@@ -434,7 +433,7 @@ def test_get_publi_info_from_publication_info_with_page_start():
 
 
 def test_get_publi_info_from_pubinfo_freetext():
-    pubinfo_freetext = Record({
+    pubinfo_freetext = InspireRecord({
         'publication_info': [
             {'pubinfo_freetext': 'Phys. Lett. 12 (1964) 132-133'}
         ]
@@ -449,7 +448,7 @@ def test_get_publi_info_from_pubinfo_freetext():
 
 
 def test_get_publi_info_from_publication_info_a_list_of_two_elements():
-    publication_info_a_list_of_two_elements = Record({
+    publication_info_a_list_of_two_elements = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'Int.J.Theor.Phys.',

--- a/tests/unit/utils/test_utils_export.py
+++ b/tests/unit/utils/test_utils_export.py
@@ -21,13 +21,12 @@
 
 import mock
 
-from invenio_records.api import Record
-
+from inspirehep.modules.records.api import InspireRecord
 from inspirehep.utils.export import Export
 
 
 def test_get_citation_key_no_external_system_numbers():
-    no_external_system_numbers = Record({})
+    no_external_system_numbers = InspireRecord({})
 
     expected = ''
     result = Export(no_external_system_numbers)._get_citation_key()
@@ -36,7 +35,7 @@ def test_get_citation_key_no_external_system_numbers():
 
 
 def test_get_citation_key_with_external_system_numbers_from_value():
-    with_external_system_numbers_from_value = Record({
+    with_external_system_numbers_from_value = InspireRecord({
         'external_system_numbers': [
             {'institute': 'INSPIRETeX', 'value': 'foo'}
         ]
@@ -51,7 +50,7 @@ def test_get_citation_key_with_external_system_numbers_from_value():
 def test_get_citation_key_no_value_no_obsolete():
     from inspirehep.utils.export import Export
 
-    no_value_no_obsolete = Record({
+    no_value_no_obsolete = InspireRecord({
         'external_system_numbers': [
             {'institute': 'INSPIRETeX'}
         ]
@@ -65,7 +64,7 @@ def test_get_citation_key_no_value_no_obsolete():
 
 def test_get_citation_key_last_one_wins():
 
-    last_one_wins = Record({
+    last_one_wins = InspireRecord({
         'external_system_numbers': [
             {'institute': 'INSPIRETeX', 'value': 'foo'},
             {'institute': 'SPIRESTeX', 'value': 'bar'},
@@ -79,7 +78,7 @@ def test_get_citation_key_last_one_wins():
 
 
 def test_get_citation_key_a_list_selects_first():
-    a_list_selects_first = Record({
+    a_list_selects_first = InspireRecord({
         'external_system_numbers': [
             {
                 'institute': 'INSPIRETeX',
@@ -95,7 +94,7 @@ def test_get_citation_key_a_list_selects_first():
 
 
 def test_get_citation_key_trims_spaces():
-    trims_spaces = Record({
+    trims_spaces = InspireRecord({
         'external_system_numbers': [
             {'institute': 'INSPIRETeX', 'value': 'f o o'}
         ]
@@ -108,7 +107,7 @@ def test_get_citation_key_trims_spaces():
 
 
 def test_get_doi_no_dois():
-    no_dois = Record({})
+    no_dois = InspireRecord({})
 
     expected = ''
     result = Export(no_dois)._get_doi()
@@ -117,7 +116,7 @@ def test_get_doi_no_dois():
 
 
 def test_get_doi_single_doi():
-    single_doi = Record({
+    single_doi = InspireRecord({
         'dois': [
             {'value': 'foo'}
         ]
@@ -131,7 +130,7 @@ def test_get_doi_single_doi():
 
 def test_get_doi_multiple_dois():
 
-    multiple_dois = Record({
+    multiple_dois = InspireRecord({
         'dois': [
             {'value': 'foo'},
             {'value': 'bar'}
@@ -146,7 +145,7 @@ def test_get_doi_multiple_dois():
 
 def test_get_doi_removes_duplicates():
 
-    with_duplicates = Record({
+    with_duplicates = InspireRecord({
         'dois': [
             {'value': 'foo'},
             {'value': 'bar'},
@@ -161,7 +160,7 @@ def test_get_doi_removes_duplicates():
 
 
 def test_arxiv_field_no_arxiv_eprints():
-    no_arxiv_eprints = Record({})
+    no_arxiv_eprints = InspireRecord({})
 
     result = Export(no_arxiv_eprints).arxiv_field
 
@@ -169,7 +168,7 @@ def test_arxiv_field_no_arxiv_eprints():
 
 
 def test_arxiv_field_single_arxiv_eprints():
-    single_arxiv_eprints = Record({
+    single_arxiv_eprints = InspireRecord({
         'arxiv_eprints': [
             {'value': 'foo'}
         ]
@@ -182,7 +181,7 @@ def test_arxiv_field_single_arxiv_eprints():
 
 
 def test_arxiv_field_returns_first():
-    returns_first = Record({
+    returns_first = InspireRecord({
         'arxiv_eprints': [
             {'value': 'foo'},
             {'value': 'bar'}
@@ -196,7 +195,7 @@ def test_arxiv_field_returns_first():
 
 
 def test_get_arxiv_no_arxiv_eprints():
-    no_arxiv_eprints = Record({})
+    no_arxiv_eprints = InspireRecord({})
 
     expected = ''
     result = Export(no_arxiv_eprints)._get_arxiv()
@@ -205,7 +204,7 @@ def test_get_arxiv_no_arxiv_eprints():
 
 
 def test_get_arxiv_no_value():
-    no_value = Record({
+    no_value = InspireRecord({
         'arxiv_eprints': [
             {'notvalue': 'foo'}
         ]
@@ -218,7 +217,7 @@ def test_get_arxiv_no_value():
 
 
 def test_get_arxiv_value_no_categories():
-    value_no_categories = Record({
+    value_no_categories = InspireRecord({
         'arxiv_eprints': [
             {'value': 'foo'}
         ]
@@ -232,7 +231,7 @@ def test_get_arxiv_value_no_categories():
 
 def test_get_arxiv_single_category():
 
-    single_category = Record({
+    single_category = InspireRecord({
         'arxiv_eprints': [
             {
                 'value': 'foo',
@@ -249,7 +248,7 @@ def test_get_arxiv_single_category():
 
 def test_get_arxiv_multiple_categories():
 
-    multiple_categories = Record({
+    multiple_categories = InspireRecord({
         'arxiv_eprints': [
             {
                 'value': 'foo',
@@ -269,7 +268,7 @@ def test_get_arxiv_multiple_categories():
 
 def test_get_report_number_no_report_numbers():
 
-    no_report_numbers = Record({})
+    no_report_numbers = InspireRecord({})
 
     expected = []
     result = Export(no_report_numbers)._get_report_number()
@@ -279,7 +278,7 @@ def test_get_report_number_no_report_numbers():
 
 def test_get_report_number_no_value():
 
-    no_value = Record({
+    no_value = InspireRecord({
         'report_numbers': [
             {'notvalue': 'foo'}
         ]
@@ -293,7 +292,7 @@ def test_get_report_number_no_value():
 
 def test_get_report_number_single_value():
 
-    single_value = Record({
+    single_value = InspireRecord({
         'report_numbers': [
             {'value': 'foo'}
         ]
@@ -307,7 +306,7 @@ def test_get_report_number_single_value():
 
 def test_get_report_number_multiple_values():
 
-    multiple_values = Record({
+    multiple_values = InspireRecord({
         'report_numbers': [
             {'value': 'foo'},
             {'value': 'bar'}
@@ -322,7 +321,7 @@ def test_get_report_number_multiple_values():
 
 def test_get_slac_citation_from_arxiv_eprints_no_value():
 
-    from_arxiv_eprints_no_value = Record({
+    from_arxiv_eprints_no_value = InspireRecord({
         'arxiv_eprints': [
             {'notvalue': 'foo'}
         ]
@@ -335,7 +334,7 @@ def test_get_slac_citation_from_arxiv_eprints_no_value():
 
 def test_get_slac_citation_from_arxiv_eprints_with_value():
 
-    from_arxiv_eprints_with_value = Record({
+    from_arxiv_eprints_with_value = InspireRecord({
         'arxiv_eprints': [
             {'value': 'foo'}
         ]
@@ -352,7 +351,7 @@ def test_get_slac_citation_from_pubnote():
     #                 by subclasses of Export.
     Export._get_pubnote = lambda self: 'foo'
 
-    from_pubnote = Record({})
+    from_pubnote = InspireRecord({})
 
     expected = '%%CITATION = foo;%%'
     result = Export(from_pubnote)._get_slac_citation()
@@ -367,7 +366,7 @@ def test_get_slac_citation_from_report_numbers_no_arxiv_eprints():
     #                 by subclasses of Export.
     Export._get_pubnote = lambda self: False
 
-    from_report_numbers_no_arxiv_eprints = Record({
+    from_report_numbers_no_arxiv_eprints = InspireRecord({
         'report_numbers': [
             {'value': 'foo'},
             {'value': 'bar'}
@@ -387,7 +386,7 @@ def test_get_slac_citation_from_control_number():
     #                 by subclasses of Export.
     Export._get_pubnote = lambda self: False
 
-    from_recid = Record({'control_number': 1})
+    from_recid = InspireRecord({'control_number': 1})
 
     expected = '%%CITATION = INSPIRE-1;%%'
     result = Export(from_recid)._get_slac_citation()
@@ -401,7 +400,7 @@ def test_get_slac_citation_from_control_number():
 def test_get_citation_number_no_citations(g_e_r):
     g_e_r.return_value = {'citation_count': 0}
 
-    no_citations = Record({'control_number': 1})
+    no_citations = InspireRecord({'control_number': 1})
 
     expected = ''
     result = Export(no_citations)._get_citation_number()
@@ -415,7 +414,7 @@ def test_get_citation_number_one_citation(g_e_r, strftime):
     strftime.return_value = '02 Feb 1993'
     g_e_r.return_value = {'citation_count': 1}
 
-    one_citation = Record({'control_number': 1})
+    one_citation = InspireRecord({'control_number': 1})
 
     expected = '1 citation counted in INSPIRE as of 02 Feb 1993'
     result = Export(one_citation)._get_citation_number()
@@ -429,7 +428,7 @@ def test_get_citation_number_two_citations(g_e_r, strftime):
     strftime.return_value = '02 Feb 1993'
     g_e_r.return_value = {'citation_count': 2}
 
-    two_citations = Record({'control_number': 1})
+    two_citations = InspireRecord({'control_number': 1})
 
     expected = '2 citations counted in INSPIRE as of 02 Feb 1993'
     result = Export(two_citations)._get_citation_number()
@@ -441,7 +440,7 @@ def test_get_citation_number_two_citations(g_e_r, strftime):
 def test_get_citation_number_no_citation_count(g_e_r):
     g_e_r.return_value = {}
 
-    no_citation_count = Record({'control_number': 1})
+    no_citation_count = InspireRecord({'control_number': 1})
 
     expected = ''
     result = Export(no_citation_count)._get_citation_number()

--- a/tests/unit/utils/test_utils_latex.py
+++ b/tests/unit/utils/test_utils_latex.py
@@ -22,13 +22,12 @@
 import mock
 import pytest
 
-from invenio_records.api import Record
-
+from inspirehep.modules.records.api import InspireRecord
 from inspirehep.utils.latex import Latex
 
 
 def test_format_output_row_unknown_field():
-    record = Record({})
+    record = InspireRecord({})
     latex = Latex(record, 'latex_eu')
 
     expected = ''
@@ -38,7 +37,7 @@ def test_format_output_row_unknown_field():
 
 
 def test_format_output_row_one_author():
-    record = Record({})
+    record = InspireRecord({})
     latex = Latex(record, 'latex_eu')
 
     expected = u'  S.~L.~Glashow,\n'
@@ -48,7 +47,7 @@ def test_format_output_row_one_author():
 
 
 def test_format_output_row_between_one_and_eight_authors():
-    record = Record({})
+    record = InspireRecord({})
     latex = Latex(record, 'latex_eu')
 
     expected = u'  F.~Englert and R.~Brout,\n'
@@ -58,7 +57,7 @@ def test_format_output_row_between_one_and_eight_authors():
 
 
 def test_format_output_row_more_than_eight_authors_collaboration():
-    with_collaboration = Record({
+    with_collaboration = InspireRecord({
         'collaboration': [
             {'value': 'Supernova Search Team'}
         ]
@@ -78,7 +77,7 @@ def test_format_output_row_more_than_eight_authors_collaboration():
 
 
 def test_format_output_row_more_than_eight_authors_collaboration_in_collaboration():
-    collaboration_in_collaboration = Record({
+    collaboration_in_collaboration = InspireRecord({
         'collaboration': [
             {'value': 'The ATLAS Collaboration'}
         ]
@@ -95,7 +94,7 @@ def test_format_output_row_more_than_eight_authors_collaboration_in_collaboratio
 
 
 def test_format_output_row_more_than_eight_authors_no_collaboration():
-    without_collaboration = Record({})
+    without_collaboration = InspireRecord({})
     latex = Latex(without_collaboration, 'latex_eu')
 
     expected = u'  L.~Cadamuro {\it et al.},\n'
@@ -109,7 +108,7 @@ def test_format_output_row_more_than_eight_authors_no_collaboration():
 
 @pytest.mark.xfail
 def test_format_output_row_more_than_eight_authors_collaboration_an_empty_list():
-    collaboration_an_empty_list = Record({'collaboration': []})
+    collaboration_an_empty_list = InspireRecord({'collaboration': []})
     latex = Latex(collaboration_an_empty_list, 'latex_eu')
 
     expected = '  0 {\\it et al.}'
@@ -120,7 +119,7 @@ def test_format_output_row_more_than_eight_authors_collaboration_an_empty_list()
 
 @pytest.mark.xfail
 def test_format_output_row_title():
-    record = Record({})
+    record = InspireRecord({})
     latex = Latex(record, 'latex_eu')
 
     expected = u"  %``Partial Symmetries of Weak Interactions,''\n"
@@ -130,7 +129,7 @@ def test_format_output_row_title():
 
 
 def test_format_output_row_publi_info_not_a_list():
-    record = Record({})
+    record = InspireRecord({})
     latex = Latex(record, 'latex_eu')
 
     expected = u'  Phys. Lett. 12 (1964) 132-133.\n'
@@ -141,14 +140,14 @@ def test_format_output_row_publi_info_not_a_list():
 
 @pytest.mark.xfail
 def test_format_output_row_publi_info_an_empty_list():
-    record = Record({})
+    record = InspireRecord({})
     latex = Latex(record, 'latex_eu')
 
     latex._format_output_row('publi_info', [])
 
 
 def test_format_output_row_publi_info_a_list_with_one_element():
-    record = Record({})
+    record = InspireRecord({})
     latex = Latex(record, 'latex_eu')
 
     expected = u'  Phys.\\ Rev.\\ D {\\bf 73} (2006) 014022\n'
@@ -160,7 +159,7 @@ def test_format_output_row_publi_info_a_list_with_one_element():
 
 
 def test_format_output_row_publi_info_a_list_with_two_elelemts():
-    record = Record({})
+    record = InspireRecord({})
     latex = Latex(record, 'latex_eu')
 
     expected = u'''  Int.\\ J.\\ Theor.\\ Phys.\\  {\\bf 38} (1999) 1113
@@ -176,7 +175,7 @@ def test_format_output_row_publi_info_a_list_with_two_elelemts():
 
 
 def test_format_output_row_arxiv_with_publi_info():
-    with_publi_info = Record({
+    with_publi_info = InspireRecord({
         'publication_info': [
             {'journal_title': ''}
         ]
@@ -190,7 +189,7 @@ def test_format_output_row_arxiv_with_publi_info():
 
 
 def test_format_output_row_arxiv_without_publi_info():
-    without_publi_info = Record({})
+    without_publi_info = InspireRecord({})
     latex = Latex(without_publi_info, 'latex_eu')
 
     expected = u'  arXiv:1512.01296 [hep-th].\n'
@@ -200,7 +199,7 @@ def test_format_output_row_arxiv_without_publi_info():
 
 
 def test_format_output_row_report_number():
-    record = Record({})
+    record = InspireRecord({})
     latex = Latex(record, 'latex_eu')
 
     expected = u'  CMS-PAS-TOP-13-007.\n'
@@ -210,7 +209,7 @@ def test_format_output_row_report_number():
 
 
 def test_get_author_from_authors_an_empty_list():
-    authors_an_empty_list = Record({'authors': []})
+    authors_an_empty_list = InspireRecord({'authors': []})
     latex = Latex(authors_an_empty_list, 'latex_eu')
 
     expected = []
@@ -220,7 +219,7 @@ def test_get_author_from_authors_an_empty_list():
 
 
 def test_get_author_from_authors_a_list_with_one_element():
-    authors_a_list_with_one_element = Record({
+    authors_a_list_with_one_element = InspireRecord({
         'authors': [
             {'full_name': 'Glashow, S.L.'}
         ]
@@ -234,7 +233,7 @@ def test_get_author_from_authors_a_list_with_one_element():
 
 
 def test_get_author_from_authors_a_list_with_two_elements():
-    authors_a_list_with_two_elements = Record({
+    authors_a_list_with_two_elements = InspireRecord({
         'authors': [
             {'full_name': 'Englert, F.'},
             {'full_name': 'Brout, R.'}
@@ -249,7 +248,7 @@ def test_get_author_from_authors_a_list_with_two_elements():
 
 
 def test_get_author_from_authors_one_author_with_an_empty_list_of_full_names():
-    one_author_with_an_empty_list_of_full_names = Record({
+    one_author_with_an_empty_list_of_full_names = InspireRecord({
         'authors': [
             {'full_name': []}
         ]
@@ -263,7 +262,7 @@ def test_get_author_from_authors_one_author_with_an_empty_list_of_full_names():
 
 
 def test_get_author_from_authors_one_author_with_a_list_of_one_full_name():
-    one_author_with_a_list_of_one_full_name = Record({
+    one_author_with_a_list_of_one_full_name = InspireRecord({
         'authors': [
             {'full_name': ['Glashow, S.L.']}
         ]
@@ -277,7 +276,7 @@ def test_get_author_from_authors_one_author_with_a_list_of_one_full_name():
 
 
 def test_get_author_from_authors_one_author_with_a_list_of_two_full_names():
-    one_author_with_a_list_of_two_full_names = Record({
+    one_author_with_a_list_of_two_full_names = InspireRecord({
         'authors': [
             {
                 'full_name': [
@@ -296,7 +295,7 @@ def test_get_author_from_authors_one_author_with_a_list_of_two_full_names():
 
 
 def test_get_author_from_corporate_author_an_empty_list():
-    corporate_author_an_empty_list = Record({'corporate_author': []})
+    corporate_author_an_empty_list = InspireRecord({'corporate_author': []})
     latex = Latex(corporate_author_an_empty_list, 'latex_eu')
 
     expected = []
@@ -307,7 +306,7 @@ def test_get_author_from_corporate_author_an_empty_list():
 
 @pytest.mark.xfail
 def test_get_author_from_corporate_author_a_list_with_one_element():
-    corporate_author_a_list_of_one_element = Record({
+    corporate_author_a_list_of_one_element = InspireRecord({
         'corporate_author': [
             'CMS Collaboration'
         ]
@@ -322,7 +321,7 @@ def test_get_author_from_corporate_author_a_list_with_one_element():
 
 @pytest.mark.xfail
 def test_get_author_from_corporate_author_a_list_with_two_elements():
-    corporate_author_a_list_of_two_elements = Record({
+    corporate_author_a_list_of_two_elements = InspireRecord({
         'corporate_author': [
             'CMS Collaboration',
             'The ATLAS Collaboration'
@@ -337,7 +336,7 @@ def test_get_author_from_corporate_author_a_list_with_two_elements():
 
 
 def test_get_title_no_titles():
-    no_titles = Record({})
+    no_titles = InspireRecord({})
     latex = Latex(no_titles, 'latex_eu')
 
     expected = ''
@@ -347,7 +346,7 @@ def test_get_title_no_titles():
 
 
 def test_get_title_from_titles_an_empty_list():
-    titles_an_empty_list = Record({'titles': []})
+    titles_an_empty_list = InspireRecord({'titles': []})
     latex = Latex(titles_an_empty_list, 'latex_eu')
 
     expected = ''
@@ -357,7 +356,7 @@ def test_get_title_from_titles_an_empty_list():
 
 
 def test_get_title_from_titles_a_list_with_one_element():
-    titles_a_list_with_one_element = Record({
+    titles_a_list_with_one_element = InspireRecord({
         'titles': [
             {'title': 'Partial Symmetries of Weak Interactions'}
         ]
@@ -371,7 +370,7 @@ def test_get_title_from_titles_a_list_with_one_element():
 
 
 def test_get_title_from_titles_a_list_with_two_elements():
-    titles_a_list_with_two_elements = Record({
+    titles_a_list_with_two_elements = InspireRecord({
         'titles': [
             {'title': 'Broken Symmetries and the Masses of Gauge Bosons'},
             {'title': 'BROKEN SYMMETRIES AND THE MASSES OF GAUGE BOSONS.'}
@@ -386,7 +385,7 @@ def test_get_title_from_titles_a_list_with_two_elements():
 
 
 def test_get_title_from_titles_not_a_list():
-    titles_not_a_list = Record({
+    titles_not_a_list = InspireRecord({
         'titles': {
             'title': 'Partial Symmetries of Weak Interactions'
         }
@@ -400,14 +399,14 @@ def test_get_title_from_titles_not_a_list():
 
 
 def test_get_publi_info_no_publication_info():
-    no_publication_info = Record({})
+    no_publication_info = InspireRecord({})
     latex = Latex(no_publication_info, 'latex_eu')
 
     assert latex._get_publi_info() is None
 
 
 def test_get_publi_info_from_publication_info_an_empty_list():
-    publication_info_an_empty_list = Record({'publication_info': []})
+    publication_info_an_empty_list = InspireRecord({'publication_info': []})
     latex = Latex(publication_info_an_empty_list, 'latex_eu')
 
     expected = []
@@ -417,7 +416,7 @@ def test_get_publi_info_from_publication_info_an_empty_list():
 
 
 def test_get_publi_info_from_publication_info_with_journal_title_not_a_list():
-    journal_title_not_a_list = Record({
+    journal_title_not_a_list = InspireRecord({
         'publication_info': [
             {'journal_title': 'Nucl.Phys.'}
         ]
@@ -432,7 +431,7 @@ def test_get_publi_info_from_publication_info_with_journal_title_not_a_list():
 
 @pytest.mark.xfail
 def test_get_publi_info_from_publication_info_with_journal_title_an_empty_list():
-    journal_title_an_empty_list = Record({
+    journal_title_an_empty_list = InspireRecord({
         'publication_info': [
             {'journal_title': []}
         ]
@@ -446,7 +445,7 @@ def test_get_publi_info_from_publication_info_with_journal_title_an_empty_list()
 
 
 def test_get_publi_info_from_publication_info_with_journal_title_a_list_of_one_element():
-    journal_title_a_list_of_one_element = Record({
+    journal_title_a_list_of_one_element = InspireRecord({
         'publication_info': [
             {'journal_title': ['foo']}
         ]
@@ -460,7 +459,7 @@ def test_get_publi_info_from_publication_info_with_journal_title_a_list_of_one_e
 
 
 def test_get_publi_info_from_publication_info_with_journal_title_a_list_of_two_elements():
-    journal_title_a_list_of_two_elements = Record({
+    journal_title_a_list_of_two_elements = InspireRecord({
         'publication_info': [
             {'journal_title': ['foo', 'bar']}
         ]
@@ -474,7 +473,7 @@ def test_get_publi_info_from_publication_info_with_journal_title_a_list_of_two_e
 
 
 def test_get_publi_info_from_publication_info_with_journal_volume():
-    journal_volume = Record({
+    journal_volume = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'eConf',
@@ -491,7 +490,7 @@ def test_get_publi_info_from_publication_info_with_journal_volume():
 
 
 def test_get_publi_info_from_publication_info_with_journal_volume_with_letter():
-    journal_volume_with_letter = Record({
+    journal_volume_with_letter = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'Eur.Phys.J.',
@@ -508,7 +507,7 @@ def test_get_publi_info_from_publication_info_with_journal_volume_with_letter():
 
 
 def test_get_publi_info_from_publication_info_with_year_not_a_list():
-    year_not_a_list = Record({
+    year_not_a_list = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'Phys.Lett.',
@@ -526,7 +525,7 @@ def test_get_publi_info_from_publication_info_with_year_not_a_list():
 
 @pytest.mark.xfail
 def test_get_publi_info_from_publication_info_with_year_an_empty_list():
-    year_an_empty_list = Record({
+    year_an_empty_list = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'Phys.Rev.',
@@ -543,7 +542,7 @@ def test_get_publi_info_from_publication_info_with_year_an_empty_list():
 
 
 def test_get_publi_info_from_publication_info_with_year_a_list_of_one_element():
-    year_a_list_of_one_element = Record({
+    year_a_list_of_one_element = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'JHEP',
@@ -560,7 +559,7 @@ def test_get_publi_info_from_publication_info_with_year_a_list_of_one_element():
 
 
 def test_get_publi_info_from_publication_info_with_year_a_list_of_two_elements():
-    year_a_list_of_two_elements = Record({
+    year_a_list_of_two_elements = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'Phys.Rev.Lett.',
@@ -577,7 +576,7 @@ def test_get_publi_info_from_publication_info_with_year_a_list_of_two_elements()
 
 
 def test_get_publi_info_from_publication_info_with_journal_issue_latex_eu():
-    journal_issue = Record({
+    journal_issue = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'Int.J.Mod.Phys.',
@@ -594,7 +593,7 @@ def test_get_publi_info_from_publication_info_with_journal_issue_latex_eu():
 
 
 def test_get_publi_info_from_publication_info_with_journal_issue_latex_us():
-    journal_issue = Record({
+    journal_issue = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'Class.Quant.Grav.',
@@ -611,7 +610,7 @@ def test_get_publi_info_from_publication_info_with_journal_issue_latex_us():
 
 
 def test_get_publi_info_from_publication_info_with_page_start():
-    page_start = Record({
+    page_start = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'JHEP',
@@ -628,7 +627,7 @@ def test_get_publi_info_from_publication_info_with_page_start():
 
 
 def test_get_publi_info_from_pubinfo_freetext():
-    pubinfo_freetext = Record({
+    pubinfo_freetext = InspireRecord({
         'publication_info': [
             {'pubinfo_freetext': 'Phys. Lett. 12 (1964) 132-133'}
         ]
@@ -642,7 +641,7 @@ def test_get_publi_info_from_pubinfo_freetext():
 
 
 def test_get_publi_info_from_publication_info_a_list_of_two_elements():
-    publication_info_a_list_of_two_elements = Record({
+    publication_info_a_list_of_two_elements = InspireRecord({
         'publication_info': [
             {
                 'journal_title': 'Int.J.Theor.Phys.',
@@ -677,7 +676,7 @@ def test_get_report_number_no_publi_info_yes_arxiv(g_a, g_p_i):
     g_a.return_value = False
     g_p_i.return_value = True
 
-    record = Record({})
+    record = InspireRecord({})
     latex = Latex(record, 'latex_eu')
 
     assert latex._get_report_number() is None
@@ -689,7 +688,7 @@ def test_get_report_number_yes_publi_info_no_arxiv(g_a, g_p_i):
     g_a.return_value = True
     g_p_i.return_value = False
 
-    record = Record({})
+    record = InspireRecord({})
     latex = Latex(record, 'latex_eu')
 
     assert latex._get_report_number() is None
@@ -701,7 +700,7 @@ def test_get_report_number_yes_publi_info_yes_arxiv(g_a, g_p_i):
     g_a.return_value = True
     g_p_i.return_value = True
 
-    record = Record({})
+    record = InspireRecord({})
     latex = Latex(record, 'latex_eu')
 
     assert latex._get_report_number() is None

--- a/tests/unit/utils/test_utils_record.py
+++ b/tests/unit/utils/test_utils_record.py
@@ -23,13 +23,13 @@ from __future__ import absolute_import, print_function
 
 from inspirehep.utils.record import get_abstract, get_subtitle, get_title, get_value
 
-from invenio_records.api import Record
-
 import pytest
+
+from inspirehep.modules.records.api import InspireRecord
 
 
 def test_get_title_returns_empty_string_when_no_titles():
-    no_titles = Record({})
+    no_titles = InspireRecord({})
 
     expected = ''
     result = get_title(no_titles)
@@ -38,7 +38,7 @@ def test_get_title_returns_empty_string_when_no_titles():
 
 
 def test_get_subtitle_returns_empty_string_when_no_titles():
-    no_titles = Record({})
+    no_titles = InspireRecord({})
 
     expected = ''
     result = get_subtitle(no_titles)
@@ -47,7 +47,7 @@ def test_get_subtitle_returns_empty_string_when_no_titles():
 
 
 def test_get_abstract_returns_empty_string_when_no_titles():
-    no_abstracts = Record({})
+    no_abstracts = InspireRecord({})
 
     expected = ''
     result = get_abstract(no_abstracts)
@@ -56,7 +56,7 @@ def test_get_abstract_returns_empty_string_when_no_titles():
 
 
 def test_get_abstract_returns_empty_string_when_abstracts_is_empty():
-    empty_abstracts = Record({'abstracts': []})
+    empty_abstracts = InspireRecord({'abstracts': []})
 
     expected = ''
     result = get_abstract(empty_abstracts)
@@ -65,7 +65,7 @@ def test_get_abstract_returns_empty_string_when_abstracts_is_empty():
 
 
 def test_get_title_returns_the_only_title():
-    single_title = Record({
+    single_title = InspireRecord({
         'titles': [
             {
                 'source': "arXiv",
@@ -81,7 +81,7 @@ def test_get_title_returns_the_only_title():
 
 
 def test_get_subtitle_returns_the_only_subtitle():
-    single_subtitle = Record({
+    single_subtitle = InspireRecord({
         'titles': [
             {
                 "source": "arXiv",
@@ -97,7 +97,7 @@ def test_get_subtitle_returns_the_only_subtitle():
 
 
 def test_get_abstract_returns_the_only_abstract():
-    single_abstract = Record({
+    single_abstract = InspireRecord({
         "abstracts": [
             {
                 "source": "arXiv",
@@ -113,7 +113,7 @@ def test_get_abstract_returns_the_only_abstract():
 
 
 def test_get_title_returns_the_non_arxiv_title_with_source():
-    double_title = Record({
+    double_title = InspireRecord({
         "titles": [
             {
                 "source": "other",
@@ -133,7 +133,7 @@ def test_get_title_returns_the_non_arxiv_title_with_source():
 
 
 def test_get_title_returns_the_non_arxiv_title():
-    double_title = Record({
+    double_title = InspireRecord({
         "titles": [
             {
                 "title": "Importance of a consistent choice of alpha(s) in the matching of AlpGen and Pythia"
@@ -152,7 +152,7 @@ def test_get_title_returns_the_non_arxiv_title():
 
 
 def test_get_subtitle_returns_the_non_arxiv_subtitle_with_source():
-    double_subtitle = Record({
+    double_subtitle = InspireRecord({
         "titles": [
             {
                 "source": "other",
@@ -172,7 +172,7 @@ def test_get_subtitle_returns_the_non_arxiv_subtitle_with_source():
 
 
 def test_get_subtitle_returns_the_non_arxiv_subtitle():
-    double_subtitle = Record({
+    double_subtitle = InspireRecord({
         "titles": [
             {
                 "subtitle": "Importance of a consistent choice of alpha(s) in the matching of AlpGen and Pythia"
@@ -191,7 +191,7 @@ def test_get_subtitle_returns_the_non_arxiv_subtitle():
 
 
 def test_get_abstract_returns_the_non_arxiv_abstract():
-    double_abstract = Record({
+    double_abstract = InspireRecord({
         "abstracts": [
             {
                 "source": "arXiv",
@@ -210,7 +210,7 @@ def test_get_abstract_returns_the_non_arxiv_abstract():
 
 
 def test_get_abstract_with_multiple_sources_returns_the_non_arxiv_abstract():
-    double_abstract = Record({
+    double_abstract = InspireRecord({
         "abstracts": [
             {
                 "source": "arXiv",
@@ -230,7 +230,7 @@ def test_get_abstract_with_multiple_sources_returns_the_non_arxiv_abstract():
 
 
 def test_get_value_returns_the_two_titles():
-    double_title = Record({
+    double_title = InspireRecord({
         "titles": [
             {
                 "title": "Importance of a consistent choice of alpha(s) in the matching of AlpGen and Pythia"
@@ -248,7 +248,7 @@ def test_get_value_returns_the_two_titles():
 
 
 def test_get_value_returns_the_selected_title():
-    double_title = Record({
+    double_title = InspireRecord({
         "titles": [
             {
                 "title": "Importance of a consistent choice of alpha(s) in the matching of AlpGen and Pythia"
@@ -266,7 +266,7 @@ def test_get_value_returns_the_selected_title():
 
 
 def test_get_value_returns_single_title():
-    empty_titles = Record({'titles': []})
+    empty_titles = InspireRecord({'titles': []})
 
     expected = []
     result = get_value(empty_titles, "titles.title")
@@ -276,7 +276,7 @@ def test_get_value_returns_single_title():
 
 @pytest.mark.xfail(reason='Returns None instead of {}.')
 def test_get_value_returns_empty_dic_when_there_are_no_titles():
-    empty_titles = Record({'titles': []})
+    empty_titles = InspireRecord({'titles': []})
 
     expected = {}
     result = get_value(empty_titles, "foo")
@@ -285,7 +285,7 @@ def test_get_value_returns_empty_dic_when_there_are_no_titles():
 
 
 def test_get_value_returns_none_on_index_error():
-    single_title = Record({
+    single_title = InspireRecord({
         'titles': [
             {
                 'title': 'Importance of a consistent choice of alpha(s) in the matching of AlpGen and Pythia',

--- a/tests/unit/workflows/test_workflows_tasks_beard.py
+++ b/tests/unit/workflows/test_workflows_tasks_beard.py
@@ -25,8 +25,7 @@ from __future__ import absolute_import, division, print_function
 import mock
 import requests
 
-from invenio_records.api import Record
-
+from inspirehep.modules.records.api import InspireRecord
 from inspirehep.modules.workflows.tasks.beard import (
     get_beard_url,
     prepare_payload,
@@ -62,7 +61,7 @@ def test_get_beard_url_returns_none_when_not_in_configuration():
 
 
 def test_prepare_payload():
-    record = Record({
+    record = InspireRecord({
         'titles': [
             {
                 'title': 'Effects of top compositeness',

--- a/tests/unit/workflows/test_workflows_tasks_magpie.py
+++ b/tests/unit/workflows/test_workflows_tasks_magpie.py
@@ -25,8 +25,7 @@ from __future__ import absolute_import, division, print_function
 import mock
 import requests
 
-from invenio_records.api import Record
-
+from inspirehep.modules.records.api import InspireRecord
 from inspirehep.modules.workflows.tasks.magpie import (
     get_magpie_url,
     prepare_magpie_payload,
@@ -63,7 +62,7 @@ def test_get_magpie_url_returns_none_when_not_in_configuration():
 
 
 def test_prepare_magpie_payload():
-    record = Record({
+    record = InspireRecord({
         'titles': [
             {
                 'title': 'foo',


### PR DESCRIPTION
* Adds an inspire record class between invenio record and ESrecord.
   Inheritance from invenio_records.api Record.

Signed-off-by: Spiros Delviniotis <spyridon.delviniotis@cern.ch>