### PR TITLE
orcid: default to login form

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -1322,7 +1322,9 @@ INDEXER_BULK_REQUEST_TIMEOUT = float(120)
 
 # OAuthclient
 # ===========
-orcid.REMOTE_APP['params']['request_token_params'] = {'scope': '/orcid-profile/read-limited /activities/update /orcid-bio/update'}
+orcid.REMOTE_APP['params']['request_token_params'] = {
+    'scope': '/orcid-profile/read-limited /activities/update /orcid-bio/update',
+    'show_login': 'true'}
 OAUTHCLIENT_REMOTE_APPS = dict(
     orcid=orcid.REMOTE_APP,
 )


### PR DESCRIPTION
* Upon authentication, defaults to login form instead of registration
  form.
  (closes #2196 )

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>