### PR TITLE
dojson: notes -> material in publication_info

### DIFF
--- a/inspirehep/dojson/hep/rules/bd7xx.py
+++ b/inspirehep/dojson/hep/rules/bd7xx.py
@@ -26,7 +26,7 @@ from __future__ import absolute_import, division, print_function
 
 from dojson import utils
 
-from inspirehep.utils.dedupers import dedupe_list
+from inspire_schemas.utils import load_schema
 from inspirehep.utils.helpers import force_force_list
 from inspirehep.utils.pubnote import split_page_artid
 
@@ -79,6 +79,15 @@ def publication_info(self, key, value):
                 return out
         return None
 
+    def _get_material(value):
+        schema = load_schema('elements/material')
+        valid_materials = schema['enum']
+
+        m_value = force_single_element(value.get('m', ''))
+        for material in valid_materials:
+            if m_value.lower() == material:
+                return material
+
     year = get_int_value(value.get('y'))
     parent_recid = get_int_value(value.get('0'))
     journal_recid = get_int_value(value.get('1'))
@@ -106,7 +115,7 @@ def publication_info(self, key, value):
         'pubinfo_freetext': force_single_element(value.get('x')),
         'year': year,
         'isbn': force_single_element(value.get('z')),
-        'notes': dedupe_list(force_force_list(value.get('m'))),
+        'material': _get_material(value),
     }
 
     return res
@@ -136,7 +145,7 @@ def publication_info2marc(self, key, value):
         'x': value.get('pubinfo_freetext'),
         'y': value.get('year'),
         'z': value.get('isbn'),
-        'm': value.get('notes')
+        'm': value.get('material')
     }
 
 

--- a/tests/unit/dojson/test_dojson_hep_bd7xx.py
+++ b/tests/unit/dojson/test_dojson_hep_bd7xx.py
@@ -150,6 +150,55 @@ def test_collaborations_from_multiple_710__g_0_and_710__g():
     assert expected == result['710']
 
 
+def test_publication_info_from_773_c_m_p_v_y_1():
+    schema = load_schema('hep')
+    subschema = schema['properties']['publication_info']
+
+    snippet = (
+        '<datafield tag="773" ind1=" " ind2=" ">'
+        '  <subfield code="m">Erratum</subfield>'
+        '  <subfield code="p">Phys.Rev.Lett.</subfield>'
+        '  <subfield code="v">35</subfield>'
+        '  <subfield code="c">130</subfield>'
+        '  <subfield code="y">1975</subfield>'
+        '  <subfield code="1">1214495</subfield>'
+        '</datafield>'
+    )  # record/1104/export/xme
+
+    expected = [
+        {
+            'artid': '130',
+            'material': 'erratum',
+            'journal_record': {
+                '$ref': 'http://localhost:5000/api/journals/1214495',
+            },
+            'journal_title': 'Phys.Rev.Lett.',
+            'journal_volume': '35',
+            'page_start': '130',
+            'year': 1975,
+        },
+    ]
+    result = hep.do(create_record(snippet))
+
+    assert validate(result['publication_info'], subschema) is None
+    assert expected == result['publication_info']
+
+    expected = [
+        {
+            'c': [
+                '130',
+            ],
+            'm': 'erratum',
+            'p': 'Phys.Rev.Lett.',
+            'v': '35',
+            'y': 1975,
+        },
+    ]
+    result = hep2marc.do(result)
+
+    assert expected == result['773']
+
+
 def test_publication_info_from_773_c_p_w_double_v_double_y_0_1_2():
     schema = load_schema('hep')
     subschema = schema['properties']['publication_info']


### PR DESCRIPTION
Sentry: https://sentry.cern.ch/inspire-sentry/inspire-nightly/group/619224/

This function is severely undertested, so I expect more stuff to be incorrect.