### PR TITLE
records: ensure date type (and format) in mappings

### DIFF
--- a/inspirehep/modules/records/mappings/records/authors.json
+++ b/inspirehep/modules/records/mappings/records/authors.json
@@ -27,7 +27,8 @@
                 "acquisition_source": {
                     "properties": {
                         "date": {
-                            "type": "string"
+                            "type": "date",
+                            "format": "date||yyyy-MM||yyyy"
                         },
                         "email": {
                             "type": "string"
@@ -90,7 +91,8 @@
                     "type": "string"
                 },
                 "birth_date": {
-                    "type": "string"
+                    "type": "date",
+                    "format": "date||yyyy-MM||yyyy"
                 },
                 "conferences": {
                     "properties": {
@@ -104,7 +106,8 @@
                     "type": "integer"
                 },
                 "death_date": {
-                    "type": "string"
+                    "type": "date",
+                    "format": "date||yyyy-MM||yyyy"
                 },
                 "deleted": {
                     "type": "boolean"
@@ -129,7 +132,8 @@
                             "type": "boolean"
                         },
                         "end_year": {
-                            "type": "integer"
+                            "type": "date",
+                            "format": "year"
                         },
                         "name": {
                             "type": "string"
@@ -143,7 +147,8 @@
                             "type": "object"
                         },
                         "start_year": {
-                            "type": "integer"
+                            "type": "date",
+                            "format": "year"
                         }
                     },
                     "type": "object"
@@ -171,7 +176,8 @@
                     "type": "object"
                 },
                 "legacy_creation_date": {
-                    "type": "string"
+                    "type": "date",
+                    "format": "date||yyyy-MM||yyyy"
                 },
                 "name": {
                     "properties": {
@@ -220,7 +226,8 @@
                             "type": "string"
                         },
                         "end_date": {
-                            "type": "string"
+                            "type": "date",
+                            "format": "year"
                         },
                         "institution": {
                             "properties": {
@@ -248,7 +255,8 @@
                             "type": "string"
                         },
                         "start_date": {
-                            "type": "string"
+                            "type": "date",
+                            "format": "year"
                         }
                     },
                     "type": "object"
@@ -282,7 +290,8 @@
                 "source": {
                     "properties": {
                         "date_verified": {
-                            "type": "string"
+                            "type": "date",
+                            "format": "date||yyyy-MM||yyyy"
                         },
                         "name": {
                             "type": "string"

--- a/inspirehep/modules/records/mappings/records/conferences.json
+++ b/inspirehep/modules/records/mappings/records/conferences.json
@@ -70,7 +70,8 @@
                     "type": "object"
                 },
                 "closing_date": {
-                    "type": "string"
+                    "type": "date",
+                    "format": "date||yyyy-MM||yyyy"
                 },
                 "cnum": {
                     "copy_to": "conferenceautocomplete",
@@ -138,7 +139,8 @@
                     "type": "object"
                 },
                 "legacy_creation_date": {
-                    "type": "string"
+                    "type": "date",
+                    "format": "date||yyyy-MM||yyyy"
                 },
                 "new_record": {
                     "properties": {
@@ -150,8 +152,8 @@
                 },
                 "opening_date": {
                     "copy_to": "conferenceautocomplete",
-                    "format": "yyyy||yyyy-MM||yyyy-MM-dd",
-                    "type": "date"
+                    "type": "date",
+                    "format": "date||yyyy-MM||yyyy"
                 },
                 "place": {
                     "copy_to": "conferenceautocomplete",

--- a/inspirehep/modules/records/mappings/records/experiments.json
+++ b/inspirehep/modules/records/mappings/records/experiments.json
@@ -70,19 +70,24 @@
                     "type": "boolean"
                 },
                 "date_approved": {
-                    "type": "string"
+                    "type": "date",
+                    "format": "date||yyyy-MM||yyyy"
                 },
                 "date_cancelled": {
-                    "type": "string"
+                    "type": "date",
+                    "format": "date||yyyy-MM||yyyy"
                 },
                 "date_completed": {
-                    "type": "string"
+                    "type": "date",
+                    "format": "date||yyyy-MM||yyyy"
                 },
                 "date_proposed": {
-                    "type": "string"
+                    "type": "date",
+                    "format": "date||yyyy-MM||yyyy"
                 },
                 "date_started": {
-                    "type": "string"
+                    "type": "date",
+                    "format": "date||yyyy-MM||yyyy"
                 },
                 "deleted": {
                     "type": "boolean"
@@ -150,7 +155,8 @@
                     "type": "object"
                 },
                 "legacy_creation_date": {
-                    "type": "string"
+                    "type": "date",
+                    "format": "date||yyyy-MM||yyyy"
                 },
                 "new_record": {
                     "properties": {
@@ -224,7 +230,8 @@
                             "type": "boolean"
                         },
                         "end_date": {
-                            "type": "string"
+                            "type": "date",
+                            "format": "date||yyyy-MM||yyyy"
                         },
                         "ids": {
                             "properties": {
@@ -249,7 +256,8 @@
                             "type": "object"
                         },
                         "start_date": {
-                            "type": "string"
+                            "type": "date",
+                            "format": "date||yyyy-MM||yyyy"
                         }
                     },
                     "type": "object"

--- a/inspirehep/modules/records/mappings/records/hep.json
+++ b/inspirehep/modules/records/mappings/records/hep.json
@@ -16,7 +16,8 @@
                 "_desy_bookkeeping": {
                     "properties": {
                         "date": {
-                            "type": "string"
+                            "type": "date",
+                            "format": "date||yyyy-MM||yyyy"
                         },
                         "expert": {
                             "type": "string"
@@ -44,7 +45,8 @@
                             "type": "string"
                         },
                         "creation_datetime": {
-                            "type": "string"
+                            "type": "date",
+                            "format": "basic_date_time_no_millis"
                         },
                         "description": {
                             "type": "string"
@@ -155,7 +157,8 @@
                 "acquisition_source": {
                     "properties": {
                         "date": {
-                            "type": "string"
+                            "type": "date",
+                            "format": "date||yyyy-MM||yyyy"
                         },
                         "email": {
                             "type": "string"
@@ -353,8 +356,8 @@
                     "type": "object"
                 },
                 "earliest_date": {
-                    "format": "yyyy||yyyy-MM||yyyy-MM-dd",
-                    "type": "date"
+                    "type": "date",
+                    "format": "date||yyyy-MM||yyyy"
                 },
                 "editions": {
                     "type": "string"
@@ -390,7 +393,8 @@
                 "imprints": {
                     "properties": {
                         "date": {
-                            "type": "string"
+                            "type": "date",
+                            "format": "date||yyyy-MM||yyyy"
                         },
                         "place": {
                             "type": "string"
@@ -441,7 +445,8 @@
                     "type": "string"
                 },
                 "legacy_creation_date": {
-                    "type": "string"
+                    "type": "date",
+                    "format": "date||yyyy-MM||yyyy"
                 },
                 "license": {
                     "properties": {
@@ -489,7 +494,8 @@
                     "type": "object"
                 },
                 "preprint_date": {
-                    "type": "string"
+                    "type": "date",
+                    "format": "date||yyyy-MM||yyyy"
                 },
                 "public_notes": {
                     "properties": {
@@ -645,7 +651,8 @@
                                 "imprint": {
                                     "properties": {
                                         "date": {
-                                            "type": "string"
+                                            "type": "date",
+                                            "format": "date||yyyy-MM||yyyy"
                                         },
                                         "place": {
                                             "type": "string"
@@ -784,10 +791,12 @@
                 "thesis_info": {
                     "properties": {
                         "date": {
-                            "type": "string"
+                            "type": "date",
+                            "format": "date||yyyy-MM||yyyy"
                         },
                         "defense_date": {
-                            "type": "string"
+                            "type": "date",
+                            "format": "date||yyyy-MM||yyyy"
                         },
                         "degree_type": {
                             "type": "string"

--- a/inspirehep/modules/records/mappings/records/institutions.json
+++ b/inspirehep/modules/records/mappings/records/institutions.json
@@ -124,7 +124,8 @@
                     "type": "string"
                 },
                 "legacy_creation_date": {
-                    "type": "string"
+                    "type": "date",
+                    "format": "date||yyyy-MM||yyyy"
                 },
                 "location": {
                     "properties": {

--- a/inspirehep/modules/records/mappings/records/jobs.json
+++ b/inspirehep/modules/records/mappings/records/jobs.json
@@ -51,7 +51,8 @@
                     "type": "object"
                 },
                 "closed_date": {
-                    "type": "string"
+                    "type": "date",
+                    "format": "date||yyyy-MM"
                 },
                 "contact_details": {
                     "properties": {
@@ -68,7 +69,8 @@
                     "type": "integer"
                 },
                 "deadline_date": {
-                    "type": "string"
+                    "type": "date",
+                    "format": "date||yyyy-MM"
                 },
                 "deleted": {
                     "type": "boolean"
@@ -145,7 +147,8 @@
                     "type": "object"
                 },
                 "legacy_creation_date": {
-                    "type": "string"
+                    "type": "date",
+                    "format": "date||yyyy-MM"
                 },
                 "new_record": {
                     "properties": {

--- a/inspirehep/modules/records/mappings/records/journals.json
+++ b/inspirehep/modules/records/mappings/records/journals.json
@@ -80,7 +80,8 @@
                     "type": "string"
                 },
                 "legacy_creation_date": {
-                    "type": "string"
+                    "type": "date",
+                    "format": "date||yyyy-MM||yyyy"
                 },
                 "license": {
                     "type": "string"


### PR DESCRIPTION
Setting date type (instead of string) for all date-related fields.
Only special case was `hep.thesis_info.defense_date` whose values
on nightly are `PhD`. This field's type has been left as string.

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>