### PR TITLE
forms: sort conference suggestions by opening date

### DIFF
--- a/inspirehep/modules/forms/static/js/forms/conferences_typeahead.js
+++ b/inspirehep/modules/forms/static/js/forms/conferences_typeahead.js
@@ -65,6 +65,8 @@ define([
               el.metadata.place = el.metadata.address[0].original_address;
               el.metadata.title = el.metadata.titles[0].title;
               return el.metadata
+            }).sort(function(x, y) {
+              return new Date(y.opening_date) - new Date(x.opening_date);
             });
           }
         },


### PR DESCRIPTION
Closes #2011 

Not a satisfactory solution: we should rather be sorting at the ES level, but I couldn't figure out how to convince [`inspire_search_factory`](https://github.com/inspirehep/inspire-next/blob/454e73afb4b767f7701692ce4a1ac163f978681a/inspirehep/modules/search/query.py#L36-L69) to pass the `sort` parameter down to ES (through the API).