### PR TITLE
tests: add visible_acceptance test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,11 +54,6 @@ before_install:
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
-  # See: https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI
-  - export DISPLAY=:99.0
-  - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 2560x2048x16
-  - sleep 3
-  - xhost local:root
 
 install:
   - travis_retry docker-compose pull

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -83,6 +83,23 @@ services:
   acceptance:
     extends:
       service: test-service_base
+    command: py.test --driver Remote --host selenium --port 4444 --capability browserName firefox --html=selenium-report.html tests/acceptance
+    volumes_from:
+      - test-static
+    links:
+      - test-database
+      - test-indexer
+      - test-rabbitmq
+      - test-redis
+      - selenium
+    depends_on:
+      - test-web
+      - test-worker
+    environment:
+      - SERVER_NAME=test-web:5000
+  visible_acceptance:
+    extends:
+      service: test-service_base
     command: py.test --driver Firefox --host selenium --port 4444 --capability browserName firefox --html=selenium-report.html tests/acceptance
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix

--- a/docs/tests.rst
+++ b/docs/tests.rst
@@ -56,7 +56,7 @@ Via Docker with a graphical instance of Firefox (Linux)
 
 .. code-block:: bash
 
-  $ docker-compose -f docker-compose.test.yml run --rm acceptance
+  $ docker-compose -f docker-compose.test.yml run --rm visible_acceptance
 
 
 Via Docker with a graphical instance of Firefox (macOS)
@@ -108,7 +108,7 @@ Via Docker with a graphical instance of Firefox (macOS)
 
 .. code-block:: bash
 
-  $ docker-compose -f docker-compose.test.yml run --rm acceptance
+  $ docker-compose -f docker-compose.test.yml run --rm visible_acceptance
 
 
 How to Write the Selenium Tests


### PR DESCRIPTION
Closes #2045 

Adds the `visible_acceptance` test suite, and makes the
`acceptance` test suite the default on Travis.