### PR TITLE
celery: uses task_acks_late

### DIFF
--- a/inspirehep/modules/disambiguation/tasks.py
+++ b/inspirehep/modules/disambiguation/tasks.py
@@ -49,7 +49,7 @@ from inspirehep.modules.records.api import InspireRecord
 logger = get_task_logger(__name__)
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, task_acks_late=True)
 def disambiguation_daemon():
     """Run disambiguation daemon as Celery task.
 
@@ -83,7 +83,7 @@ def disambiguation_daemon():
     db.session.close()
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, task_acks_late=True)
 def disambiguation_clustering(phonetic_block):
     """Cluster phonetic blocks in parallel.
 
@@ -130,7 +130,7 @@ def disambiguation_clustering(phonetic_block):
         db.session.close()
 
 
-@shared_task
+@shared_task(ignore_result=True, task_acks_late=True)
 def update_authors_recid(record_id, uuid, profile_recid):
     """Update author profile for a given signature.
 

--- a/inspirehep/modules/migrator/tasks/records.py
+++ b/inspirehep/modules/migrator/tasks/records.py
@@ -102,7 +102,7 @@ def split_stream(stream):
             buf.append(row)
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, task_acks_late=True)
 def migrate_broken_records():
     """Migrate records declared as broken.
 
@@ -116,7 +116,7 @@ def migrate_broken_records():
         migrate_chunk.delay(chunk)
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, task_acks_late=True)
 def migrate(source, wait_for_results=False):
     """Main migration function."""
     if source.endswith('.gz'):
@@ -146,7 +146,7 @@ def migrate(source, wait_for_results=False):
         print('All migration tasks have been completed.')
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, task_acks_late=True)
 def continuous_migration():
     """Task to continuously migrate what is pushed up by Legacy."""
     redis_url = current_app.config.get('CACHE_REDIS_URL')
@@ -177,7 +177,7 @@ def create_index_op(record):
     }
 
 
-@shared_task(ignore_result=False, compress='zlib', acks_late=True)
+@shared_task(ignore_result=False, compress='zlib', task_acks_late=True)
 def migrate_chunk(chunk):
     index_queue = []
 
@@ -200,7 +200,7 @@ def migrate_chunk(chunk):
     )
 
 
-@shared_task()
+@shared_task(task_acks_late=True)
 def add_citation_counts(chunk_size=500, request_timeout=120):
     def _build_recid_to_uuid_map(citations_lookup):
         pids = PersistentIdentifier.query.filter(


### PR DESCRIPTION
* Introduces task_acks_late flag for critical tasks that are safe to
  be replayed in case of worker failure.
  (addresses #1665)

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>