### PR TITLE
workflows: comment the experiment guesser

### DIFF
--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -193,10 +193,12 @@ ENHANCE_RECORD = [
     ),
     filter_core_keywords,
     guess_categories,
-    IF(
-        is_experimental_paper,
-        [guess_experiments]
-    ),
+    # TODO: adapt the output of guess_experiment so that it
+    # can be stored in ElasticSearch (see issue #2054).
+    # IF(
+    #     is_experimental_paper,
+    #     [guess_experiments]
+    # ),
     guess_keywords,
     # Predict action for a generic HEP paper based only on title
     # and abstract.

--- a/tests/integration/workflows/test_arxiv_workflow.py
+++ b/tests/integration/workflows/test_arxiv_workflow.py
@@ -334,11 +334,10 @@ def get_halted_workflow(app, record, extra_config=None):
     assert prediction['decision'] == 'Rejected'
     assert prediction['scores']['Rejected'] == 0.8358207729691823
 
+    # TODO: add the experiments predictions to the workflow
+    # object (see issue #2054).
     experiments_prediction = obj.extra_data.get("experiments_prediction")
-    assert experiments_prediction
-    assert experiments_prediction['experiments'] == [
-        ['CMS', 0.7549515247344971]
-    ]
+    assert experiments_prediction is None
 
     keywords_prediction = obj.extra_data.get("keywords_prediction")
     assert keywords_prediction


### PR DESCRIPTION
Closes #2055 

The output of `guess_experiment` cannot currently be stored
inside of ElasticSearch because a field cannot contain both
strings and doubles.