### PR TITLE
forms: prevent error message when submitting on Firefox

### DIFF
--- a/inspirehep/modules/forms/static/js/forms/inspire-form.js
+++ b/inspirehep/modules/forms/static/js/forms/inspire-form.js
@@ -468,12 +468,14 @@ define(function(require, exports, module) {
 
       set_status(tpl_status_saving());
 
-      $.ajax(
+      var promise = $.ajax(
         json_options({
           url: url,
           data: request_data
         })
-      ).done(function(data) {
+      );
+
+      promise.done(function(data) {
         var errors = handle_response(data);
         if (errors) {
           set_status(tpl_status_saved_with_error());
@@ -496,8 +498,12 @@ define(function(require, exports, module) {
           }
         }
 
-      }).fail(function() {
-        set_status(tpl_status_error());
+      });
+
+      promise.fail(function(jqXHR, textStatus, errorThrown) {
+        if (jqXHR.status === 500) {
+          set_status(tpl_status_error());
+        }
       });
     }
 


### PR DESCRIPTION
* Firefox fires the jQuery AJAX fail handler on submit. Check the status
  code on the fail handler to only show an error when the server responds
  500. (closes #1947)

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>