### PR TITLE
records: add custom validators

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -31,6 +31,8 @@ from invenio_oauthclient.contrib import orcid
 from invenio_records_rest.facets import range_filter, terms_filter
 
 from inspirehep.modules.records.utils import get_detailed_template_from_record
+from .modules.records.validators.validator import InspireValidator
+from .modules.records.validators.validator import InspireResolver
 
 
 def _(x):
@@ -163,6 +165,10 @@ when creating records.
 
 RECORD_EDITOR_INDEX_TEMPLATE = 'inspirehep_theme/invenio_record_editor/index.html'
 RECORD_EDITOR_PREVIEW_TEMPLATE_FUNCTION = get_detailed_template_from_record
+RECORD_EDITOR_VALIDATORS = [
+    InspireValidator
+]
+RECORD_EDITOR_SCHEMA_RESOLVER = InspireResolver
 
 INSPIRE_COLLECTIONS_DEFINITION = [
     {

--- a/inspirehep/modules/migrator/tasks/records.py
+++ b/inspirehep/modules/migrator/tasks/records.py
@@ -293,6 +293,7 @@ def record_upsert(json):
         except PIDDoesNotExistError:
             record = InspireRecord.create(json, id_=None)
             # Create persistent identifier.
+           # import pytest;pytest.set_trace()
             inspire_recid_minter(str(record.id), json)
 
         if json.get('deleted'):

--- a/inspirehep/modules/records/api.py
+++ b/inspirehep/modules/records/api.py
@@ -71,6 +71,10 @@ class InspireRecord(Record):
     def _delete(self, *args, **kwargs):
         super(InspireRecord, self).delete(*args, **kwargs)
 
+    def commit(self, validators=None):
+        """Override commit() to pass custom validators"""
+        super(InspireRecord, self).commit(validators)
+
 
 class ESRecord(InspireRecord):
 

--- a/inspirehep/modules/records/validators/__init__.py
+++ b/inspirehep/modules/records/validators/__init__.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.ext
+# Copyright (C) 2017 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, print_function
+
+

--- a/inspirehep/modules/records/validators/helpers.py
+++ b/inspirehep/modules/records/validators/helpers.py
@@ -1,0 +1,77 @@
+#
+# This file is part of Invenio.
+# Copyright (C) 2017 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Helpers for validators module."""
+
+from invenio_db import db
+from jsonschema import ValidationError
+from collections import deque
+
+FIELD_REQUIRE_FIELD_VALUES_TEMPLATE = "'{field}' field requires '{required}' field to have " \
+                                      "at least one of the values {values}."
+FIELD_DUPLICATE_VALUES_FOUND_TEMPLATE = "'{field}' field with value '{value}' found in more than one record."
+GET_RESULTS_FOR_FIELD_PROPERTY_QUERYSTRING_TEMPLATE = "SELECT id FROM records_metadata as r, " \
+                                                      "json_array_elements(r.json -> '{field}') " \
+                                                      "as elem WHERE elem ->> '{prop}'='{value}'"
+FIELD_VALIDATION_TEMPLATE = "Field '{field}' with value '{value}' is not valid."
+
+
+def check_field_values_not_in_required_values_for_record(record, field, required_values):
+    document_type_values = record.get(field, [])
+    common_list = [x for x in document_type_values if x in required_values]
+    return not common_list
+
+
+def check_if_field_exists_in_dict_list_x_times(field, dict_list, limit=1):
+    return len([1 for item in dict_list if field in item]) == limit
+
+
+def execute_query(querystring):
+    return db.session.execute(querystring)
+
+
+def get_query_results_if_exceed_limit(querystring, limit):
+    res = execute_query(querystring)
+    if res.rowcount > limit:
+        return res
+    return []
+
+
+def check_if_listfield_property_values_are_valid(record, field, prop, checker, errortype='Error'):
+    for i, item in enumerate(record.get(field, [])):
+        if prop in item:
+            for e in checker(field=field, prop=prop, value=item[prop], index=i, errortype=errortype):
+                yield e
+
+
+def query_db_for_duplicates_for_field_listitem_with_index(field, prop, value, index, errortype):
+    querystring = GET_RESULTS_FOR_FIELD_PROPERTY_QUERYSTRING_TEMPLATE.format(field=field, prop=prop, value=value)
+    results = get_query_results_if_exceed_limit(querystring, 1)
+    if results:
+        yield ValidationError(path=deque(['{field}/{index}/value'.format(field=field, index=index)]),
+                              message=FIELD_DUPLICATE_VALUES_FOUND_TEMPLATE.format(
+                                  field=field,
+                                  value=value
+                              ),
+                              cause=errortype)
+

--- a/inspirehep/modules/records/validators/rules.py
+++ b/inspirehep/modules/records/validators/rules.py
@@ -1,0 +1,136 @@
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014, 2015, 2016 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+'''Validator classes for Invenio Record Editor.'''
+
+from __future__ import absolute_import, division, print_function
+from .helpers import (
+    check_if_field_exists_in_dict_list_x_times,
+    check_field_values_not_in_required_values_for_record,
+    FIELD_REQUIRE_FIELD_VALUES_TEMPLATE,
+    check_if_listfield_property_values_are_valid,
+    query_db_for_duplicates_for_field_listitem_with_index,
+    FIELD_VALIDATION_TEMPLATE
+)
+from jsonschema import ValidationError
+from idutils import is_isbn
+import pycountry
+from collections import deque
+
+
+'''
+Error Validator Functions
+'''
+
+
+def check_for_author_or_corporate_author_to_exist(record):
+    if all(k not in record for k in ['authors', 'corporate_author']):
+        yield ValidationError(path=deque(['']),
+                              message='Neither an author nor a corporate author found.')
+
+
+def check_document_type_if_book_series_exist(record):
+    if 'book_series' in record:
+        required_values = ['book', 'proceedings', 'thesis']
+        if check_field_values_not_in_required_values_for_record(record, 'document_type', required_values):
+            yield ValidationError(path=deque(['']),
+                                  message=FIELD_REQUIRE_FIELD_VALUES_TEMPLATE.format(
+                                      field='book_series',
+                                      required='document_type',
+                                      values=required_values))
+
+
+def check_document_type_if_isbns_exist(record):
+    if 'isbns' in record:
+        required_values = ['book', 'proceedings', 'thesis']
+        if check_field_values_not_in_required_values_for_record(record, 'document_type', required_values):
+            yield ValidationError(path=deque(['']),
+                                  message=FIELD_REQUIRE_FIELD_VALUES_TEMPLATE.format(
+                                      field='isbns',
+                                      required='document_type',
+                                      values=required_values))
+
+
+def check_document_type_if_cnum_exist(record):
+    if check_if_field_exists_in_dict_list_x_times('cnum', record.get('publication_info', [])):
+        required_values = ['proceedings', 'conference paper']
+        if check_field_values_not_in_required_values_for_record(record, 'document_type', required_values):
+            yield ValidationError(path=deque(['']),
+                                  message=FIELD_REQUIRE_FIELD_VALUES_TEMPLATE.format(
+                                      field='cnum',
+                                      required='document_type',
+                                      values=required_values))
+
+
+def check_document_type_if_thesis_info_exist(record):
+
+    if 'thesis_info' in record:
+        required_values = ['thesis']
+        if check_field_values_not_in_required_values_for_record(record, 'document_type', required_values):
+            yield ValidationError(path=deque(['']),
+                                  message=FIELD_REQUIRE_FIELD_VALUES_TEMPLATE.format(
+                                      field='thesis_info',
+                                      required='document_type',
+                                      values=required_values),
+                                  cause='Error')
+
+
+def check_if_isbn_is_valid(record):
+    def _check_isbn_is_valid(field, value, prop, index, errortype):
+        if not is_isbn(value):
+            yield ValidationError(path=deque(['{field}/{index}/{prop}'.format(field=field,
+                                                                               prop=prop,
+                                                                               index=index)]),
+                                  message=FIELD_VALIDATION_TEMPLATE.format(
+                                      field='isbns',
+                                      value=value
+                                  ),
+                                  cause=errortype)
+
+    for e in check_if_listfield_property_values_are_valid(record=record,
+                                                          field='isbns',
+                                                          prop='value',
+                                                          checker=_check_isbn_is_valid):
+        yield e
+
+
+def check_if_isbn_exist_in_other_records(record):
+    for e in check_if_listfield_property_values_are_valid(record=record,
+                                                          field='isbns',
+                                                          prop='value',
+                                                          checker=query_db_for_duplicates_for_field_listitem_with_index):
+        yield e
+
+
+def check_languages_if_valid_iso(record):
+    def _check_language(language, index):
+        try:
+            pycountry.languages.lookup(language)
+        except LookupError:
+            yield ValidationError(path=deque(['languages/{index}'.format(index=index)]),
+                                  message=FIELD_VALIDATION_TEMPLATE.format(
+                                      field='languages',
+                                      value=language
+                                  ),
+                                  cause='Error')
+    for i, item in enumerate(record.get('languages', [])):
+        for e in _check_language(item, i):
+            yield e

--- a/inspirehep/modules/records/validators/validator.py
+++ b/inspirehep/modules/records/validators/validator.py
@@ -1,0 +1,64 @@
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014, 2015, 2016, 2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+
+from jsonschema import Draft4Validator
+from jsonschema.validators import extend, RefResolver
+from inspire_schemas.utils import get_schema_path, load_schema
+from rules import (
+    check_for_author_or_corporate_author_to_exist,
+    check_if_isbn_exist_in_other_records,
+    check_if_isbn_is_valid,
+    check_document_type_if_book_series_exist,
+    check_document_type_if_isbns_exist,
+    check_document_type_if_cnum_exist,
+    check_document_type_if_thesis_info_exist,
+    check_languages_if_valid_iso
+)
+
+INSPIRE_VALIDATORS_LIST = [
+    check_for_author_or_corporate_author_to_exist,
+    check_if_isbn_exist_in_other_records,
+    check_if_isbn_is_valid,
+    check_document_type_if_book_series_exist,
+    check_document_type_if_isbns_exist,
+    check_document_type_if_cnum_exist,
+    check_document_type_if_thesis_info_exist,
+    check_languages_if_valid_iso
+]
+
+
+def inspire_validator_dispatcher(validator, value, instance, schema):
+    for validator in INSPIRE_VALIDATORS_LIST:
+        for error in validator(instance):
+            yield error
+
+
+class InspireResolver(RefResolver):
+
+    def resolve_remote(self, uri):
+        # """Resolve a uri or relative path to a schema."""
+        resolved = load_schema(uri.rsplit('.json', 1)[0])
+        if 'hep.json' in uri:
+            resolved['inspire_validator'] = 'Inspire validator extending Draft4Validator.'
+        return resolved
+
+InspireValidator = extend(Draft4Validator, {'inspire_validator': inspire_validator_dispatcher})

--- a/tests/integration/test_rules.py
+++ b/tests/integration/test_rules.py
@@ -1,0 +1,296 @@
+# # -*- coding: utf-8 -*-
+# #
+# # This file is part of Invenio.
+# # Copyright (C) 2017 CERN.
+# #
+# # Invenio is free software; you can redistribute it
+# # and/or modify it under the terms of the GNU General Public License as
+# # published by the Free Software Foundation; either version 2 of the
+# # License, or (at your option) any later version.
+# #
+# # Invenio is distributed in the hope that it will be
+# # useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# # General Public License for more details.
+# #
+# # You should have received a copy of the GNU General Public License
+# # along with Invenio; if not, write to the
+# # Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# # MA 02111-1307, USA.
+# #
+# # In applying this license, CERN does not
+# # waive the privileges and immunities granted to it by virtue of its status
+# # as an Intergovernmental Organization or submit itself to any jurisdiction.
+#
+#
+# """Test helpers."""
+#
+# from inspirehep.modules.recordvalidators.validators.rules import (
+#     check_if_isbn_exist_in_other_records,
+#     check_if_journal_title_is_canonical,
+#     check_if_reportnumber_exist_in_other_records,
+#     check_external_urls_if_work,
+#     check_external_dois_if_exist
+# )
+# from inspirehep.modules.records.validators.errors import ValidationError
+# from inspirehep.modules.recordvalidators.validators.helpers import (
+#     execute_query,
+#     GET_RESULTS_FOR_FIELD_PROPERTY_QUERYSTRING_TEMPLATE,
+#     FIELD_DUPLICATE_VALUES_FOUND_TEMPLATE,
+#     FIELD_VALIDATION_TEMPLATE,
+#     DOI_VALIDATION_URL
+# )
+# import pytest
+# import httpretty
+# from invenio_db import db
+# from inspirehep.modules.records.api import InspireRecord
+#
+#
+# @pytest.fixture(scope='function')
+# def test_record(app):
+#     sample_record = {
+#         '$schema': 'http://localhost:5000/schemas/records/hep.json',
+#         'control_number': 111,
+#         'document_type': [
+#             'article',
+#         ],
+#         'isbns': [
+#             {'value': '9783598215001'},
+#         ],
+#         'report_numbers': [
+#             {'value': '11111'}
+#         ],
+#         'titles': [
+#             {'title': 'sample'},
+#         ],
+#         'self': {
+#             '$ref': 'http://localhost:5000/schemas/records/hep.json',
+#         }
+#     }
+#     dupl_sample_record = {
+#         '$schema': 'http://localhost:5000/schemas/records/hep.json',
+#         'control_number': 222,
+#         'document_type': [
+#             'article',
+#         ],
+#         'isbns': [
+#             {'value': '9783598215001'},
+#         ],
+#         'report_numbers': [
+#             {'value': '11111'}
+#         ],
+#         'titles': [
+#             {'title': 'another_sample'},
+#         ],
+#         'self': {
+#             '$ref': 'http://localhost:5000/schemas/records/hep.json',
+#         }
+#     }
+#
+#     record_id = InspireRecord.create(sample_record).id
+#     dupl_record_id = InspireRecord.create(dupl_sample_record).id
+#
+#     db.session.commit()
+#
+#     yield
+#
+#     InspireRecord.get_record(record_id)._delete(force=True)
+#     InspireRecord.get_record(dupl_record_id)._delete(force=True)
+#
+#     db.session.commit()
+#
+#
+# def test_check_if_isbn_exist_in_other_records(app, test_record):
+#     sample_record = {
+#         '$schema': 'http://localhost:5000/schemas/records/hep.json',
+#         'control_number': 333,
+#         'document_type': [
+#             'book',
+#         ],
+#         'isbns': [
+#             {'value': '9783598215001'},
+#         ],
+#         'titles': [
+#             {'title': 'sample_record_title'},
+#         ],
+#         'self': {
+#             '$ref': 'http://localhost:5000/schemas/records/hep.json',
+#         }
+#     }
+#
+#     expected = {
+#         '/isbns/0/value': [{
+#             'message': FIELD_DUPLICATE_VALUES_FOUND_TEMPLATE.format(
+#                 field='isbns',
+#                 value='9783598215001'
+#             ),
+#             'type': 'Error'
+#         }]
+#     }
+#
+#     with pytest.raises(ValidationError) as excinfo:
+#         check_if_isbn_exist_in_other_records(sample_record)
+#     assert excinfo.value.error == expected
+#
+#
+# def test_check_if_journal_title_is_canonical(app):
+#     sample_record = {
+#         '$schema': 'http://localhost:5000/schemas/records/hep.json',
+#         'control_number': 333,
+#         'document_type': [
+#             'book',
+#         ],
+#         'titles': [
+#             {'title': 'sample_record_title'},
+#         ],
+#         'publication_info': [
+#             {
+#                 'journal_title': 'not_a_canonical_journal_title'
+#             }
+#         ],
+#         'self': {
+#             '$ref': 'http://localhost:5000/schemas/records/hep.json',
+#         }
+#     }
+#
+#     expected = {
+#         '/publication_info/0/journal_title': [{
+#             'message': "Journal title 'not_a_canonical_journal_title' doesn't exist.'",
+#             'type': 'Error'
+#         }]
+#     }
+#
+#     with pytest.raises(ValidationError) as excinfo:
+#         check_if_journal_title_is_canonical(sample_record)
+#     assert excinfo.value.error == expected
+#
+#
+# def test_execute_query(app, test_record):
+#
+#     zero_found_querystring = GET_RESULTS_FOR_FIELD_PROPERTY_QUERYSTRING_TEMPLATE.format(
+#         field='titles',
+#         prop='title',
+#         value='not_found_value'
+#     )
+#     one_found_querystring = GET_RESULTS_FOR_FIELD_PROPERTY_QUERYSTRING_TEMPLATE.format(
+#         field='titles',
+#         prop='title',
+#         value='sample'
+#     )
+#
+#     results = execute_query(zero_found_querystring)
+#     assert results.rowcount == 0
+#
+#     results = execute_query(one_found_querystring)
+#     assert results.rowcount == 1
+#
+#
+# def test_check_if_reportnumber_exist_in_other_records(app, test_record):
+#     sample_record = {
+#         '$schema': 'http://localhost:5000/schemas/records/hep.json',
+#         'control_number': 333,
+#         'document_type': [
+#             'book',
+#         ],
+#         'report_numbers': [
+#             {'value': '11111'}
+#         ],
+#         'titles': [
+#             {'title': 'sample_record_title'},
+#         ],
+#         'self': {
+#             '$ref': 'http://localhost:5000/schemas/records/hep.json',
+#         }
+#     }
+#
+#     expected = {
+#         '/report_numbers/0/value': [{
+#             'message': FIELD_DUPLICATE_VALUES_FOUND_TEMPLATE.format(
+#                 field='report_numbers',
+#                 value='11111'
+#             ),
+#             'type': 'Warning'
+#         }]
+#     }
+#
+#     with pytest.raises(ValidationError) as excinfo:
+#         check_if_reportnumber_exist_in_other_records(sample_record)
+#     assert excinfo.value.error == expected
+#
+#
+# @pytest.mark.httpretty
+# def test_check_external_urls_if_work():
+#     sample_record = {
+#         '$schema': 'http://localhost:5000/schemas/records/hep.json',
+#         'control_number': 333,
+#         'document_type': [
+#             'book',
+#         ],
+#         'urls': [
+#             {'value': 'http://not_working_url'}
+#         ],
+#         'titles': [
+#             {'title': 'sample_record_title'},
+#         ],
+#         'self': {
+#             '$ref': 'http://localhost:5000/schemas/records/hep.json',
+#         }
+#     }
+#
+#     expected = {
+#         '/urls/0/value': [{
+#             'message': FIELD_VALIDATION_TEMPLATE.format(
+#                 field='urls',
+#                 value='http://not_working_url'
+#             ),
+#             'type': 'Warning'
+#         }]
+#     }
+#
+#     httpretty.register_uri(
+#         httpretty.GET,
+#         "http://not_working_url/",
+#         status=404)
+#
+#     with pytest.raises(ValidationError) as excinfo:
+#         check_external_urls_if_work(sample_record)
+#     assert excinfo.value.error == expected
+#
+#
+# @pytest.mark.httpretty
+# def test_check_external_dois_if_exist():
+#     sample_record = {
+#         '$schema': 'http://localhost:5000/schemas/records/hep.json',
+#         'control_number': 333,
+#         'document_type': [
+#             'book',
+#         ],
+#         'dois': [
+#             {'value': '1111111'}
+#         ],
+#         'titles': [
+#             {'title': 'sample_record_title'},
+#         ],
+#         'self': {
+#             '$ref': 'http://localhost:5000/schemas/records/hep.json',
+#         }
+#     }
+#
+#     expected = {
+#         '/dois/0/value': [{
+#             'message': FIELD_VALIDATION_TEMPLATE.format(
+#                 field='dois',
+#                 value='1111111'
+#             ),
+#             'type': 'Warning'
+#         }]
+#     }
+#
+#     httpretty.register_uri(
+#         httpretty.GET,
+#         DOI_VALIDATION_URL.format(doi='1111111'),
+#         status=404)
+#
+#     with pytest.raises(ValidationError) as excinfo:
+#         check_external_dois_if_exist(sample_record)
+#     assert excinfo.value.error == expected

--- a/tests/unit/recordvalidators/test_rules.py
+++ b/tests/unit/recordvalidators/test_rules.py
@@ -1,0 +1,567 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2017 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+
+"""Test helpers."""
+
+from inspirehep.modules.records.validators.errors import ValidationError
+from inspirehep.modules.recordvalidators.validators.helpers import (
+    FIELD_REQUIRE_FIELD_VALUES_TEMPLATE,
+    FIELD_VALIDATION_TEMPLATE,
+    FIELD_REQUIRE_FIELD_TEMPLATE,
+    FIELD_VALUE_REQUIRE_FIELD_TEMPLATE
+)
+import pytest
+from jsonschema import Draft4Validator
+from jsonschema.exceptions import ValidationError
+from jsonschema.validators import extend, validat
+import json
+
+
+# def test_check_for_author_or_corporate_author_to_exist():
+#     sample_record = {
+#         'no_authors': {},
+#         'no_corporate_author': {}
+#     }
+#
+#     expected = {
+#         'globalErrors': [{
+#             'message': 'Neither an author nor a corporate author found.',
+#             'type': 'Error'
+#         }]
+#     }
+#     with pytest.raises(ValidationError) as excinfo:
+#         check_for_author_or_corporate_author_to_exist(sample_record)
+#     assert excinfo.value.error == expected
+#
+#
+# def test_check_document_type_if_book_series_exist():
+#     sample_record = {
+#         'book_series': [{
+#             'key': 'value'
+#         }],
+#         'document_type': ['not_one_of_required_values']
+#     }
+#     required_values = ['book', 'proceedings', 'thesis']
+#     expected = {
+#         'globalErrors': [{
+#             'message': FIELD_REQUIRE_FIELD_VALUES_TEMPLATE.format(
+#                             field='book_series',
+#                             required='document_type',
+#                             values=required_values),
+#             'type': 'Error'
+#         }]
+#     }
+#     with pytest.raises(ValidationError) as excinfo:
+#         check_document_type_if_book_series_exist(sample_record)
+#     assert excinfo.value.error == expected
+#
+#
+# def test_check_document_type_if_isbns_exist():
+#     sample_record = {
+#         'isbns': [{
+#             'key': 'value'
+#         }],
+#         'document_type': ['not_one_of_required_values']
+#     }
+#     required_values = ['book', 'proceedings', 'thesis']
+#     expected = {
+#         'globalErrors': [{
+#             'message': FIELD_REQUIRE_FIELD_VALUES_TEMPLATE.format(
+#                 field='isbns',
+#                 required='document_type',
+#                 values=required_values),
+#             'type': 'Error'
+#         }]
+#     }
+#     with pytest.raises(ValidationError) as excinfo:
+#         check_document_type_if_isbns_exist(sample_record)
+#     assert excinfo.value.error == expected
+#
+#
+# def test_check_document_type_if_cnum_exist():
+#     sample_record = {
+#         'publication_info': [{
+#             'cnum': 'cnum_value'
+#         }],
+#         'document_type': ['not_one_of_required_values']
+#     }
+#     required_values = ['proceedings', 'conference paper']
+#     expected = {
+#         'globalErrors': [{
+#             'message': FIELD_REQUIRE_FIELD_VALUES_TEMPLATE.format(
+#                 field='cnum',
+#                 required='document_type',
+#                 values=required_values),
+#             'type': 'Error'
+#         }]
+#     }
+#     with pytest.raises(ValidationError) as excinfo:
+#         check_document_type_if_cnum_exist(sample_record)
+#     assert excinfo.value.error == expected
+#
+#
+# def test_check_document_type_if_thesis_info_exist():
+#     sample_record = {
+#         'thesis_info': {
+#             'key': 'value'
+#         },
+#         'document_type': ['not_one_of_required_values']
+#     }
+#     required_values = ['thesis']
+#     expected = {
+#         'globalErrors': [{
+#             'message': FIELD_REQUIRE_FIELD_VALUES_TEMPLATE.format(
+#                 field='thesis_info',
+#                 required='document_type',
+#                 values=required_values),
+#             'type': 'Error'
+#         }]
+#     }
+#     with pytest.raises(ValidationError) as excinfo:
+#         check_document_type_if_thesis_info_exist(sample_record)
+#     assert excinfo.value.error == expected
+#
+#
+# def test_check_if_isbn_is_valid():
+#     sample_record = {
+#         'isbns': [
+#             {
+#                 'value': '978-3-319-15000-0'
+#             },
+#             {
+#                 'value': '8267411'
+#             }
+#         ]
+#     }
+#     expected = {
+#         '/isbns/1/value': [{
+#             'message': FIELD_VALIDATION_TEMPLATE.format(
+#                 field='isbns',
+#                 value='8267411'),
+#             'type': 'Error'
+#         }]
+#     }
+#     with pytest.raises(ValidationError) as excinfo:
+#         check_if_isbn_is_valid(sample_record)
+#     assert excinfo.value.error == expected
+#
+#
+# def test_check_date_present_in_record():
+#     sample_valid_record = {
+#         'thesis_info': {
+#             'date': ''
+#         }
+#     }
+#
+#     assert check_date_present_in_record(sample_valid_record) == {}
+#
+#     sample_invalid_record = {
+#         'not_date_field': {
+#             'not_date_field_key': 'value'
+#         }
+#     }
+#     expected = {
+#         'globalErrors': [{
+#             'message': 'No date present.',
+#             'type': 'Error'
+#         }]
+#     }
+#     with pytest.raises(ValidationError) as excinfo:
+#         check_date_present_in_record(sample_invalid_record)
+#     assert excinfo.value.error == expected
+#
+#
+# def test_check_languages_if_valid_iso():
+#     sample_record = {
+#         'languages': [
+#             'kr',
+#             'z2'
+#         ]
+#     }
+#     expected = {
+#         '/languages/1': [{
+#             'message': FIELD_VALIDATION_TEMPLATE.format(
+#                 field='languages',
+#                 value='z2'
+#             ),
+#             'type': 'Error'
+#         }]
+#     }
+#     with pytest.raises(ValidationError) as excinfo:
+#         check_languages_if_valid_iso(sample_record)
+#     assert excinfo.value.error == expected
+#
+#
+# def test_check_affiliations_if_authors_exist():
+#     sample_record = {
+#         'authors': [
+#             {
+#                 'not_affiliations_field': []
+#             },
+#             {
+#                 'affiliations': []
+#             },
+#             {
+#                 'affiliations': [{
+#                     'key': 'value'
+#                 }]
+#             }
+#         ]
+#     }
+#     expected = {
+#         '/authors/0': [{
+#             'message': FIELD_REQUIRE_FIELD_TEMPLATE.format(
+#                 field='authors',
+#                 required='affiliations'),
+#             'type': 'Warning'
+#         }],
+#         '/authors/1': [{
+#             'message': FIELD_REQUIRE_FIELD_TEMPLATE.format(
+#                 field='authors',
+#                 required='affiliations'),
+#             'type': 'Warning'
+#         }]
+#
+#     }
+#     with pytest.raises(ValidationError) as excinfo:
+#         check_affiliations_if_authors_exist(sample_record)
+#     assert excinfo.value.error == expected
+#
+#
+# def test_check_thesis_info_if_doctype_value_thesis_present():
+#     sample_record = {
+#         'document_type': [
+#             'thesis'
+#         ],
+#         'not_thesis_info_field': 'value'
+#     }
+#     expected = {
+#         'globalErrors': [{
+#             'message': FIELD_VALUE_REQUIRE_FIELD_TEMPLATE.format(
+#                 field='document_type',
+#                 value='thesis',
+#                 required='thesis_info'),
+#             'type': 'Warning'
+#         }]
+#     }
+#     with pytest.raises(ValidationError) as excinfo:
+#         check_thesis_info_if_doctype_value_thesis_present(sample_record)
+#     assert excinfo.value.error == expected
+#
+#
+# def test_cnum_if_doctype_value_proceedings_present():
+#     sample_record = {
+#         'document_type': [
+#             'proceedings'
+#         ],
+#         'publication_info': [{
+#             'not_cnum_field': 'value'
+#         }]
+#     }
+#     expected = {
+#         'globalErrors': [{
+#             'message': FIELD_VALUE_REQUIRE_FIELD_TEMPLATE.format(
+#                 field='document_type',
+#                 value='proceedings',
+#                 required='cnum'),
+#             'type': 'Warning'
+#         }]
+#     }
+#     with pytest.raises(ValidationError) as excinfo:
+#         check_cnum_if_doctype_value_proceedings_present(sample_record)
+#     assert excinfo.value.error == expected
+#
+#
+# def test_check_cnum_if_doctype_value_conference_paper_present():
+#     sample_record = {
+#         'document_type': [
+#             'conference paper'
+#         ],
+#         'publication_info': [{
+#             'not_cnum_field': 'value'
+#         }]
+#     }
+#     expected = {
+#         'globalErrors': [{
+#             'message': FIELD_VALUE_REQUIRE_FIELD_TEMPLATE.format(
+#                 field='document_type',
+#                 value='conference paper',
+#                 required='cnum'),
+#             'type': 'Warning'
+#         }]
+#     }
+#     with pytest.raises(ValidationError) as excinfo:
+#         check_cnum_if_doctype_value_conference_paper_present(sample_record)
+#     assert excinfo.value.error == expected
+#
+#
+# def test_check_if_2_cnum_exist_in_publication_info():
+#     sample_record = {
+#         'publication_info': [
+#             {
+#                 'cnum': 'value'
+#             },
+#             {
+#                 'cnum': 'value'
+#             },
+#             {
+#                 'not_cnum': 'value'
+#             }
+#         ]
+#     }
+#     expected = {
+#         'globalErrors': [{
+#             'message': "2 cnums found in 'publication info' field.",
+#             'type': 'Warning'
+#         }]
+#     }
+#     with pytest.raises(ValidationError) as excinfo:
+#         check_if_2_cnum_exist_in_publication_info(sample_record)
+#     assert excinfo.value.error == expected
+#
+#
+# def test_check_doctype_values_if_cnum_present():
+#     sample_record = {
+#         'publication_info': [{
+#                 'cnum': 'value'
+#         }],
+#         'document_type': [
+#             'not_one_of_the_required_values',
+#             'another_not_one_of_the_required_values'
+#         ]
+#     }
+#     required_values = ['proceedings', 'conference_paper']
+#     expected = {
+#         'globalErrors': [{
+#             'message': FIELD_REQUIRE_FIELD_VALUES_TEMPLATE.format(
+#                 field='cnum',
+#                 required='document_type',
+#                 values=required_values),
+#             'type': 'Warning'
+#         }]
+#     }
+#     with pytest.raises(ValidationError) as excinfo:
+#         check_doctype_values_if_cnum_present(sample_record)
+#     assert excinfo.value.error == expected
+#
+#
+# def test_check_accelerator_experiments_if_collaborations_exist():
+#     sample_record = {
+#         'collaborations': [{
+#             'cnum': 'value'
+#         }],
+#         'not_accelerator_experiments': []
+#     }
+#     expected = {
+#         'globalErrors': [{
+#             'message': FIELD_REQUIRE_FIELD_TEMPLATE.format(
+#                 field='collaborations',
+#                 required='accelerator_experiments'),
+#             'type': 'Warning'
+#         }]
+#     }
+#     with pytest.raises(ValidationError) as excinfo:
+#         check_accelerator_experiments_if_collaborations_exist(sample_record)
+#     assert excinfo.value.error == expected
+#
+#
+# def test_check_accelerator_experiments_for_experiment():
+#     sample_record = {
+#         'accelerator_experiments': [{
+#             'not_experiment_field': 'value'
+#         }]
+#     }
+#     expected = {
+#         'globalErrors': [{
+#             'message': "'accelerator_experiments' field should have at least "
+#                        "one experiment",
+#             'type': 'Warning'
+#         }]
+#     }
+#     with pytest.raises(ValidationError) as excinfo:
+#         check_accelerator_experiments_for_experiment(sample_record)
+#     assert excinfo.value.error == expected
+#
+#
+# def test_check_thesis_info_and_supervisor_to_exist_in_thesis():
+#     sample_record = {
+#         'not_thesis_info': 'value',
+#         'inspire_roles': ['not_supervisor'],
+#         'document_type': [
+#             'thesis'
+#         ]
+#     }
+#     expected = {
+#         'globalErrors': [{
+#             'message': "Thesis should have both 'thesis_info' and "
+#                        "'supervisor' field.",
+#             'type': 'Warning'
+#         }]
+#     }
+#     with pytest.raises(ValidationError) as excinfo:
+#         check_thesis_info_and_supervisor_to_exist_in_thesis(sample_record)
+#     assert excinfo.value.error == expected
+#
+#
+# def test_check_if_no_pages_for_publication_info():
+#     sample_record = {
+#         'publication_info': [
+#             {
+#                 'page_start': 'value'
+#             },
+#             {
+#                 'page_end': 'value'
+#             },
+#             {
+#                 'not_page_start_or_end_field': 'value'
+#             },
+#             {
+#                 'page_start': 'value',
+#                 'page_end': 'value'
+#             }
+#         ]
+#     }
+#     expected = {
+#         '/publication_info/2': [{
+#             'message': "Missing 'page_start' or 'page_end' field.",
+#             'type': 'Warning'
+#         }]
+#
+#     }
+#     with pytest.raises(ValidationError) as excinfo:
+#         check_if_no_pages_for_publication_info(sample_record)
+#     assert excinfo.value.error == expected
+
+schema = {
+    "properties": {
+        "authors": {
+        "description": ":MARC: ``520``",
+        "items": {
+            "additionalProperties": False,
+            "description": "This is used to add, besides the `value`, the `source` where this value\ncame from.",
+            "properties": {
+                "source": {
+                    "$schema": "http://json-schema.org/schema#",
+                    "description": "Source of the information in this field. As several records can be merged,\nthis information allows us to remember where every bit of metadata came\nfrom and make decisions based on it.\n\n:MARC: Often not present.",
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "value"
+            ],
+            "type": "object"
+        },
+        "title": "List of abstracts",
+        "type": "array",
+        "uniqueItems": True
+    },
+    "corporate_author": {
+      "items": {
+        "additionalProperties": False,
+        "properties": {
+          "accelerator": {
+            "description": "If present, `institution` should contain the\ninstitution where this accelerator is located.\n\n.. note::\n\n    Currently not used, see `legacy_name`.\n\n:MARC: ``693__a``",
+            "type": "string"
+          },
+          "curated_relation": {
+            "default": False,
+            "type": "boolean"
+          },
+          "experiment": {
+            "description": "If present, `institution` should contain the\ninstitution where this experiment is located and\n`accelerator` may contain the accelerator that this\nexperiment is using (if appropriate).\n\n.. note::\n\n    Currently not used, see `legacy_name`.\n\n:MARC: not present.",
+            "type": "string"
+          },
+          "institution": {
+            "description": ".. note::\n\n    Currently not used, see `legacy_name`.\n\n:MARC: not present.",
+            "title": "Institution hosting the experiment",
+            "type": "string"
+          },
+          "legacy_name": {
+            "description": "This field is used when migrating from legacy instead\nof separate `institution`, `accelerator` and\n`experiment`. In the future, it will be deprecated and\nthe other fields will be used instead.\n\n:example: ``CERN-LHC-CMS``\n:MARC: ``693__e``",
+            "title": "Identifier of the experiment on legacy",
+            "type": "string"
+          },
+          "record": {
+            "$schema": "http://json-schema.org/schema#",
+            "additionalProperties": False,
+            "properties": {
+              "$ref": {
+                "description": "URL to the referenced resource",
+                "format": "url",
+                "type": "string"
+              }
+            },
+            "required": [
+              "$ref"
+            ],
+            "title": "Reference to another record",
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "title": "List of related accelerators/experiments",
+      "type": "array",
+      "uniqueItems": True
+    }
+    }
+}
+
+record = {
+    "abstracts": [
+        {
+            "source": "arXiv",
+            "value": "Holographic RG flows are studied in an Einstein-dilaton theory with a general potential. The superpotential formalism is utilized in order to characterize and classify all solutions that are associated to asymptotically AdS space-times. Such solutions correspond to holographic RG flows and are characterized by their holographic $\\beta$-functions. Novel solutions are found that have exotic properties from a RG point-of view. Some have $\\beta$-functions that are defined patch-wise and lead to flows where the $\\beta$-function changes sign without the flow stopping. Others describe flows that end in non-neighboring extrema in field space. Finally others describe regular flows between two minima of the potential and correspond holographically to flows driven by the VEV of an irrelevant operator in the UV CFT."
+        }
+    ],
+    "accelerator_experiments": [
+      {
+        "legacy_name": "CERN-LHC-CMS",
+        "record": {
+          "$ref": "http://localhost:5000/api/experiments/1108642"
+        }
+      }
+    ]
+}
+
+
+def myValidator(validator, value, instance, schema):
+    print "Value ", value
+    if instance['abstracts']:
+        if not len(instance['accelerator_experiments']) == 0:
+            yield ValidationError("abstracts field require accelerator_experiments to have one or more values", path=("/abstracts"))
+
+
+def test_custom_validator():
+    custom_validator = extend(Draft4Validator, {'abstracts': myValidator})
+    validator = custom_validator(schema["properties"])
+    errors = [e for e in validator.iter_errors(record)]
+    if len(errors):
+        for error in errors:
+            print "Err: ", error.path
+        assert errors == {}


### PR DESCRIPTION
Intorduce custom validators ( related to this list https://github.com/inveniosoftware-contrib/invenio-record-editor/issues/9) under `/api/editor/validate` . These validators will pass through `RECORD_EDITOR_VALIDATOR_FNS` in inspirehep/config.py to `invenio-record-editor`. The latter will aggregate all the errors and return the response which will be shown in record-editor.