### PR TITLE
migrator: merge merged records after migration

### DIFF
--- a/inspirehep/modules/migrator/tasks/records.py
+++ b/inspirehep/modules/migrator/tasks/records.py
@@ -46,7 +46,7 @@ from invenio_db import db
 from invenio_indexer.api import RecordIndexer, current_record_to_index
 from invenio_pidstore.errors import PIDDoesNotExistError
 from invenio_pidstore.models import PersistentIdentifier
-from invenio_search import current_search_client
+from invenio_search import current_search_client as es
 from invenio_search.utils import schema_to_index
 
 from inspirehep.dojson.processors import overdo_marc_dict
@@ -55,7 +55,10 @@ from inspirehep.modules.pidstore.minters import inspire_recid_minter
 from inspirehep.modules.pidstore.utils import get_pid_type_from_schema
 from inspirehep.modules.records.api import InspireRecord
 from inspirehep.utils.dedupers import dedupe_list
-from inspirehep.utils.helpers import force_force_list
+from inspirehep.utils.helpers import (
+    force_force_list,
+    get_recid_from_url,
+)
 from inspirehep.utils.record import get_value
 from inspirehep.utils.record_getter import get_db_record
 
@@ -145,6 +148,8 @@ def migrate(source, wait_for_results=False):
         migrate_chunk.ignore_result = True
         print('All migration tasks have been completed.')
 
+    merge_merged_records.delay()
+
 
 @shared_task(ignore_result=True)
 def continuous_migration():
@@ -214,7 +219,7 @@ def migrate_chunk(chunk):
 
     req_timeout = current_app.config['INDEXER_BULK_REQUEST_TIMEOUT']
     es_bulk(
-        current_search_client,
+        es,
         index_queue,
         stats_only=True,
         request_timeout=req_timeout,
@@ -249,7 +254,7 @@ def add_citation_counts(chunk_size=500, request_timeout=120):
 
     click.echo('Extracting all citations...')
     with click.progressbar(es_scan(
-            current_search_client,
+            es,
             query={
                 '_source': 'references.recid',
                 'filter': {
@@ -276,7 +281,7 @@ def add_citation_counts(chunk_size=500, request_timeout=120):
 
     click.echo('Adding citation numbers...')
     success, failed = es_bulk(
-        current_search_client,
+        es,
         _get_records_to_update_generator(citations_lookup),
         chunk_size=chunk_size,
         raise_on_exception=False,
@@ -318,10 +323,7 @@ def record_upsert(json):
 
         if json.get('deleted'):
             new_recid = get_recid_from_ref(json.get('new_record'))
-            if new_recid:
-                merged_record = get_db_record(pid_type, new_recid)
-                record.merge(merged_record)
-            else:
+            if not new_recid:
                 record.delete()
 
         return record
@@ -373,3 +375,59 @@ def migrate_and_insert_record(raw_record):
         prod_record.valid = True
         db.session.merge(prod_record)
         return record
+
+
+def get_records_to_merge():
+    def _get_uuids_to_merge():
+        body = {
+            'query': {
+                'filtered': {
+                    'filter': {
+                        'bool': {
+                            'must_not': [
+                                {
+                                    'missing': {
+                                        'field': 'new_record'
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                },
+            },
+        }
+
+        index = 'records-*'
+        query = es_scan(es, query=body, index=index)
+
+        for result in query:
+            yield result['_id']
+
+    def _get_records_to_merge(uuids):
+        return InspireRecord.get_records(uuids)
+
+    uuids = _get_uuids_to_merge()
+    records = _get_records_to_merge(uuids)
+
+    return records
+
+
+@shared_task()
+def merge_merged_records():
+    """Merge all marked merged records.
+
+    The method collects the records from the database that
+    have been marked as merged and merges them.
+    """
+    def _get_other_record(recid):
+        pid = PersistentIdentifier.query.filter_by(pid_value=str(recid)).one()
+        return get_db_record(pid.pid_type, recid)
+
+    records = get_records_to_merge()
+    for record in records:
+        other_ref = record.get('new_record')
+        recid = get_recid_from_url(other_ref.get('$ref'))
+        other = _get_other_record(recid)
+        record.merge(other)
+        record.commit()
+    db.session.commit()

--- a/inspirehep/utils/helpers.py
+++ b/inspirehep/utils/helpers.py
@@ -25,8 +25,11 @@
 from __future__ import absolute_import, division, print_function
 
 from contextlib import closing
+from six.moves.urllib.parse import urlsplit
 
 import requests
+
+from inspirehep.modules.pidstore.utils import get_pid_type_from_endpoint
 
 
 def download_file(url, output_file=None, chunk_size=1024):
@@ -90,3 +93,15 @@ def get_recid_from_url(reference):
     except (ValueError, AttributeError):
         res = False
     return res
+
+
+def get_pid_type_from_ref(reference):
+    """Return the ``pid_type`` corresponding to a record URL.
+
+    The reference name corresponds to the ``endpoint`` in all cases.
+    This implementation exploits this by falling back to
+    ``get_pid_type_from_endpoint``.
+    """
+    endpoint = urlsplit(reference).path.split('/')[-2]
+
+    return get_pid_type_from_endpoint(endpoint)

--- a/inspirehep/utils/helpers.py
+++ b/inspirehep/utils/helpers.py
@@ -78,3 +78,15 @@ def force_force_list(data):
     elif isinstance(data, (tuple, set)):
         return list(data)
     return data
+
+
+def get_recid_from_url(reference):
+    """Retrieve recid from record URL.
+
+    If no recid can be parsed, return False.
+    """
+    try:
+        res = int(reference.split('/')[-1])
+    except (ValueError, AttributeError):
+        res = False
+    return res

--- a/tests/unit/utils/test_utils_helpers.py
+++ b/tests/unit/utils/test_utils_helpers.py
@@ -199,3 +199,10 @@ def test_get_recid_from_url_returns_false_on_ref_malformed():
 
 def test_get_recid_from_url():
     assert get_recid_from_url('http://localhost:5000/api/literature/111') == 111
+
+
+def test_get_pid_type_from_ref():
+    expected = 'lit'
+    result = get_pid_type_from_ref('http://localhost:5000/api/literature/111')
+
+    assert expected == result

--- a/tests/unit/utils/test_utils_helpers.py
+++ b/tests/unit/utils/test_utils_helpers.py
@@ -33,6 +33,7 @@ from inspirehep.utils.helpers import (
     download_file,
     download_file_to_record,
     get_json_for_plots,
+    get_recid_from_url,
     force_force_list,
 )
 
@@ -182,3 +183,19 @@ def test_force_force_list_does_not_touch_lists():
     result = force_force_list(['foo', 'bar', 'baz'])
 
     assert expected == result
+
+
+def test_get_recid_from_url_returns_false_on_none():
+    assert get_recid_from_url(None) == False
+
+
+def test_get_recid_from_url_returns_false_on_simple_strings():
+    assert get_recid_from_url('a_string') == False
+
+
+def test_get_recid_from_url_returns_false_on_ref_malformed():
+    assert get_recid_from_url('http://bad_url') == False
+
+
+def test_get_recid_from_url():
+    assert get_recid_from_url('http://localhost:5000/api/literature/111') == 111

--- a/tests/unit/utils/test_utils_helpers.py
+++ b/tests/unit/utils/test_utils_helpers.py
@@ -33,6 +33,7 @@ from inspirehep.utils.helpers import (
     download_file,
     download_file_to_record,
     get_json_for_plots,
+    get_pid_type_from_ref,
     get_recid_from_url,
     force_force_list,
 )


### PR DESCRIPTION
Sentry: https://sentry.cern.ch/inspire-sentry/inspire-nightly/group/618692/

* Adds merge merged records after migration procedure.
* Adds `get_recid_from_url`
* Adds `get_pid_type_from_ref`

References #484  

Signed-off-by: Spiros Delviniotis spyridon.delviniotis@cern.ch