### PR TITLE
migrator: fix logging in celery tasks

### DIFF
--- a/inspirehep/celery.py
+++ b/inspirehep/celery.py
@@ -30,6 +30,3 @@ from .factory import create_app
 
 
 celery = create_celery_app(create_app())
-# Trigger an app log message upon import. Somehow this makes Sentry logging
-# work with `get_task_logger(__name__)`.
-celery.flask_app.logger.info('Created Celery app')

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@
 
 # Bleeding edge packages not yet released on Pypi
 -e git+https://github.com/inveniosoftware/invenio-jsonschemas.git@master#egg=invenio-jsonschemas
+-e git+https://github.com/inveniosoftware/flask-celeryext.git@master#egg=flask-celeryext
 
 # FIXME temporary branch for testing
 -e git+https://github.com/inspirehep/invenio-query-parser.git@invenio3-inspire#egg=invenio-query-parser==0.6.0


### PR DESCRIPTION
As explained in inveniosoftware/flask-celeryext#26, the parent of
a logger created by `get_task_logger` is `celery.task`, which does
not propagate exceptions, therefore preventing the handler sending
logging statements to Sentry from running.

The hack in inspirehep/celery.py was making so that the parent of
these tasks was `flask.logging.DebugLogger`, which does propagate
exceptions.

Since inveniosoftware/flask-celeryext#26 was merged we no longer
need this workaround, and we will start seeing again the validation
errors on Sentry (closes #1641).

Closes #1797 