### PR TITLE
inspirehep-search-js bump version to 0.4.0

### DIFF
--- a/inspirehep/modules/search/bundles.py
+++ b/inspirehep/modules/search/bundles.py
@@ -35,6 +35,6 @@ js = NpmBundle(
     npm={
         'invenio-search-js': '~0.2.1',
         'angular-loading-bar': '~0.9.0',
-        'inspirehep-search-js': '~0.3.0'
+        'inspirehep-search-js': '~0.4.0'
     },
 )


### PR DESCRIPTION
Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>