### PR TITLE
literaturesuggest: remove dismiss btn from suggest_success

### DIFF
--- a/inspirehep/modules/authors/templates/authors/forms/new_review_accepted.html
+++ b/inspirehep/modules/authors/templates/authors/forms/new_review_accepted.html
@@ -21,7 +21,6 @@
 {% block body %}
 
 <div class="alert alert-success alert-form-success">
-  <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
   <strong>The author update has been{% if approved %} approved {% else %} rejected {% endif %}<br></strong><br><a href="{{url_for('invenio_workflows_ui.details', objectid=request.args.get('objectid'))}}">Go back to the Holding Pen record.</a>
 </div>
 {% endblock body %}

--- a/inspirehep/modules/authors/templates/authors/forms/new_success.html
+++ b/inspirehep/modules/authors/templates/authors/forms/new_success.html
@@ -20,7 +20,6 @@
 
 {% block body %}
 <div class="alert alert-success alert-form-success">
-  <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
   <strong>Thank you for adding new profile information!<br></strong><br>The INSPIRE staff will review it and keep you informed.<br>
   {% if inspire_url %}
     <br><a href="{{inspire_url}}">Go back to INSPIRE</a>

--- a/inspirehep/modules/authors/templates/authors/forms/update_success.html
+++ b/inspirehep/modules/authors/templates/authors/forms/update_success.html
@@ -20,7 +20,6 @@
 
 {% block body %}
 <div class="alert alert-success alert-form-success">
-  <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
   <strong>Thank you for your update!<br></strong><br>The INSPIRE staff will review it and your changes will be added to INSPIRE.<br>
   {% if inspire_url %}
     <br><a href="{{inspire_url}}">Go back to INSPIRE</a>

--- a/inspirehep/modules/literaturesuggest/templates/literaturesuggest/forms/suggest_success.html
+++ b/inspirehep/modules/literaturesuggest/templates/literaturesuggest/forms/suggest_success.html
@@ -20,7 +20,6 @@
 
 {% block body %}
 <div class="alert alert-success alert-form-success">
-  <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
   <strong>Thank you for your suggestion!<br></strong><br>The INSPIRE staff will review it and your changes will be added to INSPIRE.
 </div>
 {% endblock body %}


### PR DESCRIPTION
Removes dismiss button from suggest_success form which resulted in an empty page. 

This is the bootstrap alert with the dismiss button:
![submit-hep-green-notification](https://cloud.githubusercontent.com/assets/2846837/24252232/211ed0f6-0fdd-11e7-8991-613593d321fc.png)

which if clicked, resulted to this:
![empty-screen](https://cloud.githubusercontent.com/assets/2846837/24252251/33cd6c30-0fdd-11e7-9692-99b27cfc222b.png)

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>
