### PR TITLE
literaturesuggest: also remove title_translation

### DIFF
--- a/inspirehep/modules/literaturesuggest/normalizers.py
+++ b/inspirehep/modules/literaturesuggest/normalizers.py
@@ -84,5 +84,6 @@ def normalize_journal_title(obj, formdata):
 def remove_english_language(obj, formdata):
     if formdata.get('language') == 'en':
         del formdata['language']
+        del formdata['title_translation']
 
     return formdata

--- a/tests/unit/literaturesuggest/test_literaturesuggest_normalizers.py
+++ b/tests/unit/literaturesuggest/test_literaturesuggest_normalizers.py
@@ -49,7 +49,13 @@ def test_split_page_range_article_id():
 
 def test_remove_english_language():
     obj = DummyObj()
-    formdata = {'language': 'en'}
+    formdata = {
+        'language': 'en',
+        'title_translation': (
+            u'Propriété de la diagonale pour les produits'
+            u'symétriques d’une courbe lisse'
+        ),
+    }
 
     expected = {}
     result = remove_english_language(obj, formdata)


### PR DESCRIPTION
When the language is English we also don't want to have the
`title_translation` the user might have put in the form.

(As reported by @michamos)