### PR TITLE
holdingpen: set subject string encoding to unicode

### DIFF
--- a/inspirehep/modules/authors/tasks.py
+++ b/inspirehep/modules/authors/tasks.py
@@ -123,7 +123,7 @@ def recreate_data(obj, eng):
 
 def new_ticket_context(user, obj):
     """Context for authornew new tickets."""
-    subject = "Your suggestion to INSPIRE: author {0}".format(
+    subject = u"Your suggestion to INSPIRE: author {0}".format(
         obj.data.get("name").get("preferred_name")
     )
     return dict(

--- a/tests/unit/authors/test_authors_tasks.py
+++ b/tests/unit/authors/test_authors_tasks.py
@@ -89,6 +89,24 @@ def test_new_ticket_context(data, extra_data, user):
     assert ctx['user_comment'] == 'Foo bar'
 
 
+def test_new_ticket_context_handles_unicode(user):
+    data = {'name': {'preferred_name': u'Diego Martínez'}}
+    extra_data = {}
+
+    obj = MockObj(data, extra_data)
+
+    expected = {
+        'object': obj,
+        'email': 'foo@bar.com',
+        'subject': u'Your suggestion to INSPIRE: author Diego Martínez',
+        'user_comment': '',
+    }
+    result = new_ticket_context(user, obj)
+    print("Resulting object: ", result)
+
+    assert expected == result
+
+
 def test_update_ticket_context(data, extra_data, user):
     config = {
         'AUTHORS_UPDATE_BASE_URL': 'http://inspirehep.net'

--- a/tests/unit/authors/test_authors_tasks.py
+++ b/tests/unit/authors/test_authors_tasks.py
@@ -102,7 +102,6 @@ def test_new_ticket_context_handles_unicode(user):
         'user_comment': '',
     }
     result = new_ticket_context(user, obj)
-    print("Resulting object: ", result)
 
     assert expected == result
 


### PR DESCRIPTION
Changes the subject string encoding (displayed at holdingpen) from
ascii to unicode, since there are names with accented characters.

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>