### PR TITLE
editor: index template amendments

### DIFF
--- a/inspirehep/modules/theme/static/scss/base/core.scss
+++ b/inspirehep/modules/theme/static/scss/base/core.scss
@@ -70,15 +70,17 @@ Generic core styles that are included in all INSPIRE pages.
 /* External links styling
 ================================================== */
 
-a[href^="http://"]:after, a[href^="https://"]:after {
-  content: "\f08e";
-  font-size: 80%;
-  font-family: FontAwesome;
-  font-weight: normal;
-  font-style: normal;
-  display: inline-block;
-  text-decoration: none;
-  padding-left: 3px;
+body.show-external-link-icons {
+    a[href^="http://"]:after, a[href^="https://"]:after {
+      content: "\f08e";
+      font-size: 80%;
+      font-family: FontAwesome;
+      font-weight: normal;
+      font-style: normal;
+      display: inline-block;
+      text-decoration: none;
+      padding-left: 3px;
+    }
 }
 
 a.no-external-icon:after {

--- a/inspirehep/modules/theme/templates/inspirehep_theme/invenio_record_editor/index.html
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/invenio_record_editor/index.html
@@ -24,6 +24,8 @@
 
 {%- extends config.RECORD_EDITOR_BASE_TEMPLATE -%}
 
+{% set hide_external_link_icons = True %}
+
 {%- block page_body %}
 <div id="re-wrapper">
 	<re-app>
@@ -36,7 +38,16 @@
 
 {%- block page_footer %}
 {%- endblock page_footer %}
- 
+
+{% block css %}
+{{ super() }}
+<style media="screen">
+  body {
+    margin-bottom: 0px;
+  }
+</style>
+{% endblock css %}
+
 {% block javascript %}
 {{ super() }}
 <script type="text/javascript">

--- a/inspirehep/modules/theme/templates/inspirehep_theme/page.html
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/page.html
@@ -58,6 +58,15 @@
         {%- endblock css %}
     {%- endblock head %}
 </head>
+{% if body_css_classes %}
+  {% if not hide_external_link_icons %}
+    {% do body_css_classes.append("show-external-link-icons") %}
+  {% endif %}
+{% else %}
+  {% if not hide_external_link_icons %}
+    {% set body_css_classes = ["show-external-link-icons"] %}
+  {% endif %}
+{% endif %}
 <body{% if body_css_classes %} class="{{ body_css_classes|join(' ') }}"{% endif %}{% if g.ln %}
                                lang="{{ g.ln.split('_', 1)[0]|safe }}"{% if rtl_direction %} {{ rtl_direction|safe }}
     {% endif %}{% endif %} itemscope itemtype="http://schema.org/WebPage" data-spy="scroll"


### PR DESCRIPTION
* Fixes template so that editor can take 100% height.

* Adds new Jinja2 variable hide_external_link_icons that will avoid
  showing external link icons on a given page.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>