### PR TITLE
holdingpen: prevent ctrl+a from selecting all

### DIFF
--- a/inspirehep/modules/workflows/static/js/inspire_workflows_ui/holdingpen/holdingpen.controllers.js
+++ b/inspirehep/modules/workflows/static/js/inspire_workflows_ui/holdingpen/holdingpen.controllers.js
@@ -137,7 +137,8 @@
 
     var hotkey = Hotkeys.createHotkey({
       key: 'ctrl+a',
-      callback: function () {
+      callback: function (e) {
+        e.preventDefault();
         toggleAll();
       }
     });


### PR DESCRIPTION
Closes #2012

I'm not 100% sure that this works because I tested it on MacOS, where I had to remap the shortcut to Meta+A while testing, but I don't have a Linux desktop to try this right now...