### PR TITLE
Ignore Twisted pid file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ selenium-report.html
 
 # Rope project files
 .ropeproject/
+
+# Twisted
+twistd.pid


### PR DESCRIPTION
Add `twistd.pid` to `.gitignore`, as directed by @jacquerie.