### PR TITLE
dojson: use a consistent style in regexes

### DIFF
--- a/inspirehep/dojson/conferences/rules.py
+++ b/inspirehep/dojson/conferences/rules.py
@@ -35,7 +35,7 @@ from ..utils import force_single_element
 from ..utils.geo import parse_conference_address
 
 
-@conferences.over('acronym', '^111')
+@conferences.over('acronym', '^111..')
 @utils.for_each_value
 def acronym(self, key, value):
     self['opening_date'] = value.get('x')
@@ -64,7 +64,7 @@ def acronym(self, key, value):
     return value.get('e')
 
 
-@conferences.over('contact_details', '^270')
+@conferences.over('contact_details', '^270..')
 @utils.for_each_value
 def contact_details(self, key, value):
     extra_place_info = value.get('b')
@@ -81,7 +81,7 @@ def contact_details(self, key, value):
     }
 
 
-@conferences.over('short_description', '^520')
+@conferences.over('short_description', '^520..')
 @utils.for_each_value
 def short_description(self, key, value):
     return {
@@ -90,7 +90,7 @@ def short_description(self, key, value):
     }
 
 
-@conferences.over('keywords', '^6531')
+@conferences.over('keywords', '^6531.')
 def keywords(self, key, value):
     def get_value(value):
         return {
@@ -104,7 +104,7 @@ def keywords(self, key, value):
     return keywords
 
 
-@conferences.over('series', '^411')
+@conferences.over('series', '^411..')
 def series(self, key, value):
     def _get_name(value):
         return force_single_element(value.get('a'))
@@ -135,7 +135,7 @@ def series(self, key, value):
     return series
 
 
-@conferences.over('alternative_titles', '^711')
+@conferences.over('alternative_titles', '^711..')
 @utils.flatten
 @utils.for_each_value
 def alternative_titles(self, key, value):

--- a/inspirehep/dojson/hep/rules/bd1xx.py
+++ b/inspirehep/dojson/hep/rules/bd1xx.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 ORCID = re.compile('\d{4}-\d{4}-\d{4}-\d{3}[0-9Xx]')
 
 
-@hep.over('authors', '^[17]0[01]..')
+@hep.over('authors', '^(100|700|701)..')
 def authors(self, key, value):
     def _get_author(value):
         def _get_affiliations(value):
@@ -256,7 +256,7 @@ def authors2marc(self, key, value):
     return get_value_100_700(value[0])
 
 
-@hep.over('corporate_author', '^110[10_2].')
+@hep.over('corporate_author', '^110..')
 @utils.for_each_value
 def corporate_author(self, key, value):
     """Main Entry-Corporate Name."""

--- a/inspirehep/dojson/hep/rules/bd2xx.py
+++ b/inspirehep/dojson/hep/rules/bd2xx.py
@@ -34,7 +34,7 @@ from inspirehep.utils.helpers import force_force_list
 from ..model import hep, hep2marc
 
 
-@hep.over('titles', '^(210|24[2567])[10_][0_]')
+@hep.over('titles', '^(210|242|245|246|247)..')
 def titles(self, key, value):
     def is_main_title(key):
         return key.startswith('245')
@@ -81,7 +81,7 @@ def titles2marc(self, key, value):
     return [get_transformed_title(value) for value in values[1:]]
 
 
-@hep2marc.over('242', r'^title_translations$')
+@hep2marc.over('242', '^title_translations$')
 def title_translations2marc(self, key, value):
     def get_transformed_title(val):
         return {
@@ -107,7 +107,7 @@ def editions2marc(self, key, value):
     return {'a': value}
 
 
-@hep.over('imprints', '^260[_23].')
+@hep.over('imprints', '^260..')
 @utils.for_each_value
 def imprints(self, key, value):
     return {
@@ -117,7 +117,7 @@ def imprints(self, key, value):
     }
 
 
-@hep2marc.over('260', 'imprints')
+@hep2marc.over('260', '^imprints$')
 @utils.for_each_value
 def imprints2marc(self, key, value):
     return {
@@ -134,7 +134,7 @@ def preprint_date(self, key, value):
     return value.get('c')
 
 
-@hep2marc.over('269', 'preprint_date')
+@hep2marc.over('269', '^preprint_date$')
 @utils.for_each_value
 def preprint_date2marc(self, key, value):
     return {'c': value}

--- a/inspirehep/dojson/hep/rules/bd4xx.py
+++ b/inspirehep/dojson/hep/rules/bd4xx.py
@@ -29,7 +29,7 @@ from dojson import utils
 from ..model import hep, hep2marc
 
 
-@hep.over('book_series', '^490[10_].')
+@hep.over('book_series', '^490..')
 @utils.for_each_value
 def book_series(self, key, value):
     return {
@@ -38,7 +38,7 @@ def book_series(self, key, value):
     }
 
 
-@hep2marc.over('490', 'book_series')
+@hep2marc.over('490', '^book_series$')
 @utils.for_each_value
 def book_series2marc(self, key, value):
     return {

--- a/inspirehep/dojson/hep/rules/bd6xx.py
+++ b/inspirehep/dojson/hep/rules/bd6xx.py
@@ -73,7 +73,7 @@ def accelerator_experiments(self, key, acc_exps_data):
     return acc_exps_json
 
 
-@hep2marc.over('693', 'accelerator_experiments')
+@hep2marc.over('693', '^accelerator_experiments$')
 @utils.for_each_value
 def accelerator_experiments2marc(self, key, value):
     res = {
@@ -88,8 +88,7 @@ def accelerator_experiments2marc(self, key, value):
     return res
 
 
-@hep.over('keywords', '^695..')
-@hep.over('keywords', '^653[10_2][_1032546]')
+@hep.over('keywords', '^(653|695)..')
 @utils.for_each_value
 def keywords(self, key, value):
     """Parse keywords.
@@ -157,7 +156,7 @@ def keywords(self, key, value):
     return _get_keyword_dict(key, value)
 
 
-@hep2marc.over('695', 'keywords')
+@hep2marc.over('695', '^keywords$')
 def keywords2marc(self, key, values):
     values = force_force_list(values)
 
@@ -198,7 +197,7 @@ def keywords2marc(self, key, values):
     return thesaurus_terms
 
 
-@hep2marc.over('_energy_ranges', 'energy_ranges')
+@hep2marc.over('_energy_ranges', '^energy_ranges$')
 @utils.ignore_value
 def energy_ranges2marc(self, key, values):
     values = force_force_list(values)

--- a/inspirehep/dojson/hep/rules/bd7xx.py
+++ b/inspirehep/dojson/hep/rules/bd7xx.py
@@ -38,7 +38,7 @@ from ...utils import (
 )
 
 
-@hep.over('collaborations', '^710[10_2][_2]')
+@hep.over('collaborations', '^710..')
 def collaboration(self, key, value):
     value = force_force_list(value)
 
@@ -62,7 +62,7 @@ def collaboration(self, key, value):
     return collaboration
 
 
-@hep2marc.over('710', 'collaborations')
+@hep2marc.over('710', '^collaborations$')
 @utils.for_each_value
 def collaborations2marc(self, key, value):
     return {'g': value.get('value')}
@@ -120,7 +120,7 @@ def publication_info(self, key, value):
     return res
 
 
-@hep2marc.over('773', 'publication_info')
+@hep2marc.over('773', '^publication_info$')
 @utils.for_each_value
 def publication_info2marc(self, key, value):
     page_artid = []
@@ -160,7 +160,7 @@ def succeeding_entry(self, key, value):
     }
 
 
-@hep2marc.over('785', 'succeeding_entry')
+@hep2marc.over('785', '^succeeding_entry$')
 def succeeding_entry2marc(self, key, value):
     return {
         'r': value.get('relationship_code'),

--- a/inspirehep/dojson/hep/rules/bd8xx.py
+++ b/inspirehep/dojson/hep/rules/bd8xx.py
@@ -29,7 +29,7 @@ from dojson import utils
 from ..model import hep2marc
 
 
-@hep2marc.over('8564', 'urls')
+@hep2marc.over('8564', '^urls$')
 @utils.for_each_value
 def urls2marc(self, key, value):
     return {

--- a/inspirehep/dojson/hep/rules/bd9xx.py
+++ b/inspirehep/dojson/hep/rules/bd9xx.py
@@ -47,7 +47,7 @@ from ...utils import (
 RE_VALID_PUBNOTE = re.compile(".*,.*,.*(,.*)?")
 
 
-@hep.over('document_type', '^980__')
+@hep.over('document_type', '^980..')
 def document_type(self, key, value):
     publication_types = [
         'introductory',
@@ -221,7 +221,7 @@ def references(self, key, value):
     return references
 
 
-@hep2marc.over('999C5', 'references')
+@hep2marc.over('999C5', '^references$')
 @utils.for_each_value
 def references2marc(self, key, value):
     """Produce list of references."""


### PR DESCRIPTION
I know that this sounds silly, but since with @michamos we were grepping the code base to find MARC fields we didn't cover I realized that we need a consistent way of expressing those, otherwise we waste time thinking we have no match...