### PR TITLE
authors: formdata_to_model ORCID retrieval fix

### DIFF
--- a/inspirehep/modules/authors/tasks.py
+++ b/inspirehep/modules/authors/tasks.py
@@ -94,7 +94,7 @@ def formdata_to_model(obj, formdata):
         orcid = UserIdentity.query.filter_by(
             id_user=obj.id_user,
             method='orcid'
-        ).one()
+        ).one().id
     except NoResultFound:
         orcid = ''
     data['acquisition_source'] = dict(


### PR DESCRIPTION
* Gets id from UserIdentity table instead of assigning directly the model.
  Prevents a jsonschema validation error.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>