### PR TITLE
global: remove almost all definitions of __all__

### DIFF
--- a/inspirehep/__init__.py
+++ b/inspirehep/__init__.py
@@ -25,6 +25,3 @@
 from __future__ import absolute_import, division, print_function
 
 from .version import __version__
-
-
-__all__ = ('__version__',)

--- a/inspirehep/modules/arxiv/__init__.py
+++ b/inspirehep/modules/arxiv/__init__.py
@@ -25,5 +25,3 @@
 from __future__ import absolute_import, division, print_function
 
 from .ext import Arxiv
-
-__all__ = ('Arxiv')

--- a/inspirehep/modules/arxiv/ext.py
+++ b/inspirehep/modules/arxiv/ext.py
@@ -167,5 +167,3 @@ class Arxiv(object):
         resp.status_code = response_code.get(result['status'],
                                              result['status'])
         return resp
-
-__all__ = ("Arxiv", )

--- a/inspirehep/modules/authors/__init__.py
+++ b/inspirehep/modules/authors/__init__.py
@@ -27,5 +27,3 @@ from __future__ import absolute_import, division, print_function
 from .ext import INSPIREAuthors
 
 from .receivers import *
-
-__all__ = ('INSPIREAuthors', )

--- a/inspirehep/modules/authors/dojson/__init__.py
+++ b/inspirehep/modules/authors/dojson/__init__.py
@@ -23,5 +23,3 @@
 from __future__ import absolute_import, division, print_function
 
 from .fields import updateform
-
-__all__ = ('updateform',)

--- a/inspirehep/modules/cache/__init__.py
+++ b/inspirehep/modules/cache/__init__.py
@@ -26,6 +26,3 @@ from __future__ import absolute_import, division, print_function
 
 from .ext import INSPIRECache
 from .proxies import current_cache
-
-
-__all__ = ('INSPIRECache', 'current_cache')

--- a/inspirehep/modules/converter/__init__.py
+++ b/inspirehep/modules/converter/__init__.py
@@ -25,5 +25,3 @@
 from __future__ import absolute_import, division, print_function
 
 from .xslt import convert
-
-__all__ = ('convert', )

--- a/inspirehep/modules/crossref/__init__.py
+++ b/inspirehep/modules/crossref/__init__.py
@@ -25,5 +25,3 @@
 from __future__ import absolute_import, division, print_function
 
 from .ext import CrossRef
-
-__all__ = ('CrossRef')

--- a/inspirehep/modules/crossref/ext.py
+++ b/inspirehep/modules/crossref/ext.py
@@ -145,5 +145,3 @@ class CrossRef(object):
         resp = jsonify(result)
         resp.status_code = response_code.get(result['status'], 200)
         return resp
-
-__all__ = ("CrossRef", )

--- a/inspirehep/modules/disambiguation/__init__.py
+++ b/inspirehep/modules/disambiguation/__init__.py
@@ -26,6 +26,3 @@ from __future__ import absolute_import, division, print_function
 
 from .ext import InspireDisambiguation
 from .tasks import disambiguation_daemon
-
-
-__all__ = ('InspireDisambiguation', 'disambiguation_daemon')

--- a/inspirehep/modules/fixtures/__init__.py
+++ b/inspirehep/modules/fixtures/__init__.py
@@ -26,5 +26,3 @@
 from __future__ import absolute_import, division, print_function
 
 from .ext import INSPIREFixtures
-
-__all__ = ('INSPIREFixtures')

--- a/inspirehep/modules/fixtures/ext.py
+++ b/inspirehep/modules/fixtures/ext.py
@@ -41,6 +41,3 @@ class INSPIREFixtures(object):
 
         # Save reference to self on object
         app.extensions['inspire-fixtures'] = self
-
-
-__all__ = ('INSPIREFixtures',)

--- a/inspirehep/modules/forms/__init__.py
+++ b/inspirehep/modules/forms/__init__.py
@@ -25,5 +25,3 @@
 from __future__ import absolute_import, division, print_function
 
 from .ext import INSPIREForms
-
-__all__ = ('INSPIREForms', )

--- a/inspirehep/modules/forms/field_base.py
+++ b/inspirehep/modules/forms/field_base.py
@@ -106,8 +106,6 @@ from wtforms import Field
 
 from .form import CFG_FIELD_FLAGS
 
-__all__ = ('INSPIREField', )
-
 
 class INSPIREField(Field):
 

--- a/inspirehep/modules/literaturesuggest/__init__.py
+++ b/inspirehep/modules/literaturesuggest/__init__.py
@@ -25,5 +25,3 @@
 from __future__ import absolute_import, division, print_function
 
 from .ext import INSPIRELiteratureSuggestion
-
-__all__ = ('INSPIRELiteratureSuggestion', )

--- a/inspirehep/modules/literaturesuggest/fields/arxiv_id.py
+++ b/inspirehep/modules/literaturesuggest/fields/arxiv_id.py
@@ -28,8 +28,6 @@ from inspirehep.modules.forms.field_base import INSPIREField
 from inspirehep.modules.forms.filter_utils import strip_prefixes, strip_string
 from inspirehep.modules.forms.validators import arxiv_syntax_validation
 
-__all__ = ['ArXivField']
-
 
 class ArXivField(INSPIREField, TextField):
     def __init__(self, **kwargs):

--- a/inspirehep/modules/migrator/__init__.py
+++ b/inspirehep/modules/migrator/__init__.py
@@ -48,6 +48,3 @@ class INSPIREMigrator(object):
             'CFG_INSPIRE_LEGACY_BASEURL',
             'http://inspireheptest.cern.ch'
         )
-
-
-__all__ = ('INSPIREMigrator',)

--- a/inspirehep/modules/orcid/__init__.py
+++ b/inspirehep/modules/orcid/__init__.py
@@ -25,5 +25,3 @@ from __future__ import absolute_import, division, print_function
 from .ext import INSPIREOrcid
 
 from .receivers import *
-
-__all__ = ('INSPIREOrcid',)

--- a/inspirehep/modules/search/__init__.py
+++ b/inspirehep/modules/search/__init__.py
@@ -36,10 +36,3 @@ from .api import (
     JournalsSearch
 )
 from .ext import INSPIRESearch
-
-
-__all__ = (
-    'IQ', 'INSPIRESearch', 'LiteratureSearch', 'AuthorsSearch', 'DataSearch',
-    'ConferencesSearch', 'JobsSearch', 'InstitutionsSearch',
-    'ExperimentsSearch', 'JournalsSearch'
-)

--- a/inspirehep/modules/theme/__init__.py
+++ b/inspirehep/modules/theme/__init__.py
@@ -28,5 +28,3 @@ from .ext import INSPIRETheme
 
 # Needed to register the jinja filters in the Blueprint
 from .jinja2filters import *
-
-__all__ = ('INSPIRETheme')

--- a/inspirehep/modules/tools/__init__.py
+++ b/inspirehep/modules/tools/__init__.py
@@ -23,6 +23,3 @@
 from __future__ import absolute_import, division, print_function
 
 from .ext import INSPIRETools
-
-
-__all__ = ('INSPIRETools',)

--- a/inspirehep/modules/workflows/__init__.py
+++ b/inspirehep/modules/workflows/__init__.py
@@ -27,5 +27,3 @@ from __future__ import absolute_import, division, print_function
 
 from .ext import INSPIREWorkflows
 from .receivers import *
-
-__all__ = ('INSPIREWorkflows')

--- a/inspirehep/modules/workflows/actions/__init__.py
+++ b/inspirehep/modules/workflows/actions/__init__.py
@@ -28,6 +28,3 @@ from __future__ import absolute_import, division, print_function
 from .hep_approval import HEPApproval
 from .merge_approval import MergeApproval
 from .author_approval import AuthorApproval
-
-
-__all__ = ('HEPApproval', 'MergeApproval', 'AuthorApproval')

--- a/inspirehep/modules/workflows/proxies.py
+++ b/inspirehep/modules/workflows/proxies.py
@@ -48,5 +48,3 @@ def load_antikeywords():
 
 
 antihep_keywords = LocalProxy(lambda: load_antikeywords())
-
-__all__ = ('antihep_keywords',)

--- a/inspirehep/modules/workflows/workflows/__init__.py
+++ b/inspirehep/modules/workflows/workflows/__init__.py
@@ -27,6 +27,3 @@ from __future__ import absolute_import, division, print_function
 
 from .article import Article
 from .author import Author
-
-
-__all__ = ('Article', 'Author')


### PR DESCRIPTION
We use `__all__` when we expect users of our module to do
`from module import *`. Since this is almost always not the
case in INSPIRE, we can remove these definitions. The only
remaining uses are in `inspirehep/modules/forms/fields`,
where this assumption is true.