### PR TITLE
holdingpen: rename author updates card

### DIFF
--- a/inspirehep/modules/workflows/templates/inspire_workflows/index.html
+++ b/inspirehep/modules/workflows/templates/inspire_workflows/index.html
@@ -52,7 +52,7 @@
         template="{{url_for('static', filename='js/inspire_workflows_ui/templates/dashboard_stat_block.html')}}"
         filter_string="workflow_name=Author&is-update=true"
         secondary_filter="status"
-        section_title="New Author Updates">
+        section_title="Author Updates">
       </holding-pen-dashboard-item>
 
     </div>


### PR DESCRIPTION
* Now it's a bit less easy to confuse with new authors.
  (closes #2147)

Signed-off-by: David Caro <david@dcaro.es>