### PR TITLE
editor: abstract source suggester

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -424,6 +424,11 @@ RECORDS_REST_ENDPOINTS = dict(
                 'inspirehep.modules.records.serializers'
                 ':cvformattext_v1_search'),
         },
+        suggesters=dict(
+            abstract_source=dict(completion=dict(
+                field='abstracts.abstract_source_suggest'
+            ))
+        ),
         list_route='/literature/',
         item_route=(
             '/literature'

--- a/inspirehep/modules/records/mappings/records/hep.json
+++ b/inspirehep/modules/records/mappings/records/hep.json
@@ -28,6 +28,11 @@
                 },
                 "abstracts": {
                     "properties": {
+                        "abstract_source_suggest": {
+                            "analyzer": "simple",
+                            "search_analyzer": "simple",
+                            "type": "completion"
+                        },
                         "value": {
                             "copy_to": [
                                 "abstract",

--- a/inspirehep/modules/records/receivers.py
+++ b/inspirehep/modules/records/receivers.py
@@ -71,6 +71,7 @@ def enhance_record(sender, json, *args, **kwargs):
     dates_validator(sender, json, *args, **kwargs)
     add_recids_and_validate(sender, json, *args, **kwargs)
     populate_experiment_suggest(sender, json, *args, **kwargs)
+    populate_abstract_source_suggest(sender, json, *args, **kwargs)
     after_record_enhanced.send(json)
 
 
@@ -406,3 +407,18 @@ def populate_experiment_suggest(sender, json, *args, **kwargs):
                 'payload': {'$ref': get_value(json, 'self.$ref')},
             },
         })
+
+
+def populate_abstract_source_suggest(sender, json, *args, **kwargs):
+    """Populates abstract_source_suggest field of records"""
+    if 'hep.json' in json.get('$schema'):
+        abstracts = json.get('abstracts', [])
+        for abstract in abstracts:
+            source = abstract.get('source')
+            if source:
+                abstract.update({
+                    'abstract_source_suggest': {
+                        'input': source,
+                        'output': source,
+                    },
+                })


### PR DESCRIPTION
* Adds a suggest for abstracts.source which is used to autocomplete
from all abstract sources in DB.

Signed-off-by: harunurhan <harunurhan17@gmail.com>