### PR TITLE
tests: stable langdetect

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -23,6 +23,7 @@
 from __future__ import absolute_import, division, print_function
 
 import pytest
+from langdetect import DetectorFactory
 
 from inspirehep.factory import create_app
 
@@ -53,3 +54,13 @@ def app_client(app):
 def request_context(app):
     with app.test_request_context() as request_context:
         yield request_context
+
+
+@pytest.fixture(scope='function')
+def stable_langdetect(app):
+    """Ensure that ``langdetect`` always returns the same thing.
+
+    See: https://github.com/Mimino666/langdetect#basic-usage."""
+    DetectorFactory.seed = 0
+
+    yield

--- a/tests/unit/dojson/test_dojson_hep_bd2xx.py
+++ b/tests/unit/dojson/test_dojson_hep_bd2xx.py
@@ -133,7 +133,7 @@ def test_titles_from_245__a_b():
     assert expected == result['245']
 
 
-def test_title_translations_from_242__a():
+def test_title_translations_from_242__a(stable_langdetect):
     schema = load_schema('hep')
     subschema = schema['properties']['title_translations']
 
@@ -164,7 +164,7 @@ def test_title_translations_from_242__a():
     assert expected == result['242']
 
 
-def test_title_translations_from_242__a_b():
+def test_title_translations_from_242__a_b(stable_langdetect):
     schema = load_schema('hep')
     subschema = schema['properties']['title_translations']
 


### PR DESCRIPTION
A build for https://github.com/inspirehep/inspire-next/pull/1992 failed because, after merging https://github.com/inspirehep/inspire-next/commit/b58c343efaaac237074c3df749401f6f0170ade6, the output of `langdetect` became non-deterministic because the fix in https://github.com/inspirehep/inspire-next/commit/1013b95cec26268983cb765618b52ef26c88bfb7 was no longer applied.

This PR adds it back in the form of a fixture, to be used wherever the output of `langdetect` needs to be deterministic.