### PR TITLE
dojson: fix missed double quote for docstring

### DIFF
--- a/inspirehep/dojson/hep/fields/bd01x09x.py
+++ b/inspirehep/dojson/hep/fields/bd01x09x.py
@@ -90,7 +90,7 @@ RE_SPLIT_LANGUAGES = re.compile("\/| or | and |,|=|\s+")
 @hep.over('isbns', '^020..')
 @utils.for_each_value
 def isbns(self, key, value):
-    "ISBN, its medium and an additional comment."""
+    """ISBN, its medium and an additional comment."""
     try:
         isbn = normalize_isbn(force_single_element(value['a']))
     # See https://github.com/nekobcn/isbnid/issues/2 and


### PR DESCRIPTION
Signed-off-by: Spiros Delviniotis <spyridon.delviniotis@cern.ch>