### PR TITLE
workflows: create & submit rt ticket handles unicode

### DIFF
--- a/inspirehep/modules/workflows/tasks/submission.py
+++ b/inspirehep/modules/workflows/tasks/submission.py
@@ -105,8 +105,8 @@ def create_ticket(template,
 
         if not in_production_mode():
             obj.log.info(
-                "Was going to submit: {subject}\n\n{body}\n\n"
-                "To: {requestors} Queue: {queue}".format(
+                u"Was going to create ticket: {subject}\n\n{body}\n\n"
+                u"To: {requestors} Queue: {queue}".format(
                     queue=queue,
                     subject=context.get('subject'),
                     requestors=user.email,

--- a/inspirehep/modules/workflows/tasks/submission.py
+++ b/inspirehep/modules/workflows/tasks/submission.py
@@ -48,20 +48,7 @@ LOGGER = logging.getLogger(__name__)
 )
 def submit_rt_ticket(obj, queue, subject, body, requestors, ticket_id_key):
     """Submit ticket to RT with the given parameters."""
-    rt_instance = get_instance() if in_production_mode() else None
-    if not rt_instance:
-        obj.log.error("No RT instance available. Skipping!")
-        obj.log.info(
-            "Was going to submit: {subject}\n\n{body}\n\n"
-            "To: {requestors} Queue: {queue}".format(
-                queue=queue,
-                subject=subject,
-                requestors=requestors,
-                body=body
-            )
-        )
-        return
-
+    rt_instance = get_instance()
     # Trick to prepare ticket body
     body = "\n ".join([line.strip() for line in body.split("\n")])
     rt_queue = current_app.config.get("BIBCATALOG_QUEUES") or queue
@@ -115,6 +102,18 @@ def create_ticket(template,
             template,
             **context
         ).strip()
+
+        if not in_production_mode():
+            obj.log.info(
+                "Was going to submit: {subject}\n\n{body}\n\n"
+                "To: {requestors} Queue: {queue}".format(
+                    queue=queue,
+                    subject=context.get('subject'),
+                    requestors=user.email,
+                    body=body
+                )
+            )
+            return
 
         submit_rt_ticket(obj,
                          queue,

--- a/tests/unit/workflows/test_workflows_tasks_submission.py
+++ b/tests/unit/workflows/test_workflows_tasks_submission.py
@@ -22,11 +22,14 @@
 
 from __future__ import absolute_import, division, print_function
 
+from mock import patch
+import pytest
 from six import StringIO
 
 from inspirehep.modules.workflows.tasks.submission import (
     add_note_entry,
     prepare_files,
+    create_ticket
 )
 
 
@@ -74,6 +77,11 @@ class StubObj(object):
 
 class DummyEng(object):
     pass
+
+
+class DummyUser(object):
+    def __init__(self):
+        self.email = 'foo@bar.com'
 
 
 def test_add_note_entry_does_not_add_value_that_is_already_present():
@@ -215,3 +223,33 @@ def test_prepare_files_ignores_keys_not_ending_with_pdf():
     assert obj.data == {}
     assert '' == obj.log._info.getvalue()
     assert '' == obj.log._debug.getvalue()
+
+@pytest.mark.parametrize(
+    ("subject, body"),
+    [
+        (u"φοο", "foo"),
+        ("foo", u"φοο"),
+        (u"φοο", u"φοο"),
+    ],
+    ids=[
+        'test_create_ticket_without_rt_instance_handles_unicode_subject',
+        'test_create_ticket_without_rt_instance_handles_unicode_body',
+        'test_create_ticket_without_rt_instance_handles_unicode_body_and_subject'
+    ]
+)
+@patch('inspirehep.modules.workflows.tasks.submission.render_template')
+@patch('inspirehep.modules.workflows.tasks.submission.User')
+@patch('inspirehep.modules.workflows.tasks.submission.current_app.config',
+       {'PRODUCTION_MODE': False})
+def test_create_ticket_without_rt_instance_handles_unicode(
+        mocked_user, mocked_render_template, subject, body):
+    obj = StubObj(None, None, None)
+    obj.id = 100
+    obj.id_user = 1
+    mocked_user.query.get.return_value = DummyUser()
+    mocked_render_template.return_value = body
+
+    eng = DummyEng()
+
+    create_ticket_method = create_ticket(None)
+    assert create_ticket_method(obj, eng) is None


### PR DESCRIPTION
Firstly, refactors `submit_rt_ticket` to remove code for logging when not in production. 
Ensure that `create_ticket` and `submit_rt_ticket` can handle `subject` and `body` unicode strings. 

Related to https://github.com/inspirehep/inspire-next/issues/2133.