### PR TITLE
global: fix F403 and F405

### DIFF
--- a/inspirehep/modules/authors/__init__.py
+++ b/inspirehep/modules/authors/__init__.py
@@ -26,4 +26,4 @@ from __future__ import absolute_import, division, print_function
 
 from .ext import INSPIREAuthors
 
-from .receivers import *
+from .receivers import *  # noqa: F403

--- a/inspirehep/modules/forms/fields/__init__.py
+++ b/inspirehep/modules/forms/fields/__init__.py
@@ -26,10 +26,10 @@ from __future__ import absolute_import, division, print_function
 
 from wtforms.utils import unset_value
 
-from .date import *
-from .doi import *
-from .file_upload import *
-from .jinja import *
-from .language import *
-from .title import *
-from .wtformsext import *
+from .date import *  # noqa: F403
+from .doi import *  # noqa: F403
+from .file_upload import *  # noqa: F403
+from .jinja import *  # noqa: F403
+from .language import *  # noqa: F403
+from .title import *  # noqa: F403
+from .wtformsext import *  # noqa: F403

--- a/inspirehep/modules/forms/validators/__init__.py
+++ b/inspirehep/modules/forms/validators/__init__.py
@@ -22,5 +22,5 @@
 
 from __future__ import absolute_import, division, print_function
 
-from .simple_fields import *
-from .dynamic_fields import *
+from .simple_fields import *  # noqa: F403
+from .dynamic_fields import *  # noqa: F403

--- a/inspirehep/modules/orcid/__init__.py
+++ b/inspirehep/modules/orcid/__init__.py
@@ -24,4 +24,4 @@ from __future__ import absolute_import, division, print_function
 
 from .ext import INSPIREOrcid
 
-from .receivers import *
+from .receivers import *  # noqa: F403

--- a/inspirehep/modules/records/__init__.py
+++ b/inspirehep/modules/records/__init__.py
@@ -24,4 +24,4 @@
 
 from __future__ import absolute_import, division, print_function
 
-from .receivers import *
+from .receivers import *  # noqa: F403

--- a/inspirehep/modules/search/parser.py
+++ b/inspirehep/modules/search/parser.py
@@ -25,8 +25,30 @@
 
 from __future__ import absolute_import, division, print_function
 
-from invenio_query_parser.parser import *
-from invenio_query_parser.parser import _
+import re
+
+import pypeg2
+from pypeg2 import Keyword, Literal, attr, maybe_some, omit, some
+
+from invenio_query_parser.parser import (
+    BinaryRule,
+    EmptyQueryRule,
+    KeywordRule,
+    LeafRule,
+    ListRule,
+    NestableKeyword,
+    Number,
+    Query,
+    RangeOp,
+    UnaryRule,
+    Value,
+    ValueQuery,
+    Whitespace,
+    WildcardQuery,
+    _,
+    ast,
+    string_types,
+)
 
 from .config import SPIRES_KEYWORDS
 

--- a/inspirehep/modules/theme/__init__.py
+++ b/inspirehep/modules/theme/__init__.py
@@ -27,4 +27,4 @@ from __future__ import absolute_import, division, print_function
 from .ext import INSPIRETheme
 
 # Needed to register the jinja filters in the Blueprint
-from .jinja2filters import *
+from .jinja2filters import *  # noqa: F403

--- a/inspirehep/modules/workflows/__init__.py
+++ b/inspirehep/modules/workflows/__init__.py
@@ -26,4 +26,4 @@
 from __future__ import absolute_import, division, print_function
 
 from .ext import INSPIREWorkflows
-from .receivers import *
+from .receivers import *  # noqa: F403

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,6 +23,6 @@
 [pytest]
 addopts = --cov=inspirehep --cov-report=term-missing:skip-covered --flake8
 flake8-ignore =
-  *.py E121 E123 E126 E128 E501 F401 F403 F405
+  *.py E121 E123 E126 E128 E501 F401
   *.py FI12 FI14 FI15 FI16 FI17 FI50 FI51 FI53
   inspirehep/modules/search/walkers/*.py F811

--- a/tests/unit/theme/test_theme_jinja2filters.py
+++ b/tests/unit/theme/test_theme_jinja2filters.py
@@ -30,7 +30,51 @@ from mock import patch
 
 from inspirehep.modules.records.api import InspireRecord
 from inspirehep.modules.records.wrappers import LiteratureRecord
-from inspirehep.modules.theme.jinja2filters import *
+from inspirehep.modules.theme.jinja2filters import (
+    ads_links,
+    apply_template_on_array,
+    author_profile,
+    author_urls,
+    citation_phrase,
+    collection_select_current,
+    conference_date,
+    construct_date_format,
+    email_link,
+    email_links,
+    epoch_to_year_format,
+    experiment_date,
+    experiment_link,
+    find_collection_from_url,
+    format_author_name,
+    format_cnum_with_slash,
+    format_cnum_with_hyphons,
+    format_date,
+    institutes_links,
+    is_cataloger,
+    is_external_link,
+    is_institute,
+    is_list,
+    is_upper,
+    join_array,
+    join_nested_lists,
+    json_dumps,
+    limit_facet_elements,
+    link_to_hep_affiliation,
+    new_line_after,
+    proceedings_link,
+    publication_info,
+    remove_duplicates_from_list,
+    sanitize_arxiv_pdf,
+    sanitize_collection_name,
+    search_for_experiments,
+    show_citations_number,
+    sort_list_by_dict_val,
+    strip_leading_number_plot_caption,
+    url_links,
+    weblinks,
+    words,
+    words_to_end,
+)
 
 from mocks import MockUser
 


### PR DESCRIPTION
Fixes the PyFlakes errors about star imports. Some are still there,
because they actually serve as a primitive implementation of entry
points (closes #1835).