### PR TITLE
forms: affiliations autocomplete fix

### DIFF
--- a/inspirehep/modules/forms/static/js/forms/affiliations_typeahead.js
+++ b/inspirehep/modules/forms/static/js/forms/affiliations_typeahead.js
@@ -88,6 +88,9 @@ define([
         },
         suggestion: function(data) {
           function _getICN() {
+            if (!data.metadata.ICN) {
+              return;
+            }
             for (let i=0; i<data.metadata.ICN.length; i++) {
               if (data.metadata.ICN[i] !== data.metadata.legacy_ICN) {
                 return data.metadata.ICN[i];


### PR DESCRIPTION
* Adds sanity check to prevent an error when a document does not have
  an ICN key.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>