### PR TITLE
mappings: add signature_block to hep

### DIFF
--- a/inspirehep/modules/records/mappings/records/hep.json
+++ b/inspirehep/modules/records/mappings/records/hep.json
@@ -262,6 +262,9 @@
                             },
                             "type": "object"
                         },
+                        "signature_block": {
+                            "type": "string"
+                        },
                         "uuid": {
                             "type": "string"
                         }


### PR DESCRIPTION
Commit 1b62182 added `signature_block` to the `authors` key, but
forgot to amend the mapping correspondingly.