### PR TITLE
forms: prevent error message on Firefox

### DIFF
--- a/inspirehep/modules/forms/static/js/forms/inspire-form.js
+++ b/inspirehep/modules/forms/static/js/forms/inspire-form.js
@@ -496,8 +496,10 @@ define(function(require, exports, module) {
           }
         }
 
-      }).fail(function() {
-        set_status(tpl_status_error());
+      }).fail(function(jqXHR, textStatus, errorThrown) {
+        if (jqXHR.status === 500) {
+          set_status(tpl_status_error());
+        }
       });
     }
 


### PR DESCRIPTION
Closes #2014 

Checks the status code in the fail handler because Firefox appears
to fire it anyway, even if the request was successful (closes #1947).