### PR TITLE
holdingpen: ignore experiments prediction mapping

### DIFF
--- a/inspirehep/modules/workflows/mappings/holdingpen/hep.json
+++ b/inspirehep/modules/workflows/mappings/holdingpen/hep.json
@@ -11,6 +11,10 @@
                     "properties": {
                         "is-update": {
                             "type": "boolean"
+                        },
+                        "experiments_prediction": {
+                            "dynamic": "false",
+                            "type": "object"
                         }
                     },
                     "type": "object"


### PR DESCRIPTION
* This allows putting there anything, it's a temporary workaround
  until we formalize what should be the data structure there.
  (closes #2144)

Signed-off-by: David Caro <david@dcaro.es>