### PR TITLE
assets: pin ng2-bootstrap version to latest

### DIFF
--- a/inspirehep/modules/theme/bundles.py
+++ b/inspirehep/modules/theme/bundles.py
@@ -64,6 +64,7 @@ js = NpmBundle(
         "clipboard": "~1.5.8",
         "flightjs": "~1.5.0",
         "angular": "~1.4.8",
+        "ng2-bootstrap": "~1.1.16",
         "readmore-js": "~2.1.0",
         "impact-graphs": "git+https://git@github.com/inspirehep/impact-graphs.git",
         "inspirehep-typeahead-search-js": "git+https://github.com/inspirehep/inspirehep-typeahead-search-js.git",


### PR DESCRIPTION
* Ng2-bootstrap npm package has been released to 1.1.16 and not
  specifying that version breaks the build. (closes #1824)

Signed-off-by: David Caro <david@dcaro.es>