### PR TITLE
workflows: rename to relevance_prediction

### DIFF
--- a/inspirehep/modules/workflows/actions/hep_approval.py
+++ b/inspirehep/modules/workflows/actions/hep_approval.py
@@ -40,10 +40,10 @@ class HEPApproval(object):
         upload_pdf = kwargs.get("request_data", {}).get("pdf_upload", False)
 
         # Audit logging
-        prediction_results = obj.extra_data.get("relevance_prediction", {})
+        relevance_prediction = obj.extra_data.get("relevance_prediction", {})
         log_workflows_action(
             action="resolve",
-            prediction_results=prediction_results,
+            relevance_prediction=relevance_prediction,
             object_id=obj.id,
             user_id=kwargs.get('id_user'),
             source="holdingpen",

--- a/inspirehep/modules/workflows/tasks/actions.py
+++ b/inspirehep/modules/workflows/tasks/actions.py
@@ -97,12 +97,12 @@ def reject_record(message):
     """Reject record with message."""
     @wraps(reject_record)
     def _reject_record(obj, *args, **kwargs):
-        prediction_results = obj.extra_data.get("relevance_prediction")
+        relevance_prediction = obj.extra_data.get("relevance_prediction")
         log_workflows_action(
             action="reject_record",
-            prediction_results=prediction_results,
+            relevance_prediction=relevance_prediction,
             object_id=obj.id,
-            user_id=0,
+            user_id=None,
             source="workflow",
         )
 
@@ -118,12 +118,12 @@ def is_record_relevant(obj, eng):
     if is_submission(obj, eng):
         return True
 
-    prediction_results = obj.extra_data.get("prediction_results")
+    relevance_prediction = obj.extra_data.get("relevance_prediction")
     classification_results = obj.extra_data.get('classifier_results')
 
-    if prediction_results and classification_results:
-        score = prediction_results.get("max_score")
-        decision = prediction_results.get("decision")
+    if relevance_prediction and classification_results:
+        score = relevance_prediction.get("max_score")
+        decision = relevance_prediction.get("decision")
         classification_results = classification_results.get("complete_output")
         core_keywords = classification_results.get("Core keywords")
         if decision.lower() == "rejected" and score > 0 and \

--- a/inspirehep/modules/workflows/utils.py
+++ b/inspirehep/modules/workflows/utils.py
@@ -57,13 +57,13 @@ def json_api_request(url, data, headers=None):
         return response.json()
 
 
-def log_workflows_action(action, prediction_results,
+def log_workflows_action(action, relevance_prediction,
                          object_id, user_id,
                          source, user_action=""):
     """Log the action taken by user compared to a prediction."""
-    if prediction_results:
-        score = prediction_results.get("max_score")  # returns 0.222113
-        decision = prediction_results.get("decision")  # returns "Rejected"
+    if relevance_prediction:
+        score = relevance_prediction.get("max_score")  # returns 0.222113
+        decision = relevance_prediction.get("decision")  # returns "Rejected"
 
         # Map actions to align with the prediction format
         action_map = {

--- a/tests/integration/workflows/test_arxiv_workflow.py
+++ b/tests/integration/workflows/test_arxiv_workflow.py
@@ -255,9 +255,9 @@ def fake_beard_api_block_request(*args, **kwargs):
 def fake_beard_api_request(url, data):
     """Mock json_api_request func."""
     return {
-        'decision': u'Rejected',
+        'decision': u'Non-CORE',
         'scores': [
-            -0.20895982018928272, -1.6722188892559084, 0.8358207729691823
+            -0.20895982018928272, 0.8358207729691823, -1.6722188892559084
         ]
     }
 
@@ -333,8 +333,8 @@ def get_halted_workflow(app, record, extra_config=None):
     # A prediction should have been made
     prediction = obj.extra_data.get("relevance_prediction")
     assert prediction
-    assert prediction['decision'] == 'Rejected'
-    assert prediction['scores']['Rejected'] == 0.8358207729691823
+    assert prediction['decision'] == 'Non-CORE'
+    assert prediction['scores']['Non-CORE'] == 0.8358207729691823
 
     # TODO: add the experiments predictions to the workflow
     # object (see issue #2054).
@@ -375,7 +375,7 @@ def get_halted_workflow(app, record, extra_config=None):
     'inspirehep.modules.refextract.tasks.extract_references_from_file',
     side_effect=fake_refextract_extract_references_from_file,
 )
-def test_harvesting_arxiv_workflow_rejected(
+def test_harvesting_arxiv_workflow_manual_rejected(
     mocked_refextract_extract_refs,
     mocked_api_request_beard_block,
     mocked_api_request_magpie,
@@ -442,7 +442,7 @@ def test_harvesting_arxiv_workflow_rejected(
     'inspirehep.modules.refextract.tasks.extract_references_from_file',
     side_effect=fake_refextract_extract_references_from_file,
 )
-def test_harvesting_arxiv_workflow_accepted(
+def test_harvesting_arxiv_workflow_manual_accepted(
     mocked_refextract_extract_refs,
     mocked_matching_search,
     mocked_api_request_beard_block,

--- a/tests/integration/workflows/test_audit.py
+++ b/tests/integration/workflows/test_audit.py
@@ -70,13 +70,13 @@ def test_audit(small_app):
         assert audit_entry.action == "accept"
         assert audit_entry.score == 0.222113
 
-    prediction_results = dict(
+    relevance_prediction = dict(
         max_score=0.222113, decision="Rejected"
     )
     with small_app.app_context():
         log_workflows_action(
             action="accept_core",
-            prediction_results=prediction_results,
+            relevance_prediction=relevance_prediction,
             object_id=workflow_id,
             user_id=None,
             source="test",

--- a/tests/unit/workflows/test_workflows_tasks_actions.py
+++ b/tests/unit/workflows/test_workflows_tasks_actions.py
@@ -298,12 +298,12 @@ def test_reject_record(l_w_a):
     assert obj.log._log.getvalue() == 'foo'
     l_w_a.assert_called_once_with(
         action='reject_record',
-        prediction_results={
+        relevance_prediction={
             'decision': 'Rejected',
             'max_score': '0.222113',
         },
         object_id=1,
-        user_id=0,
+        user_id=None,
         source='workflow',
     )
 
@@ -315,7 +315,7 @@ def test_is_record_relevant():
                 'Core keywords': [],
             },
         },
-        'prediction_results': {
+        'relevance_prediction': {
             'max_score': '0.222113',
             'decision': 'Rejected',
         },
@@ -332,7 +332,7 @@ def test_is_record_relevant_returns_true_if_it_is_a_submission():
     assert is_record_relevant(obj, eng)
 
 
-def test_is_record_relevant_returns_true_if_no_prediction_results():
+def test_is_record_relevant_returns_true_if_no_relevance_prediction():
     obj = StubObj({}, {
         'classifier_results': {
             'complete_output': {
@@ -347,7 +347,7 @@ def test_is_record_relevant_returns_true_if_no_prediction_results():
 
 def test_is_record_relevant_returns_true_if_no_classifier_results():
     obj = StubObj({}, {
-        'prediction_results': {
+        'relevance_prediction': {
             'max_score': '0.222113',
             'decision': 'Rejected',
         },


### PR DESCRIPTION
* Fixes a borked refactoring where not all variables had
  been correctly renamed to relevance_prediction.
  (closes #2115)

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>
Co-authored-by: David Caro <david@dcaro.es>