### PR TITLE
global: bump celery to version 4

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -22,7 +22,7 @@
 
 web: gunicorn inspirehep.wsgi -c gunicorn.cfg
 cache: redis-server
-worker: celery worker -E -A inspirehep.celery --loglevel=INFO --workdir="${VIRTUAL_ENV}" --autoreload --pidfile="${VIRTUAL_ENV}/worker.pid" --purge
+worker: celery worker -E -A inspirehep.celery --loglevel=INFO --workdir="${VIRTUAL_ENV}" --pidfile="${VIRTUAL_ENV}/worker.pid" --purge
 workermon: celery flower -A inspirehep.celery
 # mathoid: node_modules/mathoid/server.js -c mathoid.config.yaml
 indexer: elasticsearch -Dcluster.name="inspire" -Ddiscovery.zen.ping.multicast.enabled=false -Dpath.data="$VIRTUAL_ENV/var/data/elasticsearch"  -Dpath.logs="$VIRTUAL_ENV/var/log/elasticsearch"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -30,8 +30,8 @@ services:
       service: base
     environment:
       - APP_SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://inspirehep:dbpass123@test-database:5432/inspirehep
-      - APP_BROKER_URL=amqp://guest:guest@test-rabbitmq:5672//
-      - APP_CELERY_RESULT_BACKEND=amqp://guest:guest@test-rabbitmq:5672//
+      - APP_CELERY_BROKER_URL=pyamqp://guest:guest@test-rabbitmq:5672//
+      - APP_CELERY_RESULT_BACKEND=rpc://guest:guest@test-rabbitmq:5672//
       - APP_CACHE_REDIS_URL=redis://test-redis:6379/0
       - APP_ACCOUNTS_SESSION_REDIS_URL=redis://test-redis:6379/2
       - APP_SEARCH_ELASTIC_HOSTS=test-indexer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,8 @@ services:
       service: base
     environment:
       - APP_SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://inspirehep:dbpass123@database:5432/inspirehep
-      - APP_BROKER_URL=amqp://guest:guest@rabbitmq:5672//
-      - APP_CELERY_RESULT_BACKEND=amqp://guest:guest@rabbitmq:5672//
+      - APP_CELERY_BROKER_URL=pyamqp://guest:guest@rabbitmq:5672//
+      - APP_CELERY_RESULT_BACKEND=rpc://guest:guest@rabbitmq:5672//
       - APP_CACHE_REDIS_URL=redis://redis:6379/0
       - APP_ACCOUNTS_SESSION_REDIS_URL=redis://redis:6379/2
       - APP_SEARCH_ELASTIC_HOSTS=indexer

--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -69,11 +69,11 @@ SQLALCHEMY_TRACK_MODIFICATIONS = True
 
 # Celery
 # ======
-BROKER_URL = "amqp://guest:guest@localhost:5672//"
-CELERY_RESULT_BACKEND = "amqp://guest:guest@localhost:5672//"
+CELERY_BROKER_URL = "pyamqp://guest:guest@localhost:5672//"
+CELERY_RESULT_BACKEND = "rpc://guest:guest@localhost:5672//"
 CELERY_ACCEPT_CONTENT = ['json', 'msgpack', 'yaml']
 CELERY_TIMEZONE = 'Europe/Amsterdam'
-CELERY_DISABLE_RATE_LIMITS = True
+CELERY_WORKER_DISABLE_RATE_LIMITS = True
 
 # Cache
 # =====

--- a/scripts/recreate_records
+++ b/scripts/recreate_records
@@ -53,7 +53,7 @@ if [ $(pwd) != "/code" ]; then
 		echo "----> Purging all pending messages"
 		celery purge -f -A inspirehep.celery --workdir="${VIRTUAL_ENV}"
 	else
-		celery worker -E -A inspirehep.celery --loglevel=${CELERY_LOGLEVEL} --workdir="${VIRTUAL_ENV}" --autoreload --pidfile="${CELERY_PIDFILE}" --purge &
+		celery worker -E -A inspirehep.celery --loglevel=${CELERY_LOGLEVEL} --workdir="${VIRTUAL_ENV}" --pidfile="${CELERY_PIDFILE}" --purge &
 		CELERY_PID=$!
 		trap 'cleanup' 0 1 2 3 6
 	fi

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,7 @@ from setuptools import find_packages, setup
 readme = open('README.rst').read()
 
 install_requires = [
-    'amqp>=1.4.9,<2.0',
-    'celery<4.0',
+    'celery>=4.0,<5.0',
     'Flask-Gravatar>=0.4.2',
     'HarvestingKit>=0.6.2',
     'plotextractor>=0.1.2',
@@ -45,7 +44,6 @@ install_requires = [
     'flower',
     'rt',
     'langdetect>=1.0.6',
-    'librabbitmq>=1.6.1',
     'idutils>=0.2.1',
     'invenio-access>=1.0.0a7',
     'invenio-accounts>=1.0.0a12',


### PR DESCRIPTION
Closes https://github.com/inspirehep/inspire-next/issues/2037.

@david-caro, I'm not going to merge this because this requires some testing on QA to ensure that this change is correct. In particular, `librabbitmq==1.6.1` needs to be uninstalled from the machines, because it's incompatible with `celery==4.0.2` (https://github.com/celery/celery/issues/3675, https://github.com/celery/librabbitmq/issues/93), and I'm fairly dissatisfied that this means that we're forced to use `pyamqp`, which ([as you wrote!](https://github.com/celery/librabbitmq/issues/84#issuecomment-237465841)) seems to be always slower than `librabbitmq`.