### PR TITLE
global: suggestion forms URL change

### DIFF
--- a/inspirehep/modules/authors/views/holdingpen.py
+++ b/inspirehep/modules/authors/views/holdingpen.py
@@ -58,7 +58,7 @@ from ..tasks import formdata_to_model
 blueprint = Blueprint(
     'inspirehep_authors_holdingpen',
     __name__,
-    url_prefix='/submit/author',
+    url_prefix='/authors',
     template_folder='../templates',
     static_folder='../static',
 )
@@ -203,7 +203,7 @@ def validate():
     return jsonify(result)
 
 
-@blueprint.route('/create', methods=['GET', 'POST'])
+@blueprint.route('/new', methods=['GET'])
 @register_breadcrumb(blueprint, '.new', _('New author information'))
 @login_required
 def new():
@@ -226,15 +226,13 @@ def new():
     return render_template('authors/forms/new_form.html', form=form, **ctx)
 
 
-@blueprint.route('/update', methods=['GET', 'POST'])
+@blueprint.route('/<int:recid>/update', methods=['GET'])
 @register_breadcrumb(blueprint, '.update', _('Update author information'))
 @login_required
-def update():
+def update(recid):
     """View for INSPIRE author update form."""
     from dojson.contrib.marc21.utils import create_record
     from inspirehep.dojson.hepnames import hepnames
-
-    recid = request.values.get('recid', 0, type=int)
 
     data = {}
     if recid:
@@ -260,11 +258,10 @@ def update():
         "id": "authorUpdateForm",
     }
 
-    # FIXME create template in authors module
     return render_template('authors/forms/update_form.html', form=form, **ctx)
 
 
-@blueprint.route('/submitupdate', methods=['POST'])
+@blueprint.route('/update/submit', methods=['POST'])
 @login_required
 def submitupdate():
     """Form action handler for INSPIRE author update form."""
@@ -294,7 +291,7 @@ def submitupdate():
     return render_template('authors/forms/update_success.html', **ctx)
 
 
-@blueprint.route('/submitnew', methods=['POST'])
+@blueprint.route('/new/submit', methods=['POST'])
 @login_required
 def submitnew():
     """Form action handler for INSPIRE author new form."""
@@ -324,7 +321,7 @@ def submitnew():
     return render_template('authors/forms/new_success.html', **ctx)
 
 
-@blueprint.route('/newreview', methods=['GET', 'POST'])
+@blueprint.route('/new/review', methods=['GET'])
 @login_required
 # @permission_required(viewauthorreview.name)
 def newreview():
@@ -363,7 +360,7 @@ def newreview():
     return render_template('authors/forms/review_form.html', form=form, **ctx)
 
 
-@blueprint.route('/reviewhandler', methods=['POST'])
+@blueprint.route('/new/review/submit', methods=['POST'])
 @login_required
 # @permission_required(viewauthorreview.name)
 def reviewhandler():

--- a/inspirehep/modules/literaturesuggest/views.py
+++ b/inspirehep/modules/literaturesuggest/views.py
@@ -52,12 +52,12 @@ from .tasks import formdata_to_model
 
 blueprint = Blueprint('inspirehep_literature_suggest',
                       __name__,
-                      url_prefix='/submit/literature',
+                      url_prefix='/literature',
                       template_folder='templates',
                       static_folder='static')
 
 
-@blueprint.route('/create', methods=['GET'])
+@blueprint.route('/new', methods=['GET'])
 @login_required
 def create():
     """View for INSPIRE suggestion create form."""
@@ -75,7 +75,7 @@ def create():
     )
 
 
-@blueprint.route('/create/submit', methods=['POST'])
+@blueprint.route('/new/submit', methods=['POST'])
 def submit():
     """Get form data and start workflow."""
     form = LiteratureForm(formdata=request.form)
@@ -99,13 +99,13 @@ def submit():
     return redirect(url_for('.success'))
 
 
-@blueprint.route('/create/success', methods=['GET'])
+@blueprint.route('/new/success', methods=['GET'])
 def success():
     """Render success template for the user."""
     return render_template('literaturesuggest/forms/suggest_success.html')
 
 
-@blueprint.route('/validate', methods=['POST'])
+@blueprint.route('/new/validate', methods=['POST'])
 def validate():
     """Validate form and return validation errors.
 

--- a/inspirehep/modules/workflows/static/js/inspire_workflows_ui/templates/details_decision_authors.html
+++ b/inspirehep/modules/workflows/static/js/inspire_workflows_ui/templates/details_decision_authors.html
@@ -1,6 +1,6 @@
 <div ng-if="vm.record._extra_data._action === 'author_approval' && vm.record._workflow.status === 'HALTED'">
 <button class="btn btn-info"
-        ng-click="Utils.redirect('/submit/author/newreview?objectid='+ vm.record.id)">Review Submission
+        ng-click="Utils.redirect('/authors/new/review?objectid='+ vm.record.id)">Review Submission
 </button>
 <button class="btn btn-danger"
         ng-click="Utils.setDecision('reject')">Reject

--- a/inspirehep/modules/workflows/static/js/inspire_workflows_ui/templates/results.html
+++ b/inspirehep/modules/workflows/static/js/inspire_workflows_ui/templates/results.html
@@ -87,7 +87,7 @@
           <div
             ng-if="record._source._workflow.data_type === 'authors' && !record._source._extra_data.user_action && record._source._workflow.status === 'HALTED'">
             <button class="btn btn-info"
-                    ng-click="redirect('/submit/author/newreview?objectid=' + record._id)">Review Submission
+                    ng-click="redirect('/authors/new/review?objectid=' + record._id)">Review Submission
             </button>
             <button class="btn btn-danger"
                     ng-click="setDecision(record._id,'reject')">Reject

--- a/tests/acceptance/test_author_create_typehead.py
+++ b/tests/acceptance/test_author_create_typehead.py
@@ -29,7 +29,7 @@ from selenium.webdriver.common.keys import Keys
 
 
 def test_institutions_typehead(selenium, login):
-    selenium.get(os.environ['SERVER_NAME'] + '/submit/author/create')
+    selenium.get(os.environ['SERVER_NAME'] + '/authors/new')
 
     institution_field = selenium.find_element_by_id('institution_history-0-name')
     _force_autocomplete_event(institution_field, 'CER')
@@ -38,7 +38,7 @@ def test_institutions_typehead(selenium, login):
 
 
 def test_experiments_typehead(selenium, login):
-    selenium.get(os.environ['SERVER_NAME'] + '/submit/author/create')
+    selenium.get(os.environ['SERVER_NAME'] + '/authors/new')
 
     experiment_field = selenium.find_element_by_id('experiments-0-name')
     _force_autocomplete_event(experiment_field, 'CM')
@@ -47,7 +47,7 @@ def test_experiments_typehead(selenium, login):
 
 
 def test_advisors_typehead(selenium, login):
-    selenium.get(os.environ['SERVER_NAME'] + '/submit/author/create')
+    selenium.get(os.environ['SERVER_NAME'] + '/authors/new')
 
     advisor_field = selenium.find_element_by_id('advisors-0-name')
     _force_autocomplete_event(advisor_field, 'mart')


### PR DESCRIPTION
* Unifies URL naming to /literature/new, /author/new and
  /author/<id>/update. (closes #1788)

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>