### PR TITLE
dojson: upgrade schemas to version ~4.0

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -312,7 +312,7 @@ SEARCH_ELASTIC_KEYWORD_MAPPING = {
     "037__c": ["arxiv_eprints.categories"],
     "246__a": ["titles.title"],
     "595": ["hidden_notes"],
-    "650__a": ["field_categories.term"],
+    "650__a": ["inspire_categories.term"],
     "695__a": ["keywords.keyword"],
     "695__e": ["energy_ranges"],
     "773__y": ["publication_info.year"],
@@ -346,7 +346,7 @@ SEARCH_ELASTIC_KEYWORD_MAPPING = {
     "reference": ["references.doi", "references.report_number",
                   "references.journal_pubnote"
                   ],
-    "subject": ["field_categories.term"],
+    "subject": ["inspire_categories.term"],
     "texkey": ["external_system_numbers.value",
                "external_system_numbers.obsolete"
                ],
@@ -969,13 +969,13 @@ RECORDS_REST_FACETS = {
     },
     "records-authors": {
         "filters": {
-            "field_categories": terms_filter('field_categories.term'),
+            "inspire_categories": terms_filter('inspire_categories.term'),
             "institution": terms_filter('positions.institution.name')
         },
         "aggs": {
-            "field_categories": {
+            "inspire_categories": {
                 "terms": {
-                    "field": "field_categories.term",
+                    "field": "inspire_categories.term",
                     "size": 20
                 }
             },
@@ -990,7 +990,7 @@ RECORDS_REST_FACETS = {
     "records-conferences": {
         "filters": {
             "series": terms_filter('series'),
-            "field_categories": terms_filter('field_categories.term')
+            "inspire_categories": terms_filter('inspire_categories.term')
         },
         "aggs": {
             "series": {
@@ -999,9 +999,9 @@ RECORDS_REST_FACETS = {
                     "size": 20
                 }
             },
-            "field_categories": {
+            "inspire_categories": {
                 "terms": {
-                    "field": "field_categories.term",
+                    "field": "inspire_categories.term",
                     "size": 20
                 }
             },
@@ -1072,7 +1072,7 @@ RECORDS_REST_FACETS = {
         "filters": {
             "regions": terms_filter('regions'),
             "ranks": terms_filter('ranks'),
-            "field_categories": terms_filter('field_categories.term')
+            "inspire_categories": terms_filter('inspire_categories.term')
         },
         "aggs": {
             "continent": {
@@ -1087,9 +1087,9 @@ RECORDS_REST_FACETS = {
                     "size": 20
                 }
             },
-            "field_categories": {
+            "inspire_categories": {
                 "terms": {
-                    "field": "field_categories.term",
+                    "field": "inspire_categories.term",
                     "size": 20
                 }
             }

--- a/inspirehep/dojson/common/base.py
+++ b/inspirehep/dojson/common/base.py
@@ -29,6 +29,7 @@ from dojson.errors import IgnoreKey
 
 from inspirehep.utils.helpers import force_force_list
 
+from inspire_schemas import api
 from ..conferences.model import conferences
 from ..experiments.model import experiments
 from ..hep.model import hep, hep2marc
@@ -319,41 +320,39 @@ def deleted_records2marc(self, key, value):
     }
 
 
-@conferences.over('field_categories', '^65017')
-@experiments.over('field_categories', '^65017')
-@hep.over('field_categories', '^650[1_][_7]')
-@hepnames.over('field_categories', '^65017')
-@institutions.over('field_categories', '^65017')
-@jobs.over('field_categories', '^65017')
+@conferences.over('inspire_categories', '^65017')
+@experiments.over('inspire_categories', '^65017')
+@hep.over('inspire_categories', '^650[1_][_7]')
+@hepnames.over('inspire_categories', '^65017')
+@institutions.over('inspire_categories', '^65017')
+@jobs.over('inspire_categories', '^65017')
 @utils.for_each_value
-def field_categories(self, key, value):
-    """Field categories."""
-    self.setdefault('field_categories', [])
+def inspire_categories(self, key, value):
+    """Inspire categories."""
+    schema = api.load_schema('elements/inspire_field')
+    possible_sources = schema['properties']['source']['enum']
 
     _terms = force_force_list(value.get('a'))
+    source = value.get('9')
 
+    if source not in possible_sources:
+        if source == 'automatically added based on DCC, PPF, DK':
+            source = 'curator'
+        elif source == 'submitter':
+            source = 'user'
+        else:
+            source = 'undefined'
+
+    self.setdefault('inspire_categories', [])
     if _terms:
         for _term in _terms:
             term = classify_field(_term)
-
-            scheme = 'INSPIRE' if term else None
-
-            _scheme = value.get('2')
-            if isinstance(_scheme, (list, tuple)):
-                _scheme = _scheme[0]
-
-            source = value.get('9')
-            if source:
-                if 'automatically' in source:
-                    source = 'INSPIRE'
-
-            self['field_categories'].append({
-                'source': source,
-                '_scheme': _scheme,
-                'scheme': scheme,
-                '_term': _term,
-                'term': term,
-            })
+            if term:
+                inspire_category = {
+                    'term': term,
+                    'source': source,
+                }
+                self['inspire_categories'].append(inspire_category)
 
 
 @conferences.over('urls', '^8564')

--- a/inspirehep/dojson/hep/fields/bd6xx.py
+++ b/inspirehep/dojson/hep/fields/bd6xx.py
@@ -32,12 +32,12 @@ from ...utils import get_record_ref, get_recid_from_ref
 from inspirehep.utils.helpers import force_force_list
 
 
-@hep2marc.over('65017', 'field_categories')
+@hep2marc.over('65017', 'inspire_categories')
 @utils.for_each_value
-def field_categories2marc(self, key, value):
-    """Field categories."""
+def inspire_categories2marc(self, key, value):
+    """Inspire categories."""
     return {
-        'a': value.get('_term'),
+        'a': value.get('term'),
         '2': value.get('scheme'),
         '9': value.get('source'),
     }

--- a/inspirehep/dojson/hep/model.py
+++ b/inspirehep/dojson/hep/model.py
@@ -29,7 +29,11 @@ from dojson import Overdo
 from inspirehep.utils.helpers import force_force_list
 
 from ..model import FilterOverdo, add_schema, clean_record
-from ..utils import force_single_element, get_record_ref
+from ..utils import (
+    force_single_element,
+    get_record_ref,
+    classify_field,
+)
 
 
 def add_book_info(record, blob):
@@ -53,9 +57,26 @@ def add_book_info(record, blob):
     return record
 
 
+def add_inspire_category_from_arxiv_categories(record, blob):
+    if not record.get('arxiv_eprints') or record.get('inspire_categories'):
+        return record
+
+    record.setdefault('inspire_categories', [])
+    for arxiv_category in record.get_value(record, 'arxiv_eprints.categories', default=[]):
+        inspire_category = classify_field(arxiv_category)
+        if inspire_category:
+            record['inspire_categories'].append({
+                'term': inspire_category,
+                'source': 'arxiv'
+            })
+
+    return record
+
+
 hep_filters = [
     add_schema('hep.json'),
     add_book_info,
+    add_inspire_category_from_arxiv_categories,
     clean_record,
 ]
 

--- a/inspirehep/dojson/hep/model.py
+++ b/inspirehep/dojson/hep/model.py
@@ -27,6 +27,7 @@ from __future__ import absolute_import, division, print_function
 from dojson import Overdo
 
 from inspirehep.utils.helpers import force_force_list
+from inspirehep.utils.record import get_value
 
 from ..model import FilterOverdo, add_schema, clean_record
 from ..utils import (
@@ -62,7 +63,7 @@ def add_inspire_category_from_arxiv_categories(record, blob):
         return record
 
     record.setdefault('inspire_categories', [])
-    for arxiv_category in record.get_value(record, 'arxiv_eprints.categories', default=[]):
+    for arxiv_category in get_value(record, 'arxiv_eprints.categories', default=[]):
         inspire_category = classify_field(arxiv_category)
         if inspire_category:
             record['inspire_categories'].append({

--- a/inspirehep/dojson/hepnames/fields/bd1xx.py
+++ b/inspirehep/dojson/hepnames/fields/bd1xx.py
@@ -293,9 +293,9 @@ def positions2marc(self, key, value):
     }
 
 
-@hepnames2marc.over('65017', '^field_categories$')
+@hepnames2marc.over('65017', '^inspire_categories')
 @utils.for_each_value
-def field_categories2marc(self, key, value):
+def inspire_categories2marc(self, key, value):
     return {
         'a': value.get('term'),
         '2': value.get('source') or "INSPIRE",

--- a/inspirehep/dojson/utils/__init__.py
+++ b/inspirehep/dojson/utils/__init__.py
@@ -49,7 +49,7 @@ def classify_field(value):
                 return category
             elif category.upper() == casted_value:
                 return category
-        return 'Other'
+        return None
 
 
 def classify_rank(value):

--- a/inspirehep/modules/api/utils.py
+++ b/inspirehep/modules/api/utils.py
@@ -56,7 +56,7 @@ def build_citesummary(search):
                 'control_number',
                 'earliest_date',
                 'facet_inspire_doc_type',
-                'field_categories',
+                'inspire_categories',
                 'titles.title',
             ]
         )
@@ -92,10 +92,8 @@ def get_id(record):
 
 
 def get_subject(record):
-    field_categories = force_force_list(get_value(record, 'field_categories'))
-    inspire_field_categories = [
-        fc for fc in field_categories if fc.get('scheme') == 'INSPIRE']
-    terms = [fc['term'] for fc in field_categories if fc.get('term')]
+    inspire_categories = force_force_list(get_value(record, 'inspire_categories'))
+    terms = [fc['term'] for fc in inspire_categories if fc.get('term')]
 
     if terms:
         return terms[0]

--- a/inspirehep/modules/api/v1/authors.py
+++ b/inspirehep/modules/api/v1/authors.py
@@ -49,7 +49,7 @@ class APIAuthorsCitesummary(object):
                 'control_number',
                 'earliest_date',
                 'facet_inspire_doc_type',
-                'field_categories',
+                'inspire_categories',
                 'titles.title',
             ],
         )

--- a/inspirehep/modules/api/v1/experiments.py
+++ b/inspirehep/modules/api/v1/experiments.py
@@ -60,7 +60,7 @@ class APIExperimentsCitesummary(object):
                 'control_number',
                 'earliest_date',
                 'facet_inspire_doc_type',
-                'field_categories',
+                'inspire_categories',
                 'titles.title',
             ],
         )

--- a/inspirehep/modules/api/v1/institutions.py
+++ b/inspirehep/modules/api/v1/institutions.py
@@ -60,7 +60,7 @@ class APIInstitutionsCitesummary(object):
                 'control_number',
                 'earliest_date',
                 'facet_inspire_doc_type',
-                'field_categories',
+                'inspire_categories',
                 'titles.title',
             ],
         )

--- a/inspirehep/modules/api/v1/journals.py
+++ b/inspirehep/modules/api/v1/journals.py
@@ -60,7 +60,7 @@ class APIJournalsCitesummary(object):
                 'control_number',
                 'earliest_date',
                 'facet_inspire_doc_type',
-                'field_categories',
+                'inspire_categories',
                 'titles.title',
             ],
         )

--- a/inspirehep/modules/api/v1/literature.py
+++ b/inspirehep/modules/api/v1/literature.py
@@ -71,7 +71,7 @@ class APILiteratureCitesummary(object):
                 'control_number',
                 'earliest_date',
                 'facet_inspire_doc_type',
-                'field_categories',
+                'inspire_categories',
                 'titles.title',
             ],
         )

--- a/inspirehep/modules/authors/dojson/fields/updateform.py
+++ b/inspirehep/modules/authors/dojson/fields/updateform.py
@@ -166,9 +166,9 @@ def public_email(self, key, value):
         self['positions'] = positions
 
 
-@updateform.over('field_categories', '^research_field$')
+@updateform.over('inspire_categories', '^research_field$')
 @utils.for_each_value
-def field_categories(self, key, value):
+def inspire_categories(self, key, value):
     return {
         "term": value,
         "source": "submitter"

--- a/inspirehep/modules/authors/templates/authors/workflows/authorupdate.html
+++ b/inspirehep/modules/authors/templates/authors/workflows/authorupdate.html
@@ -122,8 +122,8 @@
       {% endif %}
     {% endfor %}
   {% endif %}
-  {% if record['field_categories'] %}
-    <label>Field:</label> {{ record['field_categories']|join(", ") }}
+  {% if record['inspire_categories'] %}
+    <label>Field:</label> {{ record['inspire_categories']|join(", ") }}
     <br>
   {% endif %}
   {% if record['experiments'] %}

--- a/inspirehep/modules/authors/views/holdingpen.py
+++ b/inspirehep/modules/authors/views/holdingpen.py
@@ -103,10 +103,10 @@ def convert_for_form(data):
                 elif url["description"].lower() == "linkedin":
                     data["linkedin_url"] = url["value"]
         del data["urls"]
-    if 'field_categories' in data:
+    if 'inspire_categories' in data:
         data["research_field"] = []
-        for category in data.get('field_categories', []):
-            data["research_field"].append(category.get('_term'))
+        for category in data.get('inspire_categories', []):
+            data["research_field"].append(category.get('term'))
     if "positions" in data:
         data["institution_history"] = []
         data["public_emails"] = []
@@ -342,7 +342,7 @@ def newreview():
     # Converting json to populate form
     convert_for_form(workflow_metadata)
     workflow_metadata['comments'] = workflow_metadata.get('_private_note')
-    research_fields = workflow_metadata.pop('field_categories')
+    research_fields = workflow_metadata.pop('inspire_categories')
     final_research_fields = []
     for field in research_fields:
         try:

--- a/inspirehep/modules/literaturesuggest/dojson/fields/literature.py
+++ b/inspirehep/modules/literaturesuggest/dojson/fields/literature.py
@@ -91,12 +91,12 @@ def authors(self, key, value):
 def categories(self, key, value):
     subject_list = [{
         "term": c,
-        "scheme": "arXiv"
+        "source": "user"
     } for c in value.split()]
-    if 'field_categories' in self:
-        self['field_categories'].extend(subject_list)
+    if 'inspire_categories' in self:
+        self['inspire_categories'].extend(subject_list)
     else:
-        self['field_categories'] = subject_list
+        self['inspire_categories'] = subject_list
     if 'arxiv_eprints' in self:
         self['arxiv_eprints'][0]['categories'] = value.split()
     raise IgnoreKey
@@ -271,13 +271,12 @@ def report_numbers(self, key, value):
     raise IgnoreKey
 
 
-@literature.over('field_categories', '^subject_term$')
-def field_categories(self, key, value):
+@literature.over('inspire_categories', '^subject_term$')
+def inspire_categories(self, key, value):
     return [
         {
             "term": t,
-            "scheme": "INSPIRE",
-            "source": "submitter"
+            "source": "user"
         }
         for t in value]
 

--- a/inspirehep/modules/literaturesuggest/tasks.py
+++ b/inspirehep/modules/literaturesuggest/tasks.py
@@ -65,19 +65,19 @@ def formdata_to_model(obj, formdata):
     data['collections'] = [{'primary': "HEP"}]
     if form_fields['type_of_doc'] == 'thesis':
         data['collections'].append({'primary': "THESIS"})
-    if "field_categories" in data:
+
+    if get_value(form_fields, "arxiv_eprints.categories", None):
         # Check if it was imported from arXiv
-        if any([x["scheme"] == "arXiv" for x in data["field_categories"]]):
-            data['collections'].extend([{'primary': "arXiv"},
-                                        {'primary': "Citeable"}])
-            # Add arXiv as source
-            if data.get("abstracts"):
-                data['abstracts'][0]['source'] = 'arXiv'
-            if form_fields.get("arxiv_id"):
-                data['external_system_numbers'] = [{
-                    'value': 'oai:arXiv.org:' + form_fields['arxiv_id'],
-                    'institute': 'arXiv'
-                }]
+        data['collections'].extend([{'primary': "arXiv"},
+                                    {'primary': "Citeable"}])
+        # Add arXiv as source
+        if data.get("abstracts"):
+            data['abstracts'][0]['source'] = 'arXiv'
+        if form_fields.get("arxiv_id"):
+            data['external_system_numbers'] = [{
+                'value': 'oai:arXiv.org:' + form_fields['arxiv_id'],
+                'institute': 'arXiv'
+            }]
     if "publication_info" in data:
         pub_keys = data['publication_info'][0].keys()
 

--- a/inspirehep/modules/migrator/tasks/workflows.py
+++ b/inspirehep/modules/migrator/tasks/workflows.py
@@ -56,8 +56,8 @@ def fix_object_model(eng, obj):
 
     if eng['name'] in ['process_record_arxiv', 'literature']:
         # We need to convert a few things..
-        # subject_terms -> field_categories
-        obj.data['field_categories'] = obj.data.pop('subject_terms', [])
+        # subject_terms -> inspire_categories
+        obj.data['inspire_categories'] = obj.data.pop('subject_terms', [])
 
         # change urls.url to urls.value
         obj.data['urls'] = [

--- a/inspirehep/modules/records/mappings/records/hep.json
+++ b/inspirehep/modules/records/mappings/records/hep.json
@@ -274,11 +274,8 @@
                     "index": "not_analyzed",
                     "type": "string"
                 },
-                "field_categories": {
+                "inspire_categories": {
                     "properties": {
-                        "scheme": {
-                            "type": "string"
-                        },
                         "source": {
                             "type": "string"
                         },

--- a/inspirehep/modules/records/receivers.py
+++ b/inspirehep/modules/records/receivers.py
@@ -71,58 +71,6 @@ def enhance_record(sender, json, *args, **kwargs):
     after_record_enhanced.send(json)
 
 
-@before_record_insert.connect
-@before_record_update.connect
-def normalize_field_categories(sender, *args, **kwargs):
-    """Normalize the content of the `field_categories` key.
-
-    We use the heuristic that a field is normalized if its scheme is 'INSPIRE'
-    or if it contains either the `_scheme` key or the `_term` key.
-
-    If the field wasn't normalized we use some mapping defined in the
-    configuration to output a `term` belonging to a known set of values.
-
-    We also use the heuristic that the source is 'INSPIRE' if it contains the
-    word 'automatically', otherwise we preserve it.
-
-    Note that the valid `scheme`s are hardcoded in the schema, so any
-    non-recognized scheme will fail schema validation.
-    """
-    def _is_normalized(field):
-        return (
-            field.get('scheme') == 'INSPIRE'
-            or '_scheme' in field
-            or '_term' in field
-        )
-
-    for i, field in enumerate(sender.get('field_categories', [])):
-        if _is_normalized(field):
-            continue
-
-        original_term = field.get('term')
-        normalized_term = classify_field(original_term)
-        scheme = 'INSPIRE' if normalized_term else None
-
-        original_scheme = field.get('scheme')
-        if isinstance(original_scheme, (list, tuple)):
-            original_scheme = original_scheme[0]
-
-        updated_field = {
-            '_scheme': original_scheme,
-            'scheme': scheme,
-            '_term': original_term,
-            'term': normalized_term,
-        }
-
-        source = field.get('source')
-        if source:
-            if 'automatically' in source:
-                source = 'INSPIRE'
-            updated_field['source'] = source
-
-        sender['field_categories'][i].update(updated_field)
-
-
 def populate_inspire_subjects(sender, json, *args, **kwargs):
     """Populate the INSPIRE subjects before indexing.
 
@@ -130,12 +78,9 @@ def populate_inspire_subjects(sender, json, *args, **kwargs):
     faceting in the search interface. Valid terms on which to facet are
     only those that come from the INSPIRE scheme.
     """
-    def _scheme_is_inspire(field):
-        return field.get('scheme') == 'INSPIRE'
-
     inspire_subjects = [
-        field['term'] for field in json.get('field_categories', [])
-        if _scheme_is_inspire(field) and field.get('term')]
+        field['term'] for field in json.get('inspire_categories', [])
+        if field.get('term')]
 
     json['facet_inspire_subjects'] = inspire_subjects
 

--- a/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Conference_HTML_detailed.tpl
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Conference_HTML_detailed.tpl
@@ -119,11 +119,11 @@
                   {{ print_array(record, 'note') }}
                 {% endif %}
 
-                {% if record['field_categories'] %}
+                {% if record['inspire_categories'] %}
                 {% set comma = joiner('&nbsp') %}
                 <div class="detailed-record-field">
                   <label>Fields:</label>
-                  {% for field in record['field_categories'] -%}
+                  {% for field in record['inspire_categories'] -%}
                       {{ comma() }}
                   <span class="chip chip-conferences">
                     <a href="/search?q=&cc=conferences&q={{ field['tern'] }}">{{ field['term'] }}</a>

--- a/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Holding_Pen_HTML_detailed.tpl
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Holding_Pen_HTML_detailed.tpl
@@ -58,14 +58,14 @@
     {% endif %}
 
     <!-- Subjects Row-->
-    {% if record.field_categories %}
+    {% if record.inspire_categories %}
     <div class="row">
       <div class="col-md-12">
         <!-- Edit Button -->
         <a href='#' id='edit-subjects'><i class='fa fa-pencil-square-o'></i></a>
         <!-- Subjects -->
         <span id='editable-subjects'><strong> Subjects:</strong>
-        {% for term in record['field_categories'] %}
+        {% for term in record['inspire_categories'] %}
           <span> {{ term['term'] }}</span>
           {{ add_delimiter(loop, ',') }}
         {% endfor %}

--- a/inspirehep/modules/workflows/mappings/holdingpen/authors.json
+++ b/inspirehep/modules/workflows/mappings/holdingpen/authors.json
@@ -159,11 +159,8 @@
                             ],
                             "type": "string"
                         },
-                        "field_categories": {
+                        "inspire_categories": {
                             "properties": {
-                                "scheme": {
-                                    "type": "string"
-                                },
                                 "source": {
                                     "type": "string"
                                 },

--- a/inspirehep/modules/workflows/mappings/holdingpen/hep.json
+++ b/inspirehep/modules/workflows/mappings/holdingpen/hep.json
@@ -350,11 +350,8 @@
                             },
                             "type": "object"
                         },
-                        "field_categories": {
+                        "inspire_categories": {
                             "properties": {
-                                "scheme": {
-                                    "type": "string"
-                                },
                                 "source": {
                                     "type": "string"
                                 },

--- a/inspirehep/modules/workflows/search.py
+++ b/inspirehep/modules/workflows/search.py
@@ -39,9 +39,9 @@ def holdingpen_search_factory(self, search, **kwargs):
     """Override search factory."""
     search, urlkwargs = default_search_factory(self, search, **kwargs)
     includes = [
-        'metadata.titles', 'metadata.abstracts', 'metadata.field_categories',
+        'metadata.titles', 'metadata.abstracts', 'metadata.inspire_categories',
         'metadata.authors', 'metadata.name', 'metadata.positions', 'metadata.acquisition_source',
-        'metadata.field_categories', '_workflow', '_extra_data.relevance_prediction',
+        'metadata.inspire_categories', '_workflow', '_extra_data.relevance_prediction',
         '_extra_data.user_action',
         '_extra_data.classifier_results.complete_output'
     ]

--- a/inspirehep/modules/workflows/static/js/inspire_workflows_ui/holdingpen/holdingpen.directives.js
+++ b/inspirehep/modules/workflows/static/js/inspire_workflows_ui/holdingpen/holdingpen.directives.js
@@ -146,8 +146,7 @@
 
           addSubjectArea: function () {
             console.debug($scope.vm.new_subject_area);
-            $scope.vm.record.metadata.field_categories.unshift({
-              'scheme': "INSPIRE",
+            $scope.vm.record.metadata.inspire_categories.unshift({
               'source': 'curator',
               'term': $scope.vm.new_subject_area,
               'accept': true
@@ -173,8 +172,8 @@
           },
 
           deleteSubject: function (index) {
-            if (index < $scope.vm.record.metadata.field_categories.length)
-              $scope.vm.record.metadata.field_categories.splice(index, 1);
+            if (index < $scope.vm.record.metadata.inspire_categories.length)
+              $scope.vm.record.metadata.inspire_categories.splice(index, 1);
             $scope.doUpdate();
           },
 

--- a/inspirehep/modules/workflows/static/js/inspire_workflows_ui/templates/details_subject_areas.html
+++ b/inspirehep/modules/workflows/static/js/inspire_workflows_ui/templates/details_subject_areas.html
@@ -18,7 +18,7 @@
       <div class="clearfix"></div>
 
       <div class="row subject-area"
-           ng-repeat="subject_term in vm.record.metadata.field_categories">
+           ng-repeat="subject_term in vm.record.metadata.inspire_categories">
         <div class="col-md-9 col-sm-9 col-xs-8"
              ng-bind="subject_term.term"></div>
         <div class="col-md-2 col-sm-2 col-xs-3">

--- a/inspirehep/modules/workflows/static/js/inspire_workflows_ui/templates/results.html
+++ b/inspirehep/modules/workflows/static/js/inspire_workflows_ui/templates/results.html
@@ -71,11 +71,11 @@
         <div class="col-md-2 pad-top-10">
           <ul class="subject-terms">
             <li
-              ng-repeat="subject in record._source.metadata.field_categories | unique:'term' | limitTo:3"
-              ng-if="record._source.metadata.field_categories">{{subject.term}}
+              ng-repeat="subject in record._source.metadata.inspire_categories | unique:'term' | limitTo:3"
+              ng-if="record._source.metadata.inspire_categories">{{subject.term}}
             </li>
             <li
-              ng-repeat="subject in record._source.metadata.field_categories | limitTo:3"
+              ng-repeat="subject in record._source.metadata.inspire_categories | limitTo:3"
               ng-if="subject._term">{{subject._term}}
             </li>
           </ul>

--- a/inspirehep/modules/workflows/tasks/actions.py
+++ b/inspirehep/modules/workflows/tasks/actions.py
@@ -143,7 +143,7 @@ def is_record_relevant(obj, eng):
 def is_experimental_paper(obj, eng):
     """Check if the record is an experimental paper."""
     categories = list(get_value(obj.data, "arxiv_eprints.categories", [[]])[0]) + \
-        list(get_value(obj.data, "field_categories.term", []))
+        list(get_value(obj.data, "inspire_categories.term", []))
     categories_to_check = [
         "hep-ex", "nucl-ex", "astro-ph", "astro-ph.IM", "astro-ph.CO",
         "astro-ph.EP", "astro-ph.GA", "astro-ph.HE", "astro-ph.SR",

--- a/inspirehep/modules/workflows/tasks/matching.py
+++ b/inspirehep/modules/workflows/tasks/matching.py
@@ -161,7 +161,7 @@ def was_already_harvested(record):
     We use the following heuristic: if the record belongs to one of the
     CORE categories then it was probably ingested in some other way.
     """
-    categories = get_value(record, 'field_categories.term', [])
+    categories = get_value(record, 'inspire_categories.term', [])
     for category in categories:
         if category.lower() in current_app.config.get('INSPIRE_ACCEPTED_CATEGORIES', []):
             return True

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ install_requires = [
     'invenio-utils==0.2.0',  # Not fully Invenio 3 ready
     'invenio>=3.0.0a1,<3.1.0',
     'inspire-crawler~=0.2.7',
-    'inspire-schemas~=2.0',
+    'inspire-schemas~=4.0',
     'dojson==1.2.1',
     'Flask>=0.11.1',
     'Flask-Breadcrumbs>=0.3.0',

--- a/tests/unit/api/test_api_utils.py
+++ b/tests/unit/api/test_api_utils.py
@@ -94,7 +94,7 @@ def test_get_id_raises_when_no_control_number():
 
 def test_get_subject():
     record = {
-        'field_categories': [
+        'inspire_categories': [
             {
                 'scheme': 'INSPIRE',
                 'term': 'Phenomenology-HEP',
@@ -110,7 +110,7 @@ def test_get_subject():
 
 def test_get_subject_selects_first():
     record = {
-        'field_categories': [
+        'inspire_categories': [
             {
                 'scheme': 'INSPIRE',
                 'term': 'Experiments-HEP',
@@ -128,9 +128,9 @@ def test_get_subject_selects_first():
     assert expected == result
 
 
-def test_get_subject_discards_non_inspire_field_categories():
+def test_get_subject_discards_non_inspire_inspire_categories():
     record = {
-        'field_categories': [
+        'inspire_categories': [
             {
                 'scheme': 'arXiv',
                 'term': 'cond-mat.str-el',

--- a/tests/unit/authors/test_authors_dojson.py
+++ b/tests/unit/authors/test_authors_dojson.py
@@ -393,7 +393,7 @@ def test_positions_from_public_email_appends():
     assert expected == result['positions']
 
 
-def test_field_categories_from_research_field():
+def test_inspire_categories_from_research_field():
     form = GroupableOrderedDict([
         ('research_field', 'foo'),
     ])
@@ -405,8 +405,7 @@ def test_field_categories_from_research_field():
         },
     ]
     result = updateform.do(form)
-
-    assert expected == result['field_categories']
+    assert expected == result['inspire_categories']
 
 
 def test_positions_from_institutions_history():

--- a/tests/unit/dojson/test_dojson_common_base.py
+++ b/tests/unit/dojson/test_dojson_common_base.py
@@ -88,7 +88,7 @@ def test_541__a_b_c_e_from_acquisition_source():
     assert expected == result['541']
 
 
-def test_field_from_marcxml_650_with_single_a_and_9():
+def test_field_from_marcxml_650_with_single_source_and_category():
     """Simple case.
 
     One arXiv fieldcode that will be mapped to an INSPIRE category. Source
@@ -99,26 +99,22 @@ def test_field_from_marcxml_650_with_single_a_and_9():
         '  <datafield tag="650" ind1="1" ind2="7">'
         '    <subfield code="2">INSPIRE</subfield>'
         '    <subfield code="a">HEP-PH</subfield>'
-        '    <subfield code="9">automatically added based on DCC, PPF, DK </subfield>'
+        '    <subfield code="9">automatically added based on DCC, PPF, DK</subfield>'
         '  </datafield>'
         '</record>'
     )
 
-    expected = [
-        {
-            'source': 'INSPIRE',
-            '_scheme': 'INSPIRE',
-            'scheme': 'INSPIRE',
-            '_term': 'HEP-PH',
-            'term': 'Phenomenology-HEP',
-        },
-    ]
-    result = hepnames.do(create_record(snippet))
+    expected_inspire = [{
+        'term': 'Phenomenology-HEP',
+        'source': 'curator',
+    }]
 
-    assert expected == result['field_categories']
+    result = hep.do(create_record(snippet))
+
+    assert expected_inspire == result['inspire_categories']
 
 
-def test_field_from_marcxml_650_with_two_a():
+def test_field_from_marcxml_650_with_wrong_category():
     """Two 'a' subfields in one datafield.
 
     The first is an arXiv fieldcode an the second an INSPIRE category.
@@ -127,153 +123,106 @@ def test_field_from_marcxml_650_with_two_a():
         '<record>'
         '  <datafield tag="650" ind1="1" ind2="7">'
         '    <subfield code="2">INSPIRE</subfield>'
-        '    <subfield code="a">hep-ex</subfield>'
-        '    <subfield code="a">Gravitation and Cosmology</subfield>'
+        '    <subfield code="a">Wrong Category</subfield>'
+        '    <subfield code="9">Wrong Source</subfield>'
         '  </datafield>'
         '</record>'
     )
 
-    expected = [
-        {
-            '_scheme': 'INSPIRE',
-            'scheme': 'INSPIRE',
-            '_term': 'hep-ex',
-            'term': 'Experiment-HEP',
-        },
-        {
-            '_scheme': 'INSPIRE',
-            'scheme': 'INSPIRE',
-            '_term': 'Gravitation and Cosmology',
-            'term': 'Gravitation and Cosmology',
-        },
-    ]
-    result = hepnames.do(create_record(snippet))
+    result = hep.do(create_record(snippet))
 
-    assert expected == result['field_categories']
+    assert 'inspire_categories' not in result
 
 
-def test_field_from_marcxml_650_with_two_2():
-    """Two '2' subfields in one datafield.
+def test_field_from_marcxml_650_with_wrong_source():
+    """Two 'a' subfields in one datafield.
 
-    The first will be taken (this time it's correct).
+    The first is an arXiv fieldcode an the second an INSPIRE category.
     """
     snippet = (
         '<record>'
         '  <datafield tag="650" ind1="1" ind2="7">'
-        '    <subfield code="2">arXiv</subfield>'
         '    <subfield code="2">INSPIRE</subfield>'
-        '    <subfield code="a">hep-ex</subfield>'
-        '  </datafield>'
-        '</record>'
-    )
-
-    expected = [
-        {
-            '_scheme': 'arXiv',
-            'scheme': 'INSPIRE',
-            '_term': 'hep-ex',
-            'term': 'Experiment-HEP',
-        },
-    ]
-    result = hepnames.do(create_record(snippet))
-
-    assert expected == result['field_categories']
-
-
-def test_field_from_multiple_marcxml_650():
-    """Two datafields.
-
-    Both are arXiv field codes, but the other is incorrectly labeled as INSPIRE.
-    """
-    snippet = (
-        '<record>'
-        '  <datafield tag="650" ind1="1" ind2="7">'
-        '    <subfield code="2">arXiv</subfield>'
         '    <subfield code="a">HEP-PH</subfield>'
-        '  </datafield>'
-        '  <datafield tag="650" ind1="1" ind2="7">'
-        '    <subfield code="2">INSPIRE</subfield>'
-        '    <subfield code="a">astro-ph.IM</subfield>'
+        '    <subfield code="9">Wrong Source</subfield>'
         '  </datafield>'
         '</record>'
     )
 
-    expected = [
-        {
-            '_scheme': 'arXiv',
-            'scheme': 'INSPIRE',
-            '_term': 'HEP-PH',
-            'term': 'Phenomenology-HEP',
-        },
-        {
-            '_scheme': 'INSPIRE',
-            'scheme': 'INSPIRE',
-            '_term': 'astro-ph.IM',
-            'term': 'Instrumentation',
-        },
-    ]
-    result = hepnames.do(create_record(snippet))
+    expected_inspire = [{
+        'term': 'Phenomenology-HEP',
+        'source': 'undefined',
+    }]
 
-    assert expected == result['field_categories']
+    result = hep.do(create_record(snippet))
+
+    assert expected_inspire == result['inspire_categories']
 
 
-def test_field_from_marcxml_650_with_no_a():
-    """No term at all."""
+def test_field_from_marcxml_650_with_duplicate_category():
+    """Two 'a' subfields in one datafield.
+
+    The first is an arXiv fieldcode an the second an INSPIRE category.
+    """
     snippet = (
         '<record>'
         '  <datafield tag="650" ind1="1" ind2="7">'
-        '    <subfield code="2">arXiv</subfield>'
+        '    <subfield code="2">INSPIRE</subfield>'
+        '    <subfield code="a">HEP-PH</subfield>'
+        '    <subfield code="9">automatically added based on DCC, PPF, DK</subfield>'
+        '  </datafield>'
+        '  <datafield tag="650" ind1="1" ind2="7">'
+        '    <subfield code="2">INSPIRE</subfield>'
+        '    <subfield code="a">HEP-PH</subfield>'
+        '    <subfield code="9">automatically added based on DCC, PPF, DK</subfield>'
         '  </datafield>'
         '</record>'
     )
 
-    result = hepnames.do(create_record(snippet))
+    expected_inspire = [{
+        'term': 'Phenomenology-HEP',
+        'source': 'curator',
+    }]
 
-    assert 'field_categories' not in result
+    result = hep.do(create_record(snippet))
+
+    assert expected_inspire == result['inspire_categories']
 
 
-def test_field_categories_from_650__a_2():
+def test_field_from_marcxml_650_with_multiple_category():
+    """Two 'a' subfields in one datafield.
+
+    The first is an arXiv fieldcode an the second an INSPIRE category.
+    """
     snippet = (
-        '<datafield tag="650" ind1="1" ind2="7">'
-        '  <subfield code="2">Inspire</subfield>'
-        '  <subfield code="a">Experiment-HEP</subfield>'
-        '</datafield>'
-    )  # record/1426196
+        '<record>'
+        '  <datafield tag="650" ind1="1" ind2="7">'
+        '    <subfield code="2">INSPIRE</subfield>'
+        '    <subfield code="a">HEP-PH</subfield>'
+        '    <subfield code="a">astro-ph.CO</subfield>'
+        '    <subfield code="9">arxiv</subfield>'
+        '  </datafield>'
+        '  <datafield tag="650" ind1="1" ind2="7">'
+        '    <subfield code="2">INSPIRE</subfield>'
+        '    <subfield code="a">cs.DL</subfield>'
+        '    <subfield code="9">submitter</subfield>'
+        '  </datafield>'
+        '</record>'
+    )
+    expected_inspire = [{
+        'term': 'Phenomenology-HEP',
+        'source': 'arxiv',
+    },{
+        'term': 'Astrophysics',
+        'source': 'arxiv',
+    },{
+        'term': 'Computing',
+        'source': 'user',
+    }]
 
-    expected = [
-        {
-            '_scheme': 'Inspire',
-            'scheme': 'INSPIRE',
-            '_term': 'Experiment-HEP',
-            'term': 'Experiment-HEP',
-        },
-    ]
-    result = hepnames.do(create_record(snippet))
+    result = hep.do(create_record(snippet))
 
-    assert expected == result['field_categories']
-
-
-def test_field_categories_from_65017_a_2_9_with_conference():
-    snippet = (
-        '<datafield tag="650" ind1="1" ind2="7">'
-        '  <subfield code="2">INSPIRE</subfield>'
-        '  <subfield code="9">conference</subfield>'
-        '  <subfield code="a">Accelerators</subfield>'
-        '</datafield>'
-    )  # record/1479228
-
-    expected = [
-        {
-            '_scheme': 'INSPIRE',
-            'scheme': 'INSPIRE',
-            'source': 'conference',
-            '_term': 'Accelerators',
-            'term': 'Accelerators',
-        },
-    ]
-    result = hepnames.do(create_record(snippet))
-
-    assert expected == result['field_categories']
+    assert expected_inspire == result['inspire_categories']
 
 
 def test_urls_from_marcxml_856_with_single_u_single_y():

--- a/tests/unit/dojson/test_dojson_hep.py
+++ b/tests/unit/dojson/test_dojson_hep.py
@@ -33,7 +33,7 @@ from dojson.contrib.marc21.utils import create_record
 
 from inspirehep.dojson.hep import hep, hep2marc
 from inspirehep.dojson.utils import get_recid_from_ref
-
+from inspirehep.dojson.hep.model import add_inspire_category_from_arxiv_categories
 
 @pytest.fixture
 def marcxml_record():
@@ -1314,13 +1314,11 @@ def test_copyright(marcxml_to_json, json_to_marc):
             json_to_marc['542'][0]['u'])
 
 
-def test_field_categories(marcxml_to_json, json_to_marc):
-    """Test if field_categories is created correctly."""
-    assert (marcxml_to_json['field_categories'][0]['scheme'] ==
-            json_to_marc['65017'][0]['2'])
-    assert (marcxml_to_json['field_categories'][0]['term'] ==
+def test_inspire_categories(marcxml_to_json, json_to_marc):
+    """Test if inspire_categories is created correctly."""
+    assert (marcxml_to_json['inspire_categories'][0]['term'] ==
             json_to_marc['65017'][0]['a'])
-    assert (marcxml_to_json['field_categories'][0]['source'] ==
+    assert (marcxml_to_json['inspire_categories'][0]['source'] ==
             json_to_marc['65017'][0]['9'])
 
 ACCELERATOR_EXPERIMENTS_DATA = [
@@ -2068,3 +2066,69 @@ def test_book_link(marcxml_to_json_book):
     """Test if the link to the book recid is generated correctly."""
     assert (get_recid_from_ref(marcxml_to_json_book['book']['record']) ==
             1409249)
+
+
+def test_add_inspire_category_from_arxiv_categories():
+    snippet = {
+        'arxiv_eprints': {
+            'value': 'arxiv',
+            'categories': ['astro-ph', 'cs.DS'],
+        }
+    }
+
+    expected = {
+        'arxiv_eprints': {
+            'value': 'arxiv',
+            'categories': ['astro-ph', 'cs.DS'],
+        },
+        'inspire_categories': [{
+            'term': 'Astrophysics',
+            'source': 'arxiv',
+        }, {
+            'term': 'Computing',
+            'source': 'arxiv',
+        }]
+
+    }
+
+    result = add_inspire_category_from_arxiv_categories(snippet, None)
+
+    assert result == expected
+
+
+def test_add_inspire_category_without_arxiv_category():
+    snippet = {}
+
+    expected = {}
+
+    output_record = add_inspire_category_from_arxiv_categories(snippet, None)
+
+    assert output_record == expected
+
+
+def test_add_inspire_category_with_inspire_already_present():
+    snippet = {
+        'arxiv_eprints': {
+            'value': 'arxiv',
+            'categories': ['cs.DS'],
+        },
+        'inspire_categories': [{
+            'term': 'Astrophysics',
+            'source': 'arxiv',
+        }]
+    }
+
+    expected = {
+        'arxiv_eprints': {
+            'value': 'arxiv',
+            'categories': ['cs.DS'],
+        },
+        'inspire_categories': [{
+            'term': 'Astrophysics',
+            'source': 'arxiv',
+        }]
+    }
+
+    output_record = add_inspire_category_from_arxiv_categories(snippet, None)
+
+    assert output_record == expected

--- a/tests/unit/dojson/test_dojson_hepnames.py
+++ b/tests/unit/dojson/test_dojson_hepnames.py
@@ -243,13 +243,13 @@ def test_experiments(mock_get_record_ref, mock_get_recid_from_ref, test_name,
     assert json_experiments == expected_json
 
 
-def test_field_categories(marcxml_to_json, json_to_marc):
-    """Test if field_categories is created correctly."""
-    assert (marcxml_to_json['field_categories'][0]['term'] ==
+def test_inspire_categories(marcxml_to_json, json_to_marc):
+    """Test if inspire_categories is created correctly."""
+    assert (marcxml_to_json['inspire_categories'][0]['term'] ==
             json_to_marc['65017'][0]['a'])
-    assert (marcxml_to_json['field_categories'][1]['term'] ==
+    assert (marcxml_to_json['inspire_categories'][1]['term'] ==
             json_to_marc['65017'][1]['a'])
-    assert (json_to_marc['65017'][1]['2'] == 'INSPIRE')
+    assert (json_to_marc['65017'][1]['2'] == 'undefined')
 
 
 def test_ids(marcxml_to_json, json_to_marc):

--- a/tests/unit/dojson/test_dojson_utils.py
+++ b/tests/unit/dojson/test_dojson_utils.py
@@ -67,10 +67,7 @@ def test_classify_field_ignores_case():
 
 
 def test_classify_field_falls_back_on_other():
-    expected = 'Other'
-    result = classify_field('FOO')
-
-    assert expected == result
+    assert classify_field('FOO') is None
 
 
 def test_classify_rank_returns_none_on_falsy_value():

--- a/tests/unit/literaturesuggest/test_literaturesuggest_dojson.py
+++ b/tests/unit/literaturesuggest/test_literaturesuggest_dojson.py
@@ -185,27 +185,27 @@ def test_authors_from_authors_full_name_and_affiliation():
     assert expected == result['authors']
 
 
-def test_field_categories_from_categories():
+def test_inspire_categories_from_categories():
     form = GroupableOrderedDict([
         ('categories', 'foo bar'),
     ])
 
     expected = [
         {
-            'scheme': 'arXiv',
+            'source': 'user',
             'term': 'foo',
         },
         {
-            'scheme': 'arXiv',
+            'source': 'user',
             'term': 'bar',
         },
     ]
     result = literature.do(form)
 
-    assert expected == result['field_categories']
+    assert expected == result['inspire_categories']
 
 
-def test_field_categories_from_multiple_categories():
+def test_inspire_categories_from_multiple_categories():
     form = GroupableOrderedDict([
         ('categories', 'foo bar'),
         ('categories', 'baz'),
@@ -213,21 +213,21 @@ def test_field_categories_from_multiple_categories():
 
     expected = [
         {
-            'scheme': 'arXiv',
+            'source': 'user',
             'term': 'foo',
         },
         {
-            'scheme': 'arXiv',
+            'source': 'user',
             'term': 'bar',
         },
         {
-            'scheme': 'arXiv',
+            'source': 'user',
             'term': 'baz',
         },
     ]
     result = literature.do(form)
 
-    assert expected == result['field_categories']
+    assert expected == result['inspire_categories']
 
 
 def test_collaboration_from_collaboration():
@@ -721,7 +721,7 @@ def test_report_numbers_from_report_numbers():
     assert expected == result['report_numbers']
 
 
-def test_field_categories_from_subject_term():
+def test_inspire_categories_from_subject_term():
     form = {
         'subject_term': [
             'foo',
@@ -732,18 +732,16 @@ def test_field_categories_from_subject_term():
     expected = [
         {
             'term': 'foo',
-            'scheme': 'INSPIRE',
-            'source': 'submitter',
+            'source': 'user',
         },
         {
             'term': 'bar',
-            'scheme': 'INSPIRE',
-            'source': 'submitter',
+            'source': 'user',
         },
     ]
     result = literature.do(form)
 
-    assert expected == result['field_categories']
+    assert expected == result['inspire_categories']
 
 
 def test_thesis_supervisors_from_supervisors():

--- a/tests/unit/literaturesuggest/test_literaturesuggest_tasks.py
+++ b/tests/unit/literaturesuggest/test_literaturesuggest_tasks.py
@@ -101,7 +101,7 @@ def test_formdata_to_model_populates_collections_from_type_of_doc_thesis(u, ui):
 
 @mock.patch('inspirehep.modules.literaturesuggest.tasks.User')
 @mock.patch('inspirehep.modules.literaturesuggest.tasks.UserIdentity')
-def test_formdata_to_model_populates_collections_from_field_categories_if_arxiv(u, ui):
+def test_formdata_to_model_populates_collections_from_inspire_categories_if_arxiv(u, ui):
     data = {}
     extra_data = {}
     formdata = {
@@ -109,7 +109,9 @@ def test_formdata_to_model_populates_collections_from_field_categories_if_arxiv(
         'title': [
             'bar',
         ],
-        'categories': 'baz',
+        'arxiv_eprints': {
+            'categories': ['baz']
+        },
     }
 
     obj = StubObj(data, extra_data)
@@ -141,7 +143,9 @@ def test_formdata_to_model_populates_abstracts_from_abstracts_if_arxiv(u, ui):
         'title': [
             'bar',
         ],
-        'categories': 'baz',
+        'arxiv_eprints': {
+            'categories': ['baz']
+        },
         'abstract': ' qux ',
     }
 
@@ -169,6 +173,9 @@ def test_formdata_to_model_populates_external_system_numbers_from_arxiv_id(u, ui
         'title': [
             'bar',
         ],
+        'arxiv_eprints': {
+            'categories': ['baz']
+        },
         'arxiv_id': 'baz',
         'categories': 'foo'
     }

--- a/tests/unit/records/test_records_receivers.py
+++ b/tests/unit/records/test_records_receivers.py
@@ -29,7 +29,6 @@ from inspirehep.modules.records.receivers import (
     dates_validator,
     earliest_date,
     match_valid_experiments,
-    normalize_field_categories,
     populate_inspire_document_type,
     populate_inspire_subjects,
     populate_recid_from_ref,
@@ -278,146 +277,6 @@ def test_match_valid_experiments_does_nothing_on_empty_list():
     match_valid_experiments(None, json_dict)
 
     assert json_dict['accelerator_experiments'] == []
-
-
-def test_normalize_field_categories_skips_normalized_fields():
-    json_dict = {
-        'field_categories': [
-            {'scheme': 'INSPIRE'},
-            {'_scheme': 'foo'},
-            {'_term': 'bar'},
-        ],
-    }
-
-    normalize_field_categories(json_dict)
-
-    assert json_dict['field_categories'] == [
-        {'scheme': 'INSPIRE'},
-        {'_scheme': 'foo'},
-        {'_term': 'bar'},
-    ]
-
-
-def test_normalize_field_categories_recognizes_known_terms():
-    json_dict = {
-        'field_categories': [
-            {
-                'scheme': 'foo',
-                'term': 'alg-geom',
-            },
-        ],
-    }
-
-    normalize_field_categories(json_dict)
-
-    assert json_dict['field_categories'] == [
-        {
-            '_scheme': 'foo',
-            'scheme': 'INSPIRE',
-            '_term': 'alg-geom',
-            'term': 'Math and Math Physics',
-        },
-    ]
-
-
-def test_normalize_field_categories_ignores_missing_terms():
-    json_dict = {
-        'field_categories': [
-            {'scheme': 'foo'},
-        ],
-    }
-
-    normalize_field_categories(json_dict)
-
-    assert json_dict['field_categories'] == [
-        {
-            '_scheme': 'foo',
-            'scheme': None,
-            '_term': None,
-            'term': None,
-        },
-    ]
-
-
-def test_normalize_field_categories_selects_first_scheme():
-    json_dict = {
-        'field_categories': [
-            {'scheme': ['foo', 'bar']},
-        ],
-    }
-
-    normalize_field_categories(json_dict)
-
-    assert json_dict['field_categories'] == [
-        {
-            '_scheme': 'foo',
-            'scheme': None,
-            '_term': None,
-            'term': None,
-        },
-    ]
-
-
-def test_normalize_field_categories_ignores_unknown_terms_from_unknown_schemes():
-    json_dict = {
-        'field_categories': [
-            {
-                'scheme': 'foo',
-                'term': 'bar',
-            },
-        ],
-    }
-
-    normalize_field_categories(json_dict)
-
-    assert json_dict['field_categories'] == [
-        {
-            '_scheme': 'foo',
-            'scheme': 'INSPIRE',
-            '_term': 'bar',
-            'term': 'Other',
-        },
-    ]
-
-
-def test_normalize_field_categories_retains_source():
-    json_dict = {
-        'field_categories': [
-            {'source': 'foo'},
-        ],
-    }
-
-    normalize_field_categories(json_dict)
-
-    assert json_dict['field_categories'] == [
-        {
-            '_scheme': None,
-            'scheme': None,
-            '_term': None,
-            'term': None,
-            'source': 'foo',
-        },
-    ]
-
-
-def test_normalize_field_categories_changes_source_to_inspire():
-    json_dict = {
-        'field_categories': [
-            {'source': 'automatically'},
-        ],
-    }
-
-    normalize_field_categories(json_dict)
-
-    assert json_dict['field_categories'] == [
-        {
-            '_scheme': None,
-            'scheme': None,
-            '_term': None,
-            'term': None,
-            'source': 'INSPIRE',
-        },
-    ]
 
 
 def test_populate_inspire_document_type_no_doc_type_when_no_collections():
@@ -705,9 +564,8 @@ def test_populate_inspire_document_type_doc_type_from_valid_primary_and_lectures
 
 def test_populate_inspire_subjects_preserves_terms_from_inspire():
     json_dict = {
-        'field_categories': [
+        'inspire_categories': [
             {
-                'scheme': 'INSPIRE',
                 'term': 'foo',
             },
         ],
@@ -716,21 +574,6 @@ def test_populate_inspire_subjects_preserves_terms_from_inspire():
     populate_inspire_subjects(None, json_dict)
 
     assert json_dict['facet_inspire_subjects'] == ['foo']
-
-
-def test_populate_inspire_subjects_discards_terms_from_other_schemes():
-    json_dict = {
-        'field_categories': [
-            {
-                'scheme': 'foo',
-                'term': 'bar',
-            },
-        ],
-    }
-
-    populate_inspire_subjects(None, json_dict)
-
-    assert json_dict['facet_inspire_subjects'] == []
 
 
 def test_populate_recid_from_ref_naming():

--- a/tests/unit/workflows/test_workflows_tasks_actions.py
+++ b/tests/unit/workflows/test_workflows_tasks_actions.py
@@ -379,8 +379,8 @@ def test_is_experimental_paper():
     assert is_experimental_paper(obj, eng)
 
 
-def test_is_experimental_paper_returns_true_if_field_categories_in_list():
-    obj = StubObj({'field_categories': [{'term': 'Experiment-HEP'}]}, {})
+def test_is_experimental_paper_returns_true_if_inspire_categories_in_list():
+    obj = StubObj({'inspire_categories': [{'term': 'Experiment-HEP'}]}, {})
     eng = DummyEng()
 
     assert is_experimental_paper(obj, eng)


### PR DESCRIPTION
In this PR we are going to:

- Change the BL for the rule 650.*
- Rename the `field_categories` field to `inspire_categories`
- Change the code in according to the new structure of `inspire_categories` field