### PR TITLE
travis: avoid extra 1000 lines of output

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -21,6 +21,7 @@
 # or submit itself to any jurisdiction.
 
 [run]
+include = inspirehep/*.py
 omit =
   inspirehep/bat/*.py
   inspirehep/celery.py


### PR DESCRIPTION
Uh, this actually works! I also noticed that http://coverage.readthedocs.io/en/coverage-4.4b1/config.html#paths can be used to get rid of https://github.com/inspirehep/inspire-next/blob/427ce4076edc33b6f419f28a850f572ab173ea94/.travis.yml#L71-L72 ... but it's totally not urgent, so I'm closing this.