### PR TITLE
literaturesuggest: improve conference autocomplete

### DIFF
--- a/inspirehep/modules/records/mappings/records/conferences.json
+++ b/inspirehep/modules/records/mappings/records/conferences.json
@@ -43,6 +43,7 @@
                             "type": "double"
                         },
                         "original_address": {
+                            "copy_to": "conferenceautocomplete",
                             "type": "string"
                         },
                         "postal_code": {

--- a/tests/acceptance/test_literature_suggestion_form.py
+++ b/tests/acceptance/test_literature_suggestion_form.py
@@ -173,7 +173,7 @@ def test_journal_info_autocomplete_title(login):
 def test_conference_info_autocomplete_title(login):
     create_literature.go_to()
     assert create_literature.write_conference(
-        'sos',
+        'autrans',
         'IN2P3 School of Statistics, 2012-05-28, Autrans, France',
     ).has_error()
 


### PR DESCRIPTION
* Updates ElasticSearch mapping to fix conference autocompletion.
  (closes #1941)

* Amends acceptance test with a more real scenario.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>