### PR TITLE
authors: advisor degree import fix

### DIFF
--- a/inspirehep/modules/authors/forms.py
+++ b/inspirehep/modules/authors/forms.py
@@ -241,22 +241,19 @@ class AdvisorsInlineForm(INSPIREForm):
         export_key='full_name',
     )
 
+    degree_types_schema = load_schema('elements/degree_type.json')
+    degree_type_options = [
+        (val, val.capitalize())
+        for val in degree_types_schema['enum']
+    ]
+    degree_type_options.sort(key=lambda x: x[1])
     degree_type = fields.SelectField(
+        choices=degree_type_options,
         label=_('Degree Type'),
         widget_classes="form-control",
         default="phd",
         widget=ColumnSelect(class_="col-xs-5", description=u"Degree Type"),
     )
-
-    def __init__(self, *args, **kwargs):
-        """Constructor."""
-        super(AdvisorsInlineForm, self).__init__(*args, **kwargs)
-        self.degree_type.choices = [
-            ("bachelor", _("Bachelor")),
-            ("master", _("Master")),
-            ("phd", _("PhD")),
-            ("other", _("Other")),
-        ]
 
 
 class WebpageInlineForm(INSPIREForm):

--- a/inspirehep/modules/authors/views/holdingpen.py
+++ b/inspirehep/modules/authors/views/holdingpen.py
@@ -150,7 +150,7 @@ def convert_for_form(data):
         for advisor in advisors:
             adv = {}
             adv["name"] = advisor.get("name", "")
-            adv["degree_type"] = advisor.get("_degree_type", "")
+            adv["degree_type"] = advisor.get("degree_type", "")
             data["advisors"].append(adv)
     if "ids" in data:
         for id in data["ids"]:

--- a/tests/unit/authors/test_authors_views.py
+++ b/tests/unit/authors/test_authors_views.py
@@ -60,17 +60,38 @@ def test_convert_for_form_public_emails():
 
     expected = [
         {
-          "email": "michael.abbott@uct.ac.za",
-          "original_email": "michael.abbott@uct.ac.za"
+            "email": "michael.abbott@uct.ac.za",
+            "original_email": "michael.abbott@uct.ac.za"
         },
         {
-          "email": "abbott@theory.tifr.res.in",
-          "original_email": "abbott@theory.tifr.res.in"
+            "email": "abbott@theory.tifr.res.in",
+            "original_email": "abbott@theory.tifr.res.in"
         }
     ]
 
     assert expected == current_and_old_emails['public_emails']
 
+
+def test_convert_for_form_advisors():
+    record = {
+        'advisors': [
+            {
+                'degree_type': 'other',
+                'name': 'Avignone, Frank T.',
+                'curated_relation': False
+            }
+        ]
+    }
+    convert_for_form(record)
+
+    expected = [
+        {
+            'degree_type': 'other',
+            'name': 'Avignone, Frank T.'
+        }
+    ]
+
+    assert expected == record['advisors']
 
 # TODO: test convert_for_form
 


### PR DESCRIPTION
* Reads advisor degree type from correct field when importing data.

* Adds unit test for the functionality.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>