### PR TITLE
setup: pin selenium to 3.3.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,7 @@ tests_require = [
     'pytest>=2.8.0',
     'mock>=1.3.0',
     'requests_mock',
+    'selenium<3.3.2',
 ]
 
 extras_require = {


### PR DESCRIPTION
Something started failing with `selenium==3.3.2`.

Here's a passing build just before the release: https://travis-ci.org/inspirehep/inspire-next/jobs/218453576
Here's a failing build just after the release: https://travis-ci.org/inspirehep/inspire-next/jobs/218456386