### PR TITLE
literaturesuggest: fix arXiv categories importing

### DIFF
--- a/inspirehep/modules/literaturesuggest/forms.py
+++ b/inspirehep/modules/literaturesuggest/forms.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2016 CERN.
+# Copyright (C) 2016, 2017 CERN.
 #
 # INSPIRE is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -244,8 +244,9 @@ class LiteratureForm(INSPIREForm):
         validators=[arxiv_syntax_validation, duplicated_arxiv_id_validator],
     )
 
-    categories = fields.TextField(
+    categories_arXiv = fields.TextField(
         widget=HiddenInput(),
+        export_key='categories',
     )
 
     # isbn = ISBNField(
@@ -586,7 +587,7 @@ class LiteratureForm(INSPIREForm):
         ('Links',
             ['url', 'additional_url']),
         ('Basic Information',
-            ['title', 'title_arXiv', 'categories', 'language',
+            ['title', 'title_arXiv', 'categories_arXiv', 'language',
              'other_language', 'title_translation', 'subject', 'authors',
              'collaboration', 'experiment', 'abstract',
              'report_numbers']),

--- a/inspirehep/modules/workflows/tasks/actions.py
+++ b/inspirehep/modules/workflows/tasks/actions.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2014, 2015, 2016 CERN.
+# Copyright (C) 2014, 2015, 2016, 2017 CERN.
 #
 # INSPIRE is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -158,8 +158,12 @@ def is_experimental_paper(obj, eng):
 
 def is_arxiv_paper(obj, *args, **kwargs):
     """Check if the record is from arXiv."""
-    return bool(get_value(obj.data, "arxiv_eprints.categories", [[]])[0]) or \
-        get_clean_arXiv_id(obj.data)
+    arxiv_id = get_clean_arXiv_id(obj.data)
+    categories = get_value(obj.data, 'arxiv_eprints.categories')
+
+    if arxiv_id or categories:
+        return True
+    return False
 
 
 def is_submission(obj, eng):

--- a/tests/unit/workflows/test_workflows_tasks_actions.py
+++ b/tests/unit/workflows/test_workflows_tasks_actions.py
@@ -406,6 +406,12 @@ def test_is_arxiv_paper():
     assert is_arxiv_paper(obj)
 
 
+def test_is_arxiv_paper_returns_false_when_arxiv_eprints_is_empty():
+    obj = StubObj({'arxiv_eprints': []}, {})
+
+    assert not is_arxiv_paper(obj)
+
+
 def test_is_submission():
     obj = StubObj({'acquisition_source': {'method': 'submission'}}, {})
     eng = DummyEng()


### PR DESCRIPTION
Fixes the key that the literaturesuggest form was using for imported
arXiv categories, which was preventing them from being sent to the
server.

Also fixes a bug in the `is_arxiv_paper` task, uncovered by the above
(closes #1893).