### PR TITLE
tests: enforce future imports through flake8

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -24,4 +24,5 @@
 addopts = --cov=inspirehep --cov-report=term-missing:skip-covered --flake8
 flake8-ignore =
   *.py E121 E123 E126 E128 E501 F401 F403 F405
+  *.py FI12 FI14 FI15 FI16 FI17 FI50 FI51 FI53
   inspirehep/modules/search/walkers/*.py F811

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ install_requires = [
 tests_require = [
     'check-manifest>=0.25',
     'coverage>=4.0',
+    'flake8-future-import>=0.4.3',
     'isort>=4.2.2',
     'pep257>=0.7.0',
     'pytest-cache>=1.0',


### PR DESCRIPTION
Uses `flake8-future-import` to make sure that all Python files
import exactly `absolute_import`, `division`, `print_function`
from `__future__`, preventing a regression on #1838.