### PR TITLE
tests: add pytest-randomly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ tests_require = [
     'pytest-cov>=1.8.0',
     'pytest-httpretty>=0.2.0',
     'pytest-pep8>=1.0.6',
+    'pytest-randomly>=1.1.2',
     'pytest-selenium>=1.3.1',
     'pytest>=2.8.0',
     'mock>=1.3.0',


### PR DESCRIPTION
Introduces `pytest-randomly` to randomize the order of execution of
tests, so that we discover bugs hidden by the deterministic execution
of tests.