### PR TITLE
literaturesuggest: prevent duplicate URLs

### DIFF
--- a/inspirehep/modules/forms/validators/simple_fields.py
+++ b/inspirehep/modules/forms/validators/simple_fields.py
@@ -177,6 +177,27 @@ def pdf_validator(form, field):
         raise StopValidation(message)
 
 
+def no_pdf_validator(form, field):
+    """Validate that url is not from a PDF."""
+    import requests
+
+    def get_content_type(url):
+        session = requests.Session()
+        try:
+            response = session.head(
+                url,
+                allow_redirects=True
+            )
+        except:
+            return
+        return response.headers['content-type']
+
+    message = "Please, use the field above to link to a PDF."
+
+    if field.data and get_content_type(field.data) == 'application/pdf':
+        raise StopValidation(message)
+
+
 def date_validator(form, field):
     message = ("Please, provide a valid date in the format YYYY-MM-DD, YYYY-MM"
                " or YYYY.")

--- a/inspirehep/modules/literaturesuggest/forms.py
+++ b/inspirehep/modules/literaturesuggest/forms.py
@@ -50,7 +50,7 @@ from inspirehep.modules.forms.filter_utils import clean_empty_list
 from inspirehep.modules.forms.validation_utils import DOISyntaxValidator
 from inspirehep.modules.forms.validators.simple_fields import duplicated_doi_validator, \
     duplicated_arxiv_id_validator, arxiv_syntax_validation, \
-    pdf_validator, date_validator
+    pdf_validator, no_pdf_validator, date_validator
 from inspirehep.modules.forms.validators.dynamic_fields import AuthorsValidation
 
 from inspirehep.modules.literaturesuggest.fields.arxiv_id import ArXivField
@@ -557,7 +557,7 @@ class LiteratureForm(INSPIREForm):
         label=_('Link to additional information (e.g. abstract)'),
         description=_('Which page should we link from INSPIRE?'),
         placeholder='http://www.example.com/splash-page.html',
-        # validators=[pdf_validator],
+        validators=[no_pdf_validator],
         widget_classes="form-control",
     )
 

--- a/inspirehep/modules/literaturesuggest/tasks.py
+++ b/inspirehep/modules/literaturesuggest/tasks.py
@@ -183,12 +183,15 @@ def formdata_to_model(obj, formdata):
         source='arXiv' if form_fields.get('categories') else 'CrossRef'
     )
 
-    if not _is_arxiv_url(form_fields.get('url', '')):
-        builder.add_url(url=form_fields.get('url'))
-        obj.extra_data['submission_pdf'] = form_fields.get('url')
+    form_url = form_fields.get('url')
+    form_additional_url = form_fields.get('additional_url')
+    if form_url and not _is_arxiv_url(form_url):
+        obj.extra_data['submission_pdf'] = form_url
+        if not form_additional_url:
+            builder.add_url(url=form_url)
 
-    if not _is_arxiv_url(form_fields.get('url', '')):
-        builder.add_url(url=form_fields.get('additional_url'))
+    if form_additional_url and not _is_arxiv_url(form_additional_url):
+        builder.add_url(url=form_additional_url)
 
     [builder.add_report_number(
         report_number=report_number.get('report_number')


### PR DESCRIPTION
* Do not allow a PDF to be inserted in the additional url field.

* Avoid adding two equal URLs to the record.

* Only add PDF as a link when no additional url is present. (closes #2066)

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>