### PR TITLE
literaturesuggest: normalize journal title names

### DIFF
--- a/inspirehep/modules/records/mappings/records/journals.json
+++ b/inspirehep/modules/records/mappings/records/journals.json
@@ -192,6 +192,19 @@
                         "journalautocomplete"
                     ],
                     "type": "string"
+                },
+                "title_variants": {
+                    "properties": {
+                      "title": {
+                        "type": "string",
+                        "fields": {
+                          "lowercased": {
+                            "type": "string",
+                            "analyzer": "lowercase_analyzer"
+                          }
+                        }
+                      }
+                    }
                 }
             }
         }

--- a/tests/unit/authors/test_authors_receivers.py
+++ b/tests/unit/authors/test_authors_receivers.py
@@ -25,6 +25,7 @@ from __future__ import absolute_import, division, print_function
 import httpretty
 import mock
 import pytest
+from flask import current_app
 
 from inspirehep.modules.authors import receivers
 
@@ -68,84 +69,81 @@ def test_name_variations():
 
 
 @pytest.mark.httpretty
-def test_phonetic_block_generation_ascii(app):
+def test_phonetic_block_generation_ascii():
     extra_config = {
         "BEARD_API_URL": "http://example.com/beard",
     }
 
-    with app.app_context():
-        with mock.patch.dict(app.config, extra_config):
-            httpretty.register_uri(
-                httpretty.POST,
-                "{base_url}/text/phonetic_blocks".format(
-                    base_url=app.config.get('BEARD_API_URL')),
-                content_type="application/json",
-                body='{"phonetic_blocks": {"John Richard Ellis": "ELj"}}',
-                status=200)
+    with mock.patch.dict(current_app.config, extra_config):
+        httpretty.register_uri(
+            httpretty.POST,
+            "{base_url}/text/phonetic_blocks".format(
+                base_url=current_app.config.get('BEARD_API_URL')),
+            content_type="application/json",
+            body='{"phonetic_blocks": {"John Richard Ellis": "ELj"}}',
+            status=200)
 
-            json_dict = {
-                "authors": [{
-                    "full_name": "John Richard Ellis"
-                }]
-            }
+        json_dict = {
+            "authors": [{
+                "full_name": "John Richard Ellis"
+            }]
+        }
 
-            receivers.assign_phonetic_block(json_dict)
+        receivers.assign_phonetic_block(json_dict)
 
-            assert json_dict['authors'][0]['signature_block'] == "ELj"
+        assert json_dict['authors'][0]['signature_block'] == "ELj"
 
 
 @pytest.mark.httpretty
-def test_phonetic_block_generation_broken(app):
+def test_phonetic_block_generation_broken():
     extra_config = {
         "BEARD_API_URL": "http://example.com/beard",
     }
 
-    with app.app_context():
-        with mock.patch.dict(app.config, extra_config):
-            httpretty.register_uri(
-                httpretty.POST,
-                "{base_url}/text/phonetic_blocks".format(
-                    base_url=app.config.get('BEARD_API_URL')),
-                content_type="application/json",
-                body='{"phonetic_blocks": {}}',
-                status=200)
+    with mock.patch.dict(current_app.config, extra_config):
+        httpretty.register_uri(
+            httpretty.POST,
+            "{base_url}/text/phonetic_blocks".format(
+                base_url=current_app.config.get('BEARD_API_URL')),
+            content_type="application/json",
+            body='{"phonetic_blocks": {}}',
+            status=200)
 
-            json_dict = {
-                "authors": [{
-                    "full_name": "** NOT VALID **"
-                }]
-            }
+        json_dict = {
+            "authors": [{
+                "full_name": "** NOT VALID **"
+            }]
+        }
 
-            receivers.assign_phonetic_block(json_dict)
+        receivers.assign_phonetic_block(json_dict)
 
-            assert json_dict['authors'][0]['signature_block'] is None
+        assert json_dict['authors'][0]['signature_block'] is None
 
 
 @pytest.mark.httpretty
-def test_phonetic_block_generation_unicode(app):
+def test_phonetic_block_generation_unicode():
     extra_config = {
         "BEARD_API_URL": "http://example.com/beard",
     }
 
-    with app.app_context():
-        with mock.patch.dict(app.config, extra_config):
-            httpretty.register_uri(
-                httpretty.POST,
-                "{base_url}/text/phonetic_blocks".format(
-                    base_url=app.config.get('BEARD_API_URL')),
-                content_type="application/json",
-                body=u'{"phonetic_blocks": {"Grzegorz Jacenków": "JACANCg"}}',
-                status=200)
+    with mock.patch.dict(current_app.config, extra_config):
+        httpretty.register_uri(
+            httpretty.POST,
+            "{base_url}/text/phonetic_blocks".format(
+                base_url=current_app.config.get('BEARD_API_URL')),
+            content_type="application/json",
+            body=u'{"phonetic_blocks": {"Grzegorz Jacenków": "JACANCg"}}',
+            status=200)
 
-            json_dict = {
-                "authors": [{
-                    "full_name": u"Grzegorz Jacenków"
-                }]
-            }
+        json_dict = {
+            "authors": [{
+                "full_name": u"Grzegorz Jacenków"
+            }]
+        }
 
-            receivers.assign_phonetic_block(json_dict)
+        receivers.assign_phonetic_block(json_dict)
 
-            assert json_dict['authors'][0]['signature_block'] == "JACANCg"
+        assert json_dict['authors'][0]['signature_block'] == "JACANCg"
 
 
 def test_uuid_generation():

--- a/tests/unit/authors/test_authors_tasks.py
+++ b/tests/unit/authors/test_authors_tasks.py
@@ -23,6 +23,7 @@
 from __future__ import absolute_import, division, print_function
 
 import pytest
+from flask import current_app
 from mock import patch
 
 from invenio_accounts.models import User
@@ -88,21 +89,20 @@ def test_new_ticket_context(data, extra_data, user):
     assert ctx['user_comment'] == 'Foo bar'
 
 
-def test_update_ticket_context(app, data, extra_data, user):
+def test_update_ticket_context(data, extra_data, user):
     config = {
         'AUTHORS_UPDATE_BASE_URL': 'http://inspirehep.net'
     }
     obj = MockObj(data, extra_data)
-    with app.app_context():
-        with patch.dict(app.config, config):
-            expected = {
-                'url': 'http://inspirehep.net/record/123',
-                'bibedit_url': 'http://inspirehep.net/record/123/edit',
-                'email': 'foo@bar.com',
-                'user_comment': 'Foo bar'
-            }
-            ctx = update_ticket_context(user, obj)
-            assert ctx == expected
+    with patch.dict(current_app.config, config):
+        expected = {
+            'url': 'http://inspirehep.net/record/123',
+            'bibedit_url': 'http://inspirehep.net/record/123/edit',
+            'email': 'foo@bar.com',
+            'user_comment': 'Foo bar'
+        }
+        ctx = update_ticket_context(user, obj)
+        assert ctx == expected
 
 
 def test_reply_ticket_context(data, extra_data, user):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -27,7 +27,7 @@ import pytest
 from inspirehep.factory import create_app
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(autouse=True, scope='session')
 def app():
     app = create_app(
         DEBUG=True,
@@ -41,3 +41,15 @@ def app():
 
     with app.app_context():
         yield app
+
+
+@pytest.fixture(scope='function')
+def app_client(app):
+    with app.test_client() as client:
+        yield client
+
+
+@pytest.fixture(scope='function')
+def request_context(app):
+    with app.test_request_context() as request_context:
+        yield request_context

--- a/tests/unit/dojson/test_dojson_utils.py
+++ b/tests/unit/dojson/test_dojson_utils.py
@@ -22,7 +22,8 @@
 
 from __future__ import absolute_import, division, print_function
 
-import mock
+from flask import current_app
+from mock import patch
 
 from inspirehep.dojson.utils import (
     classify_field,
@@ -154,58 +155,58 @@ def test_get_int_value_returns_none_when_value_is_a_tuple():
     assert get_int_value({'y': ('2015', '2016')}, 'y') is None
 
 
-@mock.patch('inspirehep.dojson.utils.current_app')
-def test_get_record_ref_with_empty_server_name(current_app):
-    current_app.config = {}
+def test_get_record_ref_with_empty_server_name():
+    config = {}
 
-    expected = 'http://inspirehep.net/api/endpoint/123'
-    result = get_record_ref(123, 'endpoint')
+    with patch.dict(current_app.config, config, clear=True):
+        expected = 'http://inspirehep.net/api/endpoint/123'
+        result = get_record_ref(123, 'endpoint')
 
-    assert expected == result['$ref']
-
-
-@mock.patch('inspirehep.dojson.utils.current_app')
-def test_get_record_ref_with_server_name_localhost(current_app):
-    current_app.config = {'SERVER_NAME': 'localhost:5000'}
-
-    expected = 'http://localhost:5000/api/endpoint/123'
-    result = get_record_ref(123, 'endpoint')
-
-    assert expected == result['$ref']
+        assert expected == result['$ref']
 
 
-@mock.patch('inspirehep.dojson.utils.current_app')
-def test_get_record_ref_with_http_server_name(current_app):
-    current_app.config = {'SERVER_NAME': 'http://example.com'}
+def test_get_record_ref_with_server_name_localhost():
+    config = {'SERVER_NAME': 'localhost:5000'}
 
-    expected = 'http://example.com/api/endpoint/123'
-    result = get_record_ref(123, 'endpoint')
+    with patch.dict(current_app.config, config):
+        expected = 'http://localhost:5000/api/endpoint/123'
+        result = get_record_ref(123, 'endpoint')
 
-    assert expected == result['$ref']
+        assert expected == result['$ref']
 
 
-@mock.patch('inspirehep.dojson.utils.current_app')
-def test_get_record_ref_with_https_server_name(current_app):
-    current_app.config = {'SERVER_NAME': 'https://example.com'}
+def test_get_record_ref_with_http_server_name():
+    config = {'SERVER_NAME': 'http://example.com'}
 
-    expected = 'https://example.com/api/endpoint/123'
-    result = get_record_ref(123, 'endpoint')
+    with patch.dict(current_app.config, config):
+        expected = 'http://example.com/api/endpoint/123'
+        result = get_record_ref(123, 'endpoint')
 
-    assert expected == result['$ref']
+        assert expected == result['$ref']
+
+
+def test_get_record_ref_with_https_server_name():
+    config = {'SERVER_NAME': 'https://example.com'}
+
+    with patch.dict(current_app.config, config):
+        expected = 'https://example.com/api/endpoint/123'
+        result = get_record_ref(123, 'endpoint')
+
+        assert expected == result['$ref']
 
 
 def test_get_record_ref_without_recid_returns_none():
     assert get_record_ref(None, 'endpoint') is None
 
 
-@mock.patch('inspirehep.dojson.utils.current_app')
-def test_get_record_ref_without_endpoint_defaults_to_record(current_app):
-    current_app.config = {}
+def test_get_record_ref_without_endpoint_defaults_to_record():
+    config = {}
 
-    expected = 'http://inspirehep.net/api/record/123'
-    result = get_record_ref(123)
+    with patch.dict(current_app.config, config, clear=True):
+        expected = 'http://inspirehep.net/api/record/123'
+        result = get_record_ref(123)
 
-    assert expected == result['$ref']
+        assert expected == result['$ref']
 
 
 def test_get_recid_from_ref_returns_none_on_none():

--- a/tests/unit/records/test_records_json_ref_loader.py
+++ b/tests/unit/records/test_records_json_ref_loader.py
@@ -22,7 +22,8 @@
 
 from __future__ import absolute_import, division, print_function
 
-import mock
+from flask import current_app
+from mock import patch
 
 from jsonref import JsonRef
 
@@ -31,36 +32,33 @@ from inspirehep.modules.records.json_ref_loader import (
 from inspirehep.utils.record_getter import RecordGetterError
 
 
-def _build_url(app, endpoint='literature', recid='42'):
-    server = app.config['SERVER_NAME']
+def _build_url(endpoint='literature', recid='42'):
+    server = current_app.config['SERVER_NAME']
     if not server.startswith('http://'):
         server = 'http://{}'.format(server)
     return '{}/api/{}/{}'.format(server, endpoint, recid)
 
 
-@mock.patch('inspirehep.modules.records.json_ref_loader.record_getter.get_es_record')
-@mock.patch('inspirehep.modules.records.json_ref_loader.record_getter.get_db_record')
-def test_replace_refs_correct_sources(get_db_rec, get_es_rec, app):
+@patch('inspirehep.modules.records.json_ref_loader.record_getter.get_es_record')
+@patch('inspirehep.modules.records.json_ref_loader.record_getter.get_db_record')
+def test_replace_refs_correct_sources(get_db_rec, get_es_rec):
     with_es_record = {'ES': 'ES'}
     with_db_record = {'DB': 'DB'}
 
     get_es_rec.return_value = with_es_record
     get_db_rec.return_value = with_db_record
 
-    with app.app_context():
-        db_rec = replace_refs({'$ref': _build_url(app)}, 'db')
-        es_rec = replace_refs({'$ref': _build_url(app)}, 'es')
+    db_rec = replace_refs({'$ref': _build_url()}, 'db')
+    es_rec = replace_refs({'$ref': _build_url()}, 'es')
 
-        # Lazy objects need to be evaluated in app_context.
-        assert db_rec == with_db_record
-        assert es_rec == with_es_record
+    assert db_rec == with_db_record
+    assert es_rec == with_es_record
 
 
-@mock.patch('inspirehep.modules.records.json_ref_loader.current_app')
-@mock.patch('inspirehep.modules.records.json_ref_loader.get_pid_type_from_endpoint')
-@mock.patch('inspirehep.modules.records.json_ref_loader.JsonLoader.get_remote_json')
-@mock.patch('inspirehep.modules.records.json_ref_loader.AbstractRecordLoader.get_record')
-def test_abstract_loader_url_fallbacks(get_record, super_get_r_j, g_p_t_f_e, current_app):
+@patch('inspirehep.modules.records.json_ref_loader.get_pid_type_from_endpoint')
+@patch('inspirehep.modules.records.json_ref_loader.JsonLoader.get_remote_json')
+@patch('inspirehep.modules.records.json_ref_loader.AbstractRecordLoader.get_record')
+def test_abstract_loader_url_fallbacks(get_record, super_get_r_j, g_p_t_f_e):
     with_super = {'SUPER': 'SUPER'}
     with_actual = {'ACTUAL': 'ACTUAL'}
     g_p_t_f_e = 'pt'
@@ -68,112 +66,119 @@ def test_abstract_loader_url_fallbacks(get_record, super_get_r_j, g_p_t_f_e, cur
     get_record.return_value = with_actual
 
     # Check against prod SERVER_NAME
-    current_app.config = {'SERVER_NAME': 'http://inspirehep.net'}
+    config = {'SERVER_NAME': 'http://inspirehep.net'}
 
-    expect_actual = JsonRef({'$ref': 'http://inspirehep.net/api/e/1'},
+    with patch.dict(current_app.config, config):
+        expect_actual = JsonRef({'$ref': 'http://inspirehep.net/api/e/1'},
+                                loader=AbstractRecordLoader())
+        assert expect_actual == with_actual
+
+        expect_actual = JsonRef({'$ref': '/api/e/1'},
+                                loader=AbstractRecordLoader())
+        assert expect_actual == with_actual
+
+        expect_super = JsonRef({'$ref': 'http://otherhost.net/api/e/1'},
                             loader=AbstractRecordLoader())
-    assert expect_actual == with_actual
-
-    expect_actual = JsonRef({'$ref': '/api/e/1'},
-                            loader=AbstractRecordLoader())
-    assert expect_actual == with_actual
-
-    expect_super = JsonRef({'$ref': 'http://otherhost.net/api/e/1'},
-                           loader=AbstractRecordLoader())
-    assert expect_super == with_super
+        assert expect_super == with_super
 
     # Check against dev SERVER_NAME
-    current_app.config = {'SERVER_NAME': 'localhost:5000'}
-    expect_actual = JsonRef({'$ref': 'http://localhost:5000/api/e/1'},
-                            loader=AbstractRecordLoader())
-    assert expect_actual == with_actual
+    config = {'SERVER_NAME': 'localhost:5000'}
 
-    expect_actual = JsonRef({'$ref': '/api/e/1'},
-                            loader=AbstractRecordLoader())
-    assert expect_actual == with_actual
+    with patch.dict(current_app.config, config):
+        expect_actual = JsonRef({'$ref': 'http://localhost:5000/api/e/1'},
+                                loader=AbstractRecordLoader())
+        assert expect_actual == with_actual
 
-    expect_super = JsonRef({'$ref': 'http://inspirehep.net/api/e/1'},
-                           loader=AbstractRecordLoader())
-    assert expect_super == with_super
+        expect_actual = JsonRef({'$ref': '/api/e/1'},
+                                loader=AbstractRecordLoader())
+        assert expect_actual == with_actual
+
+        expect_super = JsonRef({'$ref': 'http://inspirehep.net/api/e/1'},
+                            loader=AbstractRecordLoader())
+        assert expect_super == with_super
 
     # Check against prod https SERVER_NAME
-    current_app.config = {'SERVER_NAME': 'https://inspirehep.net'}
-    expect_actual = JsonRef({'$ref': 'https://inspirehep.net/api/e/1'},
+    config = {'SERVER_NAME': 'https://inspirehep.net'}
+
+    with patch.dict(current_app.config, config):
+        expect_actual = JsonRef({'$ref': 'https://inspirehep.net/api/e/1'},
+                                loader=AbstractRecordLoader())
+        assert expect_actual == with_actual
+
+        expect_actual = JsonRef({'$ref': '/api/e/1'},
+                                loader=AbstractRecordLoader())
+        assert expect_actual == with_actual
+
+        # https should be backwards compatible with resources indexed with http://.
+        expect_actual = JsonRef({'$ref': 'http://inspirehep.net/api/e/1'},
+                                loader=AbstractRecordLoader())
+        assert expect_actual == with_actual
+
+        expect_super = JsonRef({'$ref': 'http://otherhost.net/api/e/1'},
                             loader=AbstractRecordLoader())
-    assert expect_actual == with_actual
-
-    expect_actual = JsonRef({'$ref': '/api/e/1'},
-                            loader=AbstractRecordLoader())
-    assert expect_actual == with_actual
-
-    # https should be backwards compatible with resources indexed with http://.
-    expect_actual = JsonRef({'$ref': 'http://inspirehep.net/api/e/1'},
-                            loader=AbstractRecordLoader())
-    assert expect_actual == with_actual
-
-    expect_super = JsonRef({'$ref': 'http://otherhost.net/api/e/1'},
-                           loader=AbstractRecordLoader())
-    assert expect_super == with_super
+        assert expect_super == with_super
 
 
-@mock.patch('inspirehep.modules.records.json_ref_loader.current_app')
-@mock.patch('inspirehep.modules.records.json_ref_loader.get_pid_type_from_endpoint')
-@mock.patch('inspirehep.modules.records.json_ref_loader.AbstractRecordLoader.get_record')
-def test_abstract_loader_recid_parsing(get_record, g_p_t_f_e, current_app):
-    current_app.config = {'SERVER_NAME': 'http://inspirehep.net'}
+@patch('inspirehep.modules.records.json_ref_loader.get_pid_type_from_endpoint')
+@patch('inspirehep.modules.records.json_ref_loader.AbstractRecordLoader.get_record')
+def test_abstract_loader_recid_parsing(get_record, g_p_t_f_e):
     with_actual = {'ACTUAL': 'ACTUAL'}
     g_p_t_f_e.side_effect = ['pt1', 'pt2', 'pt3']
     get_record.return_value = with_actual
 
-    expect_actual = JsonRef({'$ref': 'http://inspirehep.net/api/e1/1'},
+    config = {'SERVER_NAME': 'http://inspirehep.net'}
+
+    with patch.dict(current_app.config, config):
+        expect_actual = JsonRef({'$ref': 'http://inspirehep.net/api/e1/1'},
+                                loader=AbstractRecordLoader())
+        # Force evaluation of get_record by this assertion.
+        assert expect_actual == with_actual
+        get_record.assert_called_with('pt1', '1')
+
+        expect_actual = JsonRef({'$ref': '/api/e2/2'},
+                                loader=AbstractRecordLoader())
+        assert expect_actual == with_actual
+        get_record.assert_called_with('pt2', '2')
+
+        expect_actual = JsonRef({'$ref': '/e3/3/'},
+                                loader=AbstractRecordLoader())
+        assert expect_actual == with_actual
+        get_record.assert_called_with('pt3', '3')
+
+
+@patch('inspirehep.modules.records.json_ref_loader.AbstractRecordLoader.get_record')
+def test_abstract_loader_return_none(get_record):
+    config = {'SERVER_NAME': 'http://inspirehep.net'}
+
+    with patch.dict(current_app.config, config):
+        expect_none = JsonRef({'$ref': 'http://inspirehep.net'},
                             loader=AbstractRecordLoader())
-    # Force evaluation of get_record by this assertion.
-    assert expect_actual == with_actual
-    get_record.assert_called_with('pt1', '1')
-
-    expect_actual = JsonRef({'$ref': '/api/e2/2'},
+        assert expect_none == None
+        expect_none = JsonRef({'$ref': 'http://inspirehep.net/'},
                             loader=AbstractRecordLoader())
-    assert expect_actual == with_actual
-    get_record.assert_called_with('pt2', '2')
-
-    expect_actual = JsonRef({'$ref': '/e3/3/'},
+        assert expect_none == None
+        expect_none = JsonRef({'$ref': 'http://inspirehep.net/bad'},
                             loader=AbstractRecordLoader())
-    assert expect_actual == with_actual
-    get_record.assert_called_with('pt3', '3')
+        assert expect_none == None
+        assert get_record.call_count == 0
 
 
-@mock.patch('inspirehep.modules.records.json_ref_loader.current_app')
-@mock.patch('inspirehep.modules.records.json_ref_loader.AbstractRecordLoader.get_record')
-def test_abstract_loader_return_none(get_record, current_app):
-    current_app.config = {'SERVER_NAME': 'http://inspirehep.net'}
-
-    expect_none = JsonRef({'$ref': 'http://inspirehep.net'},
-                          loader=AbstractRecordLoader())
-    assert expect_none == None
-    expect_none = JsonRef({'$ref': 'http://inspirehep.net/'},
-                          loader=AbstractRecordLoader())
-    assert expect_none == None
-    expect_none = JsonRef({'$ref': 'http://inspirehep.net/bad'},
-                          loader=AbstractRecordLoader())
-    assert expect_none == None
-    assert get_record.call_count == 0
-
-
-@mock.patch('inspirehep.modules.records.json_ref_loader.current_app')
-@mock.patch('inspirehep.modules.records.json_ref_loader.get_pid_type_from_endpoint')
-@mock.patch('inspirehep.modules.records.json_ref_loader.record_getter.get_es_record')
-@mock.patch('inspirehep.modules.records.json_ref_loader.record_getter.get_db_record')
-def test_specific_loaders_return_none(get_db_rec, get_es_rec, g_p_t_f_e, current_app):
-    current_app.config = {'SERVER_NAME': 'http://inspirehep.net'}
+@patch('inspirehep.modules.records.json_ref_loader.get_pid_type_from_endpoint')
+@patch('inspirehep.modules.records.json_ref_loader.record_getter.get_es_record')
+@patch('inspirehep.modules.records.json_ref_loader.record_getter.get_db_record')
+def test_specific_loaders_return_none(get_db_rec, get_es_rec, g_p_t_f_e):
     g_p_t_f_e.return_value = 'pt'
     get_es_rec.side_effect = RecordGetterError('err', None)
     get_db_rec.side_effect = RecordGetterError('err', None)
 
-    expect_none = JsonRef({'$ref': 'http://inspirehep.net/api/e/1'},
-                          loader=DatabaseJsonLoader())
-    assert expect_none == None
-    expect_none = JsonRef({'$ref': 'http://inspirehep.net/api/e/2'},
-                          loader=ESJsonLoader())
-    assert expect_none == None
-    assert get_db_rec.call_count == 1
-    assert get_es_rec.call_count == 1
+    config = {'SERVER_NAME': 'http://inspirehep.net'}
+
+    with patch.dict(current_app.config, config):
+        expect_none = JsonRef({'$ref': 'http://inspirehep.net/api/e/1'},
+                            loader=DatabaseJsonLoader())
+        assert expect_none == None
+        expect_none = JsonRef({'$ref': 'http://inspirehep.net/api/e/2'},
+                            loader=ESJsonLoader())
+        assert expect_none == None
+        assert get_db_rec.call_count == 1
+        assert get_es_rec.call_count == 1

--- a/tests/unit/records/test_records_tasks.py
+++ b/tests/unit/records/test_records_tasks.py
@@ -22,12 +22,13 @@
 
 from __future__ import absolute_import, division, print_function
 
+from flask import current_app
 from mock import patch
 
 from inspirehep.modules.records.tasks import update_links
 
 
-def test_update_links(app):
+def test_update_links():
     config = {
         'INSPIRE_REF_UPDATER_WHITELISTS': {
             'literature': [
@@ -36,26 +37,25 @@ def test_update_links(app):
         },
     }
 
-    with app.app_context():
-        with patch.dict(app.config, config):
-            record = {
-                '$schema': 'http://localhost:5000/schemas/record/hep.json',
-                'record': {
-                    '$ref': 'http://localhost:5000/record/1',
-                },
-            }
+    with patch.dict(current_app.config, config):
+        record = {
+            '$schema': 'http://localhost:5000/schemas/record/hep.json',
+            'record': {
+                '$ref': 'http://localhost:5000/record/1',
+            },
+        }
 
-            update_links(record, 'http://localhost:5000/record/1', 'http://localhost:5000/record/2')
+        update_links(record, 'http://localhost:5000/record/1', 'http://localhost:5000/record/2')
 
-            assert record == {
-                '$schema': 'http://localhost:5000/schemas/record/hep.json',
-                'record': {
-                    '$ref': 'http://localhost:5000/record/2',
-                },
-            }
+        assert record == {
+            '$schema': 'http://localhost:5000/schemas/record/hep.json',
+            'record': {
+                '$ref': 'http://localhost:5000/record/2',
+            },
+        }
 
 
-def test_update_links_handles_nested_paths(app):
+def test_update_links_handles_nested_paths():
     config = {
         'INSPIRE_REF_UPDATER_WHITELISTS': {
             'literature': [
@@ -64,30 +64,29 @@ def test_update_links_handles_nested_paths(app):
         },
     }
 
-    with app.app_context():
-        with patch.dict(app.config, config):
-            record = {
-                '$schema': 'http://localhost:5000/schemas/record/hep.json',
-                'foo': {
-                    'record': {
-                        '$ref': 'http://localhost:5000/record/1',
-                    },
+    with patch.dict(current_app.config, config):
+        record = {
+            '$schema': 'http://localhost:5000/schemas/record/hep.json',
+            'foo': {
+                'record': {
+                    '$ref': 'http://localhost:5000/record/1',
                 },
-            }
+            },
+        }
 
-            update_links(record, 'http://localhost:5000/record/1', 'http://localhost:5000/record/2')
+        update_links(record, 'http://localhost:5000/record/1', 'http://localhost:5000/record/2')
 
-            assert record == {
-                '$schema': 'http://localhost:5000/schemas/record/hep.json',
-                'foo': {
-                    'record': {
-                        '$ref': 'http://localhost:5000/record/2',
-                    },
+        assert record == {
+            '$schema': 'http://localhost:5000/schemas/record/hep.json',
+            'foo': {
+                'record': {
+                    '$ref': 'http://localhost:5000/record/2',
                 },
-            }
+            },
+        }
 
 
-def test_update_links_handles_lists(app):
+def test_update_links_handles_lists():
     config = {
         'INSPIRE_REF_UPDATER_WHITELISTS': {
             'literature': [
@@ -96,28 +95,27 @@ def test_update_links_handles_lists(app):
         },
     }
 
-    with app.app_context():
-        with patch.dict(app.config, config):
-            record = {
-                '$schema': 'http://localhost:5000/schemas/record/hep.json',
-                'foos': [
-                    {'record': {'$ref': 'http://localhost:5000/record/1'}},
-                    {'record': {'$ref': 'http://localhost:5000/record/2'}},
-                ],
-            }
+    with patch.dict(current_app.config, config):
+        record = {
+            '$schema': 'http://localhost:5000/schemas/record/hep.json',
+            'foos': [
+                {'record': {'$ref': 'http://localhost:5000/record/1'}},
+                {'record': {'$ref': 'http://localhost:5000/record/2'}},
+            ],
+        }
 
-            update_links(record, 'http://localhost:5000/record/1', 'http://localhost:5000/record/2')
+        update_links(record, 'http://localhost:5000/record/1', 'http://localhost:5000/record/2')
 
-            assert record == {
-                '$schema': 'http://localhost:5000/schemas/record/hep.json',
-                'foos': [
-                    {'record': {'$ref': 'http://localhost:5000/record/2'}},
-                    {'record': {'$ref': 'http://localhost:5000/record/2'}},
-                ],
-            }
+        assert record == {
+            '$schema': 'http://localhost:5000/schemas/record/hep.json',
+            'foos': [
+                {'record': {'$ref': 'http://localhost:5000/record/2'}},
+                {'record': {'$ref': 'http://localhost:5000/record/2'}},
+            ],
+        }
 
 
-def test_update_links_ignores_non_whitelisted_paths(app):
+def test_update_links_ignores_non_whitelisted_paths():
     config = {
         'INSPIRE_REF_UPDATER_WHITELISTS': {
             'literature': [
@@ -126,26 +124,25 @@ def test_update_links_ignores_non_whitelisted_paths(app):
         },
     }
 
-    with app.app_context():
-        with patch.dict(app.config, config):
-            record = {
-                '$schema': 'http://localhost:5000/schemas/record/hep.json',
-                'foo': {
-                    'record': {'$ref': 'http://localhost:5000/record/1'},
-                },
-                'bar': {
-                    'record': {'$ref': 'http://localhost:5000/record/1'},
-                }
+    with patch.dict(current_app.config, config):
+        record = {
+            '$schema': 'http://localhost:5000/schemas/record/hep.json',
+            'foo': {
+                'record': {'$ref': 'http://localhost:5000/record/1'},
+            },
+            'bar': {
+                'record': {'$ref': 'http://localhost:5000/record/1'},
             }
+        }
 
-            update_links(record, 'http://localhost:5000/record/1', 'http://localhost:5000/record/2')
+        update_links(record, 'http://localhost:5000/record/1', 'http://localhost:5000/record/2')
 
-            assert record == {
-                '$schema': 'http://localhost:5000/schemas/record/hep.json',
-                'foo': {
-                    'record': {'$ref': 'http://localhost:5000/record/2'},
-                },
-                'bar': {
-                    'record': {'$ref': 'http://localhost:5000/record/1'},
-                }
+        assert record == {
+            '$schema': 'http://localhost:5000/schemas/record/hep.json',
+            'foo': {
+                'record': {'$ref': 'http://localhost:5000/record/2'},
+            },
+            'bar': {
+                'record': {'$ref': 'http://localhost:5000/record/1'},
             }
+        }

--- a/tests/unit/theme/test_theme_jinja2filters.py
+++ b/tests/unit/theme/test_theme_jinja2filters.py
@@ -275,12 +275,11 @@ def test_email_links_returns_email_link_on_list_of_one_element():
     assert expected == result
 
 
-def test_email_link_returns_email_link_on_element(app):
-    with app.test_request_context('/'):
-        expected = '\n<a href="mailto:foo@example.com">foo@example.com</a>'
-        result = email_link('foo@example.com')
+def test_email_link_returns_email_link_on_element(request_context):
+    expected = '\n<a href="mailto:foo@example.com">foo@example.com</a>'
+    result = email_link('foo@example.com')
 
-        assert expected == result
+    assert expected == result
 
 
 def test_url_links_returns_url_link_on_list_of_one_element():
@@ -1138,25 +1137,23 @@ def test_format_date_when_datestruct_has_one_element(c_d):
 
 
 @mock.patch('inspirehep.modules.theme.jinja2filters.create_datestruct')
-def test_format_date_when_datestruct_has_two_elements(c_d, app):
-    with app.test_request_context():
-        c_d.return_value = (1993, 2)
+def test_format_date_when_datestruct_has_two_elements(c_d, request_context):
+    c_d.return_value = (1993, 2)
 
-        expected = 'Feb 1993'
-        result = format_date('banana')
+    expected = 'Feb 1993'
+    result = format_date('banana')
 
-        assert expected == result
+    assert expected == result
 
 
 @mock.patch('inspirehep.modules.theme.jinja2filters.create_datestruct')
-def test_format_date_when_datestruct_has_three_elements(c_d, app):
-    with app.test_request_context():
-        c_d.return_value = (1993, 2, 2)
+def test_format_date_when_datestruct_has_three_elements(c_d, request_context):
+    c_d.return_value = (1993, 2, 2)
 
-        expected = 'Feb 2, 1993'
-        result = format_date('banana')
+    expected = 'Feb 2, 1993'
+    result = format_date('banana')
 
-        assert expected == result
+    assert expected == result
 
 
 def test_find_collection_from_url_conferences():

--- a/tests/unit/theme/test_theme_views.py
+++ b/tests/unit/theme/test_theme_views.py
@@ -44,56 +44,51 @@ user_with_email = MockUser('foo@bar.com')
 user_empty_email = MockUser('')
 
 
-def test_postfeedback_provided_email(app):
+def test_postfeedback_provided_email(app_client):
     """Accepts feedback when providing en email."""
-    with app.test_client() as client:
-        response = client.post('/postfeedback', data=dict(
-            feedback='foo bar', replytoaddr='foo@bar.com'))
+    response = app_client.post('/postfeedback', data=dict(
+        feedback='foo bar', replytoaddr='foo@bar.com'))
 
-        assert response.status_code == 200
-        assert json.loads(response.data) == {'success': True}
+    assert response.status_code == 200
+    assert json.loads(response.data) == {'success': True}
 
 
 @mock.patch('inspirehep.modules.theme.views.current_user', user_with_email)
-def test_postfeedback_logged_in_user(app):
+def test_postfeedback_logged_in_user(app_client):
     """Falls back to the email of the logged in user."""
-    with app.test_client() as client:
-        response = client.post('/postfeedback', data=dict(feedback='foo bar'))
+    response = app_client.post('/postfeedback', data=dict(feedback='foo bar'))
 
-        assert response.status_code == 200
-        assert json.loads(response.data) == {'success': True}
+    assert response.status_code == 200
+    assert json.loads(response.data) == {'success': True}
 
 
 @mock.patch('inspirehep.modules.theme.views.current_user', user_empty_email)
-def test_postfeedback_empty_email(app):
+def test_postfeedback_empty_email(app_client):
     """Rejects feedback from user with empty email."""
-    with app.test_client() as client:
-        response = client.post('/postfeedback', data=dict(feedback='foo bar'))
+    response = app_client.post('/postfeedback', data=dict(feedback='foo bar'))
 
-        assert response.status_code == 403
-        assert json.loads(response.data) == {'success': False}
+    assert response.status_code == 403
+    assert json.loads(response.data) == {'success': False}
 
 
-def test_postfeedback_anonymous_user(app):
+def test_postfeedback_anonymous_user(app_client):
     """Rejects feedback without an email."""
-    with app.test_client() as client:
-        response = client.post('/postfeedback', data=dict(feedback='foo bar'))
+    response = app_client.post('/postfeedback', data=dict(feedback='foo bar'))
 
-        assert response.status_code == 403
-        assert json.loads(response.data) == {'success': False}
+    assert response.status_code == 403
+    assert json.loads(response.data) == {'success': False}
 
 
-def test_postfeedback_empty_feedback(app):
+def test_postfeedback_empty_feedback(app_client):
     """Rejects empty feedback."""
-    with app.test_client() as client:
-        response = client.post('/postfeedback', data=dict(feedback=''))
+    response = app_client.post('/postfeedback', data=dict(feedback=''))
 
-        assert response.status_code == 400
-        assert json.loads(response.data) == {'success': False}
+    assert response.status_code == 400
+    assert json.loads(response.data) == {'success': False}
 
 
 @mock.patch('inspirehep.modules.theme.views.send_email.delay')
-def test_postfeedback_send_email_failure(delay, app):
+def test_postfeedback_send_email_failure(delay, app_client):
     """Informs the user when a server error occurred."""
     class FailedResult():
         def failed(self):
@@ -101,9 +96,8 @@ def test_postfeedback_send_email_failure(delay, app):
 
     delay.return_value = FailedResult()
 
-    with app.test_client() as client:
-        response = client.post('/postfeedback', data=dict(
-            feedback='foo bar', replytoaddr='foo@bar.com'))
+    response = app_client.post('/postfeedback', data=dict(
+        feedback='foo bar', replytoaddr='foo@bar.com'))
 
-        assert response.status_code == 500
-        assert json.loads(response.data) == {'success': False}
+    assert response.status_code == 500
+    assert json.loads(response.data) == {'success': False}

--- a/tests/unit/utils/test_utils_robotupload.py
+++ b/tests/unit/utils/test_utils_robotupload.py
@@ -24,6 +24,7 @@ from __future__ import absolute_import, division, print_function
 
 import httpretty
 import pytest
+from flask import current_app
 from mock import patch
 
 from inspirehep.utils.robotupload import make_robotupload_marcxml
@@ -42,16 +43,15 @@ def test_make_robotupload_marcxml():
 
 
 @pytest.mark.httpretty
-def test_make_robotupload_marcxml_falls_back_to_config_when_url_is_none(app):
+def test_make_robotupload_marcxml_falls_back_to_config_when_url_is_none():
     httpretty.HTTPretty.allow_net_connect = False
     httpretty.register_uri(
         httpretty.POST, 'http://inspirehep.net/batchuploader/robotupload/insert')
 
     config = {'LEGACY_ROBOTUPLOAD_URL': 'http://inspirehep.net'}
 
-    with app.app_context():
-        with patch.dict(app.config, config):
-            make_robotupload_marcxml(None, '<record></record>', 'insert')
+    with patch.dict(current_app.config, config):
+        make_robotupload_marcxml(None, '<record></record>', 'insert')
 
     httpretty.HTTPretty.allow_net_connect = True
 

--- a/tests/unit/utils/test_utils_url.py
+++ b/tests/unit/utils/test_utils_url.py
@@ -19,17 +19,18 @@
 
 from __future__ import absolute_import, division, print_function
 
-import mock
+from flask import current_app
+from mock import patch
 
 from inspirehep.utils.url import make_user_agent_string
 
-@mock.patch('inspirehep.utils.url.current_app')
-@mock.patch('inspirehep.utils.url.__version__', '0.1.0')
-def test_make_user_agent_string(current_app, app):
-    """Test that user agent is created."""
-    current_app.config = {'SERVER_NAME': 'http://inspirehep.net'}
 
-    with app.app_context():
+@patch('inspirehep.utils.url.__version__', '0.1.0')
+def test_make_user_agent_string():
+    """Test that user agent is created."""
+    config = {'SERVER_NAME': 'http://inspirehep.net'}
+
+    with patch.dict(current_app.config, config):
         user_agent = make_user_agent_string()
         assert user_agent == "InspireHEP-0.1.0 (+http://inspirehep.net;)"
 


### PR DESCRIPTION
Closes #1868

I sketched a partial implementation of https://github.com/inspirehep/inspire-next/pull/1868#discussion_r97288690. Further uses of the `app` fixture can be found with:
```
$ ag "def test[^(]+\([^)]*app[^)]*\)" tests/unit
```
After that is done, the main commit of #1868 will be rebased on top.

- [x] Refactor `tests/unit/authors/test_authors_receivers.py`
- [x] Refactor `tests/unit/authors/test_authors_tasks.py`
- [x] Refactor `tests/unit/dojson/test_dojson_utils.py`
- [x] Refactor `tests/unit/records/test_records_json_ref_loader.py`
- [x] Refactor `tests/unit/records/test_records_tasks.py`
- [x] Refactor `tests/unit/theme/test_theme_views.py`
- [x] Refactor `tests/unit/theme/test_theme_jinja2filters.py`
- [x] Refactor `tests/unit/utils/test_utils_robotuplodad.py`
- [x] Refactor `tests/unit/utils/test_utils_url.py`
- [x] Review @jmartinm's commit