### PR TITLE
docker: adapt to non-root user

### DIFF
--- a/docker-compose.deps.yml
+++ b/docker-compose.deps.yml
@@ -20,7 +20,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-version: '2'
+version: '2.1'
 
 services:
   pip:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -20,7 +20,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-version: '2'
+version: '2.1'
 
 services:
   test-service_base:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-version: '2'
+version: '2.1'
 
 services:
   service_base:

--- a/services.yml
+++ b/services.yml
@@ -20,14 +20,14 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-version: '2'
+version: '2.1'
 
 services:
   base:
     image: inspirehep/python-base
     environment:
-      - BASE_USER_UID=${BASE_USER_UID}
-      - BASE_USER_GIT=${BASE_USER_GIT}
+      - BASE_USER_UID=${BASE_USER_UID:-1000}
+      - BASE_USER_GIT=${BASE_USER_GIT:-1000}
   indexer:
     image: inspirehep/elasticsearch
     command: elasticsearch -Dcluster.name="inspire" -Ddiscovery.zen.ping.multicast.enabled=false

--- a/services.yml
+++ b/services.yml
@@ -25,6 +25,9 @@ version: '2'
 services:
   base:
     image: inspirehep/python-base
+    environment:
+      - BASE_USER_UID=${BASE_USER_UID}
+      - BASE_USER_GIT=${BASE_USER_GIT}
   indexer:
     image: inspirehep/elasticsearch
     command: elasticsearch -Dcluster.name="inspire" -Ddiscovery.zen.ping.multicast.enabled=false

--- a/services.yml
+++ b/services.yml
@@ -25,6 +25,7 @@ version: '2.1'
 services:
   base:
     image: inspirehep/python-base
+    tty: true
     environment:
       - BASE_USER_UID=${BASE_USER_UID:-1000}
       - BASE_USER_GIT=${BASE_USER_GIT:-1000}


### PR DESCRIPTION
* The venv dir must be created before mounting to avoid the docker
  daemon from creating it, as it does as root no matter what.

Signed-off-by: David Caro <david@dcaro.es>