### PR TITLE
workflows: improve earliest_date parsing and enable on devel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ install_requires = [
     'invenio-utils==0.2.0',  # Not fully Invenio 3 ready
     'invenio>=3.0.0a1,<3.1.0',
     'inspire-crawler~=0.2.7',
-    'inspire-schemas~=30.0',
+    'inspire-schemas~=30.0,>=30.2.3',
     'dojson>=1.3.0',
     'Flask>=0.11.1',
     'Flask-Breadcrumbs>=0.3.0',
@@ -135,7 +135,7 @@ extras_require = {
         #'invenio-migrator>=1.0.0a6',
     ],
     'crawler': [
-        'hepcrawl>=0.2.42',
+        'hepcrawl>=0.3.4',
     ],
     'tests': tests_require,
     'development': [

--- a/tests/integration/fixtures/journal_article_expected.json
+++ b/tests/integration/fixtures/journal_article_expected.json
@@ -316,6 +316,6 @@
       "orcid":"0000-0001-9412-8627",
       "email":"test_orcid_user@inspirehep.net"
    },
-   "preprint_date": "2010-01-25T00:00:00",
+   "preprint_date": "2010-01-25",
     "languages": ["en"]
 }

--- a/tests/integration/workflows/test_arxiv_workflow.py
+++ b/tests/integration/workflows/test_arxiv_workflow.py
@@ -24,11 +24,11 @@
 
 from __future__ import absolute_import, division, print_function
 
+import datetime
 import json
 import os
 import pkg_resources
 import re
-import logging
 
 import requests_mock
 import mock
@@ -107,6 +107,9 @@ def record():
     record_marc = create_record(record_oai_arxiv_plots_marcxml)
     json_data = hep.do(record_marc)
 
+    if 'preprint_date' in json_data:
+        json_data['preprint_date'] = datetime.date.today().isoformat()
+
     return json_data
 
 
@@ -129,7 +132,6 @@ def to_accept_record():
     json_data = hep.do(record_marc)
 
     return json_data
-
 
 
 def _do_resolve_workflow(app, workflow_id, action='accept_core'):
@@ -414,7 +416,6 @@ def test_harvesting_arxiv_workflow_rejected(
         obj = workflow_object_class.get(obj_id)
         # It was rejected
         assert obj.status == ObjectStatus.COMPLETED
-
 
 
 @mock.patch(


### PR DESCRIPTION
* Enabled checking even in non-production code.
* Parsing the standard format that we put on preprint_date.

Signed-off-by: David Caro <david@dcaro.es>