### PR TITLE
dojson: fix bug in historical_data rule

### DIFF
--- a/inspirehep/dojson/institutions/fields/bd1xx.py
+++ b/inspirehep/dojson/institutions/fields/bd1xx.py
@@ -192,7 +192,7 @@ def public_notes(self, key, value):
 def historical_data(self, key, value):
     """Historical data."""
     values = self.get('historical_data', [])
-    values.extend(el for el in value.get('a'))
+    values.extend(el for el in force_force_list(value.get('a')))
 
     return values
 

--- a/tests/unit/dojson/test_dojson_institutions.py
+++ b/tests/unit/dojson/test_dojson_institutions.py
@@ -623,7 +623,6 @@ def test_public_notes_from_680__a():
     assert expected == result['public_notes']
 
 
-@pytest.mark.xfail(reason='subfield is exploded in single characters')
 def test_historical_data_from_6781_a():
     snippet = (
         '<datafield tag="678" ind1="1" ind2=" ">'

--- a/tests/unit/dojson/test_dojson_institutions.py
+++ b/tests/unit/dojson/test_dojson_institutions.py
@@ -623,6 +623,7 @@ def test_public_notes_from_680__a():
     assert expected == result['public_notes']
 
 
+@pytest.mark.xfail(reason='subfield is exploded in single characters')
 def test_historical_data_from_6781_a():
     snippet = (
         '<datafield tag="678" ind1="1" ind2=" ">'
@@ -638,7 +639,7 @@ def test_historical_data_from_6781_a():
     assert expected == result['historical_data']
 
 
-def test_historical_data_from_6781_a():
+def test_historical_data_from_6781_multiple_a():
     snippet = (
         '<datafield tag="678" ind1="1" ind2=" ">'
         '  <subfield code="a">Conseil européen pour la Recherche Nucléaire (1952-1954)</subfield>'


### PR DESCRIPTION
This bug was deviously hidden by a repeated test name, which was shadowing the broken test with a passing one.