### PR TITLE
holdingpen: save changes before decision

### DIFF
--- a/inspirehep/modules/workflows/static/js/inspire_workflows_ui/holdingpen/holdingpen.directives.js
+++ b/inspirehep/modules/workflows/static/js/inspire_workflows_ui/holdingpen/holdingpen.directives.js
@@ -255,7 +255,10 @@
           },
 
           setDecision: function (decision) {
-            HoldingPenRecordService.setDecision($scope.vm, $scope.workflowId, decision)
+            HoldingPenRecordService.updateRecord($scope.vm, $scope.workflowId)
+            .then(function successCallback(response) {
+              HoldingPenRecordService.setDecision($scope.vm, $scope.workflowId, decision)
+            });
           },
 
           redirect: function (url) {

--- a/inspirehep/modules/workflows/static/js/inspire_workflows_ui/holdingpen/holdingpen.services.js
+++ b/inspirehep/modules/workflows/static/js/inspire_workflows_ui/holdingpen/holdingpen.services.js
@@ -46,7 +46,7 @@
             },
 
             updateRecord: function (vm, workflowId) {
-              $http.post('/api/holdingpen/' + workflowId + '/action/edit', vm.record).then(function (response) {
+              return $http.post('/api/holdingpen/' + workflowId + '/action/edit', vm.record).then(function (response) {
                 vm.saved = true;
                 vm.update_ready = false;
               }).catch(function (value) {


### PR DESCRIPTION
* Saves changes done to the Holding Pen entry before executing an action.
  (closes #1952) (closes #1953)

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>