### PR TITLE
literaturesuggest: use legacy_ICN for autocompletion

### DIFF
--- a/inspirehep/bat/pages/create_literature.py
+++ b/inspirehep/bat/pages/create_literature.py
@@ -305,7 +305,7 @@ def write_date_thesis(date_field, error_message_id, date):
 
 def write_institution_thesis(institution, expected_data):
     def _write_institution_thesis():
-        return expected_data in Arsenic().write_in_autocomplete_field(
+        return expected_data == Arsenic().write_in_autocomplete_field(
             'supervisors-0-affiliation', institution)
 
     _skip_import_data()
@@ -336,7 +336,7 @@ def write_journal_title(journal_title, expected_data):
 
 def write_affiliation(affiliation, expected_data):
     def _write_affiliation():
-        return expected_data in Arsenic().write_in_autocomplete_field(
+        return expected_data == Arsenic().write_in_autocomplete_field(
             'authors-0-affiliation', affiliation)
 
     _skip_import_data()

--- a/inspirehep/modules/forms/static/js/forms/affiliations_typeahead.js
+++ b/inspirehep/modules/forms/static/js/forms/affiliations_typeahead.js
@@ -57,9 +57,9 @@ define([
     this.$element = $element;
 
     var suggestionTemplate = Hogan.compile(
-      '<strong>{{ ICN }}</strong><br>' +
+      '<strong>{{ legacy_ICN }}</strong><br>' +
       '<small>' +
-      '{{#new_ICN}}{{#show_future_name}}Alternative name: {{new_ICN}}<br>{{/show_future_name}}{{/new_ICN}}' +
+      '{{#ICN}}{{#show_future_name}}Alternative name: {{future_name}}<br>{{/show_future_name}}{{/ICN}}' +
       '{{#department}}{{ department }}<br>{{/department}}' +
       '{{#institution}}{{ institution }}{{/institution}}' +
       '</small>'
@@ -80,15 +80,24 @@ define([
         }.bind(this));
       }.bind(this),
       displayKey: function(data) {
-        return data.metadata.ICN[0];
+        return data.metadata.legacy_ICN;
       },
       templates: {
         empty: function(data) {
           return 'Cannot find this affiliation in our database.';
         },
         suggestion: function(data) {
-          if (data.new_ICN != data.ICN) {
-            data.show_future_name = true;
+          function _getICN() {
+            for (let i=0; i<data.metadata.ICN.length; i++) {
+              if (data.metadata.ICN[i] !== data.metadata.legacy_ICN) {
+                return data.metadata.ICN[i];
+              }
+            }
+          }
+          let ICN = _getICN();
+          if (ICN) {
+            data.metadata.show_future_name = true;
+            data.metadata.future_name = ICN;
           }
           return suggestionTemplate.render.call(suggestionTemplate, data.metadata);
         }.bind(this)

--- a/inspirehep/modules/records/mappings/records/institutions.json
+++ b/inspirehep/modules/records/mappings/records/institutions.json
@@ -112,6 +112,7 @@
                     "type": "string"
                 },
                 "legacy_ICN": {
+                    "copy_to": "affautocomplete",
                     "type": "string"
                 },
                 "legacy_creation_date": {

--- a/tests/acceptance/test_literature_suggestion_form.py
+++ b/tests/acceptance/test_literature_suggestion_form.py
@@ -180,7 +180,7 @@ def test_conference_info_autocomplete_title(login):
 
 def test_basic_info_autocomplete_affiliation(login):
     create_literature.go_to()
-    assert create_literature.write_affiliation('oxf', 'U. Oxford').has_error()
+    assert create_literature.write_affiliation('oxf', 'Oxford U.').has_error()
 
 
 def test_import_from_arXiv(login):


### PR DESCRIPTION
* Adapt to data model change in institutions and use legacy_ICN instead of
  ICN. (closes #1962)

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>