### PR TITLE
dojson: don't export magpie keywords

### DIFF
--- a/inspirehep/dojson/hep/rules/bd6xx.py
+++ b/inspirehep/dojson/hep/rules/bd6xx.py
@@ -167,7 +167,8 @@ def keywords2marc(self, key, values):
             if '653' not in self:
                 self['653'] = []
 
-            self['653'].append(marc_dict)
+            if marc_dict.get('9') != 'magpie':
+                self['653'].append(marc_dict)
             continue
 
     return thesaurus_terms

--- a/tests/unit/dojson/test_dojson_hep_bd6xx.py
+++ b/tests/unit/dojson/test_dojson_hep_bd6xx.py
@@ -39,6 +39,19 @@ def test_keywords_from_653__9_ignores_lone_sources():
     assert 'keywords' not in hep.do(create_record(snippet))
 
 
+def test_keywords2marc_does_not_export_magpie_keywords():
+    record = {
+        'keywords': [
+            {
+                'source': 'magpie',
+                'value': 'cosmological model',
+            },
+        ],
+    }
+
+    assert '653' not in hep2marc.do(record)
+
+
 def test_accelerator_experiments_from_693__a_e():
     schema = load_schema('hep')
     subschema = schema['properties']['accelerator_experiments']


### PR DESCRIPTION
This is a stopgap solution requested by @ksachs during standup yesterday before we properly implement https://github.com/inspirehep/inspire-next/issues/2216.