### PR TITLE
workflows: rewrite prepare_files in tasks/submission

### DIFF
--- a/inspirehep/dojson/common/base.py
+++ b/inspirehep/dojson/common/base.py
@@ -291,6 +291,7 @@ def fft(self, key, value):
         'flag': value.get('o'),
         'description': value.get('d'),
         'filename': value.get('n'),
+        'filetype': value.get('f'),
     }
 
 
@@ -304,6 +305,7 @@ def fft2marc(self, key, value):
         'o': value.get('flag'),
         'd': value.get('description'),
         'n': value.get('filename'),
+        'f': value.get('filetype'),
     }
 
 

--- a/tests/unit/dojson/test_dojson_common_base.py
+++ b/tests/unit/dojson/test_dojson_common_base.py
@@ -508,3 +508,57 @@ def test_collections_from_980__double_a_double_b():
     marc_result['980'].sort()
 
     assert expected_marc == marc_result['980']
+
+
+def test_fft_from_FFT_a_d_f_n_o_t():
+    snippet = (
+        '<datafield tag="FFT">'
+        '  <subfield code="a">url</subfield>'
+        '  <subfield code="t">docfile_type</subfield>'
+        '  <subfield code="o">flag</subfield>'
+        '  <subfield code="d">description</subfield>'
+        '  <subfield code="n">filename</subfield>'
+        '  <subfield code="f">filetype</subfield>'
+        '</datafield>'
+    )
+
+    expected = [
+        {
+            'url': 'url',
+            'docfile_type': 'docfile_type',
+            'flag': 'flag',
+            'description': 'description',
+            'filename': 'filename',
+            'filetype': 'filetype',
+        },
+    ]
+    result = hep.do(create_record(snippet))
+
+    assert expected == result['fft']
+
+
+def test_fft_roundtrips():
+    snippet = (
+        '<datafield tag="FFT" >'
+        '  <subfield code="a">url</subfield>'
+        '  <subfield code="t">docfile_type</subfield>'
+        '  <subfield code="o">flag</subfield>'
+        '  <subfield code="d">description</subfield>'
+        '  <subfield code="n">filename</subfield>'
+        '  <subfield code="f">filetype</subfield>'
+        '</datafield>'
+    )
+
+    expected = [
+        {
+            'a': 'url',
+            't': 'docfile_type',
+            'o': 'flag',
+            'd': 'description',
+            'n': 'filename',
+            'f': 'filetype',
+        },
+    ]
+    result = hep2marc.do(hep.do(create_record(snippet)))
+
+    assert expected == result['FFT']

--- a/tests/unit/workflows/test_workflows_tasks_submission.py
+++ b/tests/unit/workflows/test_workflows_tasks_submission.py
@@ -36,8 +36,19 @@ class DummyEng(object):
 
 
 def test_add_note_entry_does_not_add_value_that_is_already_present():
-    obj = StubObj({'public_notes': [{'value': '*Temporary entry*'}]}, {'core': 'something'})
+    data = {
+        'public_notes': [
+            {'value': '*Temporary entry*'},
+        ],
+    }
+    extra_data = {'core': 'something'}
+
+    obj = StubObj(data, extra_data)
     eng = DummyEng()
 
     assert add_note_entry(obj, eng) is None
-    assert {'public_notes': [{'value': '*Temporary entry*'}]} == obj.data
+    assert obj.data == {
+        'public_notes': [
+            {'value': '*Temporary entry*'},
+        ],
+    }


### PR DESCRIPTION
Closes #1769 

* First commit amends a DoJSON rule to also include a `filetype` subfield in `fft`.
* Second commit is just a preparatory commit for the next one.
* Third commit reimplements `prepare_files` from scratch, with complete test coverage.