### PR TITLE
workflow: doctype for arXiv PDFs in FFT

### DIFF
--- a/inspirehep/modules/workflows/tasks/submission.py
+++ b/inspirehep/modules/workflows/tasks/submission.py
@@ -381,7 +381,7 @@ def prepare_files(obj, eng):
 
         return {
             'url': os.path.realpath(url),
-            'docfile_type': 'INSPIRE-PUBLIC',
+            'docfile_type': is_arxiv_paper(obj) and 'arXiv' or 'INSPIRE-PUBLIC',
             'filename': _get_filename(obj, filename),
             'filetype': filetype,
         }

--- a/tests/unit/workflows/test_workflows_tasks_submission.py
+++ b/tests/unit/workflows/test_workflows_tasks_submission.py
@@ -155,7 +155,7 @@ def test_prepare_files_annotates_files_from_arxiv():
         'fft': [
             {
                 'url': '/data/foo.pdf',
-                'docfile_type': 'INSPIRE-PUBLIC',
+                'docfile_type': 'arXiv',
                 'filename': 'arxiv:foo',
                 'filetype': '.pdf',
             },


### PR DESCRIPTION
* FIX Uses the correct FFT doctype `arXiv` when sending to legacy
  PDFs originated from arXiv. This is necessary in order to have
  legacy hide them.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>