### PR TITLE
docs: pin clean-css version

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -114,7 +114,7 @@ We build assets using `npm`. Make sure you have installed it system wide.
 .. code-block:: console
 
     (inspirehep)$ sudo npm update
-    (inspirehep)$ sudo npm install -g node-sass@3.8.0 clean-css requirejs uglify-js
+    (inspirehep)$ sudo npm install -g node-sass@3.8.0 clean-css@^3.4.24 requirejs uglify-js
 
 
 .. note::


### PR DESCRIPTION
Version 4 of `clean-css` introduced several incompatible changes,
for which our asset pipeline is not yet ready. Meanwhile, we pin
it to version 3.