### PR TITLE
permissions: add author view permissions

### DIFF
--- a/inspirehep/modules/authors/permissions.py
+++ b/inspirehep/modules/authors/permissions.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+
+from invenio_access.permissions import (
+    DynamicPermission,
+    ParameterizedActionNeed
+)
+
+
+action_admin_holdingpen_authors = ParameterizedActionNeed(
+    'admin-holdingpen-authors', argument=None
+)
+
+holdingpen_author_permission = DynamicPermission(
+    action_admin_holdingpen_authors
+)

--- a/inspirehep/modules/authors/views/holdingpen.py
+++ b/inspirehep/modules/authors/views/holdingpen.py
@@ -52,6 +52,7 @@ from invenio_workflows_ui.api import WorkflowUIRecord
 from inspirehep.modules.forms.form import DataExporter
 
 from ..forms import AuthorUpdateForm
+from ..permissions import holdingpen_author_permission
 from ..tasks import formdata_to_model
 
 
@@ -325,7 +326,7 @@ def submitnew():
 
 @blueprint.route('/new/review', methods=['GET'])
 @login_required
-# @permission_required(viewauthorreview.name)
+@holdingpen_author_permission.require(http_exception=403)
 def newreview():
     """View for INSPIRE author new form review by a cataloger."""
     objectid = request.values.get('objectid', 0, type=int)
@@ -364,7 +365,7 @@ def newreview():
 
 @blueprint.route('/new/review/submit', methods=['POST'])
 @login_required
-# @permission_required(viewauthorreview.name)
+@holdingpen_author_permission.require(http_exception=403)
 def reviewhandler():
     """Form handler when a cataloger accepts an author review."""
     objectid = request.values.get('objectid', 0, type=int)
@@ -391,7 +392,7 @@ def reviewhandler():
 
 @blueprint.route('/holdingpenreview', methods=['GET', 'POST'])
 @login_required
-# @permission_required(viewauthorreview.name)
+@holdingpen_author_permission.require(http_exception=403)
 def holdingpenreview():
     """Handler for approval or rejection of new authors in Holding Pen."""
     objectid = request.values.get('objectid', 0, type=int)

--- a/inspirehep/modules/fixtures/users.py
+++ b/inspirehep/modules/fixtures/users.py
@@ -68,4 +68,9 @@ def init_users_and_permissions():
             role=cataloger_role)
         )
 
+        db.session.add(ActionRoles(
+            action='admin-holdingpen-authors',
+            role=cataloger_role)
+        )
+
     db.session.commit()

--- a/setup.py
+++ b/setup.py
@@ -206,6 +206,7 @@ setup(
             'view_restricted_collection'
             ' = inspirehep.modules.records.permissions:'
             'action_view_restricted_collection',
+            'admin_holdingpen_authors = inspirehep.modules.authors.permissions:action_admin_holdingpen_authors'
         ],
         'invenio_base.api_apps': [
             'inspire_cache = inspirehep.modules.cache.ext:INSPIRECache',

--- a/tests/integration/test_holdingpen_permissions.py
+++ b/tests/integration/test_holdingpen_permissions.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+
+from __future__ import absolute_import, division, print_function
+
+import pytest
+from flask import url_for
+from flask_security.utils import encrypt_password
+
+from invenio_access.models import ActionUsers
+from invenio_accounts.models import User
+from invenio_accounts.testutils import login_user_via_session
+from invenio_db import db
+
+
+@pytest.fixture(scope='function')
+def users(app):
+    """Create user fixtures."""
+    encrypted_password = encrypt_password('123456')
+    user = User(
+        email='user@inspirehep.net',
+        password=encrypted_password,
+        active=True
+    )
+    user_allowed = User(
+        email='user_allowed@inspirehep.net',
+        password=encrypted_password,
+        active=True
+    )
+
+    db.session.add_all([user, user_allowed])
+    db.session.commit()
+
+    author_admin = ActionUsers(
+        action='admin-holdingpen-authors',
+        user_id=user_allowed.id
+    )
+
+    db.session.add(author_admin)
+    db.session.commit()
+
+    yield
+
+    ActionUsers.query.filter_by(action='admin-holdingpen-authors').delete()
+    User.query.filter_by(email='user@inspirehep.net').delete()
+    User.query.filter_by(email='user_allowed@inspirehep.net').delete()
+    db.session.commit()
+
+
+def test_holdingpen_author_views_access(app, app_client, users):
+    """Check permissions of author related views."""
+    # First make sure anonymous user is redirected to login page
+    res = app_client.get(url_for('inspirehep_authors_holdingpen.newreview'))
+    assert res.status_code == 302
+    assert 'login' in res.location
+
+    res = app_client.post(
+        url_for('inspirehep_authors_holdingpen.reviewhandler')
+    )
+    assert res.status_code == 302
+    assert 'login' in res.location
+
+    res = app_client.get(
+        url_for('inspirehep_authors_holdingpen.holdingpenreview')
+    )
+    assert res.status_code == 302
+    assert 'login' in res.location
+
+    # Logged-in user with no permission should receive 403
+    login_user_via_session(app_client, email='user@inspirehep.net')
+    res = app_client.get(url_for('inspirehep_authors_holdingpen.newreview'))
+    assert res.status_code == 403
+    res = app_client.post(
+        url_for('inspirehep_authors_holdingpen.reviewhandler')
+    )
+    assert res.status_code == 403
+    res = app_client.get(
+        url_for('inspirehep_authors_holdingpen.holdingpenreview')
+    )
+    assert res.status_code == 403
+
+    # User with admin-holdingpen-authors action allowed can access
+    # 400 is returned because no object id is passed to the views
+    login_user_via_session(app_client, email='user_allowed@inspirehep.net')
+    res = app_client.get(url_for('inspirehep_authors_holdingpen.newreview'))
+    assert res.status_code == 400
+    res = app_client.post(
+        url_for('inspirehep_authors_holdingpen.reviewhandler')
+    )
+    assert res.status_code == 400
+    res = app_client.get(
+        url_for('inspirehep_authors_holdingpen.holdingpenreview')
+    )
+    assert res.status_code == 400


### PR DESCRIPTION
* Adds new action admin-holdingpen-authors for access control to
  holding pen views related to authors. (addresses #920)

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>