### PR TITLE
search: show correct debug output for search queries

### DIFF
--- a/inspirehep/modules/search/query.py
+++ b/inspirehep/modules/search/query.py
@@ -24,6 +24,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+import json
+
 from flask import current_app, request
 
 from invenio_records_rest.errors import InvalidQueryRESTError
@@ -51,6 +53,11 @@ def inspire_search_factory(self, search):
                 request.values.get('q', '')),
             exc_info=True)
         raise InvalidQueryRESTError()
+    finally:
+        if current_app.debug:
+                current_app.logger.debug(
+                    json.dumps(search.to_dict(), indent=4)
+                )
 
     search_index = search._index[0]
     search, urlkwargs = default_facets_factory(search, search_index)

--- a/inspirehep/modules/search/query_factory.py
+++ b/inspirehep/modules/search/query_factory.py
@@ -24,8 +24,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import json
-
 import pypeg2
 from elasticsearch_dsl import Q
 from flask import current_app
@@ -71,11 +69,6 @@ def inspire_query_factory():
                 )
             ))
         finally:
-            if current_app.debug:
-                current_app.logger.debug(
-                    json.dumps(search.to_dict(), indent=4)
-                )
-
             return query
 
     return invenio_query

--- a/tests/integration/test_permissions.py
+++ b/tests/integration/test_permissions.py
@@ -142,6 +142,7 @@ def restricted_record(app):
     current_app.extensions[
         'invenio-db'].versioning_manager.transaction_cls.query.delete()
     db.session.commit()
+    current_cache.delete('restricted_collections')
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
* (closes #1795).

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>