### PR TITLE
tests: refactor configuration mocking

### DIFF
--- a/tests/unit/theme/test_theme_jinja2filters.py
+++ b/tests/unit/theme/test_theme_jinja2filters.py
@@ -22,12 +22,11 @@
 
 from __future__ import absolute_import, division, print_function
 
-import datetime
-
 import jinja2
-import mock
 import pytest
 from elasticsearch_dsl import result
+from flask import current_app
+from mock import patch
 
 from inspirehep.modules.records.api import InspireRecord
 from inspirehep.modules.records.wrappers import LiteratureRecord
@@ -189,7 +188,7 @@ def mock_perform_es_search_tworecord():
     )
 
 
-@mock.patch('inspirehep.modules.theme.jinja2filters.current_app.jinja_env.get_template')
+@patch('inspirehep.modules.theme.jinja2filters.current_app.jinja_env.get_template')
 def test_apply_template_on_array_returns_empty_list_on_empty_list(g_t, jinja_env):
     g_t.return_value = jinja_env.from_string('{{ content }}')
 
@@ -199,7 +198,7 @@ def test_apply_template_on_array_returns_empty_list_on_empty_list(g_t, jinja_env
     assert expected == result
 
 
-@mock.patch('inspirehep.modules.theme.jinja2filters.current_app.jinja_env.get_template')
+@patch('inspirehep.modules.theme.jinja2filters.current_app.jinja_env.get_template')
 def test_apply_template_on_array_applies_template(g_t, jinja_env):
     g_t.return_value = jinja_env.from_string('{{ content }}')
 
@@ -209,7 +208,7 @@ def test_apply_template_on_array_applies_template(g_t, jinja_env):
     assert expected == result
 
 
-@mock.patch('inspirehep.modules.theme.jinja2filters.current_app.jinja_env.get_template')
+@patch('inspirehep.modules.theme.jinja2filters.current_app.jinja_env.get_template')
 def test_apply_template_on_array_accepts_strings_as_a_list_of_one_element(g_t, jinja_env):
     g_t.return_value = jinja_env.from_string('{{ content }}')
 
@@ -490,7 +489,7 @@ def test_proceedings_link_returns_empty_string_without_cnum():
     assert expected == result
 
 
-@mock.patch('inspirehep.modules.theme.jinja2filters.LiteratureSearch.execute')
+@patch('inspirehep.modules.theme.jinja2filters.LiteratureSearch.execute')
 def test_proceedings_link_returns_empty_string_with_zero_search_results(c, mock_perform_es_search_empty):
     c.return_value = mock_perform_es_search_empty
 
@@ -502,7 +501,7 @@ def test_proceedings_link_returns_empty_string_with_zero_search_results(c, mock_
     assert expected == result
 
 
-@mock.patch('inspirehep.modules.theme.jinja2filters.LiteratureSearch.execute')
+@patch('inspirehep.modules.theme.jinja2filters.LiteratureSearch.execute')
 def test_proceedings_link_returns_a_link_with_one_search_result(c, mock_perform_es_search_onerecord):
     c.return_value = mock_perform_es_search_onerecord
 
@@ -514,7 +513,7 @@ def test_proceedings_link_returns_a_link_with_one_search_result(c, mock_perform_
     assert expected == result
 
 
-@mock.patch('inspirehep.modules.theme.jinja2filters.LiteratureSearch.execute')
+@patch('inspirehep.modules.theme.jinja2filters.LiteratureSearch.execute')
 def test_proceedings_link_joins_with_a_comma_and_a_space(s, mock_perform_es_search_tworecord):
     s.return_value = mock_perform_es_search_tworecord
 
@@ -574,7 +573,7 @@ def test_link_to_hep_affiliation_returns_empty_string_when_record_has_no_ICN():
     assert expected == result
 
 
-@mock.patch('inspirehep.modules.theme.jinja2filters.InstitutionsSearch.execute')
+@patch('inspirehep.modules.theme.jinja2filters.InstitutionsSearch.execute')
 def test_link_to_hep_affiliation_returns_empty_string_when_empty_results(s, mock_perform_es_search_empty):
     s.return_value = mock_perform_es_search_empty
 
@@ -586,7 +585,7 @@ def test_link_to_hep_affiliation_returns_empty_string_when_empty_results(s, mock
     assert expected == result
 
 
-@mock.patch('inspirehep.modules.theme.jinja2filters.InstitutionsSearch.execute')
+@patch('inspirehep.modules.theme.jinja2filters.InstitutionsSearch.execute')
 def test_link_to_hep_affiliation_singular_when_one_result(s, mock_perform_es_search_onerecord):
     s.return_value = mock_perform_es_search_onerecord
 
@@ -598,7 +597,7 @@ def test_link_to_hep_affiliation_singular_when_one_result(s, mock_perform_es_sea
     assert expected == result
 
 
-@mock.patch('inspirehep.modules.theme.jinja2filters.InstitutionsSearch.execute')
+@patch('inspirehep.modules.theme.jinja2filters.InstitutionsSearch.execute')
 def test_link_to_hep_affiliation_plural_when_more_results(s, mock_perform_es_search_tworecord):
     s.return_value = mock_perform_es_search_tworecord
 
@@ -685,14 +684,14 @@ def test_construct_date_format():
     assert expected == result
 
 
-@mock.patch(
-    'inspirehep.modules.theme.jinja2filters.current_app.config',
-    {'FACETS_SIZE_LIMIT': 2})
 def test_limit_facet_elements():
-    expected = ['foo', 'bar']
-    result = limit_facet_elements(['foo', 'bar', 'baz'])
+    config = {'FACETS_SIZE_LIMIT': 2}
 
-    assert expected == result
+    with patch.dict(current_app.config, config):
+        expected = ['foo', 'bar']
+        result = limit_facet_elements(['foo', 'bar', 'baz'])
+
+        assert expected == result
 
 
 def test_author_urls_returns_empty_string_on_empty_list():
@@ -957,7 +956,7 @@ def test_publication_info_from_pubinfo_freetext():
     assert expected == result
 
 
-@mock.patch('inspirehep.modules.records.wrappers.replace_refs')
+@patch('inspirehep.modules.records.wrappers.replace_refs')
 def test_publication_info_from_conference_recid_and_parent_recid(r_r, mock_replace_refs):
     conf_rec = {'$ref': 'http://x/y/976391'}
     parent_rec = {'$ref': 'http://x/y/1402672'}
@@ -985,7 +984,7 @@ def test_publication_info_from_conference_recid_and_parent_recid(r_r, mock_repla
     assert expected == result
 
 
-@mock.patch('inspirehep.modules.records.wrappers.replace_refs')
+@patch('inspirehep.modules.records.wrappers.replace_refs')
 def test_publication_info_from_conference_recid_and_parent_recid_with_pages(r_r, mock_replace_refs):
     with_title = '50th Rencontres de Moriond on EW Interactions and Unified Theories'
     conf_rec = {'$ref': 'http://x/y/1331207'}
@@ -1016,7 +1015,7 @@ def test_publication_info_from_conference_recid_and_parent_recid_with_pages(r_r,
     assert expected == result
 
 
-@mock.patch('inspirehep.modules.records.wrappers.replace_refs')
+@patch('inspirehep.modules.records.wrappers.replace_refs')
 def test_publication_info_with_pub_info_and_conf_info(r_r, mock_replace_refs):
     with_title = '2005 International Linear Collider Workshop (LCWS 2005)'
     conf_rec = {'$ref': 'http://x/y/976391'}
@@ -1049,7 +1048,7 @@ def test_publication_info_with_pub_info_and_conf_info(r_r, mock_replace_refs):
     assert expected == result
 
 
-@mock.patch('inspirehep.modules.records.wrappers.replace_refs')
+@patch('inspirehep.modules.records.wrappers.replace_refs')
 def test_publication_info_with_pub_info_and_conf_info_not_found(r_r):
     conf_rec = {'$ref': 'http://x/y/976391'}
     parent_rec = {'$ref': 'http://x/y/706120'}
@@ -1077,7 +1076,7 @@ def test_publication_info_with_pub_info_and_conf_info_not_found(r_r):
     assert expected == result
 
 
-@mock.patch('inspirehep.modules.records.wrappers.replace_refs')
+@patch('inspirehep.modules.records.wrappers.replace_refs')
 def test_publication_info_from_conference_recid_and_not_parent_recid(r_r, mock_replace_refs):
     with_title = '20th International Workshop on Deep-Inelastic Scattering and Related Subjects'
     conf_rec = {'$ref': 'http://x/y/1086512'}
@@ -1119,14 +1118,14 @@ def test_publication_info_from_not_conference_recid_and_parent_recid():
     assert expected == result
 
 
-@mock.patch('inspirehep.modules.theme.jinja2filters.create_datestruct')
+@patch('inspirehep.modules.theme.jinja2filters.create_datestruct')
 def test_format_date_returns_none_when_datestruct_is_none(c_d):
     c_d.return_value = None
 
     assert format_date('banana') is None
 
 
-@mock.patch('inspirehep.modules.theme.jinja2filters.create_datestruct')
+@patch('inspirehep.modules.theme.jinja2filters.create_datestruct')
 def test_format_date_when_datestruct_has_one_element(c_d):
     c_d.return_value = (1993,)
 
@@ -1136,7 +1135,7 @@ def test_format_date_when_datestruct_has_one_element(c_d):
     assert expected == result
 
 
-@mock.patch('inspirehep.modules.theme.jinja2filters.create_datestruct')
+@patch('inspirehep.modules.theme.jinja2filters.create_datestruct')
 def test_format_date_when_datestruct_has_two_elements(c_d, request_context):
     c_d.return_value = (1993, 2)
 
@@ -1146,7 +1145,7 @@ def test_format_date_when_datestruct_has_two_elements(c_d, request_context):
     assert expected == result
 
 
-@mock.patch('inspirehep.modules.theme.jinja2filters.create_datestruct')
+@patch('inspirehep.modules.theme.jinja2filters.create_datestruct')
 def test_format_date_when_datestruct_has_three_elements(c_d, request_context):
     c_d.return_value = (1993, 2, 2)
 

--- a/tests/unit/workflows/test_workflows_tasks_actions.py
+++ b/tests/unit/workflows/test_workflows_tasks_actions.py
@@ -22,7 +22,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-import pytest
+from flask import current_app
 from mock import patch
 from six import StringIO
 
@@ -161,19 +161,25 @@ def test_shall_halt_workflow_returns_false_when_value_is_falsy():
     assert not shall_halt_workflow(obj)
 
 
-@patch('inspirehep.modules.workflows.tasks.actions.current_app.config', {'PRODUCTION_MODE': True})
 def test_in_production_mode():
-    assert in_production_mode()
+    config = {'PRODUCTION_MODE': True}
+
+    with patch.dict(current_app.config, config):
+        assert in_production_mode()
 
 
-@patch('inspirehep.modules.workflows.tasks.actions.current_app.config', {})
 def test_in_production_mode_returns_false_when_variable_does_not_exist():
-    assert not in_production_mode()
+    config = {}
+
+    with patch.dict(current_app.config, config, clear=True):
+        assert not in_production_mode()
 
 
-@patch('inspirehep.modules.workflows.tasks.actions.current_app.config', {'PRODUCTION_MODE': False})
 def test_in_production_mode_returns_false_when_variable_is_falsy():
-    assert not in_production_mode()
+    config = {'PRODUCTION_MODE': False}
+
+    with patch.dict(current_app.config, config):
+        assert not in_production_mode()
 
 
 def test_add_core_sets_core_to_true_if_extra_data_core_is_true():

--- a/tests/unit/workflows/test_workflows_tasks_beard.py
+++ b/tests/unit/workflows/test_workflows_tasks_beard.py
@@ -22,8 +22,9 @@
 
 from __future__ import absolute_import, division, print_function
 
-import mock
 import requests
+from flask import current_app
+from mock import patch
 
 from inspirehep.modules.records.api import InspireRecord
 from inspirehep.modules.workflows.tasks.beard import (
@@ -43,21 +44,21 @@ class DummyEng(object):
     pass
 
 
-@mock.patch(
-    'inspirehep.modules.workflows.tasks.beard.current_app.config',
-    {'BEARD_API_URL': 'https://beard.inspirehep.net'})
 def test_get_beard_url_from_configuration():
-    expected = 'https://beard.inspirehep.net/predictor/coreness'
-    result = get_beard_url()
+    config = {'BEARD_API_URL': 'https://beard.inspirehep.net'}
 
-    assert expected == result
+    with patch.dict(current_app.config, config):
+        expected = 'https://beard.inspirehep.net/predictor/coreness'
+        result = get_beard_url()
+
+        assert expected == result
 
 
-@mock.patch(
-    'inspirehep.modules.workflows.tasks.beard.current_app.config',
-    {'BEARD_API_URL': ''})
 def test_get_beard_url_returns_none_when_not_in_configuration():
-    assert get_beard_url() is None
+    config = {'BEARD_API_URL': ''}
+
+    with patch.dict(current_app.config, config):
+        assert get_beard_url() is None
 
 
 def test_prepare_payload():
@@ -94,7 +95,7 @@ def test_prepare_payload():
     assert expected == result
 
 
-@mock.patch('inspirehep.modules.workflows.tasks.beard.get_beard_url')
+@patch('inspirehep.modules.workflows.tasks.beard.get_beard_url')
 def test_guess_coreness_fails_without_a_beard_url(g_b_u):
     g_b_u.return_value = ''
 
@@ -105,8 +106,8 @@ def test_guess_coreness_fails_without_a_beard_url(g_b_u):
     assert 'relevance_prediction' not in obj.extra_data
 
 
-@mock.patch('inspirehep.modules.workflows.tasks.beard.get_beard_url')
-@mock.patch('inspirehep.modules.workflows.tasks.beard.json_api_request')
+@patch('inspirehep.modules.workflows.tasks.beard.get_beard_url')
+@patch('inspirehep.modules.workflows.tasks.beard.json_api_request')
 def test_guess_coreness_does_not_fail_when_request_fails(j_a_r, g_b_u):
     j_a_r.side_effect = requests.exceptions.RequestException()
     g_b_u.return_value = 'https://beard.inspirehep.net/predictor/coreness'
@@ -118,8 +119,8 @@ def test_guess_coreness_does_not_fail_when_request_fails(j_a_r, g_b_u):
     assert 'relevance_prediction' not in obj.extra_data
 
 
-@mock.patch('inspirehep.modules.workflows.tasks.beard.get_beard_url')
-@mock.patch('inspirehep.modules.workflows.tasks.beard.json_api_request')
+@patch('inspirehep.modules.workflows.tasks.beard.get_beard_url')
+@patch('inspirehep.modules.workflows.tasks.beard.json_api_request')
 def test_guess_coreness_when_core(j_a_r, g_b_u):
     j_a_r.return_value = {
         'decision': 'CORE',
@@ -147,8 +148,8 @@ def test_guess_coreness_when_core(j_a_r, g_b_u):
     }
 
 
-@mock.patch('inspirehep.modules.workflows.tasks.beard.get_beard_url')
-@mock.patch('inspirehep.modules.workflows.tasks.beard.json_api_request')
+@patch('inspirehep.modules.workflows.tasks.beard.get_beard_url')
+@patch('inspirehep.modules.workflows.tasks.beard.json_api_request')
 def test_guess_coreness_when_non_core(j_a_r, g_b_u):
     j_a_r.return_value = {
         'decision': 'Non-CORE',
@@ -176,8 +177,8 @@ def test_guess_coreness_when_non_core(j_a_r, g_b_u):
     }
 
 
-@mock.patch('inspirehep.modules.workflows.tasks.beard.get_beard_url')
-@mock.patch('inspirehep.modules.workflows.tasks.beard.json_api_request')
+@patch('inspirehep.modules.workflows.tasks.beard.get_beard_url')
+@patch('inspirehep.modules.workflows.tasks.beard.json_api_request')
 def test_guess_coreness_when_rejected(j_a_r, g_b_u):
     j_a_r.return_value = {
         'decision': 'Rejected',

--- a/tests/unit/workflows/test_workflows_tasks_magpie.py
+++ b/tests/unit/workflows/test_workflows_tasks_magpie.py
@@ -22,8 +22,9 @@
 
 from __future__ import absolute_import, division, print_function
 
-import mock
 import requests
+from flask import current_app
+from mock import patch
 
 from inspirehep.modules.records.api import InspireRecord
 from inspirehep.modules.workflows.tasks.magpie import (
@@ -46,19 +47,21 @@ class DummyEng(object):
     pass
 
 
-@mock.patch(
-    'inspirehep.modules.workflows.tasks.magpie.current_app.config',
-    {'MAGPIE_API_URL': 'https://magpie.inspirehep.net'})
 def test_get_magpie_url_returns_value_from_configuration():
-    expected = 'https://magpie.inspirehep.net/predict'
-    result = get_magpie_url()
+    config = {'MAGPIE_API_URL': 'https://magpie.inspirehep.net'}
 
-    assert expected == result
+    with patch.dict(current_app.config, config):
+        expected = 'https://magpie.inspirehep.net/predict'
+        result = get_magpie_url()
+
+        assert expected == result
 
 
-@mock.patch('inspirehep.modules.workflows.tasks.magpie.current_app.config', {})
 def test_get_magpie_url_returns_none_when_not_in_configuration():
-    assert get_magpie_url() is None
+    config = {}
+
+    with patch.dict(current_app.config, config, clear=True):
+        assert get_magpie_url() is None
 
 
 def test_prepare_magpie_payload():
@@ -118,8 +121,8 @@ def test_filter_magpie_response_falls_back_to_first_label():
     assert expected == result
 
 
-@mock.patch('inspirehep.modules.workflows.tasks.magpie.get_magpie_url')
-@mock.patch('inspirehep.modules.workflows.tasks.magpie.json_api_request')
+@patch('inspirehep.modules.workflows.tasks.magpie.get_magpie_url')
+@patch('inspirehep.modules.workflows.tasks.magpie.json_api_request')
 def test_guess_keywords_accepts_over_point_09(j_a_r, g_m_u):
     j_a_r.return_value = {
         'labels': [
@@ -143,8 +146,8 @@ def test_guess_keywords_accepts_over_point_09(j_a_r, g_m_u):
     }
 
 
-@mock.patch('inspirehep.modules.workflows.tasks.magpie.get_magpie_url')
-@mock.patch('inspirehep.modules.workflows.tasks.magpie.json_api_request')
+@patch('inspirehep.modules.workflows.tasks.magpie.get_magpie_url')
+@patch('inspirehep.modules.workflows.tasks.magpie.json_api_request')
 def test_guess_keywords_considers_only_first_ten(j_a_r, g_m_u):
     j_a_r.return_value = {
         'labels': [
@@ -183,8 +186,8 @@ def test_guess_keywords_considers_only_first_ten(j_a_r, g_m_u):
     }
 
 
-@mock.patch('inspirehep.modules.workflows.tasks.magpie.get_magpie_url')
-@mock.patch('inspirehep.modules.workflows.tasks.magpie.json_api_request')
+@patch('inspirehep.modules.workflows.tasks.magpie.get_magpie_url')
+@patch('inspirehep.modules.workflows.tasks.magpie.json_api_request')
 def test_guess_keywords_does_not_fail_when_request_fails(j_a_r, g_m_u):
     j_a_r.side_effect = requests.exceptions.RequestException()
     g_m_u.return_value = 'https://magpie.inspirehep.net/predict'
@@ -196,7 +199,7 @@ def test_guess_keywords_does_not_fail_when_request_fails(j_a_r, g_m_u):
     assert obj.extra_data == {}
 
 
-@mock.patch('inspirehep.modules.workflows.tasks.magpie.get_magpie_url')
+@patch('inspirehep.modules.workflows.tasks.magpie.get_magpie_url')
 def test_guess_keywords_fails_without_a_magpie_url(g_m_u):
     g_m_u.return_value = None
 
@@ -207,8 +210,8 @@ def test_guess_keywords_fails_without_a_magpie_url(g_m_u):
     assert obj.extra_data == {}
 
 
-@mock.patch('inspirehep.modules.workflows.tasks.magpie.get_magpie_url')
-@mock.patch('inspirehep.modules.workflows.tasks.magpie.json_api_request')
+@patch('inspirehep.modules.workflows.tasks.magpie.get_magpie_url')
+@patch('inspirehep.modules.workflows.tasks.magpie.json_api_request')
 def test_guess_categories_filters_under_point_22(j_a_r, g_m_u):
     j_a_r.return_value = {
         'labels': [
@@ -233,8 +236,8 @@ def test_guess_categories_filters_under_point_22(j_a_r, g_m_u):
     }
 
 
-@mock.patch('inspirehep.modules.workflows.tasks.magpie.get_magpie_url')
-@mock.patch('inspirehep.modules.workflows.tasks.magpie.json_api_request')
+@patch('inspirehep.modules.workflows.tasks.magpie.get_magpie_url')
+@patch('inspirehep.modules.workflows.tasks.magpie.json_api_request')
 def test_guess_categories_accepts_over_point_25(j_a_r, g_m_u):
     j_a_r.return_value = {
         'labels': [
@@ -258,7 +261,7 @@ def test_guess_categories_accepts_over_point_25(j_a_r, g_m_u):
     }
 
 
-@mock.patch('inspirehep.modules.workflows.tasks.magpie.get_magpie_url')
+@patch('inspirehep.modules.workflows.tasks.magpie.get_magpie_url')
 def test_guess_categories_fails_without_a_magpie_url(g_m_u):
     g_m_u.return_value = None
 
@@ -269,8 +272,8 @@ def test_guess_categories_fails_without_a_magpie_url(g_m_u):
     assert obj.extra_data == {}
 
 
-@mock.patch('inspirehep.modules.workflows.tasks.magpie.get_magpie_url')
-@mock.patch('inspirehep.modules.workflows.tasks.magpie.json_api_request')
+@patch('inspirehep.modules.workflows.tasks.magpie.get_magpie_url')
+@patch('inspirehep.modules.workflows.tasks.magpie.json_api_request')
 def test_guess_experiments_filters_under_point_50(j_a_r, g_m_u):
     j_a_r.return_value = {
         'labels': [
@@ -295,7 +298,7 @@ def test_guess_experiments_filters_under_point_50(j_a_r, g_m_u):
     }
 
 
-@mock.patch('inspirehep.modules.workflows.tasks.magpie.get_magpie_url')
+@patch('inspirehep.modules.workflows.tasks.magpie.get_magpie_url')
 def test_guess_experiments_fails_without_a_magpie_url(g_m_u):
     g_m_u.return_value = None
 


### PR DESCRIPTION
The application configuration is a dictionary like object, so we can use [`patch.dict`](https://docs.python.org/3/library/unittest.mock.html#patch-dict) on it.