### PR TITLE
dojson: add institution ids

### DIFF
--- a/inspirehep/dojson/institutions/fields/bd1xx.py
+++ b/inspirehep/dojson/institutions/fields/bd1xx.py
@@ -52,6 +52,16 @@ def location(self, key, value):
         }
 
 
+@institutions.over('ids', '^035..')
+@utils.for_each_value
+def ids(self, key, value):
+    """All identifiers, both internal and external."""
+    return {
+        'type': force_single_element(value.get('9')),
+        'value': force_single_element(value.get('a')),
+    }
+
+
 @institutions.over('timezone', '^043..')
 @utils.for_each_value
 def timezone(self, key, value):

--- a/tests/unit/dojson/test_dojson_institutions.py
+++ b/tests/unit/dojson/test_dojson_institutions.py
@@ -96,6 +96,25 @@ def test_no_location_from_034__double_d():
     assert 'location' not in result
 
 
+def test_ids_from_035__a_9():
+    snippet = (
+        '<datafield tag="035" ind1=" " ind2=" ">'
+        '  <subfield code="9">HAL</subfield>'
+        '  <subfield code="a">1969</subfield>'
+        '</datafield>'
+    )  # record/910133
+
+    expected = [
+        {
+            'type': 'HAL',
+            'value': '1969',
+        },
+    ]
+    result = institutions.do(create_record(snippet))
+
+    assert expected == result['ids']
+
+
 def test_timezone_from_043__t():
     snippet = (
         '<datafield tag="043" ind1=" " ind2=" ">'


### PR DESCRIPTION
This is populating something which is not yet part of the schemas. Will send the associated PR against `inspire-schemas` later.