### PR TITLE
refextract: handle year an empty string

### DIFF
--- a/inspirehep/dojson/hep/rules/bd3xx.py
+++ b/inspirehep/dojson/hep/rules/bd3xx.py
@@ -24,8 +24,10 @@
 
 from __future__ import absolute_import, division, print_function
 
+from inspirehep.utils.helpers import maybe_int
+
 from ..model import hep, hep2marc
-from ...utils import force_single_element, maybe_int
+from ...utils import force_single_element
 
 
 @hep.over('number_of_pages', '^300..')

--- a/inspirehep/dojson/hepnames/rules.py
+++ b/inspirehep/dojson/hepnames/rules.py
@@ -29,7 +29,7 @@ import re
 from dojson import utils
 
 from inspire_schemas.utils import load_schema
-from inspirehep.utils.helpers import force_list
+from inspirehep.utils.helpers import force_list, maybe_int
 
 from .model import hepnames, hepnames2marc
 from ..utils import (
@@ -391,15 +391,9 @@ def prizes2marc(self, key, value):
 
 @hepnames.over('experiments', '^693..')
 def experiments(self, key, values):
-    def _int_or_none(maybe_int):
-        try:
-            return int(maybe_int)
-        except (TypeError, ValueError):
-            return None
-
     def _get_json_experiments(marc_dict):
-        start_year = _int_or_none(marc_dict.get('s'))
-        end_year = _int_or_none(marc_dict.get('d'))
+        start_year = maybe_int(marc_dict.get('s'))
+        end_year = maybe_int(marc_dict.get('d'))
 
         names = force_list(marc_dict.get('e'))
         recids = force_list(marc_dict.get('0'))

--- a/inspirehep/dojson/utils/__init__.py
+++ b/inspirehep/dojson/utils/__init__.py
@@ -186,14 +186,6 @@ def legacy_export_as_marc(json, tabsize=4):
     return "".join(export)
 
 
-def maybe_int(el):
-    """Return an ``int`` if possible, otherwise ``None``."""
-    try:
-        return int(el)
-    except ValueError:
-        pass
-
-
 def strip_empty_values(obj):
     """Recursively strips empty values."""
     if isinstance(obj, dict):

--- a/inspirehep/modules/refextract/tasks.py
+++ b/inspirehep/modules/refextract/tasks.py
@@ -28,6 +28,7 @@ import json
 
 from refextract import extract_journal_reference, extract_references_from_file
 
+from inspirehep.utils.helpers import maybe_int
 from inspirehep.utils.record import get_value
 from inspirehep.utils.pubnote import split_page_artid
 
@@ -65,9 +66,9 @@ def extract_journal_info(obj, eng):
                         "title"
                     )
                 if "year" in extracted_publication_info:
-                    pubnote["year"] = int(extracted_publication_info.get(
-                        "year"
-                    ))
+                    year = maybe_int(extracted_publication_info.get('year'))
+                    if year is not None:
+                        pubnote['year'] = year
                 if "page" in extracted_publication_info:
                     page_start, page_end, artid = split_page_artid(
                         extracted_publication_info.get("page"))

--- a/inspirehep/utils/helpers.py
+++ b/inspirehep/utils/helpers.py
@@ -59,21 +59,6 @@ def download_file_to_workflow(workflow, name, url):
             return workflow.files[name]
 
 
-def get_json_for_plots(plots):
-    """Return proper FFT format from plotextracted plots."""
-    output_records = []
-    index = 0
-    for plot in plots:
-        output_records.append(dict(
-            path=plot.get('url'),
-            type='Plot',
-            description="{0:05d} {1}".format(index, "".join(plot.get('captions', []))),
-            filename=plot.get('name'),
-        ))
-        index += 1
-    return dict(_fft=output_records)
-
-
 def force_list(data):
     """Force ``data`` to become a list.
 

--- a/inspirehep/utils/helpers.py
+++ b/inspirehep/utils/helpers.py
@@ -100,3 +100,23 @@ def force_list(data):
     elif isinstance(data, (tuple, set)):
         return list(data)
     return data
+
+
+def maybe_int(el):
+    """Return an ``int`` if possible, otherwise ``None``.
+
+    Args:
+        el: any Python object.
+
+    Returns:
+        Union[int, NoneType]: an ``int`` parsed from the object, or ``None``.
+
+    Examples:
+        >>> maybe_int('10')
+        10
+
+    """
+    try:
+        return int(el)
+    except (TypeError, ValueError):
+        pass

--- a/tests/unit/dojson/test_dojson_utils.py
+++ b/tests/unit/dojson/test_dojson_utils.py
@@ -34,7 +34,6 @@ from inspirehep.dojson.utils import (
     get_recid_from_ref,
     get_record_ref,
     legacy_export_as_marc,
-    maybe_int,
     dedupe_all_lists,
     strip_empty_values,
     validate,
@@ -262,17 +261,6 @@ def test_legacy_export_as_marc_json_with_controlfield():
     result = legacy_export_as_marc(json_with_controlfield)
 
     assert expected == result
-
-
-def test_maybe_int_returns_int_if_possible():
-    expected = 10
-    result = maybe_int('10')
-
-    assert expected == result
-
-
-def test_maybe_int_returns_none_otherwise():
-    assert maybe_int('216+337') is None
 
 
 def test_dedupe_all_lists():

--- a/tests/unit/utils/test_utils_helpers.py
+++ b/tests/unit/utils/test_utils_helpers.py
@@ -29,7 +29,7 @@ import tempfile
 import httpretty
 import pytest
 
-from inspirehep.utils.helpers import download_file, force_list
+from inspirehep.utils.helpers import download_file, force_list, maybe_int
 
 
 @pytest.fixture
@@ -109,3 +109,14 @@ def test_force_list_does_not_touch_lists():
     result = force_list(['foo', 'bar', 'baz'])
 
     assert expected == result
+
+
+def test_maybe_int_returns_int_if_possible():
+    expected = 10
+    result = maybe_int('10')
+
+    assert expected == result
+
+
+def test_maybe_int_returns_none_otherwise():
+    assert maybe_int('216+337') is None

--- a/tests/unit/utils/test_utils_helpers.py
+++ b/tests/unit/utils/test_utils_helpers.py
@@ -29,11 +29,7 @@ import tempfile
 import httpretty
 import pytest
 
-from inspirehep.utils.helpers import (
-    download_file,
-    get_json_for_plots,
-    force_list,
-)
+from inspirehep.utils.helpers import download_file, force_list
 
 
 @pytest.fixture
@@ -85,54 +81,6 @@ def test_download_file_raises_if_called_without_output_file():
 
     with pytest.raises(IOError):
         download_file('http://example.com/foo-bar-baz')
-
-
-def test_get_json_for_plots():
-    plots = [
-        {
-            'captions': [
-                'foo-caption-1',
-                'foo-caption-2',
-            ],
-            'name': 'foo-name',
-            'url': 'http://example.com/foo-url',
-        },
-        {
-            'captions': [
-                'bar-caption-1',
-            ],
-            'name': 'bar-name',
-            'url': 'http://example.com/bar-url',
-        },
-        {
-        },
-    ]
-
-    expected = {
-        '_fft': [
-            {
-                'path': 'http://example.com/foo-url',
-                'type': 'Plot',
-                'description': '00000 foo-caption-1foo-caption-2',
-                'filename': 'foo-name',
-            },
-            {
-                'path': 'http://example.com/bar-url',
-                'type': 'Plot',
-                'description': '00001 bar-caption-1',
-                'filename': 'bar-name',
-            },
-            {
-                'path': None,
-                'type': 'Plot',
-                'description': '00002 ',
-                'filename': None,
-            },
-        ],
-    }
-    result = get_json_for_plots(plots)
-
-    assert expected == result
 
 
 def test_force_list_returns_empty_list_on_none():


### PR DESCRIPTION
Sentry: https://sentry.cern.ch/inspire-sentry/inspire-labs/group/820882/