### PR TITLE
setup: added extra deps for web-node

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -131,6 +131,9 @@ extras_require = {
     'migration': [
         'invenio-migrator>=1.0.0a6',
     ],
+    'web-node': [
+        'gunicorn',
+    ],
     'crawler': [
         'hepcrawl>=0.2.42',
     ],


### PR DESCRIPTION
* For now just gunicorn is needed, this simplifies a bit the
  deployment and allows to avoid custom-hidden deps out of the code.

Signed-off-by: David Caro <david@dcaro.es>