### PR TITLE
theme: configure Jinja2 to remove whitespace

### DIFF
--- a/inspirehep/modules/theme/ext.py
+++ b/inspirehep/modules/theme/ext.py
@@ -63,8 +63,10 @@ class INSPIRETheme(object):
 
         app.register_blueprint(blueprint)
 
-        # Add Jinja2 extensions.
+        # Configure Jinja2 environment.
         app.jinja_env.add_extension('jinja2.ext.do')
+        app.jinja_env.lstrip_blocks = True
+        app.jinja_env.trim_blocks = True
 
         # Register errors handlers.
         app.register_error_handler(401, unauthorized)

--- a/tests/unit/theme/test_theme_jinja2filters.py
+++ b/tests/unit/theme/test_theme_jinja2filters.py
@@ -269,7 +269,7 @@ def test_new_line_after_adds_no_break_after_empty_string():
 
 
 def test_email_links_returns_email_link_on_list_of_one_element():
-    expected = ['\n\n<a href="mailto:foo@example.com">foo@example.com</a>']
+    expected = ['\n<a href="mailto:foo@example.com">foo@example.com</a>']
     result = email_links(['foo@example.com'])
 
     assert expected == result
@@ -277,7 +277,7 @@ def test_email_links_returns_email_link_on_list_of_one_element():
 
 def test_email_link_returns_email_link_on_element(app):
     with app.test_request_context('/'):
-        expected = '\n\n<a href="mailto:foo@example.com">foo@example.com</a>'
+        expected = '\n<a href="mailto:foo@example.com">foo@example.com</a>'
         result = email_link('foo@example.com')
 
         assert expected == result
@@ -286,7 +286,7 @@ def test_email_link_returns_email_link_on_element(app):
 def test_url_links_returns_url_link_on_list_of_one_element():
     record_with_urls = InspireRecord({'urls': [{'value': 'http://www.example.com'}]})
 
-    expected = ['\n\n<a href="http://www.example.com">http://www.example.com</a>']
+    expected = ['\n<a href="http://www.example.com">http://www.example.com</a>']
     result = url_links(record_with_urls)
 
     assert expected == result
@@ -295,7 +295,7 @@ def test_url_links_returns_url_link_on_list_of_one_element():
 def test_institutes_links():
     record_with_institute = InspireRecord({'institute': ['foo']})
 
-    expected = ['\n\n<a href="search/?cc=Institutions&p=110_u%3Afoo&of=hd">foo</a>']
+    expected = ['\n<a href="search/?cc=Institutions&p=110_u%3Afoo&of=hd">foo</a>']
     result = institutes_links(record_with_institute)
 
     assert expected == result
@@ -304,7 +304,7 @@ def test_institutes_links():
 def test_author_profile():
     record_with_profile = InspireRecord({'profile': ['foo']})
 
-    expected = ['\n\n<a href="/author/search?q=foo">foo</a>']
+    expected = ['\n<a href="/author/search?q=foo">foo</a>']
     result = author_profile(record_with_profile)
 
     assert expected == result

--- a/tests/unit/utils/test_utils_conferences.py
+++ b/tests/unit/utils/test_utils_conferences.py
@@ -63,7 +63,7 @@ def test_render_conferences():
             '<a href="/conferences/1">title</a>',
             'original_address',
             '',
-            u'\n  ',
+            u'  ',
         ],
     ], 1)
     with current_app.test_request_context():
@@ -98,7 +98,7 @@ def test_render_conferences_handles_unicode():
             u'<a href="/conferences/1351301">Théorie de Cordes en France</a>',
             'Paris, France',
             '',
-            u'\n  ',
+            u'  ',
         ],
     ], 1)
     with current_app.test_request_context():
@@ -141,13 +141,13 @@ def test_render_contributions():
     expected = ([
         [
             "<a href='/literature/1'>first-title</a>",
-            u'\n  \n  \n\n\n  \n',
+            u'\n\n',
             'first-journal_title',
             1,
         ],
         [
             "<a href='/literature/2'>second-title</a>",
-            u'\n  \n  \n\n\n  \n',
+            u'\n\n',
             '',
             0,
         ],
@@ -178,7 +178,7 @@ def test_render_contributions_handles_unicode():
     expected = ([
         [
             u"<a href='/literature/1427573'>Storage Ring Based EDM Search — Achievements and Goals</a>",
-            u'\n  \n  \n\n\n  \n',
+            u'\n\n',
             '',
             0,
         ],

--- a/tests/unit/utils/test_utils_experiments.py
+++ b/tests/unit/utils/test_utils_experiments.py
@@ -89,13 +89,13 @@ def test_render_contributions():
     expected = ([
         [
             "<a href='/literature/1'>first-title</a>",
-            u'\n  \n  \n\n\n  \n',
+            u'\n\n',
             'first-journal_title',
             1,
         ],
         [
             "<a href='/literature/2'>second-title</a>",
-            u'\n  \n  \n\n\n  \n',
+            u'\n\n',
             '',
             0,
         ],


### PR DESCRIPTION
Spin off of #1785.

Adds `lstrip_blocks` and `trim_blocks` to Jinja2's configuration, so
that most whitespace is deleted from the result.
See: http://jinja.pocoo.org/docs/dev/templates/#whitespace-control.

As @jmartinm remarked [here](https://github.com/inspirehep/inspire-next/pull/1785#discussion_r91735604), this means that all `{%-` and `-%}` are
now obsolete, and should be removed in a cleanup PR.
