### PR TITLE
tests: acceptance without visible firefox instance

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -100,6 +100,23 @@ services:
     environment:
       - SERVER_NAME=web:5000
       - DISPLAY=$DISPLAY
+  not_visible_acceptance:
+    extends:
+      service: service_base
+    command: py.test --driver Remote --host selenium --port 4444 --capability browserName firefox --html=selenium-report.html tests/acceptance
+    volumes_from:
+      - static
+    links:
+      - database
+      - indexer
+      - rabbitmq
+      - redis
+      - selenium
+    depends_on:
+      - web
+      - worker
+    environment:
+      - SERVER_NAME=web:5000
   web:
     extends:
       service: service_base


### PR DESCRIPTION
I have added a service called `not_visible_acceptance`. This routine should run the acceptance tests in background. 
It is useful because sometimes we do not need to check what's going on with these tests and it allows you to do other things without be interrupted by the firefox window.