### PR TITLE
authors: pass control_number to author tasks

### DIFF
--- a/inspirehep/modules/authors/dojson/fields/updateform.py
+++ b/inspirehep/modules/authors/dojson/fields/updateform.py
@@ -228,3 +228,8 @@ def experiments(self, key, value):
         experiments.append(experiment)
 
     return experiments
+
+
+@updateform.over('control_number', '^control_number$')
+def control_number(self, key, value):
+    return value

--- a/inspirehep/modules/authors/forms.py
+++ b/inspirehep/modules/authors/forms.py
@@ -328,7 +328,7 @@ class AuthorUpdateForm(INSPIREForm):
     )
 
     # Hidden field to hold record id information
-    recid = fields.IntegerField(
+    control_number = fields.IntegerField(
         widget=HiddenInput(),
         validators=[validators.Optional()],
     )

--- a/inspirehep/modules/authors/tasks.py
+++ b/inspirehep/modules/authors/tasks.py
@@ -131,13 +131,11 @@ def new_ticket_context(user, obj):
 
 def update_ticket_context(user, obj):
     """Context for authornew new tickets."""
-    recid = obj.data.get("recid", "")
-
     subject = "Your update to author {0} on INSPIRE".format(
         obj.data.get("name").get("preferred_name")
     )
     record_url = os.path.join(current_app.config["AUTHORS_UPDATE_BASE_URL"], "record",
-                              str(recid))
+                              str(obj.data.get("control_number", "")))
     return dict(
         email=user.email,
         url=record_url,

--- a/inspirehep/modules/authors/views/holdingpen.py
+++ b/inspirehep/modules/authors/views/holdingpen.py
@@ -172,8 +172,8 @@ def get_inspire_url(data):
     url = ""
     if "bai" in data and data["bai"]:
         url = "http://inspirehep.net/author/profile/" + data["bai"]
-    elif "recid" in data and data["recid"]:
-        url = "http://inspirehep.net/record/" + str(data["recid"])
+    elif "control_number" in data and data["control_number"]:
+        url = "http://inspirehep.net/record/" + str(data["control_number"])
     else:
         url = "http://inspirehep.net/hepnames"
     return url
@@ -250,7 +250,7 @@ def update(recid):
             convert_for_form(data)
         except requests.exceptions.RequestException:
             pass
-        data["recid"] = recid
+        data["control_number"] = recid
     else:
         return redirect(url_for("inspirehep_authors_holdingpen.new"))
     form = AuthorUpdateForm(data=data, is_update=True)

--- a/tests/unit/authors/test_authors_tasks.py
+++ b/tests/unit/authors/test_authors_tasks.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import pytest
+from mock import patch
+
+from invenio_accounts.models import User
+
+from inspirehep.modules.authors.tasks import (
+    new_ticket_context,
+    update_ticket_context,
+    reply_ticket_context,
+    curation_ticket_context
+)
+
+
+class MockObj(object):
+
+    def __init__(self, data={}, extra_data={}):
+        self._data = data
+        self._extra_data = extra_data
+
+    @property
+    def data(self):
+        return self._data
+
+    @property
+    def extra_data(self):
+        return self._extra_data
+
+
+@pytest.fixture()
+def data():
+    return {
+        "control_number": 123,
+        "name": {
+            "preferred_name": "John Doe"
+        },
+        "bai": "John.Doe.1"
+    }
+
+
+@pytest.fixture()
+def extra_data():
+    return {
+        "comments": "Foo bar",
+        "reason": "Test reason",
+        "url": "http://example.com",
+        "recid": 123
+    }
+
+
+@pytest.fixture()
+def user():
+    return User(email="foo@bar.com")
+
+
+def test_new_ticket_context(data, extra_data, user):
+    obj = MockObj(data, extra_data)
+    ctx = new_ticket_context(user, obj)
+
+    assert isinstance(ctx['object'], MockObj)
+    assert ctx['email'] == 'foo@bar.com'
+    assert ctx['subject'] == 'Your suggestion to INSPIRE: author John Doe'
+    assert ctx['user_comment'] == 'Foo bar'
+
+
+def test_update_ticket_context(app, data, extra_data, user):
+    config = {
+        'AUTHORS_UPDATE_BASE_URL': 'http://inspirehep.net'
+    }
+    obj = MockObj(data, extra_data)
+    with app.app_context():
+        with patch.dict(app.config, config):
+            expected = {
+                'url': 'http://inspirehep.net/record/123',
+                'bibedit_url': 'http://inspirehep.net/record/123/edit',
+                'email': 'foo@bar.com',
+                'user_comment': 'Foo bar'
+            }
+            ctx = update_ticket_context(user, obj)
+            assert ctx == expected
+
+
+def test_reply_ticket_context(data, extra_data, user):
+    obj = MockObj(data, extra_data)
+    ctx = reply_ticket_context(user, obj)
+    assert isinstance(ctx['object'], MockObj)
+    assert isinstance(ctx['user'], User)
+    assert ctx['author_name'] == 'John Doe'
+    assert ctx['reason'] == 'Test reason'
+    assert ctx['record_url'] == 'http://example.com'
+
+
+def test_curation_ticket_context(data, extra_data, user):
+    obj = MockObj(data, extra_data)
+    ctx = curation_ticket_context(user, obj)
+    assert isinstance(ctx['object'], MockObj)
+    assert ctx['recid'] == 123
+    assert ctx['user_comment'] == 'Foo bar'
+    assert ctx['subject'] == 'Curation needed for author John Doe [John.Doe.1]'
+    assert ctx['email'] == 'foo@bar.com'
+    assert ctx['record_url'] == 'http://example.com'

--- a/tests/unit/authors/test_authors_views.py
+++ b/tests/unit/authors/test_authors_views.py
@@ -85,8 +85,8 @@ def test_get_inspire_url_with_bai():
     assert expected == result
 
 
-def test_get_inspire_url_with_recid():
-    with_recid = Record({'recid': 'TODO'})
+def test_get_inspire_url_with_control_number():
+    with_recid = Record({'control_number': 'TODO'})
 
     expected = 'http://inspirehep.net/record/TODO'
     result = get_inspire_url(with_recid)


### PR DESCRIPTION
* The emails generated doing an author workflow can access the control_number
  to properly format the URLs (closes #1803).

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>