### PR TITLE
docker: use different names for test containers

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -23,128 +23,122 @@
 version: '2'
 
 services:
-  service_base:
+  test-service_base:
     # Overrides default inspirehep config.
     extends:
       file: services.yml
       service: base
     environment:
-      - APP_SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://inspirehep:dbpass123@database:5432/inspirehep
-      - APP_BROKER_URL=amqp://guest:guest@rabbitmq:5672//
-      - APP_CELERY_RESULT_BACKEND=amqp://guest:guest@rabbitmq:5672//
-      - APP_CACHE_REDIS_URL=redis://redis:6379/0
-      - APP_ACCOUNTS_SESSION_REDIS_URL=redis://redis:6379/2
-      - APP_SEARCH_ELASTIC_HOSTS=indexer
+      - APP_SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://inspirehep:dbpass123@test-database:5432/inspirehep
+      - APP_BROKER_URL=amqp://guest:guest@test-rabbitmq:5672//
+      - APP_CELERY_RESULT_BACKEND=amqp://guest:guest@test-rabbitmq:5672//
+      - APP_CACHE_REDIS_URL=redis://test-redis:6379/0
+      - APP_ACCOUNTS_SESSION_REDIS_URL=redis://test-redis:6379/2
+      - APP_SEARCH_ELASTIC_HOSTS=test-indexer
   unit:
     extends:
-      service: service_base
+      service: test-service_base
     volumes_from:
-      - static
+      - test-static
     command: py.test inspirehep tests/unit
   disambiguation:
     extends:
-      service: service_base
+      service: test-service_base
     command: py.test tests/integration/disambiguation
     volumes_from:
-      - static
+      - test-static
     links:
-      - database
-      - indexer
-      - rabbitmq
-      - redis
+      - test-database
+      - test-indexer
+      - test-rabbitmq
+      - test-redis
     depends_on:
-      - worker
+      - test-worker
   workflows:
     extends:
-      service: service_base
+      service: test-service_base
     command: py.test tests/integration/workflows
     volumes_from:
-      - static
+      - test-static
     links:
-      - database
-      - indexer
-      - rabbitmq
-      - redis
+      - test-database
+      - test-indexer
+      - test-rabbitmq
+      - test-redis
     depends_on:
-      - worker
-  integration:
+      - test-worker
+  test-integration:
     extends:
-      service: service_base
+      service: test-service_base
     command: py.test tests/integration --ignore tests/integration/disambiguation --ignore tests/integration/workflows
     volumes_from:
-      - static
+      - test-static
     links:
-      - database
-      - indexer
-      - rabbitmq
-      - redis
+      - test-database
+      - test-indexer
+      - test-rabbitmq
+      - test-redis
     depends_on:
-      - worker
+      - test-worker
   acceptance:
     extends:
-      service: service_base
+      service: test-service_base
     command: py.test --driver Firefox --host selenium --port 4444 --capability browserName firefox --html=selenium-report.html tests/acceptance
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix
     volumes_from:
-      - static
+      - test-static
     links:
-      - database
-      - indexer
-      - rabbitmq
-      - redis
+      - test-database
+      - test-indexer
+      - test-rabbitmq
+      - test-redis
       - selenium
     depends_on:
-      - web
-      - worker
+      - test-web
+      - test-worker
     environment:
-      - SERVER_NAME=web:5000
+      - SERVER_NAME=test-web:5000
       - DISPLAY=$DISPLAY
-  web:
+  test-web:
     extends:
-      service: service_base
+      service: test-service_base
     command: gunicorn -b 0.0.0.0:5000 -t 3600 -w 1 --access-logfile "-" inspirehep.wsgi_with_coverage:application
     volumes_from:
-      - static
+      - test-static
     links:
-      - database
-      - indexer
-      - rabbitmq
-      - redis
+      - test-database
+      - test-indexer
+      - test-rabbitmq
+      - test-redis
     environment:
-      - APP_SERVER_NAME=web:5000
-  worker:
-    container_name: inspirehep-test-worker
+      - APP_SERVER_NAME=test-web:5000
+  test-worker:
     extends:
-      service: service_base
+      service: test-service_base
     command: celery worker -E -A inspirehep.celery --loglevel=INFO --purge
     volumes_from:
-      - static
+      - test-static
     links:
-      - database
-      - indexer
-      - rabbitmq
-      - redis
-  redis:
-    container_name: inspirehep-test-redis
+      - test-database
+      - test-indexer
+      - test-rabbitmq
+      - test-redis
+  test-redis:
     image: redis
-  indexer:
-    container_name: inspirehep-test-indexer
+  test-indexer:
     extends:
       file: services.yml
       service: indexer
-  rabbitmq:
-    container_name: inspirehep-test-rabbitmq
+  test-rabbitmq:
     image: rabbitmq
-  database:
-    container_name: inspirehep-test-database
+  test-database:
     extends:
       file: services.yml
       service: database
   selenium:
     image: selenium/standalone-firefox:2.53.1-beryllium
-  static:
-    container_name: inspirehep-test-static
+  test-static:
     extends:
       file: services.yml
       service: static


### PR DESCRIPTION
* This avoids the name collisions with the web node container (and
  index/database...).

Signed-off-by: David Caro <david@dcaro.es>