### PR TITLE
setup: pin inspire-schemas-30.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ install_requires = [
     'invenio-utils==0.2.0',  # Not fully Invenio 3 ready
     'invenio>=3.0.0a1,<3.1.0',
     'inspire-crawler~=0.2.7',
-    'inspire-schemas~=29.0',
+    'inspire-schemas~=30.0',
     'dojson>=1.3.0',
     'Flask>=0.11.1',
     'Flask-Breadcrumbs>=0.3.0',


### PR DESCRIPTION
* Pins inspire-schemas-30.0 which contain a fix to have the
  author.signature_block field necessary on production where
  beard is enabled.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>