### PR TITLE
dojson: ensure required value in keywords

### DIFF
--- a/inspirehep/dojson/hep/rules/bd6xx.py
+++ b/inspirehep/dojson/hep/rules/bd6xx.py
@@ -127,7 +127,9 @@ def keywords(self, key, value):
         self['energy_ranges'].append(int(value.get('e')))
         self['energy_ranges'].sort()
 
-    return _get_keyword_dict(key, value)
+    result = _get_keyword_dict(key, value)
+    if 'value' in result and result['value']:
+        return result
 
 
 @hep2marc.over('695', '^keywords$')

--- a/tests/unit/dojson/test_dojson_hep_bd6xx.py
+++ b/tests/unit/dojson/test_dojson_hep_bd6xx.py
@@ -29,6 +29,16 @@ from inspirehep.dojson.hep import hep, hep2marc
 from inspirehep.dojson.utils import validate
 
 
+def test_keywords_from_653__9_ignores_lone_sources():
+    snippet = (
+        '<datafield tag="653" ind1="1" ind2=" ">'
+        '  <subfield code="9">author</subfield>'
+        '</datafield>'
+    )  # record/1382933
+
+    assert 'keywords' not in hep.do(create_record(snippet))
+
+
 def test_accelerator_experiments_from_693__a_e():
     schema = load_schema('hep')
     subschema = schema['properties']['accelerator_experiments']


### PR DESCRIPTION
Sentry: https://sentry.cern.ch/inspire-sentry/inspire-nightly/group/619228/