### PR TITLE
literaturesuggest: convert arxiv to inspire categories on import

### DIFF
--- a/inspirehep/modules/literaturesuggest/static/js/literaturesuggest/literature_submission_form.js
+++ b/inspirehep/modules/literaturesuggest/static/js/literaturesuggest/literature_submission_form.js
@@ -122,7 +122,7 @@ define(function(require, exports, module) {
     this.$form = $("#webdeposit_form_accordion");
     this.$formWrapper = $('.form-wrapper');
     this.$inputs = this.$formWrapper.find(':input');
-    this.subject_kb = {};
+    this.subject_kb = options.arxiv_to_inspire_categories || {};
 
     /**
      * Dict with custom setter functions - a workaround for twitter typeahead
@@ -206,11 +206,6 @@ define(function(require, exports, module) {
       });
 
       this.addConferenceInfoField();
-
-      that.getKB(that.options.arxiv_to_inspire_categories_kb)
-        .done(function(response_kb) {
-          that.subject_kb = response_kb;
-        });
 
       if (!this.isFormBlank()) {
         this.showForm();

--- a/inspirehep/modules/literaturesuggest/templates/literaturesuggest/forms/suggest.html
+++ b/inspirehep/modules/literaturesuggest/templates/literaturesuggest/forms/suggest.html
@@ -86,7 +86,7 @@ require(
         }
       },
       inspire: {
-        arxiv_to_inspire_categories_kb: "{{ config.get('DEPOSIT_ARXIV_TO_INSPIRE_CATEGORIES_KB') }}",
+        arxiv_to_inspire_categories: {{ config.get('ARXIV_TO_INSPIRE_CATEGORY_MAPPING') | safe }},
         save_url: '{{ url_for("inspirehep_literature_suggest.validate") }}',
       }
     };


### PR DESCRIPTION
* Uses ARXIV_TO_INSPIRE_CATEGORY_MAPPING configuration to convert categories
  imported from arXiv to INSPIRE categories. (closes #1823)

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>