### PR TITLE
setup: pin Jinja2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ install_requires = [
     'invenio-workflows-files~=0.0.4',
     'invenio-workflows-ui~=1.0.27',
     'elasticsearch-dsl<2.2.0',
+    'Jinja2<2.9.0',
 ]
 
 tests_require = [


### PR DESCRIPTION
Travis: https://travis-ci.org/inspirehep/inspire-next/jobs/189915754

This is a temporary workaround to a regression introduced by Jinja 2.9: `ASSET_URL` variables in `assets` block now appear to be undefined. Also see: https://github.com/miracle2k/flask-assets/issues/120