### PR TITLE
setup: bump inspire-schemas to version ~30.0

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -1467,7 +1467,7 @@ WORKFLOWS_UI_REST_SORT_OPTIONS = {
         },
         "mostrecent": {
             "title": 'Most recent',
-            "fields": ['metadata.acquisition_source.date'],
+            "fields": ['metadata.acquisition_source.datetime'],
             "default_order": 'desc',
             "order": 2,
         },

--- a/inspirehep/dojson/common/rules.py
+++ b/inspirehep/dojson/common/rules.py
@@ -151,7 +151,7 @@ def acquisition_source(self, key, value):
         method = normalized_c_value
 
     return {
-        'date': value.get('d'),
+        'datetime': value.get('d'),
         'email': value.get('b'),
         'internal_uid': internal_uid,
         'method': method,
@@ -182,7 +182,7 @@ def acquisition_source2marc(self, key, value):
         'a': a_value,
         'b': value.get('email'),
         'c': c_value,
-        'd': value.get('date'),
+        'd': value.get('datetime'),
         'e': value.get('submission_number'),
     }
 

--- a/inspirehep/modules/authors/tasks.py
+++ b/inspirehep/modules/authors/tasks.py
@@ -99,7 +99,7 @@ def formdata_to_model(obj, formdata):
         orcid = ''
     data['acquisition_source'] = dict(
         email=user_email,
-        date=datetime.datetime.utcnow().isoformat(),
+        datetime=datetime.datetime.utcnow().isoformat(),
         method="submitter",
         orcid=orcid,
         submission_number=str(obj.id),

--- a/inspirehep/modules/literaturesuggest/tasks.py
+++ b/inspirehep/modules/literaturesuggest/tasks.py
@@ -204,7 +204,7 @@ def formdata_to_model(obj, formdata):
     orcid = retrieve_orcid(obj.id_user)
 
     builder.add_acquisition_source(
-        date=datetime.datetime.utcnow().isoformat(),
+        datetime=datetime.datetime.utcnow().isoformat(),
         submission_number=obj.id,
         email=email,
         orcid=orcid,

--- a/inspirehep/modules/records/mappings/records/authors.json
+++ b/inspirehep/modules/records/mappings/records/authors.json
@@ -26,7 +26,7 @@
                 },
                 "acquisition_source": {
                     "properties": {
-                        "date": {
+                        "datetime": {
                             "type": "string"
                         },
                         "email": {

--- a/inspirehep/modules/records/mappings/records/hep.json
+++ b/inspirehep/modules/records/mappings/records/hep.json
@@ -154,7 +154,7 @@
                 },
                 "acquisition_source": {
                     "properties": {
-                        "date": {
+                        "datetime": {
                             "type": "string"
                         },
                         "email": {

--- a/inspirehep/modules/workflows/mappings/holdingpen/authors.json
+++ b/inspirehep/modules/workflows/mappings/holdingpen/authors.json
@@ -32,7 +32,7 @@
                     "properties": {
                         "acquisition_source": {
                             "properties": {
-                                "date": {
+                                "datetime": {
                                     "type": "date"
                                 },
                                 "method": {

--- a/inspirehep/modules/workflows/mappings/holdingpen/hep.json
+++ b/inspirehep/modules/workflows/mappings/holdingpen/hep.json
@@ -31,7 +31,7 @@
                     "properties": {
                         "acquisition_source": {
                             "properties": {
-                                "date": {
+                                "datetime": {
                                     "type": "date"
                                 },
                                 "method": {

--- a/inspirehep/modules/workflows/static/js/inspire_workflows_ui/templates/details.html
+++ b/inspirehep/modules/workflows/static/js/inspire_workflows_ui/templates/details.html
@@ -367,11 +367,11 @@
           <p class="text-center" ng-if="vm.record.metadata.acquisition_source">
             <span ng-switch="vm.record.metadata.acquisition_source.method">
               <span ng-switch-when="submitter">
-                Submitted by <i>{{vm.record.metadata.acquisition_source.email}}</i><br/> on <i>{{vm.record.metadata.acquisition_source.date | date : "dd/MM/yy HH:mm:ss"}}</i>
+                Submitted by <i>{{vm.record.metadata.acquisition_source.email}}</i><br/> on <i>{{vm.record.metadata.acquisition_source.datetime | date : "dd/MM/yy HH:mm:ss"}}</i>
               </span>
               <span ng-switch-default>
                 Harvested on <span class="font-bolder"
-                                   ng-bind="vm.record.metadata.acquisition_source.date"></span> from
+                                   ng-bind="vm.record.metadata.acquisition_source.datetime"></span> from
                 <span class="font-bolder"
                       ng-bind="vm.record.metadata.acquisition_source.source"></span> using
                 <span class="font-bolder"

--- a/inspirehep/modules/workflows/static/js/inspire_workflows_ui/templates/results.html
+++ b/inspirehep/modules/workflows/static/js/inspire_workflows_ui/templates/results.html
@@ -62,7 +62,7 @@
         <div class="col-md-2 pad-top-10">
           <p class="workflow-type"
              ng-class="record._source._workflow.workflow_class">
-             {{record._source.metadata.acquisition_source.date| date : "dd/MM/yy HH:mm:ss"}}
+             {{record._source.metadata.acquisition_source.datetime| date : "dd/MM/yy HH:mm:ss"}}
           </p>
           <p class="workflow-type"
              ng-class="record._source._workflow.workflow_class"

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ install_requires = [
     'invenio-utils==0.2.0',  # Not fully Invenio 3 ready
     'invenio>=3.0.0a1,<3.1.0',
     'inspire-crawler~=0.2.7',
-    'inspire-schemas~=29.0',
+    'inspire-schemas~=30.0',
     'dojson>=1.3.0',
     'Flask>=0.11.1',
     'Flask-Breadcrumbs>=0.3.0',

--- a/tests/integration/fixtures/conference_article_expected.json
+++ b/tests/integration/fixtures/conference_article_expected.json
@@ -13,7 +13,7 @@
       }
    ],
    "acquisition_source":{
-      "date":"1993-02-02T06:00:00",
+      "datetime":"1993-02-02T06:00:00",
       "source":"submitter",
       "method":"submitter",
       "submission_number":"1",

--- a/tests/integration/fixtures/journal_article_expected.json
+++ b/tests/integration/fixtures/journal_article_expected.json
@@ -308,7 +308,7 @@
       }
    ],
    "acquisition_source":{
-      "date":"1993-02-02T06:00:00",
+      "datetime":"1993-02-02T06:00:00",
       "source":"submitter",
       "method":"submitter",
       "submission_number":"1",

--- a/tests/integration/fixtures/thesis_expected.json
+++ b/tests/integration/fixtures/thesis_expected.json
@@ -48,7 +48,7 @@
       }
    ],
    "acquisition_source":{
-      "date":"1993-02-02T06:00:00",
+      "datetime":"1993-02-02T06:00:00",
       "source":"submitter",
       "method":"submitter",
       "submission_number":"1",


### PR DESCRIPTION
Closes #2046 

Bumps `inspire-schemas` to version ~30.0 because they allow for the
`signature_block` field in `authors`, which is populated by Beard.

Also updates `acquisition_source` to use `datetime` instead of `date`.