### PR TITLE
theme: add redirects for literature and author forms

### DIFF
--- a/inspirehep/modules/theme/views.py
+++ b/inspirehep/modules/theme/views.py
@@ -566,7 +566,7 @@ def register_menu_items():
 
 
 #
-# Redirect /record/N
+# Legacy redirects
 #
 
 @blueprint.route('/record/<control_number>')
@@ -580,6 +580,28 @@ def record(control_number):
     return redirect('/{endpoint}/{control_number}'.format(
         endpoint=get_endpoint_from_pid_type(pid.pid_type),
         control_number=control_number)), 301
+
+
+@blueprint.route('/author/new')
+def author_new():
+    bai = request.values.get('bai', None, type=str)
+    return redirect(url_for('inspirehep_authors_holdingpen.new', bai=bai)), 301
+
+
+@blueprint.route('/author/update')
+def author_update():
+    recid = request.values.get('recid', None, type=str)
+    if recid:
+        return redirect(
+            url_for('inspirehep_authors_holdingpen.update', recid=recid)
+        ), 301
+    else:
+        return redirect(url_for('inspirehep_authors_holdingpen.new')), 301
+
+
+@blueprint.route('/submit/literature/create')
+def literature_new():
+    return redirect(url_for('inspirehep_literature_suggest.create')), 301
 
 
 #

--- a/tests/integration/test_theme_views.py
+++ b/tests/integration/test_theme_views.py
@@ -93,3 +93,43 @@ def test_record_url_redirects_to_authors(app):
 def test_record_url_returns_404_when_there_is_no_corresponding_record(app):
     with app.test_client() as client:
         assert client.get('/record/0').status_code == 404
+
+
+def test_author_new_form_redirects_without_bai(app):
+    with app.test_client() as client:
+        response = client.get('/author/new')
+
+        assert response.status_code == 301
+        assert response.location == 'http://localhost:5000/authors/new'
+
+
+def test_author_new_form_redirects_with_bai(app):
+    with app.test_client() as client:
+        response = client.get('/author/new?bai=foo')
+
+        assert response.status_code == 301
+        assert response.location == 'http://localhost:5000/authors/new?bai=foo'
+
+
+def test_author_update_form_redirects_to_new_without_recid(app):
+    with app.test_client() as client:
+        response = client.get('/author/update')
+
+        assert response.status_code == 301
+        assert response.location == 'http://localhost:5000/authors/new'
+
+
+def test_author_update_form_redirects_with_recid(app):
+    with app.test_client() as client:
+        response = client.get('/author/update?recid=123')
+
+        assert response.status_code == 301
+        assert response.location == 'http://localhost:5000/authors/123/update'
+
+
+def test_literature_new_form_redirects(app):
+    with app.test_client() as client:
+        response = client.get('/submit/literature/create')
+
+        assert response.status_code == 301
+        assert response.location == 'http://localhost:5000/literature/new'


### PR DESCRIPTION
* Adds redirects to support legacy Labs URLs for author and literature
  forms.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>