### PR TITLE
packaging: use released Flask_CeleryExt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,6 @@
 
 # Bleeding edge packages not yet released on Pypi
 -e git+https://github.com/inveniosoftware/invenio-jsonschemas.git@master#egg=invenio-jsonschemas
--e git+https://github.com/inveniosoftware/flask-celeryext.git@master#egg=flask-celeryext
 
 # FIXME temporary branch for testing
 -e git+https://github.com/inspirehep/invenio-query-parser.git@invenio3-inspire#egg=invenio-query-parser==0.6.0

--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,7 @@ install_requires = [
     'invenio-workflows-ui~=1.0.31',
     'elasticsearch-dsl<2.2.0',
     'pycountry>=17.1.8',
+    'Flask_CeleryExt>=0.3.0',
 ]
 
 tests_require = [


### PR DESCRIPTION
Spin off of #2138. Reducing packages installed through `git` makes sense independently of bumping Celery (which looks like it might take some time).