### PR TITLE
literaturesuggest: arxiv categories import fix

### DIFF
--- a/inspirehep/modules/literaturesuggest/forms.py
+++ b/inspirehep/modules/literaturesuggest/forms.py
@@ -244,8 +244,9 @@ class LiteratureForm(INSPIREForm):
         validators=[arxiv_syntax_validation, duplicated_arxiv_id_validator],
     )
 
-    categories = fields.TextField(
+    categories_arXiv = fields.TextField(
         widget=HiddenInput(),
+        export_key='categories'
     )
 
     # isbn = ISBNField(
@@ -586,7 +587,7 @@ class LiteratureForm(INSPIREForm):
         ('Links',
             ['url', 'additional_url']),
         ('Basic Information',
-            ['title', 'title_arXiv', 'categories', 'language',
+            ['title', 'title_arXiv', 'categories_arXiv', 'language',
              'other_language', 'title_translation', 'subject', 'authors',
              'collaboration', 'experiment', 'abstract',
              'report_numbers']),

--- a/inspirehep/modules/workflows/tasks/actions.py
+++ b/inspirehep/modules/workflows/tasks/actions.py
@@ -158,8 +158,10 @@ def is_experimental_paper(obj, eng):
 
 def is_arxiv_paper(obj, *args, **kwargs):
     """Check if the record is from arXiv."""
-    return bool(get_value(obj.data, "arxiv_eprints.categories", [[]])[0]) or \
-        get_clean_arXiv_id(obj.data)
+    categories = get_value(obj.data, "arxiv_eprints.categories", [[]])
+    if categories:
+        return bool(categories[0]) or get_clean_arXiv_id(obj.data)
+    return False
 
 
 def is_submission(obj, eng):

--- a/tests/unit/workflows/test_workflows_tasks_actions.py
+++ b/tests/unit/workflows/test_workflows_tasks_actions.py
@@ -406,6 +406,14 @@ def test_is_arxiv_paper():
     assert is_arxiv_paper(obj)
 
 
+def test_is_arxiv_paper_with_no_arxiv_eprints():
+    obj = StubObj({
+        'arxiv_eprints': []
+    }, {})
+
+    assert not is_arxiv_paper(obj)
+
+
 def test_is_submission():
     obj = StubObj({'acquisition_source': {'method': 'submission'}}, {})
     eng = DummyEng()


### PR DESCRIPTION
* Fixes wrong key name in literaturesuggest form that was causing imported
  arXiv categories not to be sent to the server.

* Fixes a bug in is_arxiv_paper uncovered by the problem above.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>