### PR TITLE
workflows: make arxiv_plot_extract handle unicode

### DIFF
--- a/inspirehep/modules/workflows/tasks/arxiv.py
+++ b/inspirehep/modules/workflows/tasks/arxiv.py
@@ -106,7 +106,7 @@ def arxiv_plot_extract(obj, eng):
     for idx, plot in enumerate(plots):
         obj.files[plot.get('name')] = BytesIO(open(plot.get('url')))
         obj.files[plot.get('name')]["doctype"] = "Plot"
-        obj.files[plot.get('name')]["description"] = "{0:05d} {1}".format(
+        obj.files[plot.get('name')]["description"] = u"{0:05d} {1}".format(
             idx, "".join(plot.get('captions', []))
         )
     obj.log.info("Added {0} plots.".format(len(plots)))


### PR DESCRIPTION
Sentry: https://sentry.cern.ch/inspire-sentry/inspire-labs/group/820651/

Sadly without tests, because this task uses the `files` property of a `WorkflowObject`, which is very painful to mock.