### PR TITLE
dojson: fix number of pages

### DIFF
--- a/inspirehep/dojson/hep/rules/bd3xx.py
+++ b/inspirehep/dojson/hep/rules/bd3xx.py
@@ -25,12 +25,12 @@
 from __future__ import absolute_import, division, print_function
 
 from ..model import hep, hep2marc
-from ...utils import force_single_element
+from ...utils import force_single_element, maybe_int
 
 
 @hep.over('number_of_pages', '^300..')
 def number_of_pages(self, key, value):
-    return int(force_single_element(value.get('a')))
+    return maybe_int(force_single_element(value.get('a', '')))
 
 
 @hep2marc.over('300', '^number_of_pages$')

--- a/inspirehep/dojson/utils/__init__.py
+++ b/inspirehep/dojson/utils/__init__.py
@@ -186,6 +186,14 @@ def legacy_export_as_marc(json, tabsize=4):
     return "".join(export)
 
 
+def maybe_int(el):
+    """Return an ``int`` if possible, otherwise ``None``."""
+    try:
+        return int(el)
+    except ValueError:
+        pass
+
+
 def strip_empty_values(obj):
     """Recursively strips empty values."""
     if isinstance(obj, dict):

--- a/tests/unit/dojson/test_dojson_hep_bd3xx.py
+++ b/tests/unit/dojson/test_dojson_hep_bd3xx.py
@@ -49,3 +49,13 @@ def test_number_of_pages_from_300__a():
     result = hep2marc.do(result)
 
     assert expected == result['300']
+
+
+def test_number_of_pages_from_300__a_malformed():
+    snippet = (
+        '<datafield tag="300" ind1=" " ind2=" ">'
+        '  <subfield code="a">216+337</subfield>'
+        '</datafield>'
+    )  # record/67556
+
+    assert 'number_of_pages' not in hep.do(create_record(snippet))

--- a/tests/unit/dojson/test_dojson_utils.py
+++ b/tests/unit/dojson/test_dojson_utils.py
@@ -34,6 +34,7 @@ from inspirehep.dojson.utils import (
     get_recid_from_ref,
     get_record_ref,
     legacy_export_as_marc,
+    maybe_int,
     dedupe_all_lists,
     strip_empty_values,
     validate,
@@ -261,6 +262,17 @@ def test_legacy_export_as_marc_json_with_controlfield():
     result = legacy_export_as_marc(json_with_controlfield)
 
     assert expected == result
+
+
+def test_maybe_int_returns_int_if_possible():
+    expected = 10
+    result = maybe_int('10')
+
+    assert expected == result
+
+
+def test_maybe_int_returns_none_otherwise():
+    assert maybe_int('216+337') is None
 
 
 def test_dedupe_all_lists():


### PR DESCRIPTION
https://sentry.cern.ch/inspire-sentry/inspire-nightly/group/619216

NB: this is discarding some data (in 133 records out of 1089353) in order to prevent exceptions that would discard 133 * 100 records. This seemed an acceptable tradeoff for this field (which doesn't look very useful anyway).