### PR TITLE
classifier: add core- and anti-HEP-ontology

### DIFF
--- a/inspirehep/taxonomies/HEPontCore.rdf
+++ b/inspirehep/taxonomies/HEPontCore.rdf
@@ -1,0 +1,16042 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- HEP ontology v.1.7 - April 2015 -->
+<!-- <Kirsten.Sachs@desy.de> <Florian.Schwennsen@desy.de> -->
+
+<rdf:RDF xmlns="http://www.w3.org/2004/02/skos/core#"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"> 
+
+<rdf:Property rdf:about="http://cern.ch/thesauri/HEPontology.rdf#compositeOf">
+  <rdfs:comment>Expresses a composite keyword relationship to broader concepts.</rdfs:comment>
+  <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#broader"/>
+</rdf:Property>
+
+<rdf:Property rdf:about="http://cern.ch/thesauri/HEPontology.rdf#composite">
+  <rdfs:comment>Expresses the relationship to a composite keyword</rdfs:comment>
+  <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#narrower"/>
+</rdf:Property>
+
+<ConceptScheme rdf:about="http://cern.ch/thesauri/HEPontology.rdf">
+        <dc:creator rdf:resource="http://ceres.ca.gov/"/>
+        <dc:description>This is a first draft of a subject ontology/thesaurus for High Energy Physics using RDF/SKOS syntax 
+                        Developed jointly by CERN and DESY labs.</dc:description>
+        <dc:title>HEP ontology</dc:title>
+</ConceptScheme>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#0">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.loopintegral0"/>
+  <prefLabel xml:lang="en">0</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#1">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.supersymmetry1"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.loopintegral1"/>
+  <prefLabel xml:lang="en">1</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#2">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.supersymmetry2"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottom2"/>
+  <prefLabel xml:lang="en">2</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#3">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.phi**nmodel3"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.loopintegral3"/>
+  <prefLabel xml:lang="en">3</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#4">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.supersymmetry4"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.phi**nmodel4"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.loopintegral4"/>
+  <prefLabel xml:lang="en">4</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#5">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.loopintegral5"/>
+  <prefLabel xml:lang="en">5</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#6">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.supersymmetry6"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.phi**nmodel6"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.loopintegral6"/>
+  <prefLabel xml:lang="en">6</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#8">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.supersymmetry8"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.loopintegral8"/>
+  <prefLabel xml:lang="en">8</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#ABJMmodel">
+  <prefLabel xml:lang="en">ABJM model</prefLabel>
+  <altLabel xml:lang="en">ABJM theory</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#absorption">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoabsorption"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-absorption"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+absorption"/>
+  <prefLabel xml:lang="en">absorption</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#acceleration">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.accelerationwakefield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.accelerationshockwaves"/>
+  <prefLabel xml:lang="en">acceleration</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#accelerator">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.acceleratorplasma"/>
+  <prefLabel xml:lang="en">accelerator</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#action">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.latticefieldtheoryaction"/>
+  <prefLabel xml:lang="en">action</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#ADDmodel">
+  <prefLabel xml:lang="en">ADD model</prefLabel>
+  <altLabel xml:lang="en">Arkani-Dimopoulos-Dvali</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#admixture">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muadmixture"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eadmixture"/>
+  <prefLabel xml:lang="en">admixture</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#AdS/CFTcorrespondence">
+  <prefLabel xml:lang="en">AdS/CFT correspondence</prefLabel>
+  <altLabel xml:lang="en">AdS/CFT</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Affleck-Dinemodel">
+  <prefLabel xml:lang="en">Affleck-Dine model</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#air">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoair"/>
+  <prefLabel xml:lang="en">air</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#ALEPH">
+  <prefLabel xml:lang="en">ALEPH</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#algebra">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.supersymmetryalgebra"/>
+  <prefLabel xml:lang="en">algebra</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#ALICE">
+  <prefLabel xml:lang="en">ALICE</prefLabel>
+  <altLabel xml:lang="en">CERN-LHC-ALICE</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#ALPHA">
+  <prefLabel xml:lang="en">ALPHA</prefLabel>
+  <note xml:lang="en">core</note>
+  <note xml:lang="en">noautosingle</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#AMANDA">
+  <prefLabel xml:lang="en">AMANDA</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#angulardistribution">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.angulardistributionasymmetry"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muangulardistribution"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoangulardistribution"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomangulardistribution"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0angulardistribution"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0angulardistribution"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-angulardistribution"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+angulardistribution"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaangulardistribution"/>
+  <prefLabel xml:lang="en">angular distribution</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#angularmomentum">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoangularmomentum"/>
+  <prefLabel xml:lang="en">angular momentum</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#anisotropy">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoanisotropy"/>
+  <prefLabel xml:lang="en">anisotropy</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#ANKE">
+  <prefLabel xml:lang="en">ANKE</prefLabel>
+  <altLabel xml:lang="en">COSY-ANKE</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#annihilation">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauannihilation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muannihilation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eannihilation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoannihilation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downannihilation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomannihilation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0annihilation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiannihilation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0annihilation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-annihilation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+annihilation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bannihilation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaannihilation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0annihilation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-annihilation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+annihilation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0annihilation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterannihilation"/>
+  <prefLabel xml:lang="en">annihilation</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#ANTARES">
+  <prefLabel xml:lang="en">ANTARES</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#anti-p">
+  <prefLabel xml:lang="en">anti-p</prefLabel>
+  <altLabel xml:lang="en">antiproton</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#antibaryon">
+  <prefLabel xml:lang="en">antibaryon</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#antifermion">
+  <prefLabel xml:lang="en">antifermion</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#antifield">
+  <prefLabel xml:lang="en">antifield</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#antigravitation">
+  <prefLabel xml:lang="en">antigravitation</prefLabel>
+  <altLabel xml:lang="en">antigravity</altLabel>
+  <note xml:lang="en">FC:g</note>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#antihydrogen">
+  <prefLabel xml:lang="en">antihydrogen</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#antihyperon">
+  <prefLabel xml:lang="en">antihyperon</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#antineutrino">
+  <prefLabel xml:lang="en">antineutrino</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#antinucleon">
+  <prefLabel xml:lang="en">antinucleon</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#antiparticle">
+  <prefLabel xml:lang="en">antiparticle</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#antiquark">
+  <prefLabel xml:lang="en">antiquark</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#approximation">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.approximationstrongcoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.approximationquasiparticle"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.approximationdensity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.approximationclassical"/>
+  <prefLabel xml:lang="en">approximation</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#ArgoNeuT">
+  <prefLabel xml:lang="en">ArgoNeuT</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#ARGUS">
+  <prefLabel xml:lang="en">ARGUS</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#ASACUSA">
+  <prefLabel xml:lang="en">ASACUSA</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#associatedproduction">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauassociatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muassociatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eassociatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoassociatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downassociatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomassociatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0associatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiassociatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0associatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-associatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+associatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bassociatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaassociatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0associatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-associatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+associatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0associatedproduction"/>
+  <prefLabel xml:lang="en">associated production</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#astrophysics">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoastrophysics"/>
+  <prefLabel xml:lang="en">astrophysics</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#asymmetry">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.angulardistributionasymmetry"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoasymmetry"/>
+  <prefLabel xml:lang="en">asymmetry</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#ATLAS">
+  <prefLabel xml:lang="en">ATLAS</prefLabel>
+  <altLabel xml:lang="en">CERN-LHC-ATLAS</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#atmosphere">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauatmosphere"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muatmosphere"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoatmosphere"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.showersatmosphere"/>
+  <prefLabel xml:lang="en">atmosphere</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#atom">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-atom"/>
+  <prefLabel xml:lang="en">atom</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#ATRAP">
+  <prefLabel xml:lang="en">ATRAP</prefLabel>
+  <altLabel xml:lang="en">CERN-ATRAP</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Auger">
+  <prefLabel xml:lang="en">Auger</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#AWAKE">
+  <prefLabel xml:lang="en">AWAKE</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#axigluon">
+  <prefLabel xml:lang="en">axigluon</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#axino">
+  <prefLabel xml:lang="en">axino</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#axiomaticfieldtheory">
+  <prefLabel xml:lang="en">axiomatic field theory</prefLabel>
+  <altLabel xml:lang="en">Osterwalder-Schrader</altLabel>
+  <altLabel xml:lang="en">Wightman axiom</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#axion">
+  <prefLabel xml:lang="en">axion</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#B0">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0yield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0width"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0wavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0transversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0signature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0semileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0raredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0rapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0radiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0propagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0production"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0photoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0particlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0particleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0pairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0multiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0multipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0momentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0momentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0massspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0massgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0massformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0massdifference"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0mass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0magneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0lifetime"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0leptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0leptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0invisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0intermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0inclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0hadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0hadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0groundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0formfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0finalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0exclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0excitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0exchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0energyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0energy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0electroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0electromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0electricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0distributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0directproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0decoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0decayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0decaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0decayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0decay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0couplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0coupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0condensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0cascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0branchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0associatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0annihilation"/>
+  <prefLabel xml:lang="en">B0</prefLabel>
+  <note xml:lang="en">core</note>
+  <note xml:lang="en">noautosingle</note>
+  <note xml:lang="en">nostandalone</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#B0anti-B0">
+  <prefLabel xml:lang="en">B0 anti-B0</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#BaBar">
+  <prefLabel xml:lang="en">BaBar</prefLabel>
+  <altLabel xml:lang="en">SLAC-PEP2-BABAR</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#background">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mubackground"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ebackground"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinobackground"/>
+  <prefLabel xml:lang="en">background</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#backscatter">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Comptonscatteringbackscatter"/>
+  <prefLabel xml:lang="en">backscatter</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#bagmodel">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.quarkgluonbagmodel"/>
+  <prefLabel xml:lang="en">bag model</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Bagger-Lambert-Gustavssonmodel">
+  <prefLabel xml:lang="en">Bagger-Lambert-Gustavsson model</prefLabel>
+  <altLabel xml:lang="en">BLG model</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Baikal">
+  <prefLabel xml:lang="en">Baikal</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Baksan">
+  <prefLabel xml:lang="en">Baksan</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Balitsky-Kovchegovequation">
+  <prefLabel xml:lang="en">Balitsky-Kovchegov equation</prefLabel>
+  <altLabel xml:lang="en">Balitsky-Kovchegov</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#baryon">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.baryontechnicolor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.baryonhadronspectroscopy"/>
+  <prefLabel xml:lang="en">baryon</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#baryonnumber">
+  <prefLabel xml:lang="en">baryon number</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#baryonresonance">
+  <prefLabel xml:lang="en">baryon resonance</prefLabel>
+  <altLabel xml:lang="en">baryonic resonance</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#BataviaTEVATRONColl">
+  <prefLabel xml:lang="en">Batavia TEVATRON Coll</prefLabel>
+  <altLabel xml:lang="en">Tevatron</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#BataviaTEVATRONPS">
+  <prefLabel xml:lang="en">Batavia TEVATRON PS</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#beam">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taubeam"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mubeam"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ebeam"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinobeam"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-beam"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+beam"/>
+  <prefLabel xml:lang="en">beam</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#beamprofile">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinobeamprofile"/>
+  <prefLabel xml:lang="en">beam profile</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#beamtransport">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinobeamtransport"/>
+  <prefLabel xml:lang="en">beam transport</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Becchi-Rouet-Stora">
+  <prefLabel xml:lang="en">Becchi-Rouet-Stora</prefLabel>
+  <altLabel xml:lang="en">BRS</altLabel>
+  <altLabel xml:lang="en">BRST</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#BeijingStor">
+  <prefLabel xml:lang="en">Beijing Stor</prefLabel>
+  <altLabel xml:lang="en">BEPC</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#BELLE">
+  <prefLabel xml:lang="en">BELLE</prefLabel>
+  <altLabel xml:lang="en">Belle</altLabel>
+  <altLabel xml:lang="en">KEK-BF-BELLE</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#BerkeleyBevalac">
+  <prefLabel xml:lang="en">Berkeley Bevalac</prefLabel>
+  <altLabel xml:lang="en">Bevalac</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#BESS">
+  <prefLabel xml:lang="en">BESS</prefLabel>
+  <note xml:lang="en">core</note>
+  <definition xml:lang="en">Balloon-borne Experiment with Superconducting Spectrometer</definition>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#betabeam">
+  <prefLabel xml:lang="en">beta beam</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#BFmodel">
+  <prefLabel xml:lang="en">BF model</prefLabel>
+  <altLabel xml:lang="en">BF theory</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#BFKLequation">
+  <prefLabel xml:lang="en">BFKL equation</prefLabel>
+  <altLabel xml:lang="en">BFKL</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#BICEP">
+  <prefLabel xml:lang="en">BICEP</prefLabel>
+  <altLabel xml:lang="en">BICEP2</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#bindingenergy">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-bindingenergy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdabindingenergy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-bindingenergy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etabindingenergy"/>
+  <prefLabel xml:lang="en">binding energy</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#blackbrane">
+  <prefLabel xml:lang="en">black brane</prefLabel>
+  <note xml:lang="en">FC:g</note>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#blackhole">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.blackholeentropy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.blackholecharge"/>
+  <prefLabel xml:lang="en">black hole</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#blackstring">
+  <prefLabel xml:lang="en">black string</prefLabel>
+  <note xml:lang="en">FC:g</note>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Bogomolnyiequation">
+  <prefLabel xml:lang="en">Bogomolnyi equation</prefLabel>
+  <note xml:lang="en">FC:t</note>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#BonnELSAStor">
+  <prefLabel xml:lang="en">Bonn ELSA Stor</prefLabel>
+  <altLabel xml:lang="en">ELSA</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#BooNE">
+  <prefLabel xml:lang="en">BooNE</prefLabel>
+  <altLabel xml:lang="en">FNAL-E-0898</altLabel>
+  <altLabel xml:lang="en">MiniBooNE</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#boostedparticle">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0boostedparticle"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.topboostedparticle"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Higgsparticleboostedparticle"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomboostedparticle"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomboostedparticle"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0boostedparticle"/>
+  <prefLabel xml:lang="en">boosted particle</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Borexino">
+  <prefLabel xml:lang="en">Borexino</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Born-Infeldmodel">
+  <prefLabel xml:lang="en">Born-Infeld model</prefLabel>
+  <altLabel xml:lang="en">DBI</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#boson">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.stringmodelboson"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.gaugefieldtheoryboson"/>
+  <prefLabel xml:lang="en">boson</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#bosonization">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinobosonization"/>
+  <prefLabel xml:lang="en">bosonization</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#bottom">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.jetbottom"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomparticleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomboostedparticle"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomyield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomwidth"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomwavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomvectorparticle"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomvector"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomtransversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomtotalcrosssection"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomsuppression"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomsingleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomsignature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomsemileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomraredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomrapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomradiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottompropagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomphotoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomparticlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomparticleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottompairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommultiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommultipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommomentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommirrorparticle"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommassspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommassgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommassformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommagneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomlifetime"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomleptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomleptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomleadingparticle"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottominvisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomintermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottominclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomhadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomhadronization"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomhadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomgroundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomfusion"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomfragmentationfunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomfragmentation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomformfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomfinalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomexclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomexcitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomexchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomenergyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomenergyloss"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomenergy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomellipticflow"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomelectroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomelectromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomelectricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomdistributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomdirectproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomdecoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomdecayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomdecaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomdecayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomcouplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomcoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomcondensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomcascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottombranchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomboostedparticle"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomassociatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomannihilation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomangulardistribution"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottom2"/>
+  <prefLabel xml:lang="en">bottom</prefLabel>
+  <altLabel xml:lang="en">b-quark</altLabel>
+  <note xml:lang="en">core</note>
+  <note xml:lang="en">noautosingle</note>
+  <note xml:lang="en">nostandalone</note>
+  <broader rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#heavyquark"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#bottomanti-bottom">
+  <prefLabel xml:lang="en">bottom anti-bottom</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Boulby">
+  <prefLabel xml:lang="en">Boulby</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#boundstate">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoboundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaboundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-boundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.heliumboundstate"/>
+  <prefLabel xml:lang="en">bound state</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#BRAHMS">
+  <prefLabel xml:lang="en">BRAHMS</prefLabel>
+  <altLabel xml:lang="en">BNL-RHIC-BRAHMS</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#branchingratio">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taubranchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mubranchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ebranchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinobranchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downbranchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottombranchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0branchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xibranchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0branchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-branchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+branchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bbranchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdabranchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0branchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-branchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+branchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0branchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etabranchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterbranchingratio"/>
+  <prefLabel xml:lang="en">branching ratio</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#branon">
+  <prefLabel xml:lang="en">branon</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Brans-Dickemodel">
+  <prefLabel xml:lang="en">Brans-Dicke model</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#bremsstrahlung">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinobremsstrahlung"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0bremsstrahlung"/>
+  <prefLabel xml:lang="en">bremsstrahlung</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#BrookhavenPS">
+  <prefLabel xml:lang="en">Brookhaven PS</prefLabel>
+  <altLabel xml:lang="en">AGS</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#BrookhavenRHICColl">
+  <prefLabel xml:lang="en">Brookhaven RHIC Coll</prefLabel>
+  <altLabel xml:lang="en">RHIC</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#BTeV">
+  <prefLabel xml:lang="en">BTeV</prefLabel>
+  <altLabel xml:lang="en">FNAL-E-0918</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#burst">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoburst"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0burst"/>
+  <prefLabel xml:lang="en">burst</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Cabibboangle">
+  <prefLabel xml:lang="en">Cabibbo angle</prefLabel>
+  <note xml:lang="en">FC:p</note>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Cabibbomodel">
+  <prefLabel xml:lang="en">Cabibbo model</prefLabel>
+  <note xml:lang="en">FC:p</note>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#calcium">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.calciumtungsten"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.calciumfluorine"/>
+  <prefLabel xml:lang="en">calcium</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CALET">
+  <prefLabel xml:lang="en">CALET</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CALICE">
+  <prefLabel xml:lang="en">CALICE</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Callan-Gross">
+  <prefLabel xml:lang="en">Callan-Gross</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#calorimeter">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocalorimeter"/>
+  <prefLabel xml:lang="en">calorimeter</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#caloron">
+  <prefLabel xml:lang="en">caloron</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#capture">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mucapture"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ecapture"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocapture"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-capture"/>
+  <prefLabel xml:lang="en">capture</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#cascadedecay">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taucascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mucascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ecascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downcascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomcascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0cascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xicascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0cascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-cascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+cascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bcascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdacascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0cascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-cascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+cascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0cascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmattercascadedecay"/>
+  <prefLabel xml:lang="en">cascade decay</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#causality">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.causalityviolation"/>
+  <prefLabel xml:lang="en">causality</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CCFMequation">
+  <prefLabel xml:lang="en">CCFM equation</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CDF">
+  <prefLabel xml:lang="en">CDF</prefLabel>
+  <altLabel xml:lang="en">Collider Detector at Fermilab</altLabel>
+  <altLabel xml:lang="en">FNAL-E-0830</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CELLO">
+  <prefLabel xml:lang="en">CELLO</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CERES">
+  <prefLabel xml:lang="en">CERES</prefLabel>
+  <altLabel xml:lang="en">CERN-NA-045</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CERNCLIC">
+  <prefLabel xml:lang="en">CERN CLIC</prefLabel>
+  <altLabel xml:lang="en">CLIC</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CERNLab">
+  <prefLabel xml:lang="en">CERN Lab</prefLabel>
+  <altLabel xml:lang="en">CERN</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CERNLEAR">
+  <prefLabel xml:lang="en">CERN LEAR</prefLabel>
+  <altLabel xml:lang="en">LEAR</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CERNLEPStor">
+  <prefLabel xml:lang="en">CERN LEP Stor</prefLabel>
+  <altLabel xml:lang="en">LEP</altLabel>
+  <altLabel xml:lang="en">LEP2</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CERNLHCColl">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.CERNLHCCollupgrade"/>
+  <prefLabel xml:lang="en">CERN LHC Coll</prefLabel>
+  <altLabel xml:lang="en">LHC</altLabel>
+  <altLabel xml:lang="en">Large Hadron Collider</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CERNSPS">
+  <prefLabel xml:lang="en">CERN SPS</prefLabel>
+  <altLabel xml:lang="en">SPS</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CERNSPSColl">
+  <prefLabel xml:lang="en">CERN SPS Coll</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Chaplygin">
+  <prefLabel xml:lang="en">Chaplygin</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#charge">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.blackholecharge"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocharge"/>
+  <prefLabel xml:lang="en">charge</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#chargeradius">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinochargeradius"/>
+  <prefLabel xml:lang="en">charge radius</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#chargedparticle">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Higgsparticlechargedparticle"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterchargedparticle"/>
+  <prefLabel xml:lang="en">charged particle</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#chargino">
+  <prefLabel xml:lang="en">chargino</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#charm">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.charmparton"/>
+  <prefLabel xml:lang="en">charm</prefLabel>
+  <note xml:lang="en">core</note>
+  <broader rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#heavyquark"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#charmonium">
+  <prefLabel xml:lang="en">charmonium</prefLabel>
+  <altLabel xml:lang="en">charmonia</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Cherenkov">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.radiationCherenkov"/>
+  <prefLabel xml:lang="en">Cherenkov</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Cherenkovcounter">
+  <prefLabel xml:lang="en">Cherenkov counter</prefLabel>
+  <altLabel xml:lang="en">Cherenkov detector</altLabel>
+  <altLabel xml:lang="en">Cherenkov telescope</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Chern-Simonsterm">
+  <prefLabel xml:lang="en">Chern-Simons term</prefLabel>
+  <altLabel xml:lang="en">Chern-Simons formulation</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#chiral">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinochiral"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionchiral"/>
+  <prefLabel xml:lang="en">chiral</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#chiralquarksolitonmodel">
+  <prefLabel xml:lang="en">chiral quark soliton model</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CHORUS">
+  <prefLabel xml:lang="en">CHORUS</prefLabel>
+  <altLabel xml:lang="en">CERN-WA-095</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Chou-Yangmodel">
+  <prefLabel xml:lang="en">Chou-Yang model</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#chromoelectric">
+  <prefLabel xml:lang="en">chromoelectric</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#chromomagnetic">
+  <prefLabel xml:lang="en">chromomagnetic</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CKMmatrix">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.CKMmatrixunitarity"/>
+  <prefLabel xml:lang="en">CKM matrix</prefLabel>
+  <altLabel xml:lang="en">CKM angle</altLabel>
+  <altLabel xml:lang="en">Cabibbo-Kobayashi-Maskawa matrix</altLabel>
+  <altLabel xml:lang="en">Kobayashi-Maskawa angle</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CLAS">
+  <prefLabel xml:lang="en">CLAS</prefLabel>
+  <altLabel xml:lang="en">CEBAF Large Acceptance Spectrometer</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#classical">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.approximationclassical"/>
+  <prefLabel xml:lang="en">classical</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CLEO">
+  <prefLabel xml:lang="en">CLEO</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#cloud">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocloud"/>
+  <prefLabel xml:lang="en">cloud</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#cluster">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocluster"/>
+  <prefLabel xml:lang="en">cluster</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CMD-2">
+  <prefLabel xml:lang="en">CMD-2</prefLabel>
+  <altLabel xml:lang="en">NOVOSIBIRSK-CMD-2</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CMS">
+  <prefLabel xml:lang="en">CMS</prefLabel>
+  <altLabel xml:lang="en">CERN-LHC-CMS</altLabel>
+  <altLabel xml:lang="en">Compact Muon Solenoid</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#COBRA">
+  <prefLabel xml:lang="en">COBRA</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#coherence">
+<composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.approximationquasiparticlecoherence"/>
+  <prefLabel xml:lang="en">coherence</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#coherentinteraction">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocoherentinteraction"/>
+  <prefLabel xml:lang="en">coherent interaction</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#collectivephenomena">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocollectivephenomena"/>
+  <prefLabel xml:lang="en">collective phenomena</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#collidingbeams">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.electronnucleoncollidingbeams"/>
+  <prefLabel xml:lang="en">colliding beams</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#colorflavorlockedphase">
+  <prefLabel xml:lang="en">color flavor locked phase</prefLabel>
+  <altLabel xml:lang="en">CFL</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#colorglasscondensate">
+  <prefLabel xml:lang="en">color glass condensate</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#colorspinlockedphase">
+  <prefLabel xml:lang="en">color spin locked phase</prefLabel>
+  <altLabel xml:lang="en">CSL</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#coloredparticle">
+  <prefLabel xml:lang="en">colored particle</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#coloron">
+  <prefLabel xml:lang="en">coloron</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#COMPASS">
+  <prefLabel xml:lang="en">COMPASS</prefLabel>
+  <altLabel xml:lang="en">CERN-NA-058</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#composite">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocomposite"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0composite"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermioncomposite"/>
+  <prefLabel xml:lang="en">composite</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Comptonscattering">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Comptonscatteringbackscatter"/>
+  <prefLabel xml:lang="en">Compton scattering</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#computer">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.computernetwork"/>
+  <prefLabel xml:lang="en">computer</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#condensation">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taucondensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mucondensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/econdensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocondensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downcondensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomcondensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0condensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xicondensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0condensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-condensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+condensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bcondensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdacondensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0condensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-condensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+condensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0condensation"/>
+  <prefLabel xml:lang="en">condensation</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#confinement">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoconfinement"/>
+  <prefLabel xml:lang="en">confinement</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CornellCESRStor">
+  <prefLabel xml:lang="en">Cornell CESR Stor</prefLabel>
+  <altLabel xml:lang="en">CESR</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#correlation">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocorrelation"/>
+  <prefLabel xml:lang="en">correlation</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#cosmicbackgroundradiation">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.cosmicbackgroundradiationpolarization"/>
+  <prefLabel xml:lang="en">cosmic background radiation</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#cosmicradiation">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.cosmicradiationUHE"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taucosmicradiation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mucosmicradiation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ecosmicradiation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocosmicradiation"/>
+  <prefLabel xml:lang="en">cosmic radiation</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#cosmicstring">
+  <prefLabel xml:lang="en">cosmic string</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#cosmion">
+  <prefLabel xml:lang="en">cosmion</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#COSY-11">
+  <prefLabel xml:lang="en">COSY-11</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#COSY-TOF">
+  <prefLabel xml:lang="en">COSY-TOF</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#coupling">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taucoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mucoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ecoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downcoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomcoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0coupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xicoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0coupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-coupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+coupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bcoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdacoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0coupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-coupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+coupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0coupling"/>
+  <prefLabel xml:lang="en">coupling</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#couplingconstant">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.weakinteractioncouplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.stronginteractioncouplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taucouplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mucouplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ecouplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocouplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downcouplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomcouplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0couplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xicouplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0couplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-couplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+couplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bcouplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdacouplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0couplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-couplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+couplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0couplingconstant"/>
+  <prefLabel xml:lang="en">coupling constant</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CP">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.CPviolation"/>
+  <prefLabel xml:lang="en">CP</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CP(N)model">
+  <prefLabel xml:lang="en">CP(N) model</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CPLEAR">
+  <prefLabel xml:lang="en">CPLEAR</prefLabel>
+  <altLabel xml:lang="en">CERN-PS-195</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CPT">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.CPTviolation"/>
+  <prefLabel xml:lang="en">CPT</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CREAM">
+  <prefLabel xml:lang="en">CREAM</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CRESST">
+  <prefLabel xml:lang="en">CRESST</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#criticalphenomena">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.electroweakinteractioncriticalphenomena"/>
+  <prefLabel xml:lang="en">critical phenomena</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#crosssection">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocrosssection"/>
+  <prefLabel xml:lang="en">cross section</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CrystalBall">
+  <prefLabel xml:lang="en">Crystal Ball</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#current">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocurrent"/>
+  <prefLabel xml:lang="en">current</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#curvaton">
+  <prefLabel xml:lang="en">curvaton</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CUSB">
+  <prefLabel xml:lang="en">CUSB</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#CVCmodel">
+  <prefLabel xml:lang="en">CVC model</prefLabel>
+  <altLabel xml:lang="en">conserved vector current</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#D-brane">
+  <prefLabel xml:lang="en">D-brane</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#D-particle">
+  <prefLabel xml:lang="en">D-particle</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#darkenergy">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodarkenergy"/>
+  <prefLabel xml:lang="en">dark energy</prefLabel>
+  <altLabel xml:lang="en">DE</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#darkmatter">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterstring"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterlifetime"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodarkmatter"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterwidth"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterspin"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterscattering"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterpairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterleptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterdirectdetection"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterdecayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterdecaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterchargedparticle"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmattercascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterbranchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterannihilation"/>
+  <prefLabel xml:lang="en">dark matter</prefLabel>
+  <altLabel xml:lang="en">CDM</altLabel>
+  <altLabel xml:lang="en">DM</altLabel>
+  <altLabel xml:lang="en">dark radiation</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#DEAP-3600">
+  <prefLabel xml:lang="en">DEAP-3600</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#decay">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.stringdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.decayweakinteraction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taudecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mudecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/edecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0decay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xidecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0decay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-decay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+decay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdadecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0decay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-decay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+decay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0decay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterdecay"/>
+  <prefLabel xml:lang="en">decay</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#decayconstant">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taudecayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mudecayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/edecayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodecayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downdecayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomdecayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0decayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xidecayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0decayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-decayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+decayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bdecayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdadecayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0decayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-decayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+decayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0decayconstant"/>
+  <prefLabel xml:lang="en">decay constant</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#decaymodes">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taudecaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mudecaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/edecaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodecaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downdecaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomdecaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0decaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xidecaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0decaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-decaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+decaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bdecaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdadecaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0decaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-decaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+decaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0decaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etadecaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterdecaymodes"/>
+  <prefLabel xml:lang="en">decay modes</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#decayrate">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taudecayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mudecayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/edecayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodecayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downdecayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomdecayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0decayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xidecayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0decayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-decayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+decayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bdecayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdadecayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0decayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-decayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+decayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0decayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterdecayrate"/>
+  <prefLabel xml:lang="en">decay rate</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#decoupling">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taudecoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mudecoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/edecoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodecoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downdecoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomdecoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0decoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xidecoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0decoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-decoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+decoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bdecoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdadecoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0decoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-decoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+decoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0decoupling"/>
+  <prefLabel xml:lang="en">decoupling</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#deepinelasticscattering">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.deepinelasticscatteringsemi-inclusivereaction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.deepinelasticscatteringinclusivereaction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodeepinelasticscattering"/>
+  <prefLabel xml:lang="en">deep inelastic scattering</prefLabel>
+  <altLabel xml:lang="en">DIS</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#deepundergrounddetector">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodeepundergrounddetector"/>
+  <prefLabel xml:lang="en">deep underground detector</prefLabel>
+  <altLabel xml:lang="en">underground detector</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#deeplyvirtualComptonscattering">
+  <prefLabel xml:lang="en">deeply virtual Compton scattering</prefLabel>
+  <altLabel xml:lang="en">DVCS</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#deflection">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodeflection"/>
+  <prefLabel xml:lang="en">deflection</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#DELPHI">
+  <prefLabel xml:lang="en">DELPHI</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#density">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.approximationdensity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mudensity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodensity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-density"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdadensity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0density"/>
+  <prefLabel xml:lang="en">density</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#densitymatrix">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodensitymatrix"/>
+  <prefLabel xml:lang="en">density matrix</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#DESYHERAStor">
+  <prefLabel xml:lang="en">DESY HERA Stor</prefLabel>
+  <altLabel xml:lang="en">HERA</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#DESYTESLALinac">
+  <prefLabel xml:lang="en">DESY TESLA Linac</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#detector">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/edetector"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodetector"/>
+  <prefLabel xml:lang="en">detector</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#DGLAPequation">
+  <prefLabel xml:lang="en">DGLAP equation</prefLabel>
+  <altLabel xml:lang="en">DGLAP</altLabel>
+  <altLabel xml:lang="en">GLAP</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#diffraction">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodiffraction"/>
+  <prefLabel xml:lang="en">diffraction</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#diffusion">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taudiffusion"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodiffusion"/>
+  <prefLabel xml:lang="en">diffusion</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#dilaton">
+  <prefLabel xml:lang="en">dilaton</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#dilepton">
+  <prefLabel xml:lang="en">dilepton</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#diquark">
+  <prefLabel xml:lang="en">diquark</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Dirac">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumfieldtheoryDirac"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoDirac"/>
+  <prefLabel xml:lang="en">Dirac</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Dirac-Kaehlerequation">
+  <prefLabel xml:lang="en">Dirac-Kaehler equation</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#directdetection">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/edirectdetection"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodirectdetection"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterdirectdetection"/>
+  <prefLabel xml:lang="en">direct detection</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#directproduction">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taudirectproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mudirectproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/edirectproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodirectproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downdirectproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomdirectproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0directproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xidirectproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0directproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-directproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+directproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bdirectproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdadirectproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0directproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-directproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+directproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0directproduction"/>
+  <prefLabel xml:lang="en">direct production</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#discretelightconequantization">
+  <prefLabel xml:lang="en">discrete light cone quantization</prefLabel>
+  <altLabel xml:lang="en">DLCQ</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#dispersionrelation">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodispersionrelation"/>
+  <prefLabel xml:lang="en">dispersion relation</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#distributionamplitude">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taudistributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mudistributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/edistributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodistributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downdistributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomdistributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0distributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xidistributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0distributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-distributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+distributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bdistributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdadistributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0distributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-distributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+distributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0distributionamplitude"/>
+  <prefLabel xml:lang="en">distribution amplitude</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#distributionfunction">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.partondistributionfunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodistributionfunction"/>
+  <prefLabel xml:lang="en">distribution function</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#domainwall">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodomainwall"/>
+  <prefLabel xml:lang="en">domain wall</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#DONUT">
+  <prefLabel xml:lang="en">DONUT</prefLabel>
+  <altLabel xml:lang="en">FNAL-E-0872</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#DoubleChooz">
+  <prefLabel xml:lang="en">Double Chooz</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#doublefieldtheory">
+  <prefLabel xml:lang="en">double field theory</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#double-betadecay">
+  <prefLabel xml:lang="en">double-beta decay</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#doublet">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodoublet"/>
+  <prefLabel xml:lang="en">doublet</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#doubling">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermiondoubling"/>
+  <prefLabel xml:lang="en">doubling</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#doublyspecialrelativity">
+  <prefLabel xml:lang="en">doubly special relativity</prefLabel>
+  <altLabel xml:lang="en">deformed special relativity</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#down">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downyield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downwavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downtransversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downsuppression"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downsignature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downsemileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downraredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downrapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downradiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downpropagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downphotoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downparticlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downparticleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downpairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downmultiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downmultipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downmomentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downmomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downmassspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downmassgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downmassformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downmass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downmagneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downleptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downinvisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downintermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downinclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downhadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downhadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downgroundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downformfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downfinalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downexclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downexcitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downexchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downenergyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downenergy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downelectroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downelectromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downelectricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downdistributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downdirectproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downdecoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downdecayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downdecaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downdecayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downcouplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downcoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downcondensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downcascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downbranchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downassociatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downannihilation"/>
+  <prefLabel xml:lang="en">down</prefLabel>
+  <altLabel xml:lang="en">d-quark</altLabel>
+  <note xml:lang="en">core</note>
+  <note xml:lang="en">noautosingle</note>
+  <note xml:lang="en">nostandalone</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Drell-Hearn-Gerasimov">
+  <prefLabel xml:lang="en">Drell-Hearn-Gerasimov</prefLabel>
+  <altLabel xml:lang="en">GDH</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Drell-Yanprocess">
+  <prefLabel xml:lang="en">Drell-Yan process</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#dualresonancemodel">
+  <prefLabel xml:lang="en">dual resonance model</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#DubnaNuclotron">
+  <prefLabel xml:lang="en">Dubna Nuclotron</prefLabel>
+  <altLabel xml:lang="en">Nuclotron</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#DubnaPS">
+  <prefLabel xml:lang="en">Dubna PS</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Duffin-Kemmer-Petiauequation">
+  <prefLabel xml:lang="en">Duffin-Kemmer-Petiau equation</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#DUMAND">
+  <prefLabel xml:lang="en">DUMAND</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Dvali-Gabadadze-Porratimodel">
+  <prefLabel xml:lang="en">Dvali-Gabadadze-Porrati model</prefLabel>
+  <altLabel xml:lang="en">DGP model</altLabel>
+  <altLabel xml:lang="en">Dvali-Gabadadze-Porrati</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#dynamicalsymmetrybreaking">
+  <prefLabel xml:lang="en">dynamical symmetry breaking</prefLabel>
+  <altLabel xml:lang="en">DSB</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#dyon">
+  <prefLabel xml:lang="en">dyon</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Dyson-Schwingerequation">
+  <prefLabel xml:lang="en">Dyson-Schwinger equation</prefLabel>
+  <altLabel xml:lang="en">Schwinger-Dyson equation</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#DZERO">
+  <prefLabel xml:lang="en">DZERO</prefLabel>
+  <altLabel xml:lang="en">FNAL-E-0823</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#EDDA">
+  <prefLabel xml:lang="en">EDDA</prefLabel>
+  <altLabel xml:lang="en">COSY-EDDA</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#effect">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoeffect"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaeffect"/>
+  <prefLabel xml:lang="en">effect</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#effectivegaugebosonapproximation">
+  <prefLabel xml:lang="en">effective gauge boson approximation</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Eguchi-Kawaimodel">
+  <prefLabel xml:lang="en">Eguchi-Kawai model</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Einstein-Yang-Millstheory">
+  <prefLabel xml:lang="en">Einstein-Yang-Mills theory</prefLabel>
+  <altLabel xml:lang="en">EYM</altLabel>
+  <altLabel xml:lang="en">Einstein-Yang-Mills</altLabel>
+  <note xml:lang="en">FC:g</note>
+  <note xml:lang="en">FC:t</note>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Einstein-Yang-Mills-Higgstheory">
+  <prefLabel xml:lang="en">Einstein-Yang-Mills-Higgs theory</prefLabel>
+  <altLabel xml:lang="en">EYMH</altLabel>
+  <note xml:lang="en">FC:g</note>
+  <note xml:lang="en">FC:t</note>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#ekpyrotic">
+  <prefLabel xml:lang="en">ekpyrotic</prefLabel>
+  <note xml:lang="en">FC:g</note>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#elasticscattering">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoelasticscattering"/>
+  <prefLabel xml:lang="en">elastic scattering</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#electricfield">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.electricfieldlow"/>
+  <prefLabel xml:lang="en">electric field</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#electricmoment">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauelectricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muelectricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eelectricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoelectricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downelectricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomelectricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0electricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xielectricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0electricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-electricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+electricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/belectricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaelectricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0electricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-electricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+electricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0electricmoment"/>
+  <prefLabel xml:lang="en">electric moment</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#electromagnetic">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.gravitationelectromagnetic"/>
+  <prefLabel xml:lang="en">electromagnetic</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#electromagneticdecay">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauelectromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muelectromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eelectromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoelectromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downelectromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomelectromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0electromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xielectromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0electromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-electromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+electromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/belectromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaelectromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0electromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-electromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+electromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0electromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaelectromagneticdecay"/>
+  <prefLabel xml:lang="en">electromagnetic decay</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#electromagneticfield">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.electromagneticfieldlow"/>
+  <prefLabel xml:lang="en">electromagnetic field</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#electromagneticinteraction">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoelectromagneticinteraction"/>
+  <prefLabel xml:lang="en">electromagnetic interaction</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#electronnucleon">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.electronnucleoncollidingbeams"/>
+  <prefLabel xml:lang="en">electron nucleon</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#electroproduction">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauelectroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muelectroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eelectroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoelectroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downelectroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomelectroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0electroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xielectroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0electroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-electroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+electroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/belectroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaelectroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0electroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-electroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+electroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0electroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaelectroproduction"/>
+  <prefLabel xml:lang="en">electroproduction</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#electroweakinteraction">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.scaleelectroweakinteraction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.electroweakinteractionsymmetrybreaking"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.electroweakinteractionprecisionmeasurement"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.electroweakinteractioncriticalphenomena"/>
+  <prefLabel xml:lang="en">electroweak interaction</prefLabel>
+  <altLabel xml:lang="en">electroweak</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#ellipticflow">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomellipticflow"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+ellipticflow"/>
+  <prefLabel xml:lang="en">elliptic flow</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Ellis-Jaffe">
+  <prefLabel xml:lang="en">Ellis-Jaffe</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#emission">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauemission"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muemission"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eemission"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoemission"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+emission"/>
+  <prefLabel xml:lang="en">emission</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#energy">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauenergy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muenergy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eenergy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoenergy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downenergy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomenergy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0energy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xienergy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0energy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-energy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+energy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/benergy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaenergy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0energy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-energy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+energy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0energy"/>
+  <prefLabel xml:lang="en">energy</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#energyeigenstate">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoenergyeigenstate"/>
+  <prefLabel xml:lang="en">energy eigenstate</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#energylevels">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoenergylevels"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaenergylevels"/>
+  <prefLabel xml:lang="en">energy levels</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#energyloss">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoenergyloss"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomenergyloss"/>
+  <prefLabel xml:lang="en">energy loss</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#energyspectrum">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauenergyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muenergyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eenergyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoenergyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downenergyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomenergyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0energyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xienergyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0energyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-energyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+energyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/benergyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaenergyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0energyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-energyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+energyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0energyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaenergyspectrum"/>
+  <prefLabel xml:lang="en">energy spectrum</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#energy-momentum">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoenergy-momentum"/>
+  <prefLabel xml:lang="en">energy-momentum</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#entanglement">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0entanglement"/>
+  <prefLabel xml:lang="en">entanglement</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#entropy">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.blackholeentropy"/>
+  <prefLabel xml:lang="en">entropy</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#EPRLmodel">
+  <prefLabel xml:lang="en">EPRL model</prefLabel>
+  <note xml:lang="en">FC:g</note>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#equivalentgaugeboson">
+  <prefLabel xml:lang="en">equivalent gauge boson</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#eRHIC">
+  <prefLabel xml:lang="en">eRHIC</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#eta">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etawidth"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etawavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etathreshold"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etasinglet"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etascatteringlength"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etararedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaradiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaphotoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etapairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaoctet"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etamass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaintermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etahadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etahadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaformfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaexcitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaenergyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaelectroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaelectromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etadecaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etabranchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etabindingenergy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaangulardistribution"/>
+  <prefLabel xml:lang="en">eta</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#eventshapeanalysis">
+  <prefLabel xml:lang="en">event shape analysis</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#exchange">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauexchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muexchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eexchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoexchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downexchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomexchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0exchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiexchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0exchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-exchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+exchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bexchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaexchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0exchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-exchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+exchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0exchange"/>
+  <prefLabel xml:lang="en">exchange</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#excitedstate">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauexcitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muexcitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eexcitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoexcitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downexcitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomexcitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0excitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiexcitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0excitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-excitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+excitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bexcitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaexcitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0excitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-excitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+excitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0excitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionexcitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaexcitedstate"/>
+  <prefLabel xml:lang="en">excited state</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#exclusiveproduction">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauexclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muexclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eexclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoexclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downexclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomexclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0exclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiexclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0exclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-exclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+exclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bexclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaexclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0exclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-exclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+exclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0exclusiveproduction"/>
+  <prefLabel xml:lang="en">exclusive production</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#exotic">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoexotic"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionexotic"/>
+  <prefLabel xml:lang="en">exotic</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#falsevacuum">
+  <prefLabel xml:lang="en">false vacuum</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#family">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinofamily"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionfamily"/>
+  <prefLabel xml:lang="en">family</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#FENICE">
+  <prefLabel xml:lang="en">FENICE</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#fermion">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermiontechnicolor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionzeromode"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionuniversality"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermiontriplet"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermiontexture"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionsymplectic"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionstaggered"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionsplit"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionsea"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionright-handed"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionquantumnumber"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionoverlap"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionmultiplet"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionmixingangle"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionmixing"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionmassspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionmassratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionmassgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionmagneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionleft-handed"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermioninterference"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionhelicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionformfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionflavor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionfamily"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionexotic"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionexcitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermiondoubling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermioncomposite"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionchiral"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionWilson"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionWeyl"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionMajorana"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionKaluza-Klein"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionKaehler"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionGoldstoneparticle"/>
+  <prefLabel xml:lang="en">fermion</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Feynmangauge">
+  <prefLabel xml:lang="en">Feynman gauge</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#fieldequations">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fieldequationsYang-Mills"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinofieldequations"/>
+  <prefLabel xml:lang="en">field equations</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#fieldtheoreticalmodel">
+  <prefLabel xml:lang="en">field theoretical model</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#fieldtheory">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fieldtheorytopological"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fieldtheoryquintessence"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fieldtheorytopological"/>
+  <prefLabel xml:lang="en">field theory</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#fifthforce">
+  <prefLabel xml:lang="en">fifth force</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#finalstate">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taufinalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mufinalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/efinalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinofinalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downfinalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomfinalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0finalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xifinalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0finalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-finalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+finalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bfinalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdafinalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0finalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-finalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+finalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0finalstate"/>
+  <prefLabel xml:lang="en">final state</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#FINeSSE">
+  <prefLabel xml:lang="en">FINeSSE</prefLabel>
+  <altLabel xml:lang="en">FNAL-E-0937</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#FINUDA">
+  <prefLabel xml:lang="en">FINUDA</prefLabel>
+  <altLabel xml:lang="en">FRASCATI-DAFNE-FINUDA</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#flavor">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoflavor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.flavorviolation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionflavor"/>
+  <prefLabel xml:lang="en">flavor</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#flavorchanging">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutralcurrentflavorchanging"/>
+  <prefLabel xml:lang="en">flavor changing</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#fluid">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinofluid"/>
+  <prefLabel xml:lang="en">fluid</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#fluorine">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.calciumfluorine"/>
+  <prefLabel xml:lang="en">fluorine</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#flux">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauflux"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muflux"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eflux"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoflux"/>
+  <prefLabel xml:lang="en">flux</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#FNAL-E-0921">
+  <prefLabel xml:lang="en">FNAL-E-0921</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#FOCUS">
+  <prefLabel xml:lang="en">FOCUS</prefLabel>
+  <altLabel xml:lang="en">FNAL-E-0831</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#FOPI">
+  <prefLabel xml:lang="en">FOPI</prefLabel>
+  <altLabel xml:lang="en">GSI-SIS-FOPI</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#formfactor">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauformfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muformfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eformfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoformfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downformfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomformfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0formfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiformfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0formfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-formfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+formfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bformfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaformfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0formfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-formfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+formfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0formfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionformfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaformfactor"/>
+  <prefLabel xml:lang="en">form factor</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#formation">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaformation"/>
+  <prefLabel xml:lang="en">formation</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#forwardproduction">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0forwardproduction"/>
+  <prefLabel xml:lang="en">forward production</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#forwardscattering">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0forwardscattering"/>
+  <prefLabel xml:lang="en">forward scattering</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#four-fermioninteraction">
+  <prefLabel xml:lang="en">four-fermion interaction</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#fragmentation">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomfragmentation"/>
+  <prefLabel xml:lang="en">fragmentation</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#fragmentationfunction">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomfragmentationfunction"/>
+  <prefLabel xml:lang="en">fragmentation function</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#FrascatiStor">
+  <prefLabel xml:lang="en">Frascati Stor</prefLabel>
+  <altLabel xml:lang="en">DAFNE</altLabel>
+  <altLabel xml:lang="en">DAPHNE</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Frejus">
+  <prefLabel xml:lang="en">Frejus</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Froissartbound">
+  <prefLabel xml:lang="en">Froissart bound</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#fundamentalconstant">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fundamentalconstantPlanck"/>
+  <prefLabel xml:lang="en">fundamental constant</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#fusion">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomfusion"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0fusion"/>
+  <prefLabel xml:lang="en">fusion</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Gparity">
+  <prefLabel xml:lang="en">G parity</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#G0Experiment">
+  <prefLabel xml:lang="en">G0 Experiment</prefLabel>
+  <altLabel xml:lang="en">JLAB-E-00-006</altLabel>
+  <altLabel xml:lang="en">JLAB-E-04-115-101</altLabel>
+  <altLabel xml:lang="en">JLAB-E-05-008</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#GALLEX">
+  <prefLabel xml:lang="en">GALLEX</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#GAMS">
+  <prefLabel xml:lang="en">GAMS</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#GAPS">
+  <prefLabel xml:lang="en">GAPS</prefLabel>
+  <note xml:lang="en">core</note>
+  <definition xml:lang="en">General Antiparticle Spectrometer</definition>
+  <historyNote xml:lang="en">2015-09-11</historyNote>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#gas">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinogas"/>
+  <prefLabel xml:lang="en">gas</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#gaugeboson">
+  <prefLabel xml:lang="en">gauge boson</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#gaugefieldtheory">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.gaugefieldtheoryboson"/>
+  <prefLabel xml:lang="en">gauge field theory</prefLabel>
+  <altLabel xml:lang="en">gauge theory</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#gaugino">
+  <prefLabel xml:lang="en">gaugino</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Gauss-Bonnetterm">
+  <prefLabel xml:lang="en">Gauss-Bonnet term</prefLabel>
+  <altLabel xml:lang="en">Einstein-Gauss-Bonnet</altLabel>
+  <altLabel xml:lang="en">Gauss-Bonnet model</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Gell-Mann-Okubo">
+  <prefLabel xml:lang="en">Gell-Mann-Okubo</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#generalizedpartondistribution">
+  <prefLabel xml:lang="en">generalized parton distribution</prefLabel>
+  <altLabel xml:lang="en">GPD</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#generalizeduncertaintyprinciple">
+  <prefLabel xml:lang="en">generalized uncertainty principle</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#GEO600">
+  <prefLabel xml:lang="en">GEO600</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#geophysics">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinogeophysics"/>
+  <prefLabel xml:lang="en">geophysics</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Georgi-Glashowmodel">
+  <prefLabel xml:lang="en">Georgi-Glashow model</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Gepnermodel">
+  <prefLabel xml:lang="en">Gepner model</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#GERDA">
+  <prefLabel xml:lang="en">GERDA</prefLabel>
+  <altLabel xml:lang="en">Germanium detector array</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#ghost">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoghost"/>
+  <prefLabel xml:lang="en">ghost</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Ginsparg-Wilsonrelation">
+  <prefLabel xml:lang="en">Ginsparg-Wilson relation</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Glashow-Iliopoulos-Maianimodel">
+  <prefLabel xml:lang="en">Glashow-Iliopoulos-Maiani model</prefLabel>
+  <altLabel xml:lang="en">GIM</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#glasma">
+  <prefLabel xml:lang="en">glasma</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#glueball">
+  <prefLabel xml:lang="en">glueball</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#gluino">
+  <prefLabel xml:lang="en">gluino</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#gluon">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.gluonRegge"/>
+  <prefLabel xml:lang="en">gluon</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Goldstino">
+  <prefLabel xml:lang="en">Goldstino</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Goldstoneparticle">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0Goldstoneparticle"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+Goldstoneparticle"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionGoldstoneparticle"/>
+  <prefLabel xml:lang="en">Goldstone particle</prefLabel>
+  <altLabel xml:lang="en">Goldstone boson</altLabel>
+  <altLabel xml:lang="en">Nambu-Goldstone</altLabel>
+  <altLabel xml:lang="en">pseudo-Goldstone</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Goldstonetheorem">
+  <prefLabel xml:lang="en">Goldstone theorem</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#GranSasso">
+  <prefLabel xml:lang="en">Gran Sasso</prefLabel>
+  <altLabel xml:lang="en">LNGS</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#grandunifiedtheory">
+  <prefLabel xml:lang="en">grand unified theory</prefLabel>
+  <altLabel xml:lang="en">GUT</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#gravitation">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.gravitationtransverse"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.gravitationmodel"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.gravitationHorava-Lifshitz"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.gravitationelectromagnetic"/>
+  <prefLabel xml:lang="en">gravitation</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#gravitationalradiation">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.gravitationalradiationplanewave"/>
+  <prefLabel xml:lang="en">gravitational radiation</prefLabel>
+  <altLabel xml:lang="en">gravitational wave</altLabel>
+  <altLabel xml:lang="en">gravity wave</altLabel>
+  <note xml:lang="en">FC:g</note>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#gravitationalradiationdetector">
+  <prefLabel xml:lang="en">gravitational radiation detector</prefLabel>
+  <altLabel xml:lang="en">GRD</altLabel>
+  <altLabel xml:lang="en">gravitational wave detector</altLabel>
+  <note xml:lang="en">FC:g</note>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#gravitino">
+  <prefLabel xml:lang="en">gravitino</prefLabel>
+  <note xml:lang="en">FC:g</note>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#graviton">
+  <prefLabel xml:lang="en">graviton</prefLabel>
+  <note xml:lang="en">FC:g</note>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Green-Schwarz">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.stringGreen-Schwarz"/>
+  <prefLabel xml:lang="en">Green-Schwarz</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Gribovproblem">
+  <prefLabel xml:lang="en">Gribov problem</prefLabel>
+  <altLabel xml:lang="en">Gribov ambiguity</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Gross-Neveumodel">
+  <prefLabel xml:lang="en">Gross-Neveu model</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#groundstate">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taugroundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mugroundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/egroundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinogroundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downgroundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomgroundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0groundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xigroundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0groundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-groundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+groundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bgroundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdagroundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0groundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-groundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+groundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0groundstate"/>
+  <prefLabel xml:lang="en">ground state</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#GZKeffect">
+  <prefLabel xml:lang="en">GZK effect</prefLabel>
+  <altLabel xml:lang="en">GZK</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Hbaryon">
+  <prefLabel xml:lang="en">H baryon</prefLabel>
+  <altLabel xml:lang="en">H-particle</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#H1">
+  <prefLabel xml:lang="en">H1</prefLabel>
+  <note xml:lang="en">core</note>
+  <note xml:lang="en">noautosingle</note>
+  <note xml:lang="en">nostandalone</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#hadronspectroscopy">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.mesonhadronspectroscopy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.baryonhadronspectroscopy"/>
+  <prefLabel xml:lang="en">hadron spectroscopy</prefLabel>
+  <altLabel xml:lang="en">hadron spectrum</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#hadronicatom">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-hadronicatom"/>
+  <prefLabel xml:lang="en">hadronic atom</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#hadroniccomponent">
+  <prefLabel xml:lang="en">hadronic component</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#hadronicdecay">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauhadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muhadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ehadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinohadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downhadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomhadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0hadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xihadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0hadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-hadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+hadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bhadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdahadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0hadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-hadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+hadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0hadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etahadronicdecay"/>
+  <prefLabel xml:lang="en">hadronic decay</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#hadronium">
+  <prefLabel xml:lang="en">hadronium</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#hadronization">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.hadronizationstatistical"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomhadronization"/>
+  <prefLabel xml:lang="en">hadronization</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#hadroproduction">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauhadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muhadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ehadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinohadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downhadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomhadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0hadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xihadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0hadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-hadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+hadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bhadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdahadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0hadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-hadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+hadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0hadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etahadroproduction"/>
+  <prefLabel xml:lang="en">hadroproduction</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#HAPPEX">
+  <prefLabel xml:lang="en">HAPPEX</prefLabel>
+  <altLabel xml:lang="en">JLAB-E-00-114</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#hardthermalloopapproximation">
+  <prefLabel xml:lang="en">hard thermal loop approximation</prefLabel>
+  <altLabel xml:lang="en">HTL approximation</altLabel>
+  <altLabel xml:lang="en">HTLA</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#HAWC">
+  <prefLabel xml:lang="en">HAWC</prefLabel>
+  <note xml:lang="en">CORE</note>
+  <definition xml:lang="en">High Altitude Water Cherenkov</definition>
+  <historyNote xml:lang="en">2015-08-2</historyNote>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#heavy">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoheavy"/>
+  <prefLabel xml:lang="en">heavy</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#heavyion">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.heavyionscattering"/>
+  <prefLabel xml:lang="en">heavy ion</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#heavylepton">
+  <prefLabel xml:lang="en">heavy lepton</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#heavyquark">
+  <prefLabel xml:lang="en">heavy quark</prefLabel>
+  <altLabel xml:lang="en">heavy flavor</altLabel>
+  <note xml:lang="en">core</note>
+  <narrower rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#charm"/>
+  <narrower rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <narrower rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#top"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#HeavyQuarkEffectiveTheory">
+  <prefLabel xml:lang="en">Heavy Quark Effective Theory</prefLabel>
+  <altLabel xml:lang="en">HQET</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#helicity">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauhelicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinohelicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0helicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdahelicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionhelicity"/>
+  <prefLabel xml:lang="en">helicity</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#helium">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.heliumboundstate"/>
+  <prefLabel xml:lang="en">helium</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#HERA-B">
+  <prefLabel xml:lang="en">HERA-B</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#HERMES">
+  <prefLabel xml:lang="en">HERMES</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#heterotic">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.stringmodelheterotic"/>
+  <prefLabel xml:lang="en">heterotic</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#hiddensymmetry">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.supersymmetryhiddensymmetry"/>
+  <prefLabel xml:lang="en">hidden symmetry</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#hierarchy">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinohierarchy"/>
+  <prefLabel xml:lang="en">hierarchy</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Higgsmechanism">
+  <prefLabel xml:lang="en">Higgs mechanism</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Higgsmodel">
+  <prefLabel xml:lang="en">Higgs model</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Higgsparticle">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.inflatonHiggsparticle"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Higgsparticletriplet"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Higgsparticlemultiplet"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Higgsparticlemass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Higgsparticlemassdifference"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Higgsparticlechargedparticle"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Higgsparticleboostedparticle"/>
+  <prefLabel xml:lang="en">Higgs particle</prefLabel>
+  <altLabel xml:lang="en">Higgs boson</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Higgs-factory">
+  <prefLabel xml:lang="en">Higgs-factory</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Higgsino">
+  <prefLabel xml:lang="en">Higgsino</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Higgslessmodel">
+  <prefLabel xml:lang="en">Higgsless model</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#higher-dimensional">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.space-timehigher-dimensional"/>
+  <prefLabel xml:lang="en">higher-dimensional</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#higher-order">
+<composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumchromodynamicsperturbationtheoryhigher-order"/>
+  <prefLabel xml:lang="en">higher-order</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#history">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinohistory"/>
+  <prefLabel xml:lang="en">history</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Homestake">
+  <prefLabel xml:lang="en">Homestake</prefLabel>
+  <altLabel xml:lang="en">LBNE</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#hoppingparameterexpansion">
+  <prefLabel xml:lang="en">hopping parameter expansion</prefLabel>
+  <altLabel xml:lang="en">hopping expansion</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Horava-Lifshitz">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.gravitationHorava-Lifshitz"/>
+  <prefLabel xml:lang="en">Horava-Lifshitz</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Horava-Wittenmodel">
+  <prefLabel xml:lang="en">Horava-Witten model</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#hydrogen">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.hydrogenmuonicatom"/>
+  <prefLabel xml:lang="en">hydrogen</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#hypercharge">
+  <prefLabel xml:lang="en">hypercharge</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#hypercolor">
+  <prefLabel xml:lang="en">hypercolor</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#hypernucleus">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xihypernucleus"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-hypernucleus"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdahypernucleus"/>
+  <prefLabel xml:lang="en">hypernucleus</prefLabel>
+  <altLabel xml:lang="en">hyperfragment</altLabel>
+  <altLabel xml:lang="en">strange nucleus</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#hyperon">
+  <prefLabel xml:lang="en">hyperon</prefLabel>
+  <altLabel xml:lang="en">strange baryon</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#hyperonicatom">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-hyperonicatom"/>
+  <prefLabel xml:lang="en">hyperonic atom</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#IceCube">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.IceCubesurface"/>
+  <prefLabel xml:lang="en">IceCube</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Iizuka-Okubo-Zweigrule">
+  <prefLabel xml:lang="en">Iizuka-Okubo-Zweig rule</prefLabel>
+  <altLabel xml:lang="en">OZI rule</altLabel>
+  <altLabel xml:lang="en">Okubo-Zweig-Iizuka</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#ILCColl">
+  <prefLabel xml:lang="en">ILC Coll</prefLabel>
+  <altLabel xml:lang="en">International Linear Collider</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Immirziparameter">
+  <prefLabel xml:lang="en">Immirzi parameter</prefLabel>
+  <altLabel xml:lang="en">Barbero-Immirzi parameter</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#inclusiveproduction">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauinclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muinclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/einclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoinclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downinclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottominclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0inclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiinclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0inclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-inclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+inclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/binclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdainclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0inclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-inclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+inclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0inclusiveproduction"/>
+  <prefLabel xml:lang="en">inclusive production</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#inclusivereaction">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.deepinelasticscatteringinclusivereaction"/>
+  <prefLabel xml:lang="en">inclusive reaction</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#indefinitemetric">
+  <prefLabel xml:lang="en">indefinite metric</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#inelasticscattering">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muinelasticscattering"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoinelasticscattering"/>
+  <prefLabel xml:lang="en">inelastic scattering</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#inflaton">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.sneutrinoinflaton"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.inflatonHiggsparticle"/>
+  <prefLabel xml:lang="en">inflaton</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#infraredproblem">
+  <prefLabel xml:lang="en">infrared problem</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#interaction">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.partoninteraction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauinteraction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muinteraction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/einteraction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinointeraction"/>
+  <prefLabel xml:lang="en">interaction</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#interference">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinointerference"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermioninterference"/>
+  <prefLabel xml:lang="en">interference</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#intermediatestate">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauintermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muintermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eintermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinointermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downintermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomintermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0intermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiintermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0intermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-intermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+intermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bintermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaintermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0intermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-intermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+intermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0intermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaintermediatestate"/>
+  <prefLabel xml:lang="en">intermediate state</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#invisibledecay">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauinvisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muinvisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/einvisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoinvisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downinvisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottominvisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0invisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiinvisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0invisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-invisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+invisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/binvisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdainvisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0invisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-invisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+invisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0invisibledecay"/>
+  <prefLabel xml:lang="en">invisible decay</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Isgur-Wisefunction">
+  <prefLabel xml:lang="en">Isgur-Wise function</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#J/psi(3100)">
+  <prefLabel xml:lang="en">J/psi(3100)</prefLabel>
+  <altLabel xml:lang="en">J/psi</altLabel>
+  <altLabel xml:lang="en">psi(3100)</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#JADE">
+  <prefLabel xml:lang="en">JADE</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#jet">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.jetbottom"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinojet"/>
+  <prefLabel xml:lang="en">jet</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Jona-Lasinio-Nambumodel">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Jona-Lasinio-NambumodelPolyakovloop"/>
+  <prefLabel xml:lang="en">Jona-Lasinio-Nambu model</prefLabel>
+  <altLabel xml:lang="en">JLN</altLabel>
+  <altLabel xml:lang="en">NJL</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#JuelichCOSYPS">
+  <prefLabel xml:lang="en">Juelich COSY PS</prefLabel>
+  <altLabel xml:lang="en">COSY</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#JUNO">
+  <prefLabel xml:lang="en">JUNO</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#K+">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+yield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+width"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+wavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+transversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+temperature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+signature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+semileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+secondarybeam"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+raredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+rapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+rapidity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+radiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+propagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+production"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+photoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+particlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+particleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+particleflow"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+pairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+multiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+multipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+momentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+momentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+massspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+massgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+massformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+mass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+many-bodyproblem"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+magneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+leptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+leptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+invisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+intermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+inclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+hadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+hadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+groundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+formfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+finalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+exclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+excitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+exchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+energyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+energy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+emission"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+ellipticflow"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+electroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+electromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+electricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+distributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+directproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+decoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+decayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+decaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+decayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+decay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+couplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+coupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+condensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+cascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+branchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+beam"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+associatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+annihilation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+angulardistribution"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+absorption"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+Goldstoneparticle"/>
+  <prefLabel xml:lang="en">K+</prefLabel>
+  <note xml:lang="en">core</note>
+  <note xml:lang="en">noautosingle</note>
+  <note xml:lang="en">nostandalone</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#K-">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-yield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-width"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-wavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-transversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-spectralrepresentation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-signature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-semileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-secondarybeam"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-raredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-rapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-radiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-radiativecapture"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-propagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-production"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-photoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-particlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-particleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-particleflow"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-pairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-multiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-multipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-momentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-momentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-mesicatom"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-massspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-massgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-massformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-mass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-magneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-leptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-invisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-intermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-inclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-hadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-hadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-groundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-formfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-finalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-exclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-excitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-exchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-energyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-energy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-electroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-electromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-electricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-distributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-directproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-decoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-decayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-decaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-decayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-decay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-couplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-coupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-condensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-cascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-capture"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-branchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-boundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-bindingenergy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-beam"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-atom"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-associatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-annihilation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-angulardistribution"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-absorption"/>
+  <prefLabel xml:lang="en">K-</prefLabel>
+  <note xml:lang="en">core</note>
+  <note xml:lang="en">noautosingle</note>
+  <note xml:lang="en">nostandalone</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#k-essence">
+  <prefLabel xml:lang="en">k-essence</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#K0">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0yield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0width"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0wavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0transversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0signature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0semileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0secondarybeam"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0regeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0raredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0rapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0radiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0propagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0production"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0photoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0particlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0particleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0pairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0multiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0multipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0momentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0momentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0massspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0massgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0massformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0massdifference"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0mass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0magneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0lifetime"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0leptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0leptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0invisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0intermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0inclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0hadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0hadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0groundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0formfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0finalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0exclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0excitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0exchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0entanglement"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0energyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0energy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0electroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0electromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0electricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0distributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0directproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0density"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0decoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0decayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0decaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0decayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0decay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0couplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0coupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0condensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0cascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0branchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0associatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0annihilation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0angulardistribution"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0Goldstoneparticle"/>
+  <prefLabel xml:lang="en">K0</prefLabel>
+  <note xml:lang="en">core</note>
+  <note xml:lang="en">noautosingle</note>
+  <note xml:lang="en">nostandalone</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Kaehler">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionKaehler"/>
+  <prefLabel xml:lang="en">Kaehler</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Kaluza-Klein">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoKaluza-Klein"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0Kaluza-Klein"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionKaluza-Klein"/>
+  <prefLabel xml:lang="en">Kaluza-Klein</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Kaluza-Kleinmodel">
+  <prefLabel xml:lang="en">Kaluza-Klein model</prefLabel>
+  <altLabel xml:lang="en">Kaluza-Klein theory</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#KAMIOKANDE">
+  <prefLabel xml:lang="en">KAMIOKANDE</prefLabel>
+  <altLabel xml:lang="en">K2K</altLabel>
+  <altLabel xml:lang="en">Super-Kamiokande</altLabel>
+  <altLabel xml:lang="en">T2K</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#KamLAND">
+  <prefLabel xml:lang="en">KamLAND</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Kazakov-Migdalmodel">
+  <prefLabel xml:lang="en">Kazakov-Migdal model</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#KEDR">
+  <prefLabel xml:lang="en">KEDR</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#KEKLinac">
+  <prefLabel xml:lang="en">KEK Linac</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#KEKPFStor">
+  <prefLabel xml:lang="en">KEK PF Stor</prefLabel>
+  <altLabel xml:lang="en">KEK PF</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#KEKPS">
+  <prefLabel xml:lang="en">KEK PS</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#KEKTRISTANStor">
+  <prefLabel xml:lang="en">KEK TRISTAN Stor</prefLabel>
+  <altLabel xml:lang="en">TRISTAN</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#KEK-B">
+  <prefLabel xml:lang="en">KEK-B</prefLabel>
+  <altLabel xml:lang="en">super-KEKB</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Kerr/CFTcorrespondence">
+  <prefLabel xml:lang="en">Kerr/CFT correspondence</prefLabel>
+  <altLabel xml:lang="en">Kerr/CFT</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Klebanov-Strasslermodel">
+  <prefLabel xml:lang="en">Klebanov-Strassler model</prefLabel>
+  <note xml:lang="en">FC:t</note>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Klebanov-Wittenmodel">
+  <prefLabel xml:lang="en">Klebanov-Witten model</prefLabel>
+  <note xml:lang="en">FC:t</note>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#KLOE">
+  <prefLabel xml:lang="en">KLOE</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Kobayashi-Maskawamodel">
+  <prefLabel xml:lang="en">Kobayashi-Maskawa model</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#KTeV">
+  <prefLabel xml:lang="en">KTeV</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#L3">
+  <prefLabel xml:lang="en">L3</prefLabel>
+  <note xml:lang="en">core</note>
+  <note xml:lang="en">noautosingle</note>
+  <note xml:lang="en">nostandalone</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Lambda">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdayield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdawidth"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdawavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdatransversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaspin"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdasignature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdasemileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdararedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdarapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaradiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdapropagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdapolarization"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaphotoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaparticlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaparticleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaparticleflow"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdapairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaoscillation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaneutrinoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdamultiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdamultipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdamomentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdamomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdamassspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdamassgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdamassformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdamass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdamagneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdalifetime"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaleptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaleptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdainvisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaintermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdainclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdahypernucleus"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdahelicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdahadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdahadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdagroundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaformation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaformfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdafinalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaexclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaexcitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaexchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaenergyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaenergylevels"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaenergy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaelectroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaelectromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaelectricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaeffect"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdadistributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdadirectproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdadensity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdadecoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdadecayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdadecaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdadecayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdadecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdacouplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdacoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdacondensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdacascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdabranchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaboundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdabindingenergy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaassociatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaannihilation"/>
+  <prefLabel xml:lang="en">Lambda</prefLabel>
+  <note xml:lang="en">core</note>
+  <note xml:lang="en">noautosingle</note>
+  <note xml:lang="en">nostandalone</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Landau-Pomeranchuk-Migdaleffect">
+  <prefLabel xml:lang="en">Landau-Pomeranchuk-Migdal effect</prefLabel>
+  <altLabel xml:lang="en">LPM effect</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#lattice">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinolattice"/>
+  <prefLabel xml:lang="en">lattice</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#latticefieldtheory">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.latticefieldtheoryaction"/>
+  <prefLabel xml:lang="en">lattice field theory</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#leadingparticle">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomleadingparticle"/>
+  <prefLabel xml:lang="en">leading particle</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Lee-Wickmodel">
+  <prefLabel xml:lang="en">Lee-Wick model</prefLabel>
+  <altLabel xml:lang="en">Lee-Wick</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#left-handed">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoleft-handed"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionleft-handed"/>
+  <prefLabel xml:lang="en">left-handed</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#leptogenesis">
+  <prefLabel xml:lang="en">leptogenesis</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#leptonicdecay">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauleptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muleptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eleptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoleptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomleptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0leptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bleptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaleptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0leptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+leptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0leptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterleptonicdecay"/>
+  <prefLabel xml:lang="en">leptonic decay</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#leptophilic">
+  <prefLabel xml:lang="en">leptophilic</prefLabel>
+  <note xml:lang="en">core</note>
+  <historyNote xml:lang="en">2015-09-10</historyNote>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#leptophobic">
+  <prefLabel xml:lang="en">leptophobic</prefLabel>
+  <note xml:lang="en">core</note>
+  <historyNote xml:lang="en">2015-09-10</historyNote>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#leptoproduction">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauleptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muleptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eleptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoleptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downleptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomleptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0leptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xileptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0leptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-leptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+leptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bleptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaleptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0leptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-leptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+leptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0leptoproduction"/>
+  <prefLabel xml:lang="en">leptoproduction</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#leptoquark">
+  <prefLabel xml:lang="en">leptoquark</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#LHC-B">
+  <prefLabel xml:lang="en">LHC-B</prefLabel>
+  <altLabel xml:lang="en">LHCb</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#LHC-F">
+  <prefLabel xml:lang="en">LHC-F</prefLabel>
+  <altLabel xml:lang="en">LHCf</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#LHeC">
+  <prefLabel xml:lang="en">LHeC</prefLabel>
+  <altLabel xml:lang="en">CERN-LHeC</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#lifetime">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterlifetime"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinolifetime"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomlifetime"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0lifetime"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0lifetime"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-lifetime"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+lifetime"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdalifetime"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0lifetime"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0lifetime"/>
+  <prefLabel xml:lang="en">lifetime</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#lightconebehavior">
+  <prefLabel xml:lang="en">light cone behavior</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#lightconegauge">
+  <prefLabel xml:lang="en">light cone gauge</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#LIGO">
+  <prefLabel xml:lang="en">LIGO</prefLabel>
+  <altLabel xml:lang="en">Laser Interferometer Gravitational wave Observatory</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#linac-ringcollider">
+  <prefLabel xml:lang="en">linac-ring collider</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Liouville">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumfieldtheoryLiouville"/>
+  <prefLabel xml:lang="en">Liouville</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Lipatovequation">
+  <prefLabel xml:lang="en">Lipatov equation</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Lippmann-Schwingerequation">
+  <prefLabel xml:lang="en">Lippmann-Schwinger equation</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#LISA">
+  <prefLabel xml:lang="en">LISA</prefLabel>
+  <altLabel xml:lang="en">Laser Interferometer Space Antenna</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#littleHiggsmodel">
+  <prefLabel xml:lang="en">little Higgs model</prefLabel>
+  <altLabel xml:lang="en">little Higgs</altLabel>
+  <note xml:lang="en">FC:t</note>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#littlestHiggsmodel">
+  <prefLabel xml:lang="en">littlest Higgs model</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#longitudinal">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0longitudinal"/>
+  <prefLabel xml:lang="en">longitudinal</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#loopequation">
+  <prefLabel xml:lang="en">loop equation</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#loopintegral">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.loopintegral8"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.loopintegral6"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.loopintegral5"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.loopintegral4"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.loopintegral3"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.loopintegral1"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.loopintegral0"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0loopintegral"/>
+  <prefLabel xml:lang="en">loop integral</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#loopspace">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumgravityloopspace"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumcosmologyloopspace"/>
+  <prefLabel xml:lang="en">loop space</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Lorentz">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.violationLorentz"/>
+  <prefLabel xml:lang="en">Lorentz</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#low">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.electromagneticfieldlow"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.electricfieldlow"/>
+  <prefLabel xml:lang="en">low</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#LSND">
+  <prefLabel xml:lang="en">LSND</prefLabel>
+  <altLabel xml:lang="en">LAMPF-1173</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#LSP">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoLSP"/>
+  <prefLabel xml:lang="en">LSP</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#luminosity">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoluminosity"/>
+  <prefLabel xml:lang="en">luminosity</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#lunar">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinolunar"/>
+  <prefLabel xml:lang="en">lunar</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#LUX">
+  <prefLabel xml:lang="en">LUX</prefLabel>
+  <note xml:lang="en">core</note>
+  <definition xml:lang="en">Large Underground Xenon experiment</definition>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#M-brane">
+  <prefLabel xml:lang="en">M-brane</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#M-theory">
+  <prefLabel xml:lang="en">M-theory</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#magneticmoment">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taumagneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumagneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/emagneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomagneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downmagneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommagneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0magneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Ximagneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0magneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-magneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+magneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bmagneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdamagneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0magneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-magneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+magneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0magneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionmagneticmoment"/>
+  <prefLabel xml:lang="en">magnetic moment</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#magneticmonopole">
+  <prefLabel xml:lang="en">magnetic monopole</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Majorana">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muMajorana"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoMajorana"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionMajorana"/>
+  <prefLabel xml:lang="en">Majorana</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Majoron">
+  <prefLabel xml:lang="en">Majoron</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#many-bodyproblem">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+many-bodyproblem"/>
+  <prefLabel xml:lang="en">many-body problem</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#mass">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Higgsparticlemass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taumass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/emass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downmass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0mass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Ximass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0mass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-mass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+mass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bmass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdamass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0mass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-mass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+mass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0mass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etamass"/>
+  <prefLabel xml:lang="en">mass</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#massdifference">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Higgsparticlemassdifference"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumassdifference"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomassdifference"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0massdifference"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0massdifference"/>
+  <prefLabel xml:lang="en">mass difference</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#massformula">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taumassformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumassformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/emassformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomassformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downmassformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommassformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0massformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Ximassformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0massformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-massformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+massformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bmassformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdamassformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0massformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-massformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+massformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0massformula"/>
+  <prefLabel xml:lang="en">mass formula</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#massgeneration">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taumassgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumassgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/emassgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomassgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downmassgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommassgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0massgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Ximassgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0massgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-massgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+massgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bmassgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdamassgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0massgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-massgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+massgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0massgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionmassgeneration"/>
+  <prefLabel xml:lang="en">mass generation</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#massratio">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomassratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionmassratio"/>
+  <prefLabel xml:lang="en">mass ratio</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#massresolution">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomassresolution"/>
+  <prefLabel xml:lang="en">mass resolution</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#massspectrum">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taumassspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumassspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/emassspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomassspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downmassspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommassspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0massspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Ximassspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0massspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-massspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+massspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bmassspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdamassspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0massspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-massspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+massspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0massspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionmassspectrum"/>
+  <prefLabel xml:lang="en">mass spectrum</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#massive">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumassive"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomassive"/>
+  <prefLabel xml:lang="en">massive</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#massless">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomassless"/>
+  <prefLabel xml:lang="en">massless</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#matter">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.matterstrangeness"/>
+  <prefLabel xml:lang="en">matter</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#maximalabeliangauge">
+  <prefLabel xml:lang="en">maximal abelian gauge</prefLabel>
+  <altLabel xml:lang="en">MAG</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#maximallyhelicityviolatingamplitude">
+  <prefLabel xml:lang="en">maximally helicity violating amplitude</prefLabel>
+  <altLabel xml:lang="en">MHV amplitude</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#mediation">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomediation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0mediation"/>
+  <prefLabel xml:lang="en">mediation</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#membranemodel">
+  <prefLabel xml:lang="en">membrane model</prefLabel>
+  <altLabel xml:lang="en">brane</altLabel>
+  <altLabel xml:lang="en">braneworld</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#mesicatom">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.pi-mesicatom"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-mesicatom"/>
+  <prefLabel xml:lang="en">mesic atom</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#meson">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.mesonphotoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.mesonhadronspectroscopy"/>
+  <prefLabel xml:lang="en">meson</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#mesonresonance">
+  <prefLabel xml:lang="en">meson resonance</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#messenger">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomessenger"/>
+  <prefLabel xml:lang="en">messenger</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#MICE">
+  <prefLabel xml:lang="en">MICE</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Michelparameter">
+  <prefLabel xml:lang="en">Michel parameter</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#MiniCLEAN">
+  <prefLabel xml:lang="en">MiniCLEAN</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#minijet">
+  <prefLabel xml:lang="en">minijet</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#minimal">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.supergravityminimal"/>
+  <prefLabel xml:lang="en">minimal</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#minimalsupersymmetricstandardmodel">
+  <prefLabel xml:lang="en">minimal supersymmetric standard model</prefLabel>
+  <altLabel xml:lang="en">MSSM</altLabel>
+  <altLabel xml:lang="en">NMSSM</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#minisuperspace">
+  <prefLabel xml:lang="en">minisuperspace</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#MINOS">
+  <prefLabel xml:lang="en">MINOS</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#mirror">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomirror"/>
+  <prefLabel xml:lang="en">mirror</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#mirrorparticle">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomirrorparticle"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommirrorparticle"/>
+  <prefLabel xml:lang="en">mirror particle</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#mixing">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomixing"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionmixing"/>
+  <prefLabel xml:lang="en">mixing</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#mixingangle">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomixingangle"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionmixingangle"/>
+  <prefLabel xml:lang="en">mixing angle</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#model">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.gravitationmodel"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomodel"/>
+  <prefLabel xml:lang="en">model</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#moment">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomoment"/>
+  <prefLabel xml:lang="en">moment</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#momentum">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taumomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/emomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downmomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0momentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Ximomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0momentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-momentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+momentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bmomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdamomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0momentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-momentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+momentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0momentum"/>
+  <prefLabel xml:lang="en">momentum</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#momentumspectrum">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taumomentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumomentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/emomentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomomentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downmomentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommomentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0momentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Ximomentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0momentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-momentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+momentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bmomentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdamomentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0momentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-momentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+momentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0momentumspectrum"/>
+  <prefLabel xml:lang="en">momentum spectrum</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#MSWeffect">
+  <prefLabel xml:lang="en">MSW effect</prefLabel>
+  <altLabel xml:lang="en">MSW</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#multi-Regge">
+  <prefLabel xml:lang="en">multi-Regge</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#multipleproduction">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taumultipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumultipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/emultipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomultipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downmultipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommultipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0multipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Ximultipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0multipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-multipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+multipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bmultipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdamultipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0multipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-multipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+multipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0multipleproduction"/>
+  <prefLabel xml:lang="en">multiple production</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#multiplet">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Higgsparticlemultiplet"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomultiplet"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0multiplet"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionmultiplet"/>
+  <prefLabel xml:lang="en">multiplet</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#multiplicity">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taumultiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumultiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/emultiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomultiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downmultiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommultiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0multiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Ximultiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0multiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-multiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+multiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bmultiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdamultiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0multiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-multiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+multiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0multiplicity"/>
+  <prefLabel xml:lang="en">multiplicity</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#muonicatom">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.hydrogenmuonicatom"/>
+  <prefLabel xml:lang="en">muonic atom</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#muonium">
+  <prefLabel xml:lang="en">muonium</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#NA48">
+  <prefLabel xml:lang="en">NA48</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#NA49">
+  <prefLabel xml:lang="en">NA49</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#NA60">
+  <prefLabel xml:lang="en">NA60</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#NA61">
+  <prefLabel xml:lang="en">NA61</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#NA62">
+  <prefLabel xml:lang="en">NA62</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Nahmequation">
+  <prefLabel xml:lang="en">Nahm equation</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Nahmtransformation">
+  <prefLabel xml:lang="en">Nahm transformation</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#network">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.computernetwork"/>
+  <prefLabel xml:lang="en">network</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#neutralcurrent">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutralcurrentflavorchanging"/>
+  <prefLabel xml:lang="en">neutral current</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#neutralino">
+  <prefLabel xml:lang="en">neutralino</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#neutrino">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinozeromode"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoyield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinowidth"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinowavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinowater"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinovelocity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotrigger"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotransversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotransporttheory"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotransition"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotrajectory"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotime-of-flight"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotimedelay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinothermal"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotemperature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotaggedbeam"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotachyon"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosupernova"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosuperluminal"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosuperfield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinostronginteraction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinostrongcoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosterile"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinostatistics"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinostar"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinostability"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinospin"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosphere"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinospectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosolar"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosinglet"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosignature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoshowers"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosemileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosecondarybeam"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosecondary"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosearchfor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosea"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoscreening"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoscintillationcounter"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoscattering"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoscalarparticle"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoright-handed"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoreview"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinorelicdensity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinorelativistic"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoregeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoreflection"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinorecoil"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoraredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinorapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoradiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoradiation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinopropagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinopropagation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoprimary"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinopowerspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinopotential"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinopolarization"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoplasma"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinophotoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoperturbation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinopathlength"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoparticlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoparticleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinopairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinooscillation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoopacity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinonuclearreactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinononrelativistic"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinonewinteraction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomultiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomultiplet"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomultipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomomentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomodel"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomixingangle"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomixing"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomirrorparticle"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomirror"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomessenger"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomediation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomassless"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomassive"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomassspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomassresolution"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomassratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomassgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomassformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomassdifference"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomagneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinolunar"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoluminosity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinolifetime"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoleptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoleptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoleft-handed"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinolattice"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinojet"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoinvisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinointermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinointerference"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinointeraction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoinelasticscattering"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoinclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinohistory"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinohierarchy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinohelicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoheavy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinohadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinohadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinogroundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoghost"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinogeophysics"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinogas"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoformfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoflux"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinofluid"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoflavor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinofinalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinofieldequations"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinofamily"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoexotic"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoexclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoexcitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoexchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoenergy-momentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoenergyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoenergyloss"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoenergylevels"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoenergyeigenstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoenergy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoemission"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoelectroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoelectromagneticinteraction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoelectromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoelectricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoelasticscattering"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoeffect"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodoublet"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodomainwall"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodistributionfunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodistributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodispersionrelation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodirectproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodirectdetection"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodiffusion"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodiffraction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodetector"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodensitymatrix"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodensity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodeflection"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodeepundergrounddetector"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodeepinelasticscattering"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodecoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodecayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodecaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodecayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodarkmatter"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodarkenergy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocurrent"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocrosssection"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocouplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocosmicradiation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocorrelation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoconfinement"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocondensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocomposite"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocollectivephenomena"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocoherentinteraction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocluster"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocloud"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinochiral"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinochargeradius"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocharge"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocapture"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocalorimeter"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoburst"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinobremsstrahlung"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinobranchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoboundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinobosonization"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinobeamtransport"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinobeamprofile"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinobeam"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinobackground"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoatmosphere"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoasymmetry"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoastrophysics"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoassociatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoannihilation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoanisotropy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoangularmomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoangulardistribution"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoair"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoabsorption"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoWeyl"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoVHE"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoUHE"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoNLSP"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoMajorana"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoLSP"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoKaluza-Klein"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoDirac"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosuperluminal"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomass"/>
+  <prefLabel xml:lang="en">neutrino</prefLabel>
+  <note xml:lang="en">core</note>
+  <note xml:lang="en">noautosingle</note>
+  <note xml:lang="en">nostandalone</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eyield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ewavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/etransversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/esterile"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/esignature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eshowers"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/esemileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/esecondarybeam"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/esearchfor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eright-handed"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eraredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/erapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eradiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/epropagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ephotoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/epathlength"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eparticlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eparticleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/epairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eoscillation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/emultiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/emultipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/emomentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/emomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/emassspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/emassgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/emassformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/emass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/emagneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eleptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eleptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/einvisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eintermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/einteraction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/einclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ehadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ehadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/egroundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eformfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eflux"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/efinalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eexclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eexcitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eexchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eenergyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eenergy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eemission"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eelectroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eelectromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eelectricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/edistributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/edirectproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/edirectdetection"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/edetector"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/edecoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/edecayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/edecaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/edecayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/edecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ecouplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ecoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ecosmicradiation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/econdensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ecascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ecapture"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ebranchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ebeam"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ebackground"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eassociatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eannihilation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eadmixture"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eUHE"/>
+  <prefLabel xml:lang="en">neutrino/e</prefLabel>
+  <altLabel xml:lang="en">nu/e</altLabel>
+  <note xml:lang="en">core</note>
+  <note xml:lang="en">noautosingle</note>
+  <note xml:lang="en">nostandalone</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#neutrino/L">
+  <prefLabel xml:lang="en">neutrino/L</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muyield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muwavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muvelocity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mutransversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mutime-of-flight"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/musignature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/musemileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/musecondarybeam"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muright-handed"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muraredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/murapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muradiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mupropagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mupropagation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muphotoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mupathlength"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muparticlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muparticleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mupairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muoscillation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumultiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumultipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumomentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumassive"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumassspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumassgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumassformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumassdifference"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumagneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muleptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muleptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muinvisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muintermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muinteraction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muinelasticscattering"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muinclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muhadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muhadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mugroundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muformfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muflux"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mufinalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muexclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muexcitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muexchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muenergyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muenergy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muemission"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muelectroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muelectromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muelectricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mudistributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mudirectproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mudensity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mudecoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mudecayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mudecaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mudecayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mudecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mucouplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mucoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mucosmicradiation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mucondensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mucascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mucapture"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mubranchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mubeam"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mubackground"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muatmosphere"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muassociatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muannihilation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muangulardistribution"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muadmixture"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muMajorana"/>
+  <prefLabel xml:lang="en">neutrino/mu</prefLabel>
+  <altLabel xml:lang="en">nu/mu</altLabel>
+  <note xml:lang="en">core</note>
+  <note xml:lang="en">noautosingle</note>
+  <note xml:lang="en">nostandalone</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauyield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauwavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tautransversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tausignature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taushowers"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tausemileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tausecondarybeam"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tausearchfor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauright-handed"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauregeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauraredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taurapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauradiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taupropagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauphotoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taupathlength"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauparticlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauparticleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taupairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taumultiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taumultipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taumomentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taumomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taumassspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taumassgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taumassformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taumass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taumagneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauleptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauleptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauinvisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauintermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauinteraction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauinclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauhelicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauhadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauhadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taugroundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauformfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauflux"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taufinalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauexclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauexcitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauexchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauenergyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauenergy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauemission"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauelectroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauelectromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauelectricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taudistributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taudirectproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taudiffusion"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taudecoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taudecayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taudecaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taudecayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taudecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taucouplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taucoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taucosmicradiation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taucondensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taucascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taubranchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taubeam"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauatmosphere"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauassociatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauannihilation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauUHE"/>
+  <prefLabel xml:lang="en">neutrino/tau</prefLabel>
+  <altLabel xml:lang="en">nu/tau</altLabel>
+  <note xml:lang="en">core</note>
+  <note xml:lang="en">noautosingle</note>
+  <note xml:lang="en">nostandalone</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#neutrinoless">
+  <prefLabel xml:lang="en">neutrinoless</prefLabel>
+  <spiresLabel xml:lang="en">(0neutrino)</spiresLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#neutrinoproduction">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0neutrinoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaneutrinoproduction"/>
+  <prefLabel xml:lang="en">neutrinoproduction</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#newinteraction">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinonewinteraction"/>
+  <prefLabel xml:lang="en">new interaction</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#NewportNewsCEBAFLinac">
+  <prefLabel xml:lang="en">Newport News CEBAF Linac</prefLabel>
+  <altLabel xml:lang="en">CEBAF</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#NLSP">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoNLSP"/>
+  <prefLabel xml:lang="en">NLSP</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#NOMAD">
+  <prefLabel xml:lang="en">NOMAD</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#noncommutative">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumelectrodynamicsnoncommutative"/>
+  <prefLabel xml:lang="en">noncommutative</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#nonrelativistic">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumchromodynamicsnonrelativistic"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinononrelativistic"/>
+  <prefLabel xml:lang="en">nonrelativistic</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#NovosibirskStor2">
+  <prefLabel xml:lang="en">Novosibirsk Stor2</prefLabel>
+  <altLabel xml:lang="en">VEPP-2</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#NovosibirskStor3">
+  <prefLabel xml:lang="en">Novosibirsk Stor3</prefLabel>
+  <altLabel xml:lang="en">VEPP-3</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#NovosibirskStor4">
+  <prefLabel xml:lang="en">Novosibirsk Stor4</prefLabel>
+  <altLabel xml:lang="en">VEPP-4</altLabel>
+  <altLabel xml:lang="en">VEPP-4M</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#NovosibirskVEPP-2000">
+  <prefLabel xml:lang="en">Novosibirsk VEPP-2000</prefLabel>
+  <altLabel xml:lang="en">VEPP-2000</altLabel>
+  <altLabel xml:lang="en">VEPP-2M</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#nuclearreactor">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinonuclearreactor"/>
+  <prefLabel xml:lang="en">nuclear reactor</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#nucleon">
+<composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.nucleonpartondistributionfunction"/>
+  <prefLabel xml:lang="en">nucleon</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#nucleonresonance">
+  <prefLabel xml:lang="en">nucleon resonance</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#NUSEX">
+  <prefLabel xml:lang="en">NUSEX</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#octet">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaoctet"/>
+  <prefLabel xml:lang="en">octet</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#odderon">
+  <prefLabel xml:lang="en">odderon</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#off-shell">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0off-shell"/>
+  <prefLabel xml:lang="en">off-shell</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Omega/b">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/byield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bwidth"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bwavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/btransversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bsignature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bsemileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/braredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/brapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bradiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bpropagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bpolarization"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bphotoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bparticlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bparticleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bpairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bmultiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bmultipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bmomentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bmomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bmassspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bmassgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bmassformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bmass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bmagneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bleptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bleptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/binvisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bintermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/binclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bhadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bhadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bgroundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bformfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bfinalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bexclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bexcitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bexchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/benergyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/benergy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/belectroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/belectromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/belectricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bdistributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bdirectproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bdecoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bdecayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bdecaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bdecayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bcouplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bcoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bcondensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bcascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bbranchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bassociatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bannihilation"/>
+  <prefLabel xml:lang="en">Omega/b</prefLabel>
+  <note xml:lang="en">core</note>
+  <note xml:lang="en">noautosingle</note>
+  <note xml:lang="en">nostandalone</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#on-shell">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0on-shell"/>
+  <prefLabel xml:lang="en">on-shell</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#opacity">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoopacity"/>
+  <prefLabel xml:lang="en">opacity</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#OPAL">
+  <prefLabel xml:lang="en">OPAL</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#OPERA">
+  <prefLabel xml:lang="en">OPERA</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#oscillation">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muoscillation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eoscillation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinooscillation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaoscillation"/>
+  <prefLabel xml:lang="en">oscillation</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#overlap">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionoverlap"/>
+  <prefLabel xml:lang="en">overlap</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#p-brane">
+  <prefLabel xml:lang="en">p-brane</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#pairproduction">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taupairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mupairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/epairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinopairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downpairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottompairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0pairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xipairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0pairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-pairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+pairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bpairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdapairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0pairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-pairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+pairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0pairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etapairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterpairproduction"/>
+  <prefLabel xml:lang="en">pair production</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#PAMELA">
+  <prefLabel xml:lang="en">PAMELA</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#particleflow">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaparticleflow"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-particleflow"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+particleflow"/>
+  <prefLabel xml:lang="en">particle flow</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#particleidentification">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomparticleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauparticleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muparticleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eparticleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoparticleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downparticleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomparticleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0particleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiparticleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0particleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-particleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+particleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bparticleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaparticleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0particleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-particleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+particleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0particleidentification"/>
+  <prefLabel xml:lang="en">particle identification</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#particlephysics">
+  <prefLabel xml:lang="en">particle physics</prefLabel>
+  <altLabel xml:lang="en">high energy physics</altLabel>
+  <note xml:lang="en">core</note>
+  <note xml:lang="en">noautosingle</note>
+  <note xml:lang="en">nostandalone</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#particlesource">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauparticlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muparticlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eparticlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoparticlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downparticlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomparticlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0particlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiparticlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0particlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-particlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+particlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bparticlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaparticlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0particlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-particlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+particlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0particlesource"/>
+  <prefLabel xml:lang="en">particle source</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#parton">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.partoninteraction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.partondistributionfunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.charmparton"/>
+  <prefLabel xml:lang="en">parton</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#pathlength">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taupathlength"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mupathlength"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/epathlength"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinopathlength"/>
+  <prefLabel xml:lang="en">path length</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Pati-Salammodel">
+  <prefLabel xml:lang="en">Pati-Salam model</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Peccei-Quinn">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.symmetryPeccei-Quinn"/>
+  <prefLabel xml:lang="en">Peccei-Quinn</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#penguin">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0penguin"/>
+  <prefLabel xml:lang="en">penguin</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#pentaquark">
+  <prefLabel xml:lang="en">pentaquark</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#perturbation">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoperturbation"/>
+  <prefLabel xml:lang="en">perturbation</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#perturbationtheory">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumchromodynamicsperturbationtheory"/>
+  <prefLabel xml:lang="en">perturbation theory</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#PHENIX">
+  <prefLabel xml:lang="en">PHENIX</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#phi**nmodel">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.phi**nmodel6"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.phi**nmodel4"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.phi**nmodel3"/>
+  <prefLabel xml:lang="en">phi**n model</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#PHOBOS">
+  <prefLabel xml:lang="en">PHOBOS</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#photoproduction">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.mesonphotoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauphotoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muphotoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ephotoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinophotoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downphotoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomphotoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0photoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiphotoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0photoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-photoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+photoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bphotoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaphotoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0photoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-photoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+photoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0photoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaphotoproduction"/>
+  <prefLabel xml:lang="en">photoproduction</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#pi-">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.pi-mesicatom"/>
+  <prefLabel xml:lang="en">pi-</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#PINGU">
+  <prefLabel xml:lang="en">PINGU</prefLabel>
+  <note xml:lang="en">core</note>
+  <definition xml:lang="en">Precision IceCube Next Generation Upgrade</definition>
+  <historyNote xml:lang="en">2015-09-10</historyNote>
+</Concept>
+
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#PIPER">
+  <prefLabel xml:lang="en">PIPER</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Planck">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.scalePlanck"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fundamentalconstantPlanck"/>
+  <prefLabel xml:lang="en">Planck</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#planewave">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.gravitationalradiationplanewave"/>
+  <prefLabel xml:lang="en">plane wave</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#plasma">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.acceleratorplasma"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoplasma"/>
+  <prefLabel xml:lang="en">plasma</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#polarization">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinopolarization"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0polarization"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xipolarization"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0polarization"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+polarization"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bpolarization"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdapolarization"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.cosmicbackgroundradiationpolarization"/>
+  <prefLabel xml:lang="en">polarization</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#pole">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0pole"/>
+  <prefLabel xml:lang="en">pole</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Polyakovaction">
+  <prefLabel xml:lang="en">Polyakov action</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Polyakovloop">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Jona-Lasinio-NambumodelPolyakovloop"/>
+  <prefLabel xml:lang="en">Polyakov loop</prefLabel>
+  <altLabel xml:lang="en">Polyakov line</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#pomeron">
+  <prefLabel xml:lang="en">pomeron</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#positiveparticle">
+  <prefLabel xml:lang="en">positive particle</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#positronium">
+  <prefLabel xml:lang="en">positronium</prefLabel>
+  <altLabel xml:lang="en">orthopositronium</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#postulatedparticle">
+  <prefLabel xml:lang="en">postulated particle</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#potential">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinopotential"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-potential"/>
+  <prefLabel xml:lang="en">potential</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#powerspectrum">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinopowerspectrum"/>
+  <prefLabel xml:lang="en">power spectrum</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#precisionmeasurement">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.electroweakinteractionprecisionmeasurement"/>
+  <prefLabel xml:lang="en">precision measurement</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#primary">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoprimary"/>
+  <prefLabel xml:lang="en">primary</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Proca">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumfieldtheoryProca"/>
+  <prefLabel xml:lang="en">Proca</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#production">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0production"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0production"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-production"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+production"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0production"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-production"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+production"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0production"/>
+  <prefLabel xml:lang="en">production</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#ProjectX">
+  <prefLabel xml:lang="en">Project X</prefLabel>
+  <altLabel xml:lang="en">PXIE</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#propagation">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mupropagation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinopropagation"/>
+  <prefLabel xml:lang="en">propagation</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#propagator">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taupropagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mupropagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/epropagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinopropagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downpropagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottompropagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0propagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xipropagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0propagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-propagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+propagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bpropagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdapropagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0propagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-propagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+propagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0propagator"/>
+  <prefLabel xml:lang="en">propagator</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#pseudoscalarmeson">
+  <prefLabel xml:lang="en">pseudoscalar meson</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#PTsymmetry">
+  <prefLabel xml:lang="en">PT symmetry</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#PYTHIA">
+  <prefLabel xml:lang="en">PYTHIA</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Q-ball">
+  <prefLabel xml:lang="en">Q-ball</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#quantumchromodynamics">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumchromodynamicsvacuumstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumchromodynamicsperturbationtheory"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumchromodynamicsnonrelativistic"/>
+  <prefLabel xml:lang="en">quantum chromodynamics</prefLabel>
+  <altLabel xml:lang="en">QCD</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#quantumcosmology">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumcosmologyloopspace"/>
+  <prefLabel xml:lang="en">quantum cosmology</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#quantumelectrodynamics">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumelectrodynamicssupersymmetry"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumelectrodynamicsnoncommutative"/>
+  <prefLabel xml:lang="en">quantum electrodynamics</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#quantumfieldtheory">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumfieldtheoryProca"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumfieldtheoryLiouville"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumfieldtheoryDirac"/>
+  <prefLabel xml:lang="en">quantum field theory</prefLabel>
+  <altLabel xml:lang="en">QFT</altLabel>
+  <altLabel xml:lang="en">quantum field</altLabel>
+  <spiresLabel xml:lang="en">field theory</spiresLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#quantumgravity">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumgravityloopspace"/>
+  <prefLabel xml:lang="en">quantum gravity</prefLabel>
+  <note xml:lang="en">FC:g</note>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#quantumhadrodynamics">
+  <prefLabel xml:lang="en">quantum hadrodynamics</prefLabel>
+  <altLabel xml:lang="en">QHD</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#quantumnumber">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionquantumnumber"/>
+  <prefLabel xml:lang="en">quantum number</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#quark">
+  <prefLabel xml:lang="en">quark</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#quarkgluon">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.quarkgluonbagmodel"/>
+  <prefLabel xml:lang="en">quark gluon</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#quarkonium">
+  <prefLabel xml:lang="en">quarkonium</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#quasiparticle">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.approximationquasiparticle"/>
+  <prefLabel xml:lang="en">quasiparticle</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#quintessence">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fieldtheoryquintessence"/>
+  <prefLabel xml:lang="en">quintessence</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Rparity">
+  <prefLabel xml:lang="en">R parity</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#R-hadron">
+  <prefLabel xml:lang="en">R-hadron</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#radiation">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.radiationCherenkov"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoradiation"/>
+  <prefLabel xml:lang="en">radiation</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#radiativecapture">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-radiativecapture"/>
+  <prefLabel xml:lang="en">radiative capture</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#radiativedecay">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauradiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muradiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eradiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoradiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downradiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomradiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0radiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiradiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0radiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-radiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+radiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bradiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaradiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0radiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-radiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+radiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0radiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaradiativedecay"/>
+  <prefLabel xml:lang="en">radiative decay</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Randall-Sundrummodel">
+  <prefLabel xml:lang="en">Randall-Sundrum model</prefLabel>
+  <altLabel xml:lang="en">RS model</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#rapidity">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+rapidity"/>
+  <prefLabel xml:lang="en">rapidity</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#rapidityspectrum">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taurapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/murapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/erapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinorapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downrapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomrapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0rapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xirapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0rapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-rapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+rapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/brapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdarapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0rapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-rapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+rapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0rapidityspectrum"/>
+  <prefLabel xml:lang="en">rapidity spectrum</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#raredecay">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauraredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muraredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eraredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoraredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downraredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomraredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0raredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiraredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0raredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-raredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+raredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/braredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdararedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0raredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-raredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+raredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0raredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etararedecay"/>
+  <prefLabel xml:lang="en">rare decay</prefLabel>
+  <altLabel xml:lang="en">suppressed decay</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Rarita-Schwingerequation">
+  <prefLabel xml:lang="en">Rarita-Schwinger equation</prefLabel>
+  <altLabel xml:lang="en">Rarita-Schwinger</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#recoil">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinorecoil"/>
+  <prefLabel xml:lang="en">recoil</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#reflection">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoreflection"/>
+  <prefLabel xml:lang="en">reflection</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#regeneration">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauregeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoregeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0regeneration"/>
+  <prefLabel xml:lang="en">regeneration</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Regge">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.gluonRegge"/>
+  <prefLabel xml:lang="en">Regge</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Reggepoles">
+  <prefLabel xml:lang="en">Regge poles</prefLabel>
+  <altLabel xml:lang="en">Regge trajectories</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#relativistic">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinorelativistic"/>
+  <prefLabel xml:lang="en">relativistic</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#relicdensity">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinorelicdensity"/>
+  <prefLabel xml:lang="en">relic density</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#resonance">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0resonance"/>
+  <prefLabel xml:lang="en">resonance</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#review">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoreview"/>
+  <prefLabel xml:lang="en">review</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#RICH">
+  <prefLabel xml:lang="en">RICH</prefLabel>
+  <altLabel xml:lang="en">ring imaging Cherenkov counter</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#right-handed">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauright-handed"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muright-handed"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eright-handed"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoright-handed"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionright-handed"/>
+  <prefLabel xml:lang="en">right-handed</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Rubakoveffect">
+  <prefLabel xml:lang="en">Rubakov effect</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#S-brane">
+  <prefLabel xml:lang="en">S-brane</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#S-duality">
+  <prefLabel xml:lang="en">S-duality</prefLabel>
+  <altLabel xml:lang="en">Seiberg duality</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Salam-Weinbergmodel">
+  <prefLabel xml:lang="en">Salam-Weinberg model</prefLabel>
+  <altLabel xml:lang="en">Weinberg-Salam model</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#scalarmeson">
+  <prefLabel xml:lang="en">scalar meson</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#scalarparticle">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoscalarparticle"/>
+  <prefLabel xml:lang="en">scalar particle</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#scale">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.scalePlanck"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.scaleelectroweakinteraction"/>
+  <prefLabel xml:lang="en">scale</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#scattering">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoscattering"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.heavyionscattering"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterscattering"/>
+  <prefLabel xml:lang="en">scattering</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#scatteringlength">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etascatteringlength"/>
+  <prefLabel xml:lang="en">scattering length</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Schwingermodel">
+  <prefLabel xml:lang="en">Schwinger model</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Schwingerterms">
+  <prefLabel xml:lang="en">Schwinger terms</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#SciBooNE">
+  <prefLabel xml:lang="en">SciBooNE</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#scintillationcounter">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoscintillationcounter"/>
+  <prefLabel xml:lang="en">scintillation counter</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#screening">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoscreening"/>
+  <prefLabel xml:lang="en">screening</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#sea">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosea"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionsea"/>
+  <prefLabel xml:lang="en">sea</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#searchfor">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tausearchfor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/esearchfor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosearchfor"/>
+  <prefLabel xml:lang="en">search for</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#second-classcurrent">
+  <prefLabel xml:lang="en">second-class current</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#secondary">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosecondary"/>
+  <prefLabel xml:lang="en">secondary</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#secondarybeam">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tausecondarybeam"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/musecondarybeam"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/esecondarybeam"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosecondarybeam"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-secondarybeam"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0secondarybeam"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-secondarybeam"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+secondarybeam"/>
+  <prefLabel xml:lang="en">secondary beam</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#seesawmodel">
+  <prefLabel xml:lang="en">seesaw model</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Seiberg-Wittenmap">
+  <prefLabel xml:lang="en">Seiberg-Witten map</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Seiberg-Wittenmodel">
+  <prefLabel xml:lang="en">Seiberg-Witten model</prefLabel>
+  <altLabel xml:lang="en">Seiberg-Witten theory</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#semi-inclusivereaction">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.deepinelasticscatteringsemi-inclusivereaction"/>
+  <prefLabel xml:lang="en">semi-inclusive reaction</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#semileptonicdecay">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tausemileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/musemileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/esemileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosemileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downsemileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomsemileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0semileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xisemileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0semileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-semileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+semileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bsemileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdasemileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0semileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-semileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+semileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0semileptonicdecay"/>
+  <prefLabel xml:lang="en">semileptonic decay</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#SerpukhovPS">
+  <prefLabel xml:lang="en">Serpukhov PS</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#SerpukhovUNKStor">
+  <prefLabel xml:lang="en">Serpukhov UNK Stor</prefLabel>
+  <altLabel xml:lang="en">UNK</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#SerpukhovVLEPPColl">
+  <prefLabel xml:lang="en">Serpukhov VLEPP Coll</prefLabel>
+  <altLabel xml:lang="en">VLEPP</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#sfermion">
+  <prefLabel xml:lang="en">sfermion</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#shockwaves">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.accelerationshockwaves"/>
+  <prefLabel xml:lang="en">shock waves</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#showers">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taushowers"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eshowers"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoshowers"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.showersatmosphere"/>
+  <prefLabel xml:lang="en">showers</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#sigmamodel">
+  <prefLabel xml:lang="en">sigma model</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Sigma+">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+yield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+width"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+wavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+transversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+signature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+semileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+raredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+rapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+radiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+propagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+production"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+polarization"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+photoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+particlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+particleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+pairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+multiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+multipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+momentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+momentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+massspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+massgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+massformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+mass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+magneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+lifetime"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+leptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+invisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+intermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+inclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+hadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+hadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+groundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+formfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+finalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+exclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+excitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+exchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+energyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+energy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+electroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+electromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+electricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+distributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+directproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+decoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+decayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+decaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+decayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+decay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+couplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+coupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+condensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+cascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+branchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+associatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+annihilation"/>
+  <prefLabel xml:lang="en">Sigma+</prefLabel>
+  <note xml:lang="en">core</note>
+  <note xml:lang="en">noautosingle</note>
+  <note xml:lang="en">nostandalone</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Sigma-">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-yield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-wavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-transversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-superfluid"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-signature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-semileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-secondarybeam"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-raredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-rapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-radiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-propagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-production"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-potential"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-photoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-particlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-particleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-pairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-multiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-multipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-momentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-momentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-massspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-massgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-massformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-mass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-magneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-lifetime"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-leptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-invisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-intermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-inclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-hyperonicatom"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-hypernucleus"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-hadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-hadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-hadronicatom"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-groundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-formfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-finalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-exclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-excitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-exchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-energyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-energy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-electroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-electromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-electricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-distributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-directproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-density"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-decoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-decayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-decaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-decayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-decay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-couplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-coupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-condensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-cascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-branchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-bindingenergy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-associatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-annihilation"/>
+  <prefLabel xml:lang="en">Sigma-</prefLabel>
+  <note xml:lang="en">core</note>
+  <note xml:lang="en">noautosingle</note>
+  <note xml:lang="en">nostandalone</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Sigma/b">
+  <prefLabel xml:lang="en">Sigma/b</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Sigma0">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0yield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0width"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0wavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0transversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0signature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0semileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0raredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0rapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0radiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0propagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0production"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0polarization"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0photoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0particlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0particleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0pairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0multiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0multipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0momentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0momentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0massspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0massgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0massformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0mass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0magneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0lifetime"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0leptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0invisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0intermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0inclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0hadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0hadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0groundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0formfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0finalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0exclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0excitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0exchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0energyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0energy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0electroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0electromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0electricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0distributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0directproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0decoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0decayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0decaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0decayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0decay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0couplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0coupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0condensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0cascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0branchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0associatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0annihilation"/>
+  <prefLabel xml:lang="en">Sigma0</prefLabel>
+  <note xml:lang="en">core</note>
+  <note xml:lang="en">noautosingle</note>
+  <note xml:lang="en">nostandalone</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#signature">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tausignature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/musignature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/esignature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosignature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downsignature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomsignature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0signature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xisignature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0signature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-signature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+signature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bsignature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdasignature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0signature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-signature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+signature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0signature"/>
+  <prefLabel xml:lang="en">signature</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#sine-Gordonmodel">
+  <prefLabel xml:lang="en">sine-Gordon model</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#singleproduction">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomsingleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0singleproduction"/>
+  <prefLabel xml:lang="en">single production</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#singlet">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosinglet"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etasinglet"/>
+  <prefLabel xml:lang="en">singlet</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#sinh-Gordonequation">
+  <prefLabel xml:lang="en">sinh-Gordon equation</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Siversfunction">
+  <prefLabel xml:lang="en">Sivers function</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Skyrmemodel">
+  <prefLabel xml:lang="en">Skyrme model</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Skyrmion">
+  <prefLabel xml:lang="en">Skyrmion</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#SLACPEPStor">
+  <prefLabel xml:lang="en">SLAC PEP Stor</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#SLACSLCLinac">
+  <prefLabel xml:lang="en">SLAC SLC Linac</prefLabel>
+  <altLabel xml:lang="en">SLC</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#SLACSPEARStor">
+  <prefLabel xml:lang="en">SLAC SPEAR Stor</prefLabel>
+  <altLabel xml:lang="en">SPEAR</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#SLD">
+  <prefLabel xml:lang="en">SLD</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#slepton">
+  <prefLabel xml:lang="en">slepton</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#slow-rollapproximation">
+  <prefLabel xml:lang="en">slow-roll approximation</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#sneutrino">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.sneutrinoinflaton"/>
+  <prefLabel xml:lang="en">sneutrino</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#SNO">
+  <prefLabel xml:lang="en">SNO</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#softcollineareffectivetheory">
+  <prefLabel xml:lang="en">soft collinear effective theory</prefLabel>
+  <altLabel xml:lang="en">SCET</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#solar">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosolar"/>
+  <prefLabel xml:lang="en">solar</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Soudan">
+  <prefLabel xml:lang="en">Soudan</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#space-time">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.space-timehigher-dimensional"/>
+  <prefLabel xml:lang="en">space-time</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#sparticle">
+  <prefLabel xml:lang="en">sparticle</prefLabel>
+  <altLabel xml:lang="en">superparticle</altLabel>
+  <altLabel xml:lang="en">superpartner</altLabel>
+  <altLabel xml:lang="en">supersymmetric particle</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#spectralrepresentation">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-spectralrepresentation"/>
+  <prefLabel xml:lang="en">spectral representation</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#spectrum">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinospectrum"/>
+  <prefLabel xml:lang="en">spectrum</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#sphere">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosphere"/>
+  <prefLabel xml:lang="en">sphere</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#SPIDER">
+  <prefLabel xml:lang="en">SPIDER</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#spin">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinospin"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaspin"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterspin"/>
+  <prefLabel xml:lang="en">spin</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#spinless">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0spinless"/>
+  <prefLabel xml:lang="en">spinless</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#split">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionsplit"/>
+  <prefLabel xml:lang="en">split</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#spontaneoussymmetrybreaking">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.supersymmetryspontaneoussymmetrybreaking"/>
+  <prefLabel xml:lang="en">spontaneous symmetry breaking</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#squark">
+  <prefLabel xml:lang="en">squark</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#SSCColl">
+  <prefLabel xml:lang="en">SSC Coll</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#stability">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinostability"/>
+  <prefLabel xml:lang="en">stability</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#staggered">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionstaggered"/>
+  <prefLabel xml:lang="en">staggered</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#STAR">
+  <prefLabel xml:lang="en">STAR</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#star">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.starstrangeness"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinostar"/>
+  <prefLabel xml:lang="en">star</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#statistical">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.hadronizationstatistical"/>
+  <prefLabel xml:lang="en">statistical</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#statistics">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinostatistics"/>
+  <prefLabel xml:lang="en">statistics</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#sterile">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/esterile"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosterile"/>
+  <prefLabel xml:lang="en">sterile</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#strangemeson">
+  <prefLabel xml:lang="en">strange meson</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#strangeparticle">
+  <prefLabel xml:lang="en">strange particle</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#strangelet">
+  <prefLabel xml:lang="en">strangelet</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#strangeness">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.starstrangeness"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.matterstrangeness"/>
+  <prefLabel xml:lang="en">strangeness</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#string">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.stringGreen-Schwarz"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.stringdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterstring"/>
+  <prefLabel xml:lang="en">string</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#stringmodel">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.stringmodelheterotic"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.stringmodelboson"/>
+  <prefLabel xml:lang="en">string model</prefLabel>
+  <altLabel xml:lang="en">string phenomenology</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#strongcoupling">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.approximationstrongcoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinostrongcoupling"/>
+  <prefLabel xml:lang="en">strong coupling</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#stronginteraction">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.stronginteractioncouplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinostronginteraction"/>
+  <prefLabel xml:lang="en">strong interaction</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#superfield">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosuperfield"/>
+  <prefLabel xml:lang="en">superfield</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#superfluid">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-superfluid"/>
+  <prefLabel xml:lang="en">superfluid</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#superfragment">
+  <prefLabel xml:lang="en">superfragment</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#supergravity">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.supergravityminimal"/>
+  <prefLabel xml:lang="en">supergravity</prefLabel>
+  <altLabel xml:lang="en">SUGRA</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#superluminal">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosuperluminal"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosuperluminal"/>
+  <prefLabel xml:lang="en">superluminal</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#supernova">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosupernova"/>
+  <prefLabel xml:lang="en">supernova</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#superstring">
+  <prefLabel xml:lang="en">superstring</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#supersymmetry">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.supersymmetrysymmetrybreaking"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.supersymmetryspontaneoussymmetrybreaking"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.supersymmetryhiddensymmetry"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.supersymmetryalgebra"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.supersymmetry8"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.supersymmetry6"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.supersymmetry4"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.supersymmetry2"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.supersymmetry1"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumelectrodynamicssupersymmetry"/>
+  <prefLabel xml:lang="en">supersymmetry</prefLabel>
+  <altLabel xml:lang="en">SUSY</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#superweakinteraction">
+  <prefLabel xml:lang="en">superweak interaction</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#suppression">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downsuppression"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomsuppression"/>
+  <prefLabel xml:lang="en">suppression</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#surface">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.IceCubesurface"/>
+  <prefLabel xml:lang="en">surface</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#symmetry">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.symmetryPeccei-Quinn"/>
+  <prefLabel xml:lang="en">symmetry</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#symmetrybreaking">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.supersymmetrysymmetrybreaking"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.electroweakinteractionsymmetrybreaking"/>
+  <prefLabel xml:lang="en">symmetry breaking</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#symplectic">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionsymplectic"/>
+  <prefLabel xml:lang="en">symplectic</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#T-duality">
+  <prefLabel xml:lang="en">T-duality</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#T-parity">
+  <prefLabel xml:lang="en">T-parity</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#tachyon">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotachyon"/>
+  <prefLabel xml:lang="en">tachyon</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#taggedbeam">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotaggedbeam"/>
+  <prefLabel xml:lang="en">tagged beam</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#technicolor">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermiontechnicolor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.baryontechnicolor"/>
+  <prefLabel xml:lang="en">technicolor</prefLabel>
+  <altLabel xml:lang="en">ETC</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#temperature">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotemperature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+temperature"/>
+  <prefLabel xml:lang="en">temperature</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#tetraquark">
+  <prefLabel xml:lang="en">tetraquark</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#texture">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermiontexture"/>
+  <prefLabel xml:lang="en">texture</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#thermal">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinothermal"/>
+  <prefLabel xml:lang="en">thermal</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Theta(1540)">
+  <prefLabel xml:lang="en">Theta(1540)</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Thirringmodel">
+  <prefLabel xml:lang="en">Thirring model</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#threshold">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etathreshold"/>
+  <prefLabel xml:lang="en">threshold</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#timedelay">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotimedelay"/>
+  <prefLabel xml:lang="en">time delay</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#timedependence">
+<composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomasstimedependence"/>
+  <prefLabel xml:lang="en">time dependence</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#time-of-flight">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mutime-of-flight"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotime-of-flight"/>
+  <prefLabel xml:lang="en">time-of-flight</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#top">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.topboostedparticle"/>
+  <prefLabel xml:lang="en">top</prefLabel>
+  <altLabel xml:lang="en">top-quark</altLabel>
+  <note xml:lang="en">core</note>
+  <note xml:lang="en">noautosingle</note>
+  <note xml:lang="en">nostandalone</note>
+  <broader rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#heavyquark"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#TOPAZ">
+  <prefLabel xml:lang="en">TOPAZ</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#topcolor">
+  <prefLabel xml:lang="en">topcolor</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#topological">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fieldtheorytopological"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fieldtheorytopological"/>
+  <prefLabel xml:lang="en">topological</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#totalcrosssection">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomtotalcrosssection"/>
+  <prefLabel xml:lang="en">total cross section</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#TOTEM">
+  <prefLabel xml:lang="en">TOTEM</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#traceanomaly">
+  <prefLabel xml:lang="en">trace anomaly</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#trajectory">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotrajectory"/>
+  <prefLabel xml:lang="en">trajectory</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#transition">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotransition"/>
+  <prefLabel xml:lang="en">transition</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#transporttheory">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotransporttheory"/>
+  <prefLabel xml:lang="en">transport theory</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#transverse">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.gravitationtransverse"/>
+  <prefLabel xml:lang="en">transverse</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#transversemomentum">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tautransversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mutransversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/etransversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotransversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downtransversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomtransversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0transversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xitransversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0transversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-transversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+transversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/btransversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdatransversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0transversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-transversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+transversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0transversemomentum"/>
+  <prefLabel xml:lang="en">transverse momentum</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#trigger">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotrigger"/>
+  <prefLabel xml:lang="en">trigger</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#triple-Reggelimit">
+  <prefLabel xml:lang="en">triple-Regge limit</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#triplet">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Higgsparticletriplet"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermiontriplet"/>
+  <prefLabel xml:lang="en">triplet</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#tritium">
+  <prefLabel xml:lang="en">tritium</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#tungsten">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.calciumtungsten"/>
+  <prefLabel xml:lang="en">tungsten</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#twinHiggsmodel">
+  <prefLabel xml:lang="en">twin Higgs model</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Two-Gamma">
+  <prefLabel xml:lang="en">Two-Gamma</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#U-duality">
+  <prefLabel xml:lang="en">U-duality</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#UA2">
+  <prefLabel xml:lang="en">UA2</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#UA4">
+  <prefLabel xml:lang="en">UA4</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#UHE">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.cosmicradiationUHE"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauUHE"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eUHE"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoUHE"/>
+  <prefLabel xml:lang="en">UHE</prefLabel>
+  <altLabel xml:lang="en">extremely high energy</altLabel>
+  <altLabel xml:lang="en">ultra high energy</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#unifiedfieldtheory">
+  <prefLabel xml:lang="en">unified field theory</prefLabel>
+  <altLabel xml:lang="en">unified theory</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#unitarity">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.CKMmatrixunitarity"/>
+  <prefLabel xml:lang="en">unitarity</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#universalextradimension">
+  <prefLabel xml:lang="en">universal extra dimension</prefLabel>
+  <altLabel xml:lang="en">UED</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#universality">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionuniversality"/>
+  <prefLabel xml:lang="en">universality</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#upgrade">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.CERNLHCCollupgrade"/>
+  <prefLabel xml:lang="en">upgrade</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#vacuumstate">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumchromodynamicsvacuumstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.vacuumstateYang-Mills"/>
+  <prefLabel xml:lang="en">vacuum state</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#VancouverKAONPS">
+  <prefLabel xml:lang="en">Vancouver KAON PS</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#variablespeedoflight">
+  <prefLabel xml:lang="en">variable speed of light</prefLabel>
+  <altLabel xml:lang="en">VSL model</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#vector">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomvector"/>
+  <prefLabel xml:lang="en">vector</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#vectordominance">
+  <prefLabel xml:lang="en">vector dominance</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#vectormanifestation">
+  <prefLabel xml:lang="en">vector manifestation</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#vectormeson">
+  <prefLabel xml:lang="en">vector meson</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#vectorparticle">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomvectorparticle"/>
+  <prefLabel xml:lang="en">vector particle</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#velocity">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muvelocity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinovelocity"/>
+  <prefLabel xml:lang="en">velocity</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#VENUS">
+  <prefLabel xml:lang="en">VENUS</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#VERITAS">
+  <prefLabel xml:lang="en">VERITAS</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#VHE">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoVHE"/>
+  <prefLabel xml:lang="en">VHE</prefLabel>
+  <altLabel xml:lang="en">very high energy</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#violation">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.causalityviolation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.violationLorentz"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.flavorviolation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.CPTviolation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.CPviolation"/>
+  <prefLabel xml:lang="en">violation</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#wakefield">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.accelerationwakefield"/>
+  <prefLabel xml:lang="en">wake field</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Wardidentity">
+  <prefLabel xml:lang="en">Ward identity</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Ward-Takahashiidentity">
+  <prefLabel xml:lang="en">Ward-Takahashi identity</prefLabel>
+  <altLabel xml:lang="en">WTI</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#water">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinowater"/>
+  <prefLabel xml:lang="en">water</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#wavefunction">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauwavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muwavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ewavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinowavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downwavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomwavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0wavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiwavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0wavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-wavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+wavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bwavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdawavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0wavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-wavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+wavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0wavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etawavefunction"/>
+  <prefLabel xml:lang="en">wave function</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#weakinteraction">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.weakinteractioncouplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.decayweakinteraction"/>
+  <prefLabel xml:lang="en">weak interaction</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Weinbergangle">
+  <prefLabel xml:lang="en">Weinberg angle</prefLabel>
+  <altLabel xml:lang="en">weak mixing angle</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Wess-Zuminomodel">
+  <prefLabel xml:lang="en">Wess-Zumino model</prefLabel>
+  <altLabel xml:lang="en">Wess-Zumino theory</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Wess-Zuminoterm">
+  <prefLabel xml:lang="en">Wess-Zumino term</prefLabel>
+  <altLabel xml:lang="en">WZW term</altLabel>
+  <altLabel xml:lang="en">Wess-Zumino-Witten term</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Wess-Zumino-Wittenmodel">
+  <prefLabel xml:lang="en">Wess-Zumino-Witten model</prefLabel>
+  <altLabel xml:lang="en">WZNW</altLabel>
+  <altLabel xml:lang="en">WZW model</altLabel>
+  <altLabel xml:lang="en">Wess-Zumino-Novikov-Witten model</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Weyl">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoWeyl"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionWeyl"/>
+  <prefLabel xml:lang="en">Weyl</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Wheeler-DeWittequation">
+  <prefLabel xml:lang="en">Wheeler-DeWitt equation</prefLabel>
+  <altLabel xml:lang="en">WDW equation</altLabel>
+  <altLabel xml:lang="en">WdW</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Wick-Cutkoskymodel">
+  <prefLabel xml:lang="en">Wick-Cutkosky model</prefLabel>
+  <altLabel xml:lang="en">Wick-Cutkosky</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#width">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinowidth"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomwidth"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0width"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0width"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+width"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bwidth"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdawidth"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0width"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-width"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+width"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0width"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.etawidth"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterwidth"/>
+  <prefLabel xml:lang="en">width</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Wilson">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionWilson"/>
+  <prefLabel xml:lang="en">Wilson</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Wilsonloop">
+  <prefLabel xml:lang="en">Wilson loop</prefLabel>
+  <altLabel xml:lang="en">Wilson-line</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#WIMP">
+  <prefLabel xml:lang="en">WIMP</prefLabel>
+  <altLabel xml:lang="en">weakly interacting massive particle</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Wino">
+  <prefLabel xml:lang="en">Wino</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#wormhole">
+  <prefLabel xml:lang="en">wormhole</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Xi">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiyield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiwavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xitransversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xisignature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xisemileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiraredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xirapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiradiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xipropagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xipolarization"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiphotoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiparticlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiparticleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xipairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Ximultiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Ximultipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Ximomentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Ximomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Ximassspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Ximassgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Ximassformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Ximass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Ximagneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xileptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiinvisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiintermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiinclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xihypernucleus"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xihadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xihadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xigroundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiformfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xifinalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiexclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiexcitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiexchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xienergyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xienergy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xielectroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xielectromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xielectricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xidistributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xidirectproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xidecoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xidecayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xidecaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xidecayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xidecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xicouplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xicoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xicondensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xicascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xibranchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiassociatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiannihilation"/>
+  <prefLabel xml:lang="en">Xi</prefLabel>
+  <altLabel xml:lang="en">cascade baryon</altLabel>
+  <note xml:lang="en">core</note>
+  <note xml:lang="en">noautosingle</note>
+  <note xml:lang="en">nostandalone</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Yang-Mills">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fieldequationsYang-Mills"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.vacuumstateYang-Mills"/>
+  <prefLabel xml:lang="en">Yang-Mills</prefLabel>
+  <altLabel xml:lang="en">YM</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Yang-Mills-Higgstheory">
+  <prefLabel xml:lang="en">Yang-Mills-Higgs theory</prefLabel>
+  <altLabel xml:lang="en">YMH</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#yield">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauyield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muyield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eyield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoyield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.downyield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomyield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0yield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiyield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0yield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-yield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+yield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/byield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdayield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0yield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-yield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+yield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0yield"/>
+  <prefLabel xml:lang="en">yield</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Z0">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0boostedparticle"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0yield"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0width"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0wavefunction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0transversemomentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0spinless"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0singleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0signature"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0semileptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0resonance"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0raredecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0rapidityspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0radiativedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0propagator"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0production"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0pole"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0polarization"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0photoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0penguin"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0particlesource"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0particleidentification"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0pairproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0on-shell"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0off-shell"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0neutrinoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0multiplicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0multiplet"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0multipleproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0momentumspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0momentum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0mediation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0massspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0massgeneration"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0massformula"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0mass"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0magneticmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0loopintegral"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0longitudinal"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0lifetime"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0leptoproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0leptonicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0invisibledecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0intermediatestate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0inclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0helicity"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0hadroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0hadronicdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0groundstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0fusion"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0forwardscattering"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0forwardproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0formfactor"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0finalstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0exclusiveproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0excitedstate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0exchange"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0energyspectrum"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0energy"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0electroproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0electromagneticdecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0electricmoment"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0distributionamplitude"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0directproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0decoupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0decayrate"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0decaymodes"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0decayconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0decay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0couplingconstant"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0coupling"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0condensation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0composite"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0cascadedecay"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0burst"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0bremsstrahlung"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0branchingratio"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0boostedparticle"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0associatedproduction"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0annihilation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0angulardistribution"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0Kaluza-Klein"/>
+  <prefLabel xml:lang="en">Z0</prefLabel>
+  <altLabel xml:lang="en">Z-boson</altLabel>
+  <note xml:lang="en">core</note>
+  <note xml:lang="en">noautosingle</note>
+  <note xml:lang="en">nostandalone</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#ZEPLIN">
+  <prefLabel xml:lang="en">ZEPLIN</prefLabel>
+  <altLabel xml:lang="en">ZEPLIN-II</altLabel>
+  <altLabel xml:lang="en">ZEPLIN-III</altLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#zeromode">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinozeromode"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionzeromode"/>
+  <prefLabel xml:lang="en">zero mode</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#ZEUS">
+  <prefLabel xml:lang="en">ZEUS</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Zino">
+  <prefLabel xml:lang="en">Zino</prefLabel>
+  <note xml:lang="en">core</note>
+</Concept>
+
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.CPviolation">
+<prefLabel xml:lang="en">CP: violation</prefLabel>
+  <hiddenLabel xml:lang="en">/CP[-\s]*violat\w+/</hiddenLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#CP"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#violation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.CPTviolation">
+<prefLabel xml:lang="en">CPT: violation</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#CPT"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#violation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.cosmicbackgroundradiationpolarization">
+<prefLabel xml:lang="en">cosmic background radiation: polarization</prefLabel>
+   <note xml:lang="en">core</note>
+   <historyNote xml:lang="en">2010-03-19</historyNote>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#cosmicbackgroundradiation"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#polarization"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterannihilation">
+<prefLabel xml:lang="en">dark matter: annihilation</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#darkmatter"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#annihilation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterbranchingratio">
+<prefLabel xml:lang="en">dark matter: branching ratio</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#darkmatter"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#branchingratio"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmattercascadedecay">
+<prefLabel xml:lang="en">dark matter: cascade decay</prefLabel>
+   <note xml:lang="en">core</note>
+   <historyNote xml:lang="en">2010-07-08</historyNote>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#darkmatter"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#cascadedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterchargedparticle">
+<prefLabel xml:lang="en">dark matter: charged particle</prefLabel>
+   <note xml:lang="en">core</note>
+   <historyNote xml:lang="en">2010-05-12</historyNote>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#darkmatter"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#chargedparticle"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterdecay">
+<prefLabel xml:lang="en">dark matter: decay</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#darkmatter"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterdecaymodes">
+<prefLabel xml:lang="en">dark matter: decay modes</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#darkmatter"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decaymodes"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterdecayrate">
+<prefLabel xml:lang="en">dark matter: decay rate</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#darkmatter"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayrate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterdirectdetection">
+<prefLabel xml:lang="en">dark matter: direct detection</prefLabel>
+  <hiddenLabel xml:lang="en">/direct dark matter detection/</hiddenLabel>
+   <note xml:lang="en">core</note>
+   <historyNote xml:lang="en">2010-05-05</historyNote>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#darkmatter"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#directdetection"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterleptonicdecay">
+<prefLabel xml:lang="en">dark matter: leptonic decay</prefLabel>
+   <note xml:lang="en">core</note>
+   <historyNote xml:lang="en">2010-04-23</historyNote>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#darkmatter"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterpairproduction">
+<prefLabel xml:lang="en">dark matter: pair production</prefLabel>
+   <note xml:lang="en">core</note>
+   <historyNote xml:lang="en">2010-05-26</historyNote>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#darkmatter"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#pairproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterscattering">
+<prefLabel xml:lang="en">dark matter: scattering</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#darkmatter"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#scattering"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterspin">
+<prefLabel xml:lang="en">dark matter: spin</prefLabel>
+   <note xml:lang="en">core</note>
+   <historyNote xml:lang="en">2010-08-31</historyNote>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#darkmatter"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#spin"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterwidth">
+<prefLabel xml:lang="en">dark matter: width</prefLabel>
+   <note xml:lang="en">core</note>
+   <historyNote xml:lang="en">2010-04-12</historyNote>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#darkmatter"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#width"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaangulardistribution">
+<prefLabel xml:lang="en">eta: angular distribution</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#eta"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#angulardistribution"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.etabindingenergy">
+<prefLabel xml:lang="en">eta: binding energy</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#eta"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bindingenergy"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.etabranchingratio">
+<prefLabel xml:lang="en">eta: branching ratio</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#eta"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#branchingratio"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.etadecaymodes">
+<prefLabel xml:lang="en">eta: decay modes</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#eta"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decaymodes"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaelectromagneticdecay">
+<prefLabel xml:lang="en">eta: electromagnetic decay</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#eta"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electromagneticdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaelectroproduction">
+<prefLabel xml:lang="en">eta: electroproduction</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#eta"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaenergyspectrum">
+<prefLabel xml:lang="en">eta: energy spectrum</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#eta"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energyspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaexcitedstate">
+<prefLabel xml:lang="en">eta: excited state</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#eta"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#excitedstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaformfactor">
+<prefLabel xml:lang="en">eta: form factor</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#eta"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#formfactor"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.etahadronicdecay">
+<prefLabel xml:lang="en">eta: hadronic decay</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#eta"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadronicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.etahadroproduction">
+<prefLabel xml:lang="en">eta: hadroproduction</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#eta"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaintermediatestate">
+<prefLabel xml:lang="en">eta: intermediate state</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#eta"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#intermediatestate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.etamass">
+<prefLabel xml:lang="en">eta: mass</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#eta"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mass"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaoctet">
+<prefLabel xml:lang="en">eta: octet</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#eta"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#octet"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.etapairproduction">
+<prefLabel xml:lang="en">eta: pair production</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#eta"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#pairproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaphotoproduction">
+<prefLabel xml:lang="en">eta: photoproduction</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#eta"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#photoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.etaradiativedecay">
+<prefLabel xml:lang="en">eta: radiative decay</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#eta"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#radiativedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.etararedecay">
+<prefLabel xml:lang="en">eta: rare decay</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#eta"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#raredecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.etascatteringlength">
+<prefLabel xml:lang="en">eta: scattering length</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#eta"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#scatteringlength"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.etasinglet">
+<prefLabel xml:lang="en">eta: singlet</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#eta"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#singlet"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.etathreshold">
+<prefLabel xml:lang="en">eta: threshold</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#eta"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#threshold"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.etawavefunction">
+<prefLabel xml:lang="en">eta: wave function</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#eta"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#wavefunction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.etawidth">
+<prefLabel xml:lang="en">eta: width</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#eta"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#width"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionGoldstoneparticle">
+<prefLabel xml:lang="en">fermion: Goldstone particle</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Goldstoneparticle"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionKaehler">
+<prefLabel xml:lang="en">fermion: Kaehler</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Kaehler"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionKaluza-Klein">
+<prefLabel xml:lang="en">fermion: Kaluza-Klein</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Kaluza-Klein"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionMajorana">
+<prefLabel xml:lang="en">fermion: Majorana</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Majorana"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionWeyl">
+<prefLabel xml:lang="en">fermion: Weyl</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Weyl"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionWilson">
+<prefLabel xml:lang="en">fermion: Wilson</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Wilson"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionchiral">
+<prefLabel xml:lang="en">fermion: chiral</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#chiral"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermioncomposite">
+<prefLabel xml:lang="en">fermion: composite</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#composite"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermiondoubling">
+<prefLabel xml:lang="en">fermion: doubling</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#doubling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionexcitedstate">
+<prefLabel xml:lang="en">fermion: excited state</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#excitedstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionexotic">
+<prefLabel xml:lang="en">fermion: exotic</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exotic"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionfamily">
+<prefLabel xml:lang="en">fermion: family</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#family"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionflavor">
+<prefLabel xml:lang="en">fermion: flavor</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#flavor"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionformfactor">
+<prefLabel xml:lang="en">fermion: form factor</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#formfactor"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionhelicity">
+<prefLabel xml:lang="en">fermion: helicity</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#helicity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermioninterference">
+<prefLabel xml:lang="en">fermion: interference</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#interference"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionleft-handed">
+<prefLabel xml:lang="en">fermion: left-handed</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#left-handed"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionmagneticmoment">
+<prefLabel xml:lang="en">fermion: magnetic moment</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#magneticmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionmassgeneration">
+<prefLabel xml:lang="en">fermion: mass generation</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massgeneration"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionmassratio">
+<prefLabel xml:lang="en">fermion: mass ratio</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massratio"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionmassspectrum">
+<prefLabel xml:lang="en">fermion: mass spectrum</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionmixing">
+<prefLabel xml:lang="en">fermion: mixing</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mixing"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionmixingangle">
+<prefLabel xml:lang="en">fermion: mixing angle</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mixingangle"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionmultiplet">
+<prefLabel xml:lang="en">fermion: multiplet</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multiplet"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionoverlap">
+<prefLabel xml:lang="en">fermion: overlap</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#overlap"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionquantumnumber">
+<prefLabel xml:lang="en">fermion: quantum number</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#quantumnumber"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionright-handed">
+<prefLabel xml:lang="en">fermion: right-handed</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#right-handed"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionsea">
+<prefLabel xml:lang="en">fermion: sea</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#sea"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionsplit">
+<prefLabel xml:lang="en">fermion: split</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#split"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionstaggered">
+<prefLabel xml:lang="en">fermion: staggered</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#staggered"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionsymplectic">
+<prefLabel xml:lang="en">fermion: symplectic</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#symplectic"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermiontexture">
+<prefLabel xml:lang="en">fermion: texture</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#texture"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermiontriplet">
+<prefLabel xml:lang="en">fermion: triplet</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#triplet"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionuniversality">
+<prefLabel xml:lang="en">fermion: universality</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#universality"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermionzeromode">
+<prefLabel xml:lang="en">fermion: zero mode</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#zeromode"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fieldtheorytopological">
+<prefLabel xml:lang="en">field theory: topological</prefLabel>
+  <altLabel xml:lang="en">TQFT</altLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fieldtheory"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#topological"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.flavorviolation">
+<prefLabel xml:lang="en">flavor: violation</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#flavor"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#violation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.heavyionscattering">
+<prefLabel xml:lang="en">heavy ion: scattering</prefLabel>
+  <hiddenLabel xml:lang="en">/heavy[ -]ion colli.*/</hiddenLabel>
+  <hiddenLabel xml:lang="en">/Pb[ -]+Pb colli.*/</hiddenLabel>
+  <hiddenLabel xml:lang="en">/Au[ -]+Au colli.*/</hiddenLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#heavyion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#scattering"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.heliumboundstate">
+<prefLabel xml:lang="en">helium: bound state</prefLabel>
+  <altLabel xml:lang="en">O-helium</altLabel>
+  <hiddenLabel xml:lang="en">OHe</hiddenLabel>
+   <note xml:lang="en">core</note>
+   <historyNote xml:lang="en">2011-11-17</historyNote>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#helium"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#boundstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomass">
+<composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomasstimedependence"/>
+<prefLabel xml:lang="en">neutrino: mass</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mass"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosuperluminal">
+<prefLabel xml:lang="en">neutrino: superluminal</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#superluminal"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumelectrodynamicsnoncommutative">
+<prefLabel xml:lang="en">quantum electrodynamics: noncommutative</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#quantumelectrodynamics"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#noncommutative"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.showersatmosphere">
+<prefLabel xml:lang="en">showers: atmosphere</prefLabel>
+  <hiddenLabel xml:lang="en">/air[ -]shower\w*/</hiddenLabel>
+   <note xml:lang="en">core</note>
+   <historyNote xml:lang="en">2011-04-15</historyNote>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#showers"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#atmosphere"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.space-timehigher-dimensional">
+<prefLabel xml:lang="en">space-time: higher-dimensional</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#space-time"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#higher-dimensional"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.vacuumstateYang-Mills">
+<prefLabel xml:lang="en">vacuum state: Yang-Mills</prefLabel>
+   <note xml:lang="en">core</note>
+   <historyNote xml:lang="en">2010-02-09</historyNote>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#vacuumstate"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Yang-Mills"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.violationLorentz">
+<prefLabel xml:lang="en">violation: Lorentz</prefLabel>
+  <altLabel xml:lang="en">Lorentz symmetry violation</altLabel>
+  <altLabel xml:lang="en">Lorentz invariance violation</altLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#violation"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lorentz"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0annihilation">
+<prefLabel xml:lang="en">B0: annihilation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#annihilation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0associatedproduction">
+<prefLabel xml:lang="en">B0: associated production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#associatedproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0branchingratio">
+<prefLabel xml:lang="en">B0: branching ratio</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#branchingratio"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0cascadedecay">
+<prefLabel xml:lang="en">B0: cascade decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#cascadedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0condensation">
+<prefLabel xml:lang="en">B0: condensation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#condensation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0coupling">
+<prefLabel xml:lang="en">B0: coupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#coupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0couplingconstant">
+<prefLabel xml:lang="en">B0: coupling constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#couplingconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0decay">
+<prefLabel xml:lang="en">B0: decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0decayconstant">
+<prefLabel xml:lang="en">B0: decay constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0decaymodes">
+<prefLabel xml:lang="en">B0: decay modes</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decaymodes"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0decayrate">
+<prefLabel xml:lang="en">B0: decay rate</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayrate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0decoupling">
+<prefLabel xml:lang="en">B0: decoupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decoupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0directproduction">
+<prefLabel xml:lang="en">B0: direct production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#directproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0distributionamplitude">
+<prefLabel xml:lang="en">B0: distribution amplitude</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#distributionamplitude"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0electricmoment">
+<prefLabel xml:lang="en">B0: electric moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electricmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0electromagneticdecay">
+<prefLabel xml:lang="en">B0: electromagnetic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electromagneticdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0electroproduction">
+<prefLabel xml:lang="en">B0: electroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0energy">
+<prefLabel xml:lang="en">B0: energy</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energy"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0energyspectrum">
+<prefLabel xml:lang="en">B0: energy spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energyspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0exchange">
+<prefLabel xml:lang="en">B0: exchange</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exchange"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0excitedstate">
+<prefLabel xml:lang="en">B0: excited state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#excitedstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0exclusiveproduction">
+<prefLabel xml:lang="en">B0: exclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0finalstate">
+<prefLabel xml:lang="en">B0: final state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#finalstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0formfactor">
+<prefLabel xml:lang="en">B0: form factor</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#formfactor"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0groundstate">
+<prefLabel xml:lang="en">B0: ground state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#groundstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0hadronicdecay">
+<prefLabel xml:lang="en">B0: hadronic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadronicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0hadroproduction">
+<prefLabel xml:lang="en">B0: hadroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0inclusiveproduction">
+<prefLabel xml:lang="en">B0: inclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#inclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0intermediatestate">
+<prefLabel xml:lang="en">B0: intermediate state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#intermediatestate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0invisibledecay">
+<prefLabel xml:lang="en">B0: invisible decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#invisibledecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0leptonicdecay">
+<prefLabel xml:lang="en">B0: leptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0leptoproduction">
+<prefLabel xml:lang="en">B0: leptoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0lifetime">
+<prefLabel xml:lang="en">B0: lifetime</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#lifetime"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0magneticmoment">
+<prefLabel xml:lang="en">B0: magnetic moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#magneticmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0mass">
+<prefLabel xml:lang="en">B0: mass</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mass"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0massdifference">
+<prefLabel xml:lang="en">B0: mass difference</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massdifference"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0massformula">
+<prefLabel xml:lang="en">B0: mass formula</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massformula"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0massgeneration">
+<prefLabel xml:lang="en">B0: mass generation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massgeneration"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0massspectrum">
+<prefLabel xml:lang="en">B0: mass spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0momentum">
+<prefLabel xml:lang="en">B0: momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0momentumspectrum">
+<prefLabel xml:lang="en">B0: momentum spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentumspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0multipleproduction">
+<prefLabel xml:lang="en">B0: multiple production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multipleproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0multiplicity">
+<prefLabel xml:lang="en">B0: multiplicity</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multiplicity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0pairproduction">
+<prefLabel xml:lang="en">B0: pair production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#pairproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0particleidentification">
+<prefLabel xml:lang="en">B0: particle identification</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particleidentification"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0particlesource">
+<prefLabel xml:lang="en">B0: particle source</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particlesource"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0photoproduction">
+<prefLabel xml:lang="en">B0: photoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#photoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0production">
+<prefLabel xml:lang="en">B0: production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#production"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0propagator">
+<prefLabel xml:lang="en">B0: propagator</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#propagator"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0radiativedecay">
+<prefLabel xml:lang="en">B0: radiative decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#radiativedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0rapidityspectrum">
+<prefLabel xml:lang="en">B0: rapidity spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#rapidityspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0raredecay">
+<prefLabel xml:lang="en">B0: rare decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#raredecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0semileptonicdecay">
+<prefLabel xml:lang="en">B0: semileptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#semileptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0signature">
+<prefLabel xml:lang="en">B0: signature</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#signature"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0transversemomentum">
+<prefLabel xml:lang="en">B0: transverse momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#transversemomentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0wavefunction">
+<prefLabel xml:lang="en">B0: wave function</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#wavefunction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0width">
+<prefLabel xml:lang="en">B0: width</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#width"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.B0yield">
+<prefLabel xml:lang="en">B0: yield</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#B0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#yield"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+Goldstoneparticle">
+<prefLabel xml:lang="en">K+: Goldstone particle</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Goldstoneparticle"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+absorption">
+<prefLabel xml:lang="en">K+: absorption</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#absorption"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+angulardistribution">
+<prefLabel xml:lang="en">K+: angular distribution</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#angulardistribution"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+annihilation">
+<prefLabel xml:lang="en">K+: annihilation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#annihilation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+associatedproduction">
+<prefLabel xml:lang="en">K+: associated production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#associatedproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+beam">
+<prefLabel xml:lang="en">K+: beam</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#beam"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+branchingratio">
+<prefLabel xml:lang="en">K+: branching ratio</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#branchingratio"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+cascadedecay">
+<prefLabel xml:lang="en">K+: cascade decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#cascadedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+condensation">
+<prefLabel xml:lang="en">K+: condensation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#condensation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+coupling">
+<prefLabel xml:lang="en">K+: coupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#coupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+couplingconstant">
+<prefLabel xml:lang="en">K+: coupling constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#couplingconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+decay">
+<prefLabel xml:lang="en">K+: decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+decayconstant">
+<prefLabel xml:lang="en">K+: decay constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+decaymodes">
+<prefLabel xml:lang="en">K+: decay modes</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decaymodes"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+decayrate">
+<prefLabel xml:lang="en">K+: decay rate</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayrate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+decoupling">
+<prefLabel xml:lang="en">K+: decoupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decoupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+directproduction">
+<prefLabel xml:lang="en">K+: direct production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#directproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+distributionamplitude">
+<prefLabel xml:lang="en">K+: distribution amplitude</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#distributionamplitude"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+electricmoment">
+<prefLabel xml:lang="en">K+: electric moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electricmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+electromagneticdecay">
+<prefLabel xml:lang="en">K+: electromagnetic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electromagneticdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+electroproduction">
+<prefLabel xml:lang="en">K+: electroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+ellipticflow">
+<prefLabel xml:lang="en">K+: elliptic flow</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#ellipticflow"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+emission">
+<prefLabel xml:lang="en">K+: emission</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#emission"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+energy">
+<prefLabel xml:lang="en">K+: energy</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energy"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+energyspectrum">
+<prefLabel xml:lang="en">K+: energy spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energyspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+exchange">
+<prefLabel xml:lang="en">K+: exchange</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exchange"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+excitedstate">
+<prefLabel xml:lang="en">K+: excited state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#excitedstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+exclusiveproduction">
+<prefLabel xml:lang="en">K+: exclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+finalstate">
+<prefLabel xml:lang="en">K+: final state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#finalstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+formfactor">
+<prefLabel xml:lang="en">K+: form factor</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#formfactor"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+groundstate">
+<prefLabel xml:lang="en">K+: ground state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#groundstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+hadronicdecay">
+<prefLabel xml:lang="en">K+: hadronic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadronicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+hadroproduction">
+<prefLabel xml:lang="en">K+: hadroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+inclusiveproduction">
+<prefLabel xml:lang="en">K+: inclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#inclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+intermediatestate">
+<prefLabel xml:lang="en">K+: intermediate state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#intermediatestate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+invisibledecay">
+<prefLabel xml:lang="en">K+: invisible decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#invisibledecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+leptonicdecay">
+<prefLabel xml:lang="en">K+: leptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+leptoproduction">
+<prefLabel xml:lang="en">K+: leptoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+magneticmoment">
+<prefLabel xml:lang="en">K+: magnetic moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#magneticmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+many-bodyproblem">
+<prefLabel xml:lang="en">K+: many-body problem</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#many-bodyproblem"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+mass">
+<prefLabel xml:lang="en">K+: mass</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mass"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+massformula">
+<prefLabel xml:lang="en">K+: mass formula</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massformula"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+massgeneration">
+<prefLabel xml:lang="en">K+: mass generation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massgeneration"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+massspectrum">
+<prefLabel xml:lang="en">K+: mass spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+momentum">
+<prefLabel xml:lang="en">K+: momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+momentumspectrum">
+<prefLabel xml:lang="en">K+: momentum spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentumspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+multipleproduction">
+<prefLabel xml:lang="en">K+: multiple production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multipleproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+multiplicity">
+<prefLabel xml:lang="en">K+: multiplicity</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multiplicity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+pairproduction">
+<prefLabel xml:lang="en">K+: pair production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#pairproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+particleflow">
+<prefLabel xml:lang="en">K+: particle flow</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particleflow"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+particleidentification">
+<prefLabel xml:lang="en">K+: particle identification</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particleidentification"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+particlesource">
+<prefLabel xml:lang="en">K+: particle source</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particlesource"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+photoproduction">
+<prefLabel xml:lang="en">K+: photoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#photoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+production">
+<prefLabel xml:lang="en">K+: production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#production"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+propagator">
+<prefLabel xml:lang="en">K+: propagator</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#propagator"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+radiativedecay">
+<prefLabel xml:lang="en">K+: radiative decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#radiativedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+rapidity">
+<prefLabel xml:lang="en">K+: rapidity</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#rapidity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+rapidityspectrum">
+<prefLabel xml:lang="en">K+: rapidity spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#rapidityspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+raredecay">
+<prefLabel xml:lang="en">K+: rare decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#raredecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+secondarybeam">
+<prefLabel xml:lang="en">K+: secondary beam</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#secondarybeam"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+semileptonicdecay">
+<prefLabel xml:lang="en">K+: semileptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#semileptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+signature">
+<prefLabel xml:lang="en">K+: signature</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#signature"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+temperature">
+<prefLabel xml:lang="en">K+: temperature</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#temperature"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+transversemomentum">
+<prefLabel xml:lang="en">K+: transverse momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#transversemomentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+wavefunction">
+<prefLabel xml:lang="en">K+: wave function</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#wavefunction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+width">
+<prefLabel xml:lang="en">K+: width</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#width"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K+yield">
+<prefLabel xml:lang="en">K+: yield</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#yield"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-absorption">
+<prefLabel xml:lang="en">K-: absorption</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#absorption"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-angulardistribution">
+<prefLabel xml:lang="en">K-: angular distribution</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#angulardistribution"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-annihilation">
+<prefLabel xml:lang="en">K-: annihilation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#annihilation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-associatedproduction">
+<prefLabel xml:lang="en">K-: associated production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#associatedproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-atom">
+<prefLabel xml:lang="en">K-: atom</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#atom"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-beam">
+<prefLabel xml:lang="en">K-: beam</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#beam"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-bindingenergy">
+<prefLabel xml:lang="en">K-: binding energy</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bindingenergy"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-boundstate">
+<prefLabel xml:lang="en">K-: bound state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#boundstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-branchingratio">
+<prefLabel xml:lang="en">K-: branching ratio</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#branchingratio"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-capture">
+<prefLabel xml:lang="en">K-: capture</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#capture"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-cascadedecay">
+<prefLabel xml:lang="en">K-: cascade decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#cascadedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-condensation">
+<prefLabel xml:lang="en">K-: condensation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#condensation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-coupling">
+<prefLabel xml:lang="en">K-: coupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#coupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-couplingconstant">
+<prefLabel xml:lang="en">K-: coupling constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#couplingconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-decay">
+<prefLabel xml:lang="en">K-: decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-decayconstant">
+<prefLabel xml:lang="en">K-: decay constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-decaymodes">
+<prefLabel xml:lang="en">K-: decay modes</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decaymodes"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-decayrate">
+<prefLabel xml:lang="en">K-: decay rate</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayrate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-decoupling">
+<prefLabel xml:lang="en">K-: decoupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decoupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-directproduction">
+<prefLabel xml:lang="en">K-: direct production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#directproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-distributionamplitude">
+<prefLabel xml:lang="en">K-: distribution amplitude</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#distributionamplitude"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-electricmoment">
+<prefLabel xml:lang="en">K-: electric moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electricmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-electromagneticdecay">
+<prefLabel xml:lang="en">K-: electromagnetic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electromagneticdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-electroproduction">
+<prefLabel xml:lang="en">K-: electroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-energy">
+<prefLabel xml:lang="en">K-: energy</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energy"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-energyspectrum">
+<prefLabel xml:lang="en">K-: energy spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energyspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-exchange">
+<prefLabel xml:lang="en">K-: exchange</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exchange"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-excitedstate">
+<prefLabel xml:lang="en">K-: excited state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#excitedstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-exclusiveproduction">
+<prefLabel xml:lang="en">K-: exclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-finalstate">
+<prefLabel xml:lang="en">K-: final state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#finalstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-formfactor">
+<prefLabel xml:lang="en">K-: form factor</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#formfactor"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-groundstate">
+<prefLabel xml:lang="en">K-: ground state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#groundstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-hadronicdecay">
+<prefLabel xml:lang="en">K-: hadronic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadronicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-hadroproduction">
+<prefLabel xml:lang="en">K-: hadroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-inclusiveproduction">
+<prefLabel xml:lang="en">K-: inclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#inclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-intermediatestate">
+<prefLabel xml:lang="en">K-: intermediate state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#intermediatestate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-invisibledecay">
+<prefLabel xml:lang="en">K-: invisible decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#invisibledecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-leptoproduction">
+<prefLabel xml:lang="en">K-: leptoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-magneticmoment">
+<prefLabel xml:lang="en">K-: magnetic moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#magneticmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-mass">
+<prefLabel xml:lang="en">K-: mass</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mass"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-massformula">
+<prefLabel xml:lang="en">K-: mass formula</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massformula"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-massgeneration">
+<prefLabel xml:lang="en">K-: mass generation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massgeneration"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-massspectrum">
+<prefLabel xml:lang="en">K-: mass spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-mesicatom">
+<prefLabel xml:lang="en">K-: mesic atom</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mesicatom"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-momentum">
+<prefLabel xml:lang="en">K-: momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-momentumspectrum">
+<prefLabel xml:lang="en">K-: momentum spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentumspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-multipleproduction">
+<prefLabel xml:lang="en">K-: multiple production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multipleproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-multiplicity">
+<prefLabel xml:lang="en">K-: multiplicity</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multiplicity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-pairproduction">
+<prefLabel xml:lang="en">K-: pair production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#pairproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-particleflow">
+<prefLabel xml:lang="en">K-: particle flow</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particleflow"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-particleidentification">
+<prefLabel xml:lang="en">K-: particle identification</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particleidentification"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-particlesource">
+<prefLabel xml:lang="en">K-: particle source</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particlesource"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-photoproduction">
+<prefLabel xml:lang="en">K-: photoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#photoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-production">
+<prefLabel xml:lang="en">K-: production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#production"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-propagator">
+<prefLabel xml:lang="en">K-: propagator</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#propagator"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-radiativecapture">
+<prefLabel xml:lang="en">K-: radiative capture</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#radiativecapture"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-radiativedecay">
+<prefLabel xml:lang="en">K-: radiative decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#radiativedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-rapidityspectrum">
+<prefLabel xml:lang="en">K-: rapidity spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#rapidityspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-raredecay">
+<prefLabel xml:lang="en">K-: rare decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#raredecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-secondarybeam">
+<prefLabel xml:lang="en">K-: secondary beam</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#secondarybeam"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-semileptonicdecay">
+<prefLabel xml:lang="en">K-: semileptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#semileptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-signature">
+<prefLabel xml:lang="en">K-: signature</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#signature"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-spectralrepresentation">
+<prefLabel xml:lang="en">K-: spectral representation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#spectralrepresentation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-transversemomentum">
+<prefLabel xml:lang="en">K-: transverse momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#transversemomentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-wavefunction">
+<prefLabel xml:lang="en">K-: wave function</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#wavefunction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-width">
+<prefLabel xml:lang="en">K-: width</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#width"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K-yield">
+<prefLabel xml:lang="en">K-: yield</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#yield"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0Goldstoneparticle">
+<prefLabel xml:lang="en">K0: Goldstone particle</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Goldstoneparticle"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0angulardistribution">
+<prefLabel xml:lang="en">K0: angular distribution</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#angulardistribution"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0annihilation">
+<prefLabel xml:lang="en">K0: annihilation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#annihilation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0associatedproduction">
+<prefLabel xml:lang="en">K0: associated production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#associatedproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0branchingratio">
+<prefLabel xml:lang="en">K0: branching ratio</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#branchingratio"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0cascadedecay">
+<prefLabel xml:lang="en">K0: cascade decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#cascadedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0condensation">
+<prefLabel xml:lang="en">K0: condensation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#condensation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0coupling">
+<prefLabel xml:lang="en">K0: coupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#coupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0couplingconstant">
+<prefLabel xml:lang="en">K0: coupling constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#couplingconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0decay">
+<prefLabel xml:lang="en">K0: decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0decayconstant">
+<prefLabel xml:lang="en">K0: decay constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0decaymodes">
+<prefLabel xml:lang="en">K0: decay modes</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decaymodes"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0decayrate">
+<prefLabel xml:lang="en">K0: decay rate</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayrate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0decoupling">
+<prefLabel xml:lang="en">K0: decoupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decoupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0density">
+<prefLabel xml:lang="en">K0: density</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#density"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0directproduction">
+<prefLabel xml:lang="en">K0: direct production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#directproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0distributionamplitude">
+<prefLabel xml:lang="en">K0: distribution amplitude</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#distributionamplitude"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0electricmoment">
+<prefLabel xml:lang="en">K0: electric moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electricmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0electromagneticdecay">
+<prefLabel xml:lang="en">K0: electromagnetic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electromagneticdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0electroproduction">
+<prefLabel xml:lang="en">K0: electroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0energy">
+<prefLabel xml:lang="en">K0: energy</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energy"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0energyspectrum">
+<prefLabel xml:lang="en">K0: energy spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energyspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0entanglement">
+<prefLabel xml:lang="en">K0: entanglement</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#entanglement"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0exchange">
+<prefLabel xml:lang="en">K0: exchange</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exchange"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0excitedstate">
+<prefLabel xml:lang="en">K0: excited state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#excitedstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0exclusiveproduction">
+<prefLabel xml:lang="en">K0: exclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0finalstate">
+<prefLabel xml:lang="en">K0: final state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#finalstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0formfactor">
+<prefLabel xml:lang="en">K0: form factor</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#formfactor"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0groundstate">
+<prefLabel xml:lang="en">K0: ground state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#groundstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0hadronicdecay">
+<prefLabel xml:lang="en">K0: hadronic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadronicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0hadroproduction">
+<prefLabel xml:lang="en">K0: hadroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0inclusiveproduction">
+<prefLabel xml:lang="en">K0: inclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#inclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0intermediatestate">
+<prefLabel xml:lang="en">K0: intermediate state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#intermediatestate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0invisibledecay">
+<prefLabel xml:lang="en">K0: invisible decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#invisibledecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0leptonicdecay">
+<prefLabel xml:lang="en">K0: leptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0leptoproduction">
+<prefLabel xml:lang="en">K0: leptoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0lifetime">
+<prefLabel xml:lang="en">K0: lifetime</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#lifetime"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0magneticmoment">
+<prefLabel xml:lang="en">K0: magnetic moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#magneticmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0mass">
+<prefLabel xml:lang="en">K0: mass</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mass"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0massdifference">
+<prefLabel xml:lang="en">K0: mass difference</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massdifference"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0massformula">
+<prefLabel xml:lang="en">K0: mass formula</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massformula"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0massgeneration">
+<prefLabel xml:lang="en">K0: mass generation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massgeneration"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0massspectrum">
+<prefLabel xml:lang="en">K0: mass spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0momentum">
+<prefLabel xml:lang="en">K0: momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0momentumspectrum">
+<prefLabel xml:lang="en">K0: momentum spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentumspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0multipleproduction">
+<prefLabel xml:lang="en">K0: multiple production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multipleproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0multiplicity">
+<prefLabel xml:lang="en">K0: multiplicity</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multiplicity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0pairproduction">
+<prefLabel xml:lang="en">K0: pair production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#pairproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0particleidentification">
+<prefLabel xml:lang="en">K0: particle identification</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particleidentification"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0particlesource">
+<prefLabel xml:lang="en">K0: particle source</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particlesource"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0photoproduction">
+<prefLabel xml:lang="en">K0: photoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#photoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0production">
+<prefLabel xml:lang="en">K0: production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#production"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0propagator">
+<prefLabel xml:lang="en">K0: propagator</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#propagator"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0radiativedecay">
+<prefLabel xml:lang="en">K0: radiative decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#radiativedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0rapidityspectrum">
+<prefLabel xml:lang="en">K0: rapidity spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#rapidityspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0raredecay">
+<prefLabel xml:lang="en">K0: rare decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#raredecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0regeneration">
+<prefLabel xml:lang="en">K0: regeneration</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#regeneration"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0secondarybeam">
+<prefLabel xml:lang="en">K0: secondary beam</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#secondarybeam"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0semileptonicdecay">
+<prefLabel xml:lang="en">K0: semileptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#semileptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0signature">
+<prefLabel xml:lang="en">K0: signature</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#signature"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0transversemomentum">
+<prefLabel xml:lang="en">K0: transverse momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#transversemomentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0wavefunction">
+<prefLabel xml:lang="en">K0: wave function</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#wavefunction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0width">
+<prefLabel xml:lang="en">K0: width</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#width"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.K0yield">
+<prefLabel xml:lang="en">K0: yield</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#K0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#yield"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaannihilation">
+<prefLabel xml:lang="en">Lambda: annihilation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#annihilation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaassociatedproduction">
+<prefLabel xml:lang="en">Lambda: associated production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#associatedproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdabindingenergy">
+<prefLabel xml:lang="en">Lambda: binding energy</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bindingenergy"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaboundstate">
+<prefLabel xml:lang="en">Lambda: bound state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#boundstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdabranchingratio">
+<prefLabel xml:lang="en">Lambda: branching ratio</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#branchingratio"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdacascadedecay">
+<prefLabel xml:lang="en">Lambda: cascade decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#cascadedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdacondensation">
+<prefLabel xml:lang="en">Lambda: condensation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#condensation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdacoupling">
+<prefLabel xml:lang="en">Lambda: coupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#coupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdacouplingconstant">
+<prefLabel xml:lang="en">Lambda: coupling constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#couplingconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdadecay">
+<prefLabel xml:lang="en">Lambda: decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdadecayconstant">
+<prefLabel xml:lang="en">Lambda: decay constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdadecaymodes">
+<prefLabel xml:lang="en">Lambda: decay modes</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decaymodes"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdadecayrate">
+<prefLabel xml:lang="en">Lambda: decay rate</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayrate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdadecoupling">
+<prefLabel xml:lang="en">Lambda: decoupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decoupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdadensity">
+<prefLabel xml:lang="en">Lambda: density</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#density"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdadirectproduction">
+<prefLabel xml:lang="en">Lambda: direct production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#directproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdadistributionamplitude">
+<prefLabel xml:lang="en">Lambda: distribution amplitude</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#distributionamplitude"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaeffect">
+<prefLabel xml:lang="en">Lambda: effect</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#effect"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaelectricmoment">
+<prefLabel xml:lang="en">Lambda: electric moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electricmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaelectromagneticdecay">
+<prefLabel xml:lang="en">Lambda: electromagnetic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electromagneticdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaelectroproduction">
+<prefLabel xml:lang="en">Lambda: electroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaenergy">
+<prefLabel xml:lang="en">Lambda: energy</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energy"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaenergylevels">
+<prefLabel xml:lang="en">Lambda: energy levels</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energylevels"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaenergyspectrum">
+<prefLabel xml:lang="en">Lambda: energy spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energyspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaexchange">
+<prefLabel xml:lang="en">Lambda: exchange</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exchange"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaexcitedstate">
+<prefLabel xml:lang="en">Lambda: excited state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#excitedstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaexclusiveproduction">
+<prefLabel xml:lang="en">Lambda: exclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdafinalstate">
+<prefLabel xml:lang="en">Lambda: final state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#finalstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaformfactor">
+<prefLabel xml:lang="en">Lambda: form factor</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#formfactor"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaformation">
+<prefLabel xml:lang="en">Lambda: formation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#formation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdagroundstate">
+<prefLabel xml:lang="en">Lambda: ground state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#groundstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdahadronicdecay">
+<prefLabel xml:lang="en">Lambda: hadronic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadronicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdahadroproduction">
+<prefLabel xml:lang="en">Lambda: hadroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdahelicity">
+<prefLabel xml:lang="en">Lambda: helicity</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#helicity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdahypernucleus">
+<prefLabel xml:lang="en">Lambda: hypernucleus</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hypernucleus"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdainclusiveproduction">
+<prefLabel xml:lang="en">Lambda: inclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#inclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaintermediatestate">
+<prefLabel xml:lang="en">Lambda: intermediate state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#intermediatestate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdainvisibledecay">
+<prefLabel xml:lang="en">Lambda: invisible decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#invisibledecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaleptonicdecay">
+<prefLabel xml:lang="en">Lambda: leptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaleptoproduction">
+<prefLabel xml:lang="en">Lambda: leptoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdalifetime">
+<prefLabel xml:lang="en">Lambda: lifetime</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#lifetime"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdamagneticmoment">
+<prefLabel xml:lang="en">Lambda: magnetic moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#magneticmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdamass">
+<prefLabel xml:lang="en">Lambda: mass</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mass"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdamassformula">
+<prefLabel xml:lang="en">Lambda: mass formula</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massformula"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdamassgeneration">
+<prefLabel xml:lang="en">Lambda: mass generation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massgeneration"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdamassspectrum">
+<prefLabel xml:lang="en">Lambda: mass spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdamomentum">
+<prefLabel xml:lang="en">Lambda: momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdamomentumspectrum">
+<prefLabel xml:lang="en">Lambda: momentum spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentumspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdamultipleproduction">
+<prefLabel xml:lang="en">Lambda: multiple production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multipleproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdamultiplicity">
+<prefLabel xml:lang="en">Lambda: multiplicity</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multiplicity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaneutrinoproduction">
+<prefLabel xml:lang="en">Lambda: neutrinoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrinoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaoscillation">
+<prefLabel xml:lang="en">Lambda: oscillation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#oscillation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdapairproduction">
+<prefLabel xml:lang="en">Lambda: pair production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#pairproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaparticleflow">
+<prefLabel xml:lang="en">Lambda: particle flow</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particleflow"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaparticleidentification">
+<prefLabel xml:lang="en">Lambda: particle identification</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particleidentification"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaparticlesource">
+<prefLabel xml:lang="en">Lambda: particle source</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particlesource"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaphotoproduction">
+<prefLabel xml:lang="en">Lambda: photoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#photoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdapolarization">
+<prefLabel xml:lang="en">Lambda: polarization</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#polarization"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaproduction">
+<prefLabel xml:lang="en">Lambda: production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#production"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdapropagator">
+<prefLabel xml:lang="en">Lambda: propagator</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#propagator"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaradiativedecay">
+<prefLabel xml:lang="en">Lambda: radiative decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#radiativedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdarapidityspectrum">
+<prefLabel xml:lang="en">Lambda: rapidity spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#rapidityspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdararedecay">
+<prefLabel xml:lang="en">Lambda: rare decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#raredecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdasemileptonicdecay">
+<prefLabel xml:lang="en">Lambda: semileptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#semileptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdasignature">
+<prefLabel xml:lang="en">Lambda: signature</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#signature"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdaspin">
+<prefLabel xml:lang="en">Lambda: spin</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#spin"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdatransversemomentum">
+<prefLabel xml:lang="en">Lambda: transverse momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#transversemomentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdawavefunction">
+<prefLabel xml:lang="en">Lambda: wave function</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#wavefunction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdawidth">
+<prefLabel xml:lang="en">Lambda: width</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#width"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Lambdayield">
+<prefLabel xml:lang="en">Lambda: yield</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Lambda"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#yield"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bannihilation">
+<prefLabel xml:lang="en">Omega/b: annihilation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#annihilation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bassociatedproduction">
+<prefLabel xml:lang="en">Omega/b: associated production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#associatedproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bbranchingratio">
+<prefLabel xml:lang="en">Omega/b: branching ratio</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#branchingratio"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bcascadedecay">
+<prefLabel xml:lang="en">Omega/b: cascade decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#cascadedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bcondensation">
+<prefLabel xml:lang="en">Omega/b: condensation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#condensation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bcoupling">
+<prefLabel xml:lang="en">Omega/b: coupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#coupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bcouplingconstant">
+<prefLabel xml:lang="en">Omega/b: coupling constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#couplingconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bdecay">
+<prefLabel xml:lang="en">Omega/b: decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bdecayconstant">
+<prefLabel xml:lang="en">Omega/b: decay constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bdecaymodes">
+<prefLabel xml:lang="en">Omega/b: decay modes</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decaymodes"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bdecayrate">
+<prefLabel xml:lang="en">Omega/b: decay rate</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayrate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bdecoupling">
+<prefLabel xml:lang="en">Omega/b: decoupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decoupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bdirectproduction">
+<prefLabel xml:lang="en">Omega/b: direct production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#directproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bdistributionamplitude">
+<prefLabel xml:lang="en">Omega/b: distribution amplitude</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#distributionamplitude"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/belectricmoment">
+<prefLabel xml:lang="en">Omega/b: electric moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electricmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/belectromagneticdecay">
+<prefLabel xml:lang="en">Omega/b: electromagnetic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electromagneticdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/belectroproduction">
+<prefLabel xml:lang="en">Omega/b: electroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/benergy">
+<prefLabel xml:lang="en">Omega/b: energy</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energy"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/benergyspectrum">
+<prefLabel xml:lang="en">Omega/b: energy spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energyspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bexchange">
+<prefLabel xml:lang="en">Omega/b: exchange</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exchange"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bexcitedstate">
+<prefLabel xml:lang="en">Omega/b: excited state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#excitedstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bexclusiveproduction">
+<prefLabel xml:lang="en">Omega/b: exclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bfinalstate">
+<prefLabel xml:lang="en">Omega/b: final state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#finalstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bformfactor">
+<prefLabel xml:lang="en">Omega/b: form factor</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#formfactor"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bgroundstate">
+<prefLabel xml:lang="en">Omega/b: ground state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#groundstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bhadronicdecay">
+<prefLabel xml:lang="en">Omega/b: hadronic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadronicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bhadroproduction">
+<prefLabel xml:lang="en">Omega/b: hadroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/binclusiveproduction">
+<prefLabel xml:lang="en">Omega/b: inclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#inclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bintermediatestate">
+<prefLabel xml:lang="en">Omega/b: intermediate state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#intermediatestate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/binvisibledecay">
+<prefLabel xml:lang="en">Omega/b: invisible decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#invisibledecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bleptonicdecay">
+<prefLabel xml:lang="en">Omega/b: leptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bleptoproduction">
+<prefLabel xml:lang="en">Omega/b: leptoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bmagneticmoment">
+<prefLabel xml:lang="en">Omega/b: magnetic moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#magneticmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bmass">
+<prefLabel xml:lang="en">Omega/b: mass</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mass"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bmassformula">
+<prefLabel xml:lang="en">Omega/b: mass formula</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massformula"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bmassgeneration">
+<prefLabel xml:lang="en">Omega/b: mass generation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massgeneration"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bmassspectrum">
+<prefLabel xml:lang="en">Omega/b: mass spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bmomentum">
+<prefLabel xml:lang="en">Omega/b: momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bmomentumspectrum">
+<prefLabel xml:lang="en">Omega/b: momentum spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentumspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bmultipleproduction">
+<prefLabel xml:lang="en">Omega/b: multiple production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multipleproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bmultiplicity">
+<prefLabel xml:lang="en">Omega/b: multiplicity</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multiplicity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bpairproduction">
+<prefLabel xml:lang="en">Omega/b: pair production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#pairproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bparticleidentification">
+<prefLabel xml:lang="en">Omega/b: particle identification</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particleidentification"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bparticlesource">
+<prefLabel xml:lang="en">Omega/b: particle source</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particlesource"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bphotoproduction">
+<prefLabel xml:lang="en">Omega/b: photoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#photoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bpolarization">
+<prefLabel xml:lang="en">Omega/b: polarization</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#polarization"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bproduction">
+<prefLabel xml:lang="en">Omega/b: production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#production"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bpropagator">
+<prefLabel xml:lang="en">Omega/b: propagator</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#propagator"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bradiativedecay">
+<prefLabel xml:lang="en">Omega/b: radiative decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#radiativedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/brapidityspectrum">
+<prefLabel xml:lang="en">Omega/b: rapidity spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#rapidityspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/braredecay">
+<prefLabel xml:lang="en">Omega/b: rare decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#raredecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bsemileptonicdecay">
+<prefLabel xml:lang="en">Omega/b: semileptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#semileptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bsignature">
+<prefLabel xml:lang="en">Omega/b: signature</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#signature"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/btransversemomentum">
+<prefLabel xml:lang="en">Omega/b: transverse momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#transversemomentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bwavefunction">
+<prefLabel xml:lang="en">Omega/b: wave function</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#wavefunction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/bwidth">
+<prefLabel xml:lang="en">Omega/b: width</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#width"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Omega/byield">
+<prefLabel xml:lang="en">Omega/b: yield</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Omega/b"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#yield"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+annihilation">
+<prefLabel xml:lang="en">Sigma+: annihilation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#annihilation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+associatedproduction">
+<prefLabel xml:lang="en">Sigma+: associated production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#associatedproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+branchingratio">
+<prefLabel xml:lang="en">Sigma+: branching ratio</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#branchingratio"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+cascadedecay">
+<prefLabel xml:lang="en">Sigma+: cascade decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#cascadedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+condensation">
+<prefLabel xml:lang="en">Sigma+: condensation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#condensation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+coupling">
+<prefLabel xml:lang="en">Sigma+: coupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#coupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+couplingconstant">
+<prefLabel xml:lang="en">Sigma+: coupling constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#couplingconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+decay">
+<prefLabel xml:lang="en">Sigma+: decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+decayconstant">
+<prefLabel xml:lang="en">Sigma+: decay constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+decaymodes">
+<prefLabel xml:lang="en">Sigma+: decay modes</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decaymodes"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+decayrate">
+<prefLabel xml:lang="en">Sigma+: decay rate</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayrate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+decoupling">
+<prefLabel xml:lang="en">Sigma+: decoupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decoupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+directproduction">
+<prefLabel xml:lang="en">Sigma+: direct production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#directproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+distributionamplitude">
+<prefLabel xml:lang="en">Sigma+: distribution amplitude</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#distributionamplitude"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+electricmoment">
+<prefLabel xml:lang="en">Sigma+: electric moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electricmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+electromagneticdecay">
+<prefLabel xml:lang="en">Sigma+: electromagnetic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electromagneticdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+electroproduction">
+<prefLabel xml:lang="en">Sigma+: electroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+energy">
+<prefLabel xml:lang="en">Sigma+: energy</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energy"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+energyspectrum">
+<prefLabel xml:lang="en">Sigma+: energy spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energyspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+exchange">
+<prefLabel xml:lang="en">Sigma+: exchange</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exchange"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+excitedstate">
+<prefLabel xml:lang="en">Sigma+: excited state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#excitedstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+exclusiveproduction">
+<prefLabel xml:lang="en">Sigma+: exclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+finalstate">
+<prefLabel xml:lang="en">Sigma+: final state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#finalstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+formfactor">
+<prefLabel xml:lang="en">Sigma+: form factor</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#formfactor"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+groundstate">
+<prefLabel xml:lang="en">Sigma+: ground state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#groundstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+hadronicdecay">
+<prefLabel xml:lang="en">Sigma+: hadronic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadronicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+hadroproduction">
+<prefLabel xml:lang="en">Sigma+: hadroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+inclusiveproduction">
+<prefLabel xml:lang="en">Sigma+: inclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#inclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+intermediatestate">
+<prefLabel xml:lang="en">Sigma+: intermediate state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#intermediatestate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+invisibledecay">
+<prefLabel xml:lang="en">Sigma+: invisible decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#invisibledecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+leptoproduction">
+<prefLabel xml:lang="en">Sigma+: leptoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+lifetime">
+<prefLabel xml:lang="en">Sigma+: lifetime</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#lifetime"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+magneticmoment">
+<prefLabel xml:lang="en">Sigma+: magnetic moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#magneticmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+mass">
+<prefLabel xml:lang="en">Sigma+: mass</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mass"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+massformula">
+<prefLabel xml:lang="en">Sigma+: mass formula</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massformula"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+massgeneration">
+<prefLabel xml:lang="en">Sigma+: mass generation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massgeneration"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+massspectrum">
+<prefLabel xml:lang="en">Sigma+: mass spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+momentum">
+<prefLabel xml:lang="en">Sigma+: momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+momentumspectrum">
+<prefLabel xml:lang="en">Sigma+: momentum spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentumspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+multipleproduction">
+<prefLabel xml:lang="en">Sigma+: multiple production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multipleproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+multiplicity">
+<prefLabel xml:lang="en">Sigma+: multiplicity</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multiplicity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+pairproduction">
+<prefLabel xml:lang="en">Sigma+: pair production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#pairproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+particleidentification">
+<prefLabel xml:lang="en">Sigma+: particle identification</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particleidentification"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+particlesource">
+<prefLabel xml:lang="en">Sigma+: particle source</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particlesource"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+photoproduction">
+<prefLabel xml:lang="en">Sigma+: photoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#photoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+polarization">
+<prefLabel xml:lang="en">Sigma+: polarization</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#polarization"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+production">
+<prefLabel xml:lang="en">Sigma+: production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#production"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+propagator">
+<prefLabel xml:lang="en">Sigma+: propagator</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#propagator"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+radiativedecay">
+<prefLabel xml:lang="en">Sigma+: radiative decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#radiativedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+rapidityspectrum">
+<prefLabel xml:lang="en">Sigma+: rapidity spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#rapidityspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+raredecay">
+<prefLabel xml:lang="en">Sigma+: rare decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#raredecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+semileptonicdecay">
+<prefLabel xml:lang="en">Sigma+: semileptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#semileptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+signature">
+<prefLabel xml:lang="en">Sigma+: signature</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#signature"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+transversemomentum">
+<prefLabel xml:lang="en">Sigma+: transverse momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#transversemomentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+wavefunction">
+<prefLabel xml:lang="en">Sigma+: wave function</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#wavefunction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+width">
+<prefLabel xml:lang="en">Sigma+: width</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#width"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma+yield">
+<prefLabel xml:lang="en">Sigma+: yield</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma+"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#yield"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-annihilation">
+<prefLabel xml:lang="en">Sigma-: annihilation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#annihilation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-associatedproduction">
+<prefLabel xml:lang="en">Sigma-: associated production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#associatedproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-bindingenergy">
+<prefLabel xml:lang="en">Sigma-: binding energy</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bindingenergy"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-branchingratio">
+<prefLabel xml:lang="en">Sigma-: branching ratio</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#branchingratio"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-cascadedecay">
+<prefLabel xml:lang="en">Sigma-: cascade decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#cascadedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-condensation">
+<prefLabel xml:lang="en">Sigma-: condensation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#condensation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-coupling">
+<prefLabel xml:lang="en">Sigma-: coupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#coupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-couplingconstant">
+<prefLabel xml:lang="en">Sigma-: coupling constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#couplingconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-decay">
+<prefLabel xml:lang="en">Sigma-: decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-decayconstant">
+<prefLabel xml:lang="en">Sigma-: decay constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-decaymodes">
+<prefLabel xml:lang="en">Sigma-: decay modes</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decaymodes"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-decayrate">
+<prefLabel xml:lang="en">Sigma-: decay rate</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayrate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-decoupling">
+<prefLabel xml:lang="en">Sigma-: decoupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decoupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-density">
+<prefLabel xml:lang="en">Sigma-: density</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#density"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-directproduction">
+<prefLabel xml:lang="en">Sigma-: direct production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#directproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-distributionamplitude">
+<prefLabel xml:lang="en">Sigma-: distribution amplitude</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#distributionamplitude"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-electricmoment">
+<prefLabel xml:lang="en">Sigma-: electric moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electricmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-electromagneticdecay">
+<prefLabel xml:lang="en">Sigma-: electromagnetic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electromagneticdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-electroproduction">
+<prefLabel xml:lang="en">Sigma-: electroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-energy">
+<prefLabel xml:lang="en">Sigma-: energy</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energy"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-energyspectrum">
+<prefLabel xml:lang="en">Sigma-: energy spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energyspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-exchange">
+<prefLabel xml:lang="en">Sigma-: exchange</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exchange"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-excitedstate">
+<prefLabel xml:lang="en">Sigma-: excited state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#excitedstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-exclusiveproduction">
+<prefLabel xml:lang="en">Sigma-: exclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-finalstate">
+<prefLabel xml:lang="en">Sigma-: final state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#finalstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-formfactor">
+<prefLabel xml:lang="en">Sigma-: form factor</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#formfactor"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-groundstate">
+<prefLabel xml:lang="en">Sigma-: ground state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#groundstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-hadronicatom">
+<prefLabel xml:lang="en">Sigma-: hadronic atom</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadronicatom"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-hadronicdecay">
+<prefLabel xml:lang="en">Sigma-: hadronic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadronicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-hadroproduction">
+<prefLabel xml:lang="en">Sigma-: hadroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-hypernucleus">
+<prefLabel xml:lang="en">Sigma-: hypernucleus</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hypernucleus"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-hyperonicatom">
+<prefLabel xml:lang="en">Sigma-: hyperonic atom</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hyperonicatom"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-inclusiveproduction">
+<prefLabel xml:lang="en">Sigma-: inclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#inclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-intermediatestate">
+<prefLabel xml:lang="en">Sigma-: intermediate state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#intermediatestate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-invisibledecay">
+<prefLabel xml:lang="en">Sigma-: invisible decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#invisibledecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-leptoproduction">
+<prefLabel xml:lang="en">Sigma-: leptoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-lifetime">
+<prefLabel xml:lang="en">Sigma-: lifetime</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#lifetime"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-magneticmoment">
+<prefLabel xml:lang="en">Sigma-: magnetic moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#magneticmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-mass">
+<prefLabel xml:lang="en">Sigma-: mass</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mass"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-massformula">
+<prefLabel xml:lang="en">Sigma-: mass formula</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massformula"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-massgeneration">
+<prefLabel xml:lang="en">Sigma-: mass generation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massgeneration"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-massspectrum">
+<prefLabel xml:lang="en">Sigma-: mass spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-momentum">
+<prefLabel xml:lang="en">Sigma-: momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-momentumspectrum">
+<prefLabel xml:lang="en">Sigma-: momentum spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentumspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-multipleproduction">
+<prefLabel xml:lang="en">Sigma-: multiple production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multipleproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-multiplicity">
+<prefLabel xml:lang="en">Sigma-: multiplicity</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multiplicity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-pairproduction">
+<prefLabel xml:lang="en">Sigma-: pair production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#pairproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-particleidentification">
+<prefLabel xml:lang="en">Sigma-: particle identification</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particleidentification"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-particlesource">
+<prefLabel xml:lang="en">Sigma-: particle source</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particlesource"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-photoproduction">
+<prefLabel xml:lang="en">Sigma-: photoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#photoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-potential">
+<prefLabel xml:lang="en">Sigma-: potential</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#potential"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-production">
+<prefLabel xml:lang="en">Sigma-: production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#production"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-propagator">
+<prefLabel xml:lang="en">Sigma-: propagator</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#propagator"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-radiativedecay">
+<prefLabel xml:lang="en">Sigma-: radiative decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#radiativedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-rapidityspectrum">
+<prefLabel xml:lang="en">Sigma-: rapidity spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#rapidityspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-raredecay">
+<prefLabel xml:lang="en">Sigma-: rare decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#raredecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-secondarybeam">
+<prefLabel xml:lang="en">Sigma-: secondary beam</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#secondarybeam"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-semileptonicdecay">
+<prefLabel xml:lang="en">Sigma-: semileptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#semileptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-signature">
+<prefLabel xml:lang="en">Sigma-: signature</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#signature"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-superfluid">
+<prefLabel xml:lang="en">Sigma-: superfluid</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#superfluid"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-transversemomentum">
+<prefLabel xml:lang="en">Sigma-: transverse momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#transversemomentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-wavefunction">
+<prefLabel xml:lang="en">Sigma-: wave function</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#wavefunction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma-yield">
+<prefLabel xml:lang="en">Sigma-: yield</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#yield"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0annihilation">
+<prefLabel xml:lang="en">Sigma0: annihilation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#annihilation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0associatedproduction">
+<prefLabel xml:lang="en">Sigma0: associated production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#associatedproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0branchingratio">
+<prefLabel xml:lang="en">Sigma0: branching ratio</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#branchingratio"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0cascadedecay">
+<prefLabel xml:lang="en">Sigma0: cascade decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#cascadedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0condensation">
+<prefLabel xml:lang="en">Sigma0: condensation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#condensation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0coupling">
+<prefLabel xml:lang="en">Sigma0: coupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#coupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0couplingconstant">
+<prefLabel xml:lang="en">Sigma0: coupling constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#couplingconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0decay">
+<prefLabel xml:lang="en">Sigma0: decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0decayconstant">
+<prefLabel xml:lang="en">Sigma0: decay constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0decaymodes">
+<prefLabel xml:lang="en">Sigma0: decay modes</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decaymodes"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0decayrate">
+<prefLabel xml:lang="en">Sigma0: decay rate</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayrate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0decoupling">
+<prefLabel xml:lang="en">Sigma0: decoupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decoupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0directproduction">
+<prefLabel xml:lang="en">Sigma0: direct production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#directproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0distributionamplitude">
+<prefLabel xml:lang="en">Sigma0: distribution amplitude</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#distributionamplitude"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0electricmoment">
+<prefLabel xml:lang="en">Sigma0: electric moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electricmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0electromagneticdecay">
+<prefLabel xml:lang="en">Sigma0: electromagnetic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electromagneticdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0electroproduction">
+<prefLabel xml:lang="en">Sigma0: electroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0energy">
+<prefLabel xml:lang="en">Sigma0: energy</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energy"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0energyspectrum">
+<prefLabel xml:lang="en">Sigma0: energy spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energyspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0exchange">
+<prefLabel xml:lang="en">Sigma0: exchange</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exchange"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0excitedstate">
+<prefLabel xml:lang="en">Sigma0: excited state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#excitedstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0exclusiveproduction">
+<prefLabel xml:lang="en">Sigma0: exclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0finalstate">
+<prefLabel xml:lang="en">Sigma0: final state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#finalstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0formfactor">
+<prefLabel xml:lang="en">Sigma0: form factor</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#formfactor"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0groundstate">
+<prefLabel xml:lang="en">Sigma0: ground state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#groundstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0hadronicdecay">
+<prefLabel xml:lang="en">Sigma0: hadronic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadronicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0hadroproduction">
+<prefLabel xml:lang="en">Sigma0: hadroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0inclusiveproduction">
+<prefLabel xml:lang="en">Sigma0: inclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#inclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0intermediatestate">
+<prefLabel xml:lang="en">Sigma0: intermediate state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#intermediatestate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0invisibledecay">
+<prefLabel xml:lang="en">Sigma0: invisible decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#invisibledecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0leptoproduction">
+<prefLabel xml:lang="en">Sigma0: leptoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0lifetime">
+<prefLabel xml:lang="en">Sigma0: lifetime</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#lifetime"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0magneticmoment">
+<prefLabel xml:lang="en">Sigma0: magnetic moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#magneticmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0mass">
+<prefLabel xml:lang="en">Sigma0: mass</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mass"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0massformula">
+<prefLabel xml:lang="en">Sigma0: mass formula</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massformula"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0massgeneration">
+<prefLabel xml:lang="en">Sigma0: mass generation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massgeneration"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0massspectrum">
+<prefLabel xml:lang="en">Sigma0: mass spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0momentum">
+<prefLabel xml:lang="en">Sigma0: momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0momentumspectrum">
+<prefLabel xml:lang="en">Sigma0: momentum spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentumspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0multipleproduction">
+<prefLabel xml:lang="en">Sigma0: multiple production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multipleproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0multiplicity">
+<prefLabel xml:lang="en">Sigma0: multiplicity</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multiplicity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0pairproduction">
+<prefLabel xml:lang="en">Sigma0: pair production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#pairproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0particleidentification">
+<prefLabel xml:lang="en">Sigma0: particle identification</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particleidentification"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0particlesource">
+<prefLabel xml:lang="en">Sigma0: particle source</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particlesource"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0photoproduction">
+<prefLabel xml:lang="en">Sigma0: photoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#photoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0polarization">
+<prefLabel xml:lang="en">Sigma0: polarization</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#polarization"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0production">
+<prefLabel xml:lang="en">Sigma0: production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#production"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0propagator">
+<prefLabel xml:lang="en">Sigma0: propagator</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#propagator"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0radiativedecay">
+<prefLabel xml:lang="en">Sigma0: radiative decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#radiativedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0rapidityspectrum">
+<prefLabel xml:lang="en">Sigma0: rapidity spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#rapidityspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0raredecay">
+<prefLabel xml:lang="en">Sigma0: rare decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#raredecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0semileptonicdecay">
+<prefLabel xml:lang="en">Sigma0: semileptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#semileptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0signature">
+<prefLabel xml:lang="en">Sigma0: signature</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#signature"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0transversemomentum">
+<prefLabel xml:lang="en">Sigma0: transverse momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#transversemomentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0wavefunction">
+<prefLabel xml:lang="en">Sigma0: wave function</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#wavefunction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0width">
+<prefLabel xml:lang="en">Sigma0: width</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#width"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Sigma0yield">
+<prefLabel xml:lang="en">Sigma0: yield</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Sigma0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#yield"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiannihilation">
+<prefLabel xml:lang="en">Xi: annihilation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#annihilation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiassociatedproduction">
+<prefLabel xml:lang="en">Xi: associated production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#associatedproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xibranchingratio">
+<prefLabel xml:lang="en">Xi: branching ratio</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#branchingratio"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xicascadedecay">
+<prefLabel xml:lang="en">Xi: cascade decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#cascadedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xicondensation">
+<prefLabel xml:lang="en">Xi: condensation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#condensation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xicoupling">
+<prefLabel xml:lang="en">Xi: coupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#coupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xicouplingconstant">
+<prefLabel xml:lang="en">Xi: coupling constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#couplingconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xidecay">
+<prefLabel xml:lang="en">Xi: decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xidecayconstant">
+<prefLabel xml:lang="en">Xi: decay constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xidecaymodes">
+<prefLabel xml:lang="en">Xi: decay modes</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decaymodes"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xidecayrate">
+<prefLabel xml:lang="en">Xi: decay rate</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayrate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xidecoupling">
+<prefLabel xml:lang="en">Xi: decoupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decoupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xidirectproduction">
+<prefLabel xml:lang="en">Xi: direct production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#directproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xidistributionamplitude">
+<prefLabel xml:lang="en">Xi: distribution amplitude</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#distributionamplitude"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xielectricmoment">
+<prefLabel xml:lang="en">Xi: electric moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electricmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xielectromagneticdecay">
+<prefLabel xml:lang="en">Xi: electromagnetic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electromagneticdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xielectroproduction">
+<prefLabel xml:lang="en">Xi: electroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xienergy">
+<prefLabel xml:lang="en">Xi: energy</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energy"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xienergyspectrum">
+<prefLabel xml:lang="en">Xi: energy spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energyspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiexchange">
+<prefLabel xml:lang="en">Xi: exchange</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exchange"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiexcitedstate">
+<prefLabel xml:lang="en">Xi: excited state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#excitedstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiexclusiveproduction">
+<prefLabel xml:lang="en">Xi: exclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xifinalstate">
+<prefLabel xml:lang="en">Xi: final state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#finalstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiformfactor">
+<prefLabel xml:lang="en">Xi: form factor</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#formfactor"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xigroundstate">
+<prefLabel xml:lang="en">Xi: ground state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#groundstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xihadronicdecay">
+<prefLabel xml:lang="en">Xi: hadronic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadronicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xihadroproduction">
+<prefLabel xml:lang="en">Xi: hadroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xihypernucleus">
+<prefLabel xml:lang="en">Xi: hypernucleus</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hypernucleus"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiinclusiveproduction">
+<prefLabel xml:lang="en">Xi: inclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#inclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiintermediatestate">
+<prefLabel xml:lang="en">Xi: intermediate state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#intermediatestate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiinvisibledecay">
+<prefLabel xml:lang="en">Xi: invisible decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#invisibledecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xileptonicdecay">
+<prefLabel xml:lang="en">Xi: leptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xileptoproduction">
+<prefLabel xml:lang="en">Xi: leptoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Ximagneticmoment">
+<prefLabel xml:lang="en">Xi: magnetic moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#magneticmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Ximass">
+<prefLabel xml:lang="en">Xi: mass</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mass"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Ximassformula">
+<prefLabel xml:lang="en">Xi: mass formula</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massformula"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Ximassgeneration">
+<prefLabel xml:lang="en">Xi: mass generation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massgeneration"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Ximassspectrum">
+<prefLabel xml:lang="en">Xi: mass spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Ximomentum">
+<prefLabel xml:lang="en">Xi: momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Ximomentumspectrum">
+<prefLabel xml:lang="en">Xi: momentum spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentumspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Ximultipleproduction">
+<prefLabel xml:lang="en">Xi: multiple production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multipleproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Ximultiplicity">
+<prefLabel xml:lang="en">Xi: multiplicity</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multiplicity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xipairproduction">
+<prefLabel xml:lang="en">Xi: pair production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#pairproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiparticleidentification">
+<prefLabel xml:lang="en">Xi: particle identification</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particleidentification"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiparticlesource">
+<prefLabel xml:lang="en">Xi: particle source</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particlesource"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiphotoproduction">
+<prefLabel xml:lang="en">Xi: photoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#photoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xipolarization">
+<prefLabel xml:lang="en">Xi: polarization</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#polarization"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiproduction">
+<prefLabel xml:lang="en">Xi: production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#production"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xipropagator">
+<prefLabel xml:lang="en">Xi: propagator</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#propagator"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiradiativedecay">
+<prefLabel xml:lang="en">Xi: radiative decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#radiativedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xirapidityspectrum">
+<prefLabel xml:lang="en">Xi: rapidity spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#rapidityspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiraredecay">
+<prefLabel xml:lang="en">Xi: rare decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#raredecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xisemileptonicdecay">
+<prefLabel xml:lang="en">Xi: semileptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#semileptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xisignature">
+<prefLabel xml:lang="en">Xi: signature</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#signature"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xitransversemomentum">
+<prefLabel xml:lang="en">Xi: transverse momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#transversemomentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiwavefunction">
+<prefLabel xml:lang="en">Xi: wave function</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#wavefunction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Xiyield">
+<prefLabel xml:lang="en">Xi: yield</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Xi"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#yield"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0Kaluza-Klein">
+<prefLabel xml:lang="en">Z0: Kaluza-Klein</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Kaluza-Klein"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0angulardistribution">
+<prefLabel xml:lang="en">Z0: angular distribution</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#angulardistribution"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0annihilation">
+<prefLabel xml:lang="en">Z0: annihilation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#annihilation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0associatedproduction">
+<prefLabel xml:lang="en">Z0: associated production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#associatedproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0boostedparticle">
+<prefLabel xml:lang="en">Z0: boosted particle</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#boostedparticle"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0branchingratio">
+<prefLabel xml:lang="en">Z0: branching ratio</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#branchingratio"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0bremsstrahlung">
+<prefLabel xml:lang="en">Z0: bremsstrahlung</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bremsstrahlung"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0burst">
+<prefLabel xml:lang="en">Z0: burst</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#burst"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0cascadedecay">
+<prefLabel xml:lang="en">Z0: cascade decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#cascadedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0composite">
+<prefLabel xml:lang="en">Z0: composite</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#composite"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0condensation">
+<prefLabel xml:lang="en">Z0: condensation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#condensation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0coupling">
+<prefLabel xml:lang="en">Z0: coupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#coupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0couplingconstant">
+<prefLabel xml:lang="en">Z0: coupling constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#couplingconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0decay">
+<prefLabel xml:lang="en">Z0: decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0decayconstant">
+<prefLabel xml:lang="en">Z0: decay constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0decaymodes">
+<prefLabel xml:lang="en">Z0: decay modes</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decaymodes"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0decayrate">
+<prefLabel xml:lang="en">Z0: decay rate</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayrate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0decoupling">
+<prefLabel xml:lang="en">Z0: decoupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decoupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0directproduction">
+<prefLabel xml:lang="en">Z0: direct production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#directproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0distributionamplitude">
+<prefLabel xml:lang="en">Z0: distribution amplitude</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#distributionamplitude"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0electricmoment">
+<prefLabel xml:lang="en">Z0: electric moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electricmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0electromagneticdecay">
+<prefLabel xml:lang="en">Z0: electromagnetic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electromagneticdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0electroproduction">
+<prefLabel xml:lang="en">Z0: electroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0energy">
+<prefLabel xml:lang="en">Z0: energy</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energy"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0energyspectrum">
+<prefLabel xml:lang="en">Z0: energy spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energyspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0exchange">
+<prefLabel xml:lang="en">Z0: exchange</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exchange"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0excitedstate">
+<prefLabel xml:lang="en">Z0: excited state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#excitedstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0exclusiveproduction">
+<prefLabel xml:lang="en">Z0: exclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0finalstate">
+<prefLabel xml:lang="en">Z0: final state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#finalstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0formfactor">
+<prefLabel xml:lang="en">Z0: form factor</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#formfactor"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0forwardproduction">
+<prefLabel xml:lang="en">Z0: forward production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#forwardproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0forwardscattering">
+<prefLabel xml:lang="en">Z0: forward scattering</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#forwardscattering"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0fusion">
+<prefLabel xml:lang="en">Z0: fusion</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fusion"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0groundstate">
+<prefLabel xml:lang="en">Z0: ground state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#groundstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0hadronicdecay">
+<prefLabel xml:lang="en">Z0: hadronic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadronicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0hadroproduction">
+<prefLabel xml:lang="en">Z0: hadroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0helicity">
+<prefLabel xml:lang="en">Z0: helicity</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#helicity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0inclusiveproduction">
+<prefLabel xml:lang="en">Z0: inclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#inclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0intermediatestate">
+<prefLabel xml:lang="en">Z0: intermediate state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#intermediatestate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0invisibledecay">
+<prefLabel xml:lang="en">Z0: invisible decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#invisibledecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0leptonicdecay">
+<prefLabel xml:lang="en">Z0: leptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0leptoproduction">
+<prefLabel xml:lang="en">Z0: leptoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0lifetime">
+<prefLabel xml:lang="en">Z0: lifetime</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#lifetime"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0longitudinal">
+<prefLabel xml:lang="en">Z0: longitudinal</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#longitudinal"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0loopintegral">
+<prefLabel xml:lang="en">Z0: loop integral</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#loopintegral"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0magneticmoment">
+<prefLabel xml:lang="en">Z0: magnetic moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#magneticmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0mass">
+<prefLabel xml:lang="en">Z0: mass</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mass"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0massformula">
+<prefLabel xml:lang="en">Z0: mass formula</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massformula"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0massgeneration">
+<prefLabel xml:lang="en">Z0: mass generation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massgeneration"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0massspectrum">
+<prefLabel xml:lang="en">Z0: mass spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0mediation">
+<prefLabel xml:lang="en">Z0: mediation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mediation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0momentum">
+<prefLabel xml:lang="en">Z0: momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0momentumspectrum">
+<prefLabel xml:lang="en">Z0: momentum spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentumspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0multipleproduction">
+<prefLabel xml:lang="en">Z0: multiple production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multipleproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0multiplet">
+<prefLabel xml:lang="en">Z0: multiplet</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multiplet"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0multiplicity">
+<prefLabel xml:lang="en">Z0: multiplicity</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multiplicity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0neutrinoproduction">
+<prefLabel xml:lang="en">Z0: neutrinoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrinoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0off-shell">
+<prefLabel xml:lang="en">Z0: off-shell</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#off-shell"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0on-shell">
+<prefLabel xml:lang="en">Z0: on-shell</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#on-shell"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0pairproduction">
+<prefLabel xml:lang="en">Z0: pair production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#pairproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0particleidentification">
+<prefLabel xml:lang="en">Z0: particle identification</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particleidentification"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0particlesource">
+<prefLabel xml:lang="en">Z0: particle source</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particlesource"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0penguin">
+<prefLabel xml:lang="en">Z0: penguin</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#penguin"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0photoproduction">
+<prefLabel xml:lang="en">Z0: photoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#photoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0polarization">
+<prefLabel xml:lang="en">Z0: polarization</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#polarization"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0pole">
+<prefLabel xml:lang="en">Z0: pole</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#pole"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0production">
+<prefLabel xml:lang="en">Z0: production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#production"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0propagator">
+<prefLabel xml:lang="en">Z0: propagator</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#propagator"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0radiativedecay">
+<prefLabel xml:lang="en">Z0: radiative decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#radiativedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0rapidityspectrum">
+<prefLabel xml:lang="en">Z0: rapidity spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#rapidityspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0raredecay">
+<prefLabel xml:lang="en">Z0: rare decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#raredecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0resonance">
+<prefLabel xml:lang="en">Z0: resonance</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#resonance"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0semileptonicdecay">
+<prefLabel xml:lang="en">Z0: semileptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#semileptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0signature">
+<prefLabel xml:lang="en">Z0: signature</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#signature"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0singleproduction">
+<prefLabel xml:lang="en">Z0: single production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#singleproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0spinless">
+<prefLabel xml:lang="en">Z0: spinless</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#spinless"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0transversemomentum">
+<prefLabel xml:lang="en">Z0: transverse momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#transversemomentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0wavefunction">
+<prefLabel xml:lang="en">Z0: wave function</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#wavefunction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0width">
+<prefLabel xml:lang="en">Z0: width</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#width"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0yield">
+<prefLabel xml:lang="en">Z0: yield</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#yield"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottom2">
+<prefLabel xml:lang="en">bottom: 2</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#2"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomangulardistribution">
+<prefLabel xml:lang="en">bottom: angular distribution</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#angulardistribution"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomannihilation">
+<prefLabel xml:lang="en">bottom: annihilation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#annihilation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomassociatedproduction">
+<prefLabel xml:lang="en">bottom: associated production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#associatedproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomboostedparticle">
+<prefLabel xml:lang="en">bottom: boosted particle</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#boostedparticle"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottombranchingratio">
+<prefLabel xml:lang="en">bottom: branching ratio</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#branchingratio"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomcascadedecay">
+<prefLabel xml:lang="en">bottom: cascade decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#cascadedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomcondensation">
+<prefLabel xml:lang="en">bottom: condensation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#condensation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomcoupling">
+<prefLabel xml:lang="en">bottom: coupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#coupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomcouplingconstant">
+<prefLabel xml:lang="en">bottom: coupling constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#couplingconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomdecay">
+<prefLabel xml:lang="en">bottom: decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomdecayconstant">
+<prefLabel xml:lang="en">bottom: decay constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomdecaymodes">
+<prefLabel xml:lang="en">bottom: decay modes</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decaymodes"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomdecayrate">
+<prefLabel xml:lang="en">bottom: decay rate</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayrate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomdecoupling">
+<prefLabel xml:lang="en">bottom: decoupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decoupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomdirectproduction">
+<prefLabel xml:lang="en">bottom: direct production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#directproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomdistributionamplitude">
+<prefLabel xml:lang="en">bottom: distribution amplitude</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#distributionamplitude"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomelectricmoment">
+<prefLabel xml:lang="en">bottom: electric moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electricmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomelectromagneticdecay">
+<prefLabel xml:lang="en">bottom: electromagnetic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electromagneticdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomelectroproduction">
+<prefLabel xml:lang="en">bottom: electroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomellipticflow">
+<prefLabel xml:lang="en">bottom: elliptic flow</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#ellipticflow"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomenergy">
+<prefLabel xml:lang="en">bottom: energy</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energy"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomenergyloss">
+<prefLabel xml:lang="en">bottom: energy loss</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energyloss"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomenergyspectrum">
+<prefLabel xml:lang="en">bottom: energy spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energyspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomexchange">
+<prefLabel xml:lang="en">bottom: exchange</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exchange"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomexcitedstate">
+<prefLabel xml:lang="en">bottom: excited state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#excitedstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomexclusiveproduction">
+<prefLabel xml:lang="en">bottom: exclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomfinalstate">
+<prefLabel xml:lang="en">bottom: final state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#finalstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomformfactor">
+<prefLabel xml:lang="en">bottom: form factor</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#formfactor"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomfragmentation">
+<prefLabel xml:lang="en">bottom: fragmentation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fragmentation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomfragmentationfunction">
+<prefLabel xml:lang="en">bottom: fragmentation function</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fragmentationfunction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomfusion">
+<prefLabel xml:lang="en">bottom: fusion</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fusion"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomgroundstate">
+<prefLabel xml:lang="en">bottom: ground state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#groundstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomhadronicdecay">
+<prefLabel xml:lang="en">bottom: hadronic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadronicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomhadronization">
+<prefLabel xml:lang="en">bottom: hadronization</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadronization"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomhadroproduction">
+<prefLabel xml:lang="en">bottom: hadroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottominclusiveproduction">
+<prefLabel xml:lang="en">bottom: inclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#inclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomintermediatestate">
+<prefLabel xml:lang="en">bottom: intermediate state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#intermediatestate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottominvisibledecay">
+<prefLabel xml:lang="en">bottom: invisible decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#invisibledecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomleadingparticle">
+<prefLabel xml:lang="en">bottom: leading particle</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leadingparticle"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomleptonicdecay">
+<prefLabel xml:lang="en">bottom: leptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomleptoproduction">
+<prefLabel xml:lang="en">bottom: leptoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomlifetime">
+<prefLabel xml:lang="en">bottom: lifetime</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#lifetime"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommagneticmoment">
+<prefLabel xml:lang="en">bottom: magnetic moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#magneticmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommass">
+<prefLabel xml:lang="en">bottom: mass</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mass"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommassformula">
+<prefLabel xml:lang="en">bottom: mass formula</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massformula"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommassgeneration">
+<prefLabel xml:lang="en">bottom: mass generation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massgeneration"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommassspectrum">
+<prefLabel xml:lang="en">bottom: mass spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommirrorparticle">
+<prefLabel xml:lang="en">bottom: mirror particle</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mirrorparticle"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommomentum">
+<prefLabel xml:lang="en">bottom: momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommomentumspectrum">
+<prefLabel xml:lang="en">bottom: momentum spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentumspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommultipleproduction">
+<prefLabel xml:lang="en">bottom: multiple production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multipleproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottommultiplicity">
+<prefLabel xml:lang="en">bottom: multiplicity</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multiplicity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottompairproduction">
+<prefLabel xml:lang="en">bottom: pair production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#pairproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomparticleidentification">
+<prefLabel xml:lang="en">bottom: particle identification</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particleidentification"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomparticlesource">
+<prefLabel xml:lang="en">bottom: particle source</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particlesource"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomphotoproduction">
+<prefLabel xml:lang="en">bottom: photoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#photoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomproduction">
+<prefLabel xml:lang="en">bottom: production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#production"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottompropagator">
+<prefLabel xml:lang="en">bottom: propagator</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#propagator"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomradiativedecay">
+<prefLabel xml:lang="en">bottom: radiative decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#radiativedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomrapidityspectrum">
+<prefLabel xml:lang="en">bottom: rapidity spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#rapidityspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomraredecay">
+<prefLabel xml:lang="en">bottom: rare decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#raredecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomsemileptonicdecay">
+<prefLabel xml:lang="en">bottom: semileptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#semileptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomsignature">
+<prefLabel xml:lang="en">bottom: signature</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#signature"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomsingleproduction">
+<prefLabel xml:lang="en">bottom: single production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#singleproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomsuppression">
+<prefLabel xml:lang="en">bottom: suppression</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#suppression"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomtotalcrosssection">
+<prefLabel xml:lang="en">bottom: total cross section</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#totalcrosssection"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomtransversemomentum">
+<prefLabel xml:lang="en">bottom: transverse momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#transversemomentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomvector">
+<prefLabel xml:lang="en">bottom: vector</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#vector"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomvectorparticle">
+<prefLabel xml:lang="en">bottom: vector particle</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#vectorparticle"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomwavefunction">
+<prefLabel xml:lang="en">bottom: wave function</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#wavefunction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomwidth">
+<prefLabel xml:lang="en">bottom: width</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#width"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomyield">
+<prefLabel xml:lang="en">bottom: yield</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#yield"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downannihilation">
+<prefLabel xml:lang="en">down: annihilation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#annihilation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downassociatedproduction">
+<prefLabel xml:lang="en">down: associated production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#associatedproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downbranchingratio">
+<prefLabel xml:lang="en">down: branching ratio</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#branchingratio"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downcascadedecay">
+<prefLabel xml:lang="en">down: cascade decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#cascadedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downcondensation">
+<prefLabel xml:lang="en">down: condensation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#condensation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downcoupling">
+<prefLabel xml:lang="en">down: coupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#coupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downcouplingconstant">
+<prefLabel xml:lang="en">down: coupling constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#couplingconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downdecay">
+<prefLabel xml:lang="en">down: decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downdecayconstant">
+<prefLabel xml:lang="en">down: decay constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downdecaymodes">
+<prefLabel xml:lang="en">down: decay modes</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decaymodes"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downdecayrate">
+<prefLabel xml:lang="en">down: decay rate</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayrate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downdecoupling">
+<prefLabel xml:lang="en">down: decoupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decoupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downdirectproduction">
+<prefLabel xml:lang="en">down: direct production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#directproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downdistributionamplitude">
+<prefLabel xml:lang="en">down: distribution amplitude</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#distributionamplitude"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downelectricmoment">
+<prefLabel xml:lang="en">down: electric moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electricmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downelectromagneticdecay">
+<prefLabel xml:lang="en">down: electromagnetic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electromagneticdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downelectroproduction">
+<prefLabel xml:lang="en">down: electroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downenergy">
+<prefLabel xml:lang="en">down: energy</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energy"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downenergyspectrum">
+<prefLabel xml:lang="en">down: energy spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energyspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downexchange">
+<prefLabel xml:lang="en">down: exchange</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exchange"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downexcitedstate">
+<prefLabel xml:lang="en">down: excited state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#excitedstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downexclusiveproduction">
+<prefLabel xml:lang="en">down: exclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downfinalstate">
+<prefLabel xml:lang="en">down: final state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#finalstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downformfactor">
+<prefLabel xml:lang="en">down: form factor</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#formfactor"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downgroundstate">
+<prefLabel xml:lang="en">down: ground state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#groundstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downhadronicdecay">
+<prefLabel xml:lang="en">down: hadronic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadronicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downhadroproduction">
+<prefLabel xml:lang="en">down: hadroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downinclusiveproduction">
+<prefLabel xml:lang="en">down: inclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#inclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downintermediatestate">
+<prefLabel xml:lang="en">down: intermediate state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#intermediatestate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downinvisibledecay">
+<prefLabel xml:lang="en">down: invisible decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#invisibledecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downleptoproduction">
+<prefLabel xml:lang="en">down: leptoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downmagneticmoment">
+<prefLabel xml:lang="en">down: magnetic moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#magneticmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downmass">
+<prefLabel xml:lang="en">down: mass</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mass"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downmassformula">
+<prefLabel xml:lang="en">down: mass formula</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massformula"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downmassgeneration">
+<prefLabel xml:lang="en">down: mass generation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massgeneration"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downmassspectrum">
+<prefLabel xml:lang="en">down: mass spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downmomentum">
+<prefLabel xml:lang="en">down: momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downmomentumspectrum">
+<prefLabel xml:lang="en">down: momentum spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentumspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downmultipleproduction">
+<prefLabel xml:lang="en">down: multiple production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multipleproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downmultiplicity">
+<prefLabel xml:lang="en">down: multiplicity</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multiplicity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downpairproduction">
+<prefLabel xml:lang="en">down: pair production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#pairproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downparticleidentification">
+<prefLabel xml:lang="en">down: particle identification</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particleidentification"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downparticlesource">
+<prefLabel xml:lang="en">down: particle source</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particlesource"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downphotoproduction">
+<prefLabel xml:lang="en">down: photoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#photoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downproduction">
+<prefLabel xml:lang="en">down: production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#production"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downpropagator">
+<prefLabel xml:lang="en">down: propagator</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#propagator"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downradiativedecay">
+<prefLabel xml:lang="en">down: radiative decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#radiativedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downrapidityspectrum">
+<prefLabel xml:lang="en">down: rapidity spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#rapidityspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downraredecay">
+<prefLabel xml:lang="en">down: rare decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#raredecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downsemileptonicdecay">
+<prefLabel xml:lang="en">down: semileptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#semileptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downsignature">
+<prefLabel xml:lang="en">down: signature</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#signature"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downsuppression">
+<prefLabel xml:lang="en">down: suppression</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#suppression"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downtransversemomentum">
+<prefLabel xml:lang="en">down: transverse momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#transversemomentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downwavefunction">
+<prefLabel xml:lang="en">down: wave function</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#wavefunction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.downyield">
+<prefLabel xml:lang="en">down: yield</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#down"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#yield"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoDirac">
+<prefLabel xml:lang="en">neutrino: Dirac</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Dirac"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoKaluza-Klein">
+<prefLabel xml:lang="en">neutrino: Kaluza-Klein</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Kaluza-Klein"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoLSP">
+<prefLabel xml:lang="en">neutrino: LSP</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#LSP"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoMajorana">
+<prefLabel xml:lang="en">neutrino: Majorana</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Majorana"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoNLSP">
+<prefLabel xml:lang="en">neutrino: NLSP</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#NLSP"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoUHE">
+<prefLabel xml:lang="en">neutrino: UHE</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#UHE"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoVHE">
+<prefLabel xml:lang="en">neutrino: VHE</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#VHE"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoWeyl">
+<prefLabel xml:lang="en">neutrino: Weyl</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Weyl"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoabsorption">
+<prefLabel xml:lang="en">neutrino: absorption</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#absorption"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoair">
+<prefLabel xml:lang="en">neutrino: air</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#air"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoangulardistribution">
+<prefLabel xml:lang="en">neutrino: angular distribution</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#angulardistribution"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoangularmomentum">
+<prefLabel xml:lang="en">neutrino: angular momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#angularmomentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoanisotropy">
+<prefLabel xml:lang="en">neutrino: anisotropy</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#anisotropy"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoannihilation">
+<prefLabel xml:lang="en">neutrino: annihilation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#annihilation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoassociatedproduction">
+<prefLabel xml:lang="en">neutrino: associated production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#associatedproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoastrophysics">
+<prefLabel xml:lang="en">neutrino: astrophysics</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#astrophysics"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoasymmetry">
+<prefLabel xml:lang="en">neutrino: asymmetry</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#asymmetry"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoatmosphere">
+<prefLabel xml:lang="en">neutrino: atmosphere</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#atmosphere"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinobackground">
+<prefLabel xml:lang="en">neutrino: background</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#background"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinobeam">
+<prefLabel xml:lang="en">neutrino: beam</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#beam"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinobeamprofile">
+<prefLabel xml:lang="en">neutrino: beam profile</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#beamprofile"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinobeamtransport">
+<prefLabel xml:lang="en">neutrino: beam transport</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#beamtransport"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinobosonization">
+<prefLabel xml:lang="en">neutrino: bosonization</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bosonization"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoboundstate">
+<prefLabel xml:lang="en">neutrino: bound state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#boundstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinobranchingratio">
+<prefLabel xml:lang="en">neutrino: branching ratio</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#branchingratio"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinobremsstrahlung">
+<prefLabel xml:lang="en">neutrino: bremsstrahlung</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bremsstrahlung"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoburst">
+<prefLabel xml:lang="en">neutrino: burst</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#burst"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocalorimeter">
+<prefLabel xml:lang="en">neutrino: calorimeter</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#calorimeter"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocapture">
+<prefLabel xml:lang="en">neutrino: capture</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#capture"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocascadedecay">
+<prefLabel xml:lang="en">neutrino: cascade decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#cascadedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocharge">
+<prefLabel xml:lang="en">neutrino: charge</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#charge"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinochargeradius">
+<prefLabel xml:lang="en">neutrino: charge radius</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#chargeradius"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinochiral">
+<prefLabel xml:lang="en">neutrino: chiral</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#chiral"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocloud">
+<prefLabel xml:lang="en">neutrino: cloud</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#cloud"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocluster">
+<prefLabel xml:lang="en">neutrino: cluster</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#cluster"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocoherentinteraction">
+<prefLabel xml:lang="en">neutrino: coherent interaction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#coherentinteraction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocollectivephenomena">
+<prefLabel xml:lang="en">neutrino: collective phenomena</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#collectivephenomena"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocomposite">
+<prefLabel xml:lang="en">neutrino: composite</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#composite"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocondensation">
+<prefLabel xml:lang="en">neutrino: condensation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#condensation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoconfinement">
+<prefLabel xml:lang="en">neutrino: confinement</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#confinement"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocorrelation">
+<prefLabel xml:lang="en">neutrino: correlation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#correlation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocosmicradiation">
+<prefLabel xml:lang="en">neutrino: cosmic radiation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#cosmicradiation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocoupling">
+<prefLabel xml:lang="en">neutrino: coupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#coupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocouplingconstant">
+<prefLabel xml:lang="en">neutrino: coupling constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#couplingconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocrosssection">
+<prefLabel xml:lang="en">neutrino: cross section</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#crosssection"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinocurrent">
+<prefLabel xml:lang="en">neutrino: current</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#current"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodarkenergy">
+<prefLabel xml:lang="en">neutrino: dark energy</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#darkenergy"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodarkmatter">
+<prefLabel xml:lang="en">neutrino: dark matter</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#darkmatter"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodecay">
+<prefLabel xml:lang="en">neutrino: decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodecayconstant">
+<prefLabel xml:lang="en">neutrino: decay constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodecaymodes">
+<prefLabel xml:lang="en">neutrino: decay modes</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decaymodes"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodecayrate">
+<prefLabel xml:lang="en">neutrino: decay rate</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayrate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodecoupling">
+<prefLabel xml:lang="en">neutrino: decoupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decoupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodeepinelasticscattering">
+<prefLabel xml:lang="en">neutrino: deep inelastic scattering</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#deepinelasticscattering"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodeepundergrounddetector">
+<prefLabel xml:lang="en">neutrino: deep underground detector</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#deepundergrounddetector"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodeflection">
+<prefLabel xml:lang="en">neutrino: deflection</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#deflection"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodensity">
+<prefLabel xml:lang="en">neutrino: density</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#density"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodensitymatrix">
+<prefLabel xml:lang="en">neutrino: density matrix</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#densitymatrix"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodetector">
+<prefLabel xml:lang="en">neutrino: detector</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#detector"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodiffraction">
+<prefLabel xml:lang="en">neutrino: diffraction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#diffraction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodiffusion">
+<prefLabel xml:lang="en">neutrino: diffusion</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#diffusion"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodirectdetection">
+<prefLabel xml:lang="en">neutrino: direct detection</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#directdetection"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodirectproduction">
+<prefLabel xml:lang="en">neutrino: direct production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#directproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodispersionrelation">
+<prefLabel xml:lang="en">neutrino: dispersion relation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#dispersionrelation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodistributionamplitude">
+<prefLabel xml:lang="en">neutrino: distribution amplitude</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#distributionamplitude"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodistributionfunction">
+<prefLabel xml:lang="en">neutrino: distribution function</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#distributionfunction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodomainwall">
+<prefLabel xml:lang="en">neutrino: domain wall</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#domainwall"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinodoublet">
+<prefLabel xml:lang="en">neutrino: doublet</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#doublet"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoeffect">
+<prefLabel xml:lang="en">neutrino: effect</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#effect"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoelasticscattering">
+<prefLabel xml:lang="en">neutrino: elastic scattering</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#elasticscattering"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoelectricmoment">
+<prefLabel xml:lang="en">neutrino: electric moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electricmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoelectromagneticdecay">
+<prefLabel xml:lang="en">neutrino: electromagnetic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electromagneticdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoelectromagneticinteraction">
+<prefLabel xml:lang="en">neutrino: electromagnetic interaction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electromagneticinteraction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoelectroproduction">
+<prefLabel xml:lang="en">neutrino: electroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoemission">
+<prefLabel xml:lang="en">neutrino: emission</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#emission"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoenergy">
+<prefLabel xml:lang="en">neutrino: energy</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energy"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoenergyeigenstate">
+<prefLabel xml:lang="en">neutrino: energy eigenstate</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energyeigenstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoenergylevels">
+<prefLabel xml:lang="en">neutrino: energy levels</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energylevels"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoenergyloss">
+<prefLabel xml:lang="en">neutrino: energy loss</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energyloss"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoenergyspectrum">
+<prefLabel xml:lang="en">neutrino: energy spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energyspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoenergy-momentum">
+<prefLabel xml:lang="en">neutrino: energy-momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energy-momentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoexchange">
+<prefLabel xml:lang="en">neutrino: exchange</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exchange"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoexcitedstate">
+<prefLabel xml:lang="en">neutrino: excited state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#excitedstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoexclusiveproduction">
+<prefLabel xml:lang="en">neutrino: exclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoexotic">
+<prefLabel xml:lang="en">neutrino: exotic</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exotic"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinofamily">
+<prefLabel xml:lang="en">neutrino: family</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#family"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinofieldequations">
+<prefLabel xml:lang="en">neutrino: field equations</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fieldequations"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinofinalstate">
+<prefLabel xml:lang="en">neutrino: final state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#finalstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoflavor">
+<prefLabel xml:lang="en">neutrino: flavor</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#flavor"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinofluid">
+<prefLabel xml:lang="en">neutrino: fluid</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fluid"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoflux">
+<prefLabel xml:lang="en">neutrino: flux</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#flux"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoformfactor">
+<prefLabel xml:lang="en">neutrino: form factor</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#formfactor"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinogas">
+<prefLabel xml:lang="en">neutrino: gas</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#gas"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinogeophysics">
+<prefLabel xml:lang="en">neutrino: geophysics</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#geophysics"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoghost">
+<prefLabel xml:lang="en">neutrino: ghost</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#ghost"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinogroundstate">
+<prefLabel xml:lang="en">neutrino: ground state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#groundstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinohadronicdecay">
+<prefLabel xml:lang="en">neutrino: hadronic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadronicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinohadroproduction">
+<prefLabel xml:lang="en">neutrino: hadroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoheavy">
+<prefLabel xml:lang="en">neutrino: heavy</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#heavy"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinohelicity">
+<prefLabel xml:lang="en">neutrino: helicity</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#helicity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinohierarchy">
+<prefLabel xml:lang="en">neutrino: hierarchy</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hierarchy"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinohistory">
+<prefLabel xml:lang="en">neutrino: history</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#history"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoinclusiveproduction">
+<prefLabel xml:lang="en">neutrino: inclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#inclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoinelasticscattering">
+<prefLabel xml:lang="en">neutrino: inelastic scattering</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#inelasticscattering"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinointeraction">
+<prefLabel xml:lang="en">neutrino: interaction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#interaction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinointerference">
+<prefLabel xml:lang="en">neutrino: interference</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#interference"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinointermediatestate">
+<prefLabel xml:lang="en">neutrino: intermediate state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#intermediatestate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoinvisibledecay">
+<prefLabel xml:lang="en">neutrino: invisible decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#invisibledecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinojet">
+<prefLabel xml:lang="en">neutrino: jet</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#jet"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinolattice">
+<prefLabel xml:lang="en">neutrino: lattice</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#lattice"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoleft-handed">
+<prefLabel xml:lang="en">neutrino: left-handed</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#left-handed"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoleptonicdecay">
+<prefLabel xml:lang="en">neutrino: leptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoleptoproduction">
+<prefLabel xml:lang="en">neutrino: leptoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinolifetime">
+<prefLabel xml:lang="en">neutrino: lifetime</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#lifetime"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoluminosity">
+<prefLabel xml:lang="en">neutrino: luminosity</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#luminosity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinolunar">
+<prefLabel xml:lang="en">neutrino: lunar</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#lunar"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomagneticmoment">
+<prefLabel xml:lang="en">neutrino: magnetic moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#magneticmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomass">
+<composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomasstimedependence"/>
+<prefLabel xml:lang="en">neutrino: mass</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mass"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomassdifference">
+<prefLabel xml:lang="en">neutrino: mass difference</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massdifference"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomassformula">
+<prefLabel xml:lang="en">neutrino: mass formula</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massformula"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomassgeneration">
+<prefLabel xml:lang="en">neutrino: mass generation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massgeneration"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomassratio">
+<prefLabel xml:lang="en">neutrino: mass ratio</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massratio"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomassresolution">
+<prefLabel xml:lang="en">neutrino: mass resolution</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massresolution"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomassspectrum">
+<prefLabel xml:lang="en">neutrino: mass spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomassive">
+<prefLabel xml:lang="en">neutrino: massive</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massive"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomassless">
+<prefLabel xml:lang="en">neutrino: massless</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massless"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomediation">
+<prefLabel xml:lang="en">neutrino: mediation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mediation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomessenger">
+<prefLabel xml:lang="en">neutrino: messenger</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#messenger"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomirror">
+<prefLabel xml:lang="en">neutrino: mirror</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mirror"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomirrorparticle">
+<prefLabel xml:lang="en">neutrino: mirror particle</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mirrorparticle"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomixing">
+<prefLabel xml:lang="en">neutrino: mixing</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mixing"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomixingangle">
+<prefLabel xml:lang="en">neutrino: mixing angle</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mixingangle"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomodel">
+<prefLabel xml:lang="en">neutrino: model</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#model"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomoment">
+<prefLabel xml:lang="en">neutrino: moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#moment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomomentum">
+<prefLabel xml:lang="en">neutrino: momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomomentumspectrum">
+<prefLabel xml:lang="en">neutrino: momentum spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentumspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomultipleproduction">
+<prefLabel xml:lang="en">neutrino: multiple production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multipleproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomultiplet">
+<prefLabel xml:lang="en">neutrino: multiplet</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multiplet"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomultiplicity">
+<prefLabel xml:lang="en">neutrino: multiplicity</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multiplicity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinonewinteraction">
+<prefLabel xml:lang="en">neutrino: new interaction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#newinteraction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinononrelativistic">
+<prefLabel xml:lang="en">neutrino: nonrelativistic</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#nonrelativistic"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinonuclearreactor">
+<prefLabel xml:lang="en">neutrino: nuclear reactor</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#nuclearreactor"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoopacity">
+<prefLabel xml:lang="en">neutrino: opacity</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#opacity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinooscillation">
+<prefLabel xml:lang="en">neutrino: oscillation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#oscillation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinopairproduction">
+<prefLabel xml:lang="en">neutrino: pair production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#pairproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoparticleidentification">
+<prefLabel xml:lang="en">neutrino: particle identification</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particleidentification"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoparticlesource">
+<prefLabel xml:lang="en">neutrino: particle source</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particlesource"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinopathlength">
+<prefLabel xml:lang="en">neutrino: path length</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#pathlength"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoperturbation">
+<prefLabel xml:lang="en">neutrino: perturbation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#perturbation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinophotoproduction">
+<prefLabel xml:lang="en">neutrino: photoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#photoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoplasma">
+<prefLabel xml:lang="en">neutrino: plasma</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#plasma"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinopolarization">
+<prefLabel xml:lang="en">neutrino: polarization</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#polarization"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinopotential">
+<prefLabel xml:lang="en">neutrino: potential</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#potential"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinopowerspectrum">
+<prefLabel xml:lang="en">neutrino: power spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#powerspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoprimary">
+<prefLabel xml:lang="en">neutrino: primary</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#primary"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoproduction">
+<prefLabel xml:lang="en">neutrino: production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#production"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinopropagation">
+<prefLabel xml:lang="en">neutrino: propagation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#propagation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinopropagator">
+<prefLabel xml:lang="en">neutrino: propagator</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#propagator"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoradiation">
+<prefLabel xml:lang="en">neutrino: radiation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#radiation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoradiativedecay">
+<prefLabel xml:lang="en">neutrino: radiative decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#radiativedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinorapidityspectrum">
+<prefLabel xml:lang="en">neutrino: rapidity spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#rapidityspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoraredecay">
+<prefLabel xml:lang="en">neutrino: rare decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#raredecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinorecoil">
+<prefLabel xml:lang="en">neutrino: recoil</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#recoil"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoreflection">
+<prefLabel xml:lang="en">neutrino: reflection</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#reflection"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoregeneration">
+<prefLabel xml:lang="en">neutrino: regeneration</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#regeneration"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinorelativistic">
+<prefLabel xml:lang="en">neutrino: relativistic</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#relativistic"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinorelicdensity">
+<prefLabel xml:lang="en">neutrino: relic density</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#relicdensity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoreview">
+<prefLabel xml:lang="en">neutrino: review</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#review"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoright-handed">
+<prefLabel xml:lang="en">neutrino: right-handed</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#right-handed"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoscalarparticle">
+<prefLabel xml:lang="en">neutrino: scalar particle</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#scalarparticle"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoscattering">
+<prefLabel xml:lang="en">neutrino: scattering</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#scattering"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoscintillationcounter">
+<prefLabel xml:lang="en">neutrino: scintillation counter</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#scintillationcounter"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoscreening">
+<prefLabel xml:lang="en">neutrino: screening</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#screening"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosea">
+<prefLabel xml:lang="en">neutrino: sea</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#sea"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosearchfor">
+<prefLabel xml:lang="en">neutrino: search for</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#searchfor"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosecondary">
+<prefLabel xml:lang="en">neutrino: secondary</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#secondary"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosecondarybeam">
+<prefLabel xml:lang="en">neutrino: secondary beam</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#secondarybeam"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosemileptonicdecay">
+<prefLabel xml:lang="en">neutrino: semileptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#semileptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoshowers">
+<prefLabel xml:lang="en">neutrino: showers</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#showers"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosignature">
+<prefLabel xml:lang="en">neutrino: signature</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#signature"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosinglet">
+<prefLabel xml:lang="en">neutrino: singlet</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#singlet"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosolar">
+<prefLabel xml:lang="en">neutrino: solar</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#solar"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinospectrum">
+<prefLabel xml:lang="en">neutrino: spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#spectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosphere">
+<prefLabel xml:lang="en">neutrino: sphere</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#sphere"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinospin">
+<prefLabel xml:lang="en">neutrino: spin</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#spin"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinostability">
+<prefLabel xml:lang="en">neutrino: stability</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#stability"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinostar">
+<prefLabel xml:lang="en">neutrino: star</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#star"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinostatistics">
+<prefLabel xml:lang="en">neutrino: statistics</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#statistics"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosterile">
+<prefLabel xml:lang="en">neutrino: sterile</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#sterile"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinostrongcoupling">
+<prefLabel xml:lang="en">neutrino: strong coupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#strongcoupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinostronginteraction">
+<prefLabel xml:lang="en">neutrino: strong interaction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#stronginteraction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosuperfield">
+<prefLabel xml:lang="en">neutrino: superfield</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#superfield"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosuperluminal">
+<prefLabel xml:lang="en">neutrino: superluminal</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#superluminal"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinosupernova">
+<prefLabel xml:lang="en">neutrino: supernova</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#supernova"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotachyon">
+<prefLabel xml:lang="en">neutrino: tachyon</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#tachyon"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotaggedbeam">
+<prefLabel xml:lang="en">neutrino: tagged beam</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#taggedbeam"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotemperature">
+<prefLabel xml:lang="en">neutrino: temperature</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#temperature"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinothermal">
+<prefLabel xml:lang="en">neutrino: thermal</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#thermal"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotimedelay">
+<prefLabel xml:lang="en">neutrino: time delay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#timedelay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotime-of-flight">
+<prefLabel xml:lang="en">neutrino: time-of-flight</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#time-of-flight"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotrajectory">
+<prefLabel xml:lang="en">neutrino: trajectory</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#trajectory"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotransition">
+<prefLabel xml:lang="en">neutrino: transition</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#transition"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotransporttheory">
+<prefLabel xml:lang="en">neutrino: transport theory</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#transporttheory"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotransversemomentum">
+<prefLabel xml:lang="en">neutrino: transverse momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#transversemomentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinotrigger">
+<prefLabel xml:lang="en">neutrino: trigger</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#trigger"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinovelocity">
+<prefLabel xml:lang="en">neutrino: velocity</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#velocity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinowater">
+<prefLabel xml:lang="en">neutrino: water</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#water"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinowavefunction">
+<prefLabel xml:lang="en">neutrino: wave function</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#wavefunction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinowidth">
+<prefLabel xml:lang="en">neutrino: width</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#width"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoyield">
+<prefLabel xml:lang="en">neutrino: yield</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#yield"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinozeromode">
+<prefLabel xml:lang="en">neutrino: zero mode</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#zeromode"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eUHE">
+<prefLabel xml:lang="en">neutrino/e: UHE</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#UHE"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eadmixture">
+<prefLabel xml:lang="en">neutrino/e: admixture</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#admixture"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eannihilation">
+<prefLabel xml:lang="en">neutrino/e: annihilation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#annihilation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eassociatedproduction">
+<prefLabel xml:lang="en">neutrino/e: associated production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#associatedproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ebackground">
+<prefLabel xml:lang="en">neutrino/e: background</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#background"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ebeam">
+<prefLabel xml:lang="en">neutrino/e: beam</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#beam"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ebranchingratio">
+<prefLabel xml:lang="en">neutrino/e: branching ratio</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#branchingratio"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ecapture">
+<prefLabel xml:lang="en">neutrino/e: capture</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#capture"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ecascadedecay">
+<prefLabel xml:lang="en">neutrino/e: cascade decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#cascadedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/econdensation">
+<prefLabel xml:lang="en">neutrino/e: condensation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#condensation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ecosmicradiation">
+<prefLabel xml:lang="en">neutrino/e: cosmic radiation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#cosmicradiation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ecoupling">
+<prefLabel xml:lang="en">neutrino/e: coupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#coupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ecouplingconstant">
+<prefLabel xml:lang="en">neutrino/e: coupling constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#couplingconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/edecay">
+<prefLabel xml:lang="en">neutrino/e: decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/edecayconstant">
+<prefLabel xml:lang="en">neutrino/e: decay constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/edecaymodes">
+<prefLabel xml:lang="en">neutrino/e: decay modes</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decaymodes"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/edecayrate">
+<prefLabel xml:lang="en">neutrino/e: decay rate</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayrate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/edecoupling">
+<prefLabel xml:lang="en">neutrino/e: decoupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decoupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/edetector">
+<prefLabel xml:lang="en">neutrino/e: detector</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#detector"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/edirectdetection">
+<prefLabel xml:lang="en">neutrino/e: direct detection</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#directdetection"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/edirectproduction">
+<prefLabel xml:lang="en">neutrino/e: direct production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#directproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/edistributionamplitude">
+<prefLabel xml:lang="en">neutrino/e: distribution amplitude</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#distributionamplitude"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eelectricmoment">
+<prefLabel xml:lang="en">neutrino/e: electric moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electricmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eelectromagneticdecay">
+<prefLabel xml:lang="en">neutrino/e: electromagnetic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electromagneticdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eelectroproduction">
+<prefLabel xml:lang="en">neutrino/e: electroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eemission">
+<prefLabel xml:lang="en">neutrino/e: emission</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#emission"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eenergy">
+<prefLabel xml:lang="en">neutrino/e: energy</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energy"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eenergyspectrum">
+<prefLabel xml:lang="en">neutrino/e: energy spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energyspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eexchange">
+<prefLabel xml:lang="en">neutrino/e: exchange</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exchange"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eexcitedstate">
+<prefLabel xml:lang="en">neutrino/e: excited state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#excitedstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eexclusiveproduction">
+<prefLabel xml:lang="en">neutrino/e: exclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/efinalstate">
+<prefLabel xml:lang="en">neutrino/e: final state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#finalstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eflux">
+<prefLabel xml:lang="en">neutrino/e: flux</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#flux"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eformfactor">
+<prefLabel xml:lang="en">neutrino/e: form factor</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#formfactor"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/egroundstate">
+<prefLabel xml:lang="en">neutrino/e: ground state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#groundstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ehadronicdecay">
+<prefLabel xml:lang="en">neutrino/e: hadronic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadronicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ehadroproduction">
+<prefLabel xml:lang="en">neutrino/e: hadroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/einclusiveproduction">
+<prefLabel xml:lang="en">neutrino/e: inclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#inclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/einteraction">
+<prefLabel xml:lang="en">neutrino/e: interaction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#interaction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eintermediatestate">
+<prefLabel xml:lang="en">neutrino/e: intermediate state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#intermediatestate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/einvisibledecay">
+<prefLabel xml:lang="en">neutrino/e: invisible decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#invisibledecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eleptonicdecay">
+<prefLabel xml:lang="en">neutrino/e: leptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eleptoproduction">
+<prefLabel xml:lang="en">neutrino/e: leptoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/emagneticmoment">
+<prefLabel xml:lang="en">neutrino/e: magnetic moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#magneticmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/emass">
+<prefLabel xml:lang="en">neutrino/e: mass</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mass"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/emassformula">
+<prefLabel xml:lang="en">neutrino/e: mass formula</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massformula"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/emassgeneration">
+<prefLabel xml:lang="en">neutrino/e: mass generation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massgeneration"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/emassspectrum">
+<prefLabel xml:lang="en">neutrino/e: mass spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/emomentum">
+<prefLabel xml:lang="en">neutrino/e: momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/emomentumspectrum">
+<prefLabel xml:lang="en">neutrino/e: momentum spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentumspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/emultipleproduction">
+<prefLabel xml:lang="en">neutrino/e: multiple production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multipleproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/emultiplicity">
+<prefLabel xml:lang="en">neutrino/e: multiplicity</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multiplicity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eoscillation">
+<prefLabel xml:lang="en">neutrino/e: oscillation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#oscillation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/epairproduction">
+<prefLabel xml:lang="en">neutrino/e: pair production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#pairproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eparticleidentification">
+<prefLabel xml:lang="en">neutrino/e: particle identification</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particleidentification"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eparticlesource">
+<prefLabel xml:lang="en">neutrino/e: particle source</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particlesource"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/epathlength">
+<prefLabel xml:lang="en">neutrino/e: path length</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#pathlength"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ephotoproduction">
+<prefLabel xml:lang="en">neutrino/e: photoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#photoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eproduction">
+<prefLabel xml:lang="en">neutrino/e: production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#production"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/epropagator">
+<prefLabel xml:lang="en">neutrino/e: propagator</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#propagator"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eradiativedecay">
+<prefLabel xml:lang="en">neutrino/e: radiative decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#radiativedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/erapidityspectrum">
+<prefLabel xml:lang="en">neutrino/e: rapidity spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#rapidityspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eraredecay">
+<prefLabel xml:lang="en">neutrino/e: rare decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#raredecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eright-handed">
+<prefLabel xml:lang="en">neutrino/e: right-handed</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#right-handed"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/esearchfor">
+<prefLabel xml:lang="en">neutrino/e: search for</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#searchfor"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/esecondarybeam">
+<prefLabel xml:lang="en">neutrino/e: secondary beam</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#secondarybeam"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/esemileptonicdecay">
+<prefLabel xml:lang="en">neutrino/e: semileptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#semileptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eshowers">
+<prefLabel xml:lang="en">neutrino/e: showers</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#showers"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/esignature">
+<prefLabel xml:lang="en">neutrino/e: signature</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#signature"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/esterile">
+<prefLabel xml:lang="en">neutrino/e: sterile</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#sterile"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/etransversemomentum">
+<prefLabel xml:lang="en">neutrino/e: transverse momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#transversemomentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/ewavefunction">
+<prefLabel xml:lang="en">neutrino/e: wave function</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#wavefunction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/eyield">
+<prefLabel xml:lang="en">neutrino/e: yield</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/e"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#yield"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muMajorana">
+<prefLabel xml:lang="en">neutrino/mu: Majorana</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Majorana"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muadmixture">
+<prefLabel xml:lang="en">neutrino/mu: admixture</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#admixture"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muangulardistribution">
+<prefLabel xml:lang="en">neutrino/mu: angular distribution</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#angulardistribution"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muannihilation">
+<prefLabel xml:lang="en">neutrino/mu: annihilation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#annihilation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muassociatedproduction">
+<prefLabel xml:lang="en">neutrino/mu: associated production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#associatedproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muatmosphere">
+<prefLabel xml:lang="en">neutrino/mu: atmosphere</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#atmosphere"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mubackground">
+<prefLabel xml:lang="en">neutrino/mu: background</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#background"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mubeam">
+<prefLabel xml:lang="en">neutrino/mu: beam</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#beam"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mubranchingratio">
+<prefLabel xml:lang="en">neutrino/mu: branching ratio</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#branchingratio"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mucapture">
+<prefLabel xml:lang="en">neutrino/mu: capture</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#capture"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mucascadedecay">
+<prefLabel xml:lang="en">neutrino/mu: cascade decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#cascadedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mucondensation">
+<prefLabel xml:lang="en">neutrino/mu: condensation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#condensation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mucosmicradiation">
+<prefLabel xml:lang="en">neutrino/mu: cosmic radiation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#cosmicradiation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mucoupling">
+<prefLabel xml:lang="en">neutrino/mu: coupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#coupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mucouplingconstant">
+<prefLabel xml:lang="en">neutrino/mu: coupling constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#couplingconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mudecay">
+<prefLabel xml:lang="en">neutrino/mu: decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mudecayconstant">
+<prefLabel xml:lang="en">neutrino/mu: decay constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mudecaymodes">
+<prefLabel xml:lang="en">neutrino/mu: decay modes</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decaymodes"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mudecayrate">
+<prefLabel xml:lang="en">neutrino/mu: decay rate</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayrate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mudecoupling">
+<prefLabel xml:lang="en">neutrino/mu: decoupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decoupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mudensity">
+<prefLabel xml:lang="en">neutrino/mu: density</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#density"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mudirectproduction">
+<prefLabel xml:lang="en">neutrino/mu: direct production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#directproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mudistributionamplitude">
+<prefLabel xml:lang="en">neutrino/mu: distribution amplitude</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#distributionamplitude"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muelectricmoment">
+<prefLabel xml:lang="en">neutrino/mu: electric moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electricmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muelectromagneticdecay">
+<prefLabel xml:lang="en">neutrino/mu: electromagnetic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electromagneticdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muelectroproduction">
+<prefLabel xml:lang="en">neutrino/mu: electroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muemission">
+<prefLabel xml:lang="en">neutrino/mu: emission</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#emission"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muenergy">
+<prefLabel xml:lang="en">neutrino/mu: energy</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energy"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muenergyspectrum">
+<prefLabel xml:lang="en">neutrino/mu: energy spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energyspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muexchange">
+<prefLabel xml:lang="en">neutrino/mu: exchange</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exchange"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muexcitedstate">
+<prefLabel xml:lang="en">neutrino/mu: excited state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#excitedstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muexclusiveproduction">
+<prefLabel xml:lang="en">neutrino/mu: exclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mufinalstate">
+<prefLabel xml:lang="en">neutrino/mu: final state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#finalstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muflux">
+<prefLabel xml:lang="en">neutrino/mu: flux</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#flux"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muformfactor">
+<prefLabel xml:lang="en">neutrino/mu: form factor</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#formfactor"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mugroundstate">
+<prefLabel xml:lang="en">neutrino/mu: ground state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#groundstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muhadronicdecay">
+<prefLabel xml:lang="en">neutrino/mu: hadronic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadronicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muhadroproduction">
+<prefLabel xml:lang="en">neutrino/mu: hadroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muinclusiveproduction">
+<prefLabel xml:lang="en">neutrino/mu: inclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#inclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muinelasticscattering">
+<prefLabel xml:lang="en">neutrino/mu: inelastic scattering</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#inelasticscattering"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muinteraction">
+<prefLabel xml:lang="en">neutrino/mu: interaction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#interaction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muintermediatestate">
+<prefLabel xml:lang="en">neutrino/mu: intermediate state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#intermediatestate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muinvisibledecay">
+<prefLabel xml:lang="en">neutrino/mu: invisible decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#invisibledecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muleptonicdecay">
+<prefLabel xml:lang="en">neutrino/mu: leptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muleptoproduction">
+<prefLabel xml:lang="en">neutrino/mu: leptoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumagneticmoment">
+<prefLabel xml:lang="en">neutrino/mu: magnetic moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#magneticmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumass">
+<prefLabel xml:lang="en">neutrino/mu: mass</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mass"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumassdifference">
+<prefLabel xml:lang="en">neutrino/mu: mass difference</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massdifference"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumassformula">
+<prefLabel xml:lang="en">neutrino/mu: mass formula</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massformula"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumassgeneration">
+<prefLabel xml:lang="en">neutrino/mu: mass generation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massgeneration"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumassspectrum">
+<prefLabel xml:lang="en">neutrino/mu: mass spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumassive">
+<prefLabel xml:lang="en">neutrino/mu: massive</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massive"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumomentum">
+<prefLabel xml:lang="en">neutrino/mu: momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumomentumspectrum">
+<prefLabel xml:lang="en">neutrino/mu: momentum spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentumspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumultipleproduction">
+<prefLabel xml:lang="en">neutrino/mu: multiple production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multipleproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mumultiplicity">
+<prefLabel xml:lang="en">neutrino/mu: multiplicity</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multiplicity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muoscillation">
+<prefLabel xml:lang="en">neutrino/mu: oscillation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#oscillation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mupairproduction">
+<prefLabel xml:lang="en">neutrino/mu: pair production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#pairproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muparticleidentification">
+<prefLabel xml:lang="en">neutrino/mu: particle identification</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particleidentification"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muparticlesource">
+<prefLabel xml:lang="en">neutrino/mu: particle source</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particlesource"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mupathlength">
+<prefLabel xml:lang="en">neutrino/mu: path length</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#pathlength"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muphotoproduction">
+<prefLabel xml:lang="en">neutrino/mu: photoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#photoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muproduction">
+<prefLabel xml:lang="en">neutrino/mu: production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#production"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mupropagation">
+<prefLabel xml:lang="en">neutrino/mu: propagation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#propagation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mupropagator">
+<prefLabel xml:lang="en">neutrino/mu: propagator</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#propagator"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muradiativedecay">
+<prefLabel xml:lang="en">neutrino/mu: radiative decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#radiativedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/murapidityspectrum">
+<prefLabel xml:lang="en">neutrino/mu: rapidity spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#rapidityspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muraredecay">
+<prefLabel xml:lang="en">neutrino/mu: rare decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#raredecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muright-handed">
+<prefLabel xml:lang="en">neutrino/mu: right-handed</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#right-handed"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/musecondarybeam">
+<prefLabel xml:lang="en">neutrino/mu: secondary beam</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#secondarybeam"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/musemileptonicdecay">
+<prefLabel xml:lang="en">neutrino/mu: semileptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#semileptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/musignature">
+<prefLabel xml:lang="en">neutrino/mu: signature</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#signature"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mutime-of-flight">
+<prefLabel xml:lang="en">neutrino/mu: time-of-flight</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#time-of-flight"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/mutransversemomentum">
+<prefLabel xml:lang="en">neutrino/mu: transverse momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#transversemomentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muvelocity">
+<prefLabel xml:lang="en">neutrino/mu: velocity</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#velocity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muwavefunction">
+<prefLabel xml:lang="en">neutrino/mu: wave function</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#wavefunction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/muyield">
+<prefLabel xml:lang="en">neutrino/mu: yield</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/mu"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#yield"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauUHE">
+<prefLabel xml:lang="en">neutrino/tau: UHE</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#UHE"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauannihilation">
+<prefLabel xml:lang="en">neutrino/tau: annihilation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#annihilation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauassociatedproduction">
+<prefLabel xml:lang="en">neutrino/tau: associated production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#associatedproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauatmosphere">
+<prefLabel xml:lang="en">neutrino/tau: atmosphere</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#atmosphere"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taubeam">
+<prefLabel xml:lang="en">neutrino/tau: beam</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#beam"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taubranchingratio">
+<prefLabel xml:lang="en">neutrino/tau: branching ratio</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#branchingratio"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taucascadedecay">
+<prefLabel xml:lang="en">neutrino/tau: cascade decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#cascadedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taucondensation">
+<prefLabel xml:lang="en">neutrino/tau: condensation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#condensation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taucosmicradiation">
+<prefLabel xml:lang="en">neutrino/tau: cosmic radiation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#cosmicradiation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taucoupling">
+<prefLabel xml:lang="en">neutrino/tau: coupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#coupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taucouplingconstant">
+<prefLabel xml:lang="en">neutrino/tau: coupling constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#couplingconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taudecay">
+<prefLabel xml:lang="en">neutrino/tau: decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taudecayconstant">
+<prefLabel xml:lang="en">neutrino/tau: decay constant</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taudecaymodes">
+<prefLabel xml:lang="en">neutrino/tau: decay modes</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decaymodes"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taudecayrate">
+<prefLabel xml:lang="en">neutrino/tau: decay rate</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decayrate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taudecoupling">
+<prefLabel xml:lang="en">neutrino/tau: decoupling</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decoupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taudiffusion">
+<prefLabel xml:lang="en">neutrino/tau: diffusion</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#diffusion"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taudirectproduction">
+<prefLabel xml:lang="en">neutrino/tau: direct production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#directproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taudistributionamplitude">
+<prefLabel xml:lang="en">neutrino/tau: distribution amplitude</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#distributionamplitude"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauelectricmoment">
+<prefLabel xml:lang="en">neutrino/tau: electric moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electricmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauelectromagneticdecay">
+<prefLabel xml:lang="en">neutrino/tau: electromagnetic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electromagneticdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauelectroproduction">
+<prefLabel xml:lang="en">neutrino/tau: electroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauemission">
+<prefLabel xml:lang="en">neutrino/tau: emission</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#emission"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauenergy">
+<prefLabel xml:lang="en">neutrino/tau: energy</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energy"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauenergyspectrum">
+<prefLabel xml:lang="en">neutrino/tau: energy spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#energyspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauexchange">
+<prefLabel xml:lang="en">neutrino/tau: exchange</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exchange"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauexcitedstate">
+<prefLabel xml:lang="en">neutrino/tau: excited state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#excitedstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauexclusiveproduction">
+<prefLabel xml:lang="en">neutrino/tau: exclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#exclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taufinalstate">
+<prefLabel xml:lang="en">neutrino/tau: final state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#finalstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauflux">
+<prefLabel xml:lang="en">neutrino/tau: flux</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#flux"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauformfactor">
+<prefLabel xml:lang="en">neutrino/tau: form factor</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#formfactor"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taugroundstate">
+<prefLabel xml:lang="en">neutrino/tau: ground state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#groundstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauhadronicdecay">
+<prefLabel xml:lang="en">neutrino/tau: hadronic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadronicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauhadroproduction">
+<prefLabel xml:lang="en">neutrino/tau: hadroproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadroproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauhelicity">
+<prefLabel xml:lang="en">neutrino/tau: helicity</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#helicity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauinclusiveproduction">
+<prefLabel xml:lang="en">neutrino/tau: inclusive production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#inclusiveproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauinteraction">
+<prefLabel xml:lang="en">neutrino/tau: interaction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#interaction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauintermediatestate">
+<prefLabel xml:lang="en">neutrino/tau: intermediate state</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#intermediatestate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauinvisibledecay">
+<prefLabel xml:lang="en">neutrino/tau: invisible decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#invisibledecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauleptonicdecay">
+<prefLabel xml:lang="en">neutrino/tau: leptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauleptoproduction">
+<prefLabel xml:lang="en">neutrino/tau: leptoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#leptoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taumagneticmoment">
+<prefLabel xml:lang="en">neutrino/tau: magnetic moment</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#magneticmoment"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taumass">
+<prefLabel xml:lang="en">neutrino/tau: mass</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mass"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taumassformula">
+<prefLabel xml:lang="en">neutrino/tau: mass formula</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massformula"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taumassgeneration">
+<prefLabel xml:lang="en">neutrino/tau: mass generation</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massgeneration"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taumassspectrum">
+<prefLabel xml:lang="en">neutrino/tau: mass spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taumomentum">
+<prefLabel xml:lang="en">neutrino/tau: momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taumomentumspectrum">
+<prefLabel xml:lang="en">neutrino/tau: momentum spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#momentumspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taumultipleproduction">
+<prefLabel xml:lang="en">neutrino/tau: multiple production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multipleproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taumultiplicity">
+<prefLabel xml:lang="en">neutrino/tau: multiplicity</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multiplicity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taupairproduction">
+<prefLabel xml:lang="en">neutrino/tau: pair production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#pairproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauparticleidentification">
+<prefLabel xml:lang="en">neutrino/tau: particle identification</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particleidentification"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauparticlesource">
+<prefLabel xml:lang="en">neutrino/tau: particle source</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particlesource"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taupathlength">
+<prefLabel xml:lang="en">neutrino/tau: path length</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#pathlength"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauphotoproduction">
+<prefLabel xml:lang="en">neutrino/tau: photoproduction</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#photoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauproduction">
+<prefLabel xml:lang="en">neutrino/tau: production</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#production"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taupropagator">
+<prefLabel xml:lang="en">neutrino/tau: propagator</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#propagator"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauradiativedecay">
+<prefLabel xml:lang="en">neutrino/tau: radiative decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#radiativedecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taurapidityspectrum">
+<prefLabel xml:lang="en">neutrino/tau: rapidity spectrum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#rapidityspectrum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauraredecay">
+<prefLabel xml:lang="en">neutrino/tau: rare decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#raredecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauregeneration">
+<prefLabel xml:lang="en">neutrino/tau: regeneration</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#regeneration"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauright-handed">
+<prefLabel xml:lang="en">neutrino/tau: right-handed</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#right-handed"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tausearchfor">
+<prefLabel xml:lang="en">neutrino/tau: search for</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#searchfor"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tausecondarybeam">
+<prefLabel xml:lang="en">neutrino/tau: secondary beam</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#secondarybeam"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tausemileptonicdecay">
+<prefLabel xml:lang="en">neutrino/tau: semileptonic decay</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#semileptonicdecay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/taushowers">
+<prefLabel xml:lang="en">neutrino/tau: showers</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#showers"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tausignature">
+<prefLabel xml:lang="en">neutrino/tau: signature</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#signature"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tautransversemomentum">
+<prefLabel xml:lang="en">neutrino/tau: transverse momentum</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#transversemomentum"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauwavefunction">
+<prefLabel xml:lang="en">neutrino/tau: wave function</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#wavefunction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrino/tauyield">
+<prefLabel xml:lang="en">neutrino/tau: yield</prefLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrino/tau"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#yield"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.accelerationshockwaves">
+<prefLabel xml:lang="en">acceleration: shock waves</prefLabel>
+  <altLabel xml:lang="en">shock acceleration</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#acceleration"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#shockwaves"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.accelerationwakefield">
+<prefLabel xml:lang="en">acceleration: wake field</prefLabel>
+  <altLabel xml:lang="en">wakefield acceleration</altLabel>
+  <altLabel xml:lang="en">wake field acceleration</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#acceleration"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#wakefield"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.acceleratorplasma">
+<prefLabel xml:lang="en">accelerator: plasma</prefLabel>
+  <altLabel xml:lang="en">plasma wakefield acceleration</altLabel>
+  <altLabel xml:lang="en">plasma wake field acceleration</altLabel>
+  <altLabel xml:lang="en">laser-plasma acceleration</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#accelerator"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#plasma"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.angulardistributionasymmetry">
+<prefLabel xml:lang="en">angular distribution: asymmetry</prefLabel>
+  <altLabel xml:lang="en">azimuthal asymmetry</altLabel>
+  <altLabel xml:lang="en">forward-backward asymmetry</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#angulardistribution"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#asymmetry"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.approximationclassical">
+<prefLabel xml:lang="en">approximation: classical</prefLabel>
+  <altLabel xml:lang="en">classical limit</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#approximation"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#classical"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.approximationdensity">
+<prefLabel xml:lang="en">approximation: density</prefLabel>
+  <altLabel xml:lang="en">local density approximation</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#approximation"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#density"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.approximationquasiparticle">
+<composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.approximationquasiparticlecoherence"/>
+<prefLabel xml:lang="en">approximation: quasiparticle</prefLabel>
+  <altLabel xml:lang="en">QPA</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#approximation"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#quasiparticle"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.approximationstrongcoupling">
+<prefLabel xml:lang="en">approximation: strong coupling</prefLabel>
+  <altLabel xml:lang="en">strong coupling limit</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#approximation"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#strongcoupling"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.baryonhadronspectroscopy">
+<prefLabel xml:lang="en">baryon: hadron spectroscopy</prefLabel>
+  <altLabel xml:lang="en">baryon spectroscopy</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#baryon"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadronspectroscopy"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.baryontechnicolor">
+<prefLabel xml:lang="en">baryon: technicolor</prefLabel>
+  <altLabel xml:lang="en">technibaryon</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#baryon"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#technicolor"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.blackholecharge">
+<prefLabel xml:lang="en">black hole: charge</prefLabel>
+  <altLabel xml:lang="en">charged black hole</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#blackhole"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#charge"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.blackholeentropy">
+<prefLabel xml:lang="en">black hole: entropy</prefLabel>
+  <altLabel xml:lang="en">Bekenstein-Hawking</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#blackhole"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#entropy"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomboostedparticle">
+<prefLabel xml:lang="en">bottom: boosted particle</prefLabel>
+  <altLabel xml:lang="en">boosted bottom</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#boostedparticle"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.bottomparticleidentification">
+<prefLabel xml:lang="en">bottom: particle identification</prefLabel>
+  <altLabel xml:lang="en">b-tagging</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#particleidentification"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.calciumfluorine">
+<prefLabel xml:lang="en">calcium: fluorine</prefLabel>
+  <altLabel xml:lang="en">CdF</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#calcium"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fluorine"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.calciumtungsten">
+<prefLabel xml:lang="en">calcium: tungsten</prefLabel>
+  <altLabel xml:lang="en">CaW</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#calcium"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#tungsten"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.causalityviolation">
+<prefLabel xml:lang="en">causality: violation</prefLabel>
+  <altLabel xml:lang="en">CTC</altLabel>
+  <altLabel xml:lang="en">closed timelike curve</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#causality"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#violation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.CERNLHCCollupgrade">
+<prefLabel xml:lang="en">CERN LHC Coll: upgrade</prefLabel>
+  <altLabel xml:lang="en">SLHC</altLabel>
+  <altLabel xml:lang="en">HL-LHC</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#CERNLHCColl"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#upgrade"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.charmparton">
+<prefLabel xml:lang="en">charm: parton</prefLabel>
+  <altLabel xml:lang="en">charm content</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#charm"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#parton"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.CKMmatrixunitarity">
+<prefLabel xml:lang="en">CKM matrix: unitarity</prefLabel>
+  <altLabel xml:lang="en">unitarity triangle</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#CKMmatrix"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#unitarity"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Comptonscatteringbackscatter">
+<prefLabel xml:lang="en">Compton scattering: backscatter</prefLabel>
+  <altLabel xml:lang="en">backward Compton scattering</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Comptonscattering"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#backscatter"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.computernetwork">
+<prefLabel xml:lang="en">computer: network</prefLabel>
+  <altLabel xml:lang="en">computer cluster</altLabel>
+  <altLabel xml:lang="en">computer farm</altLabel>
+  <altLabel xml:lang="en">grid computing</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#computer"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#network"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.cosmicradiationUHE">
+<prefLabel xml:lang="en">cosmic radiation: UHE</prefLabel>
+  <altLabel xml:lang="en">UHECR</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#cosmicradiation"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#UHE"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterlifetime">
+<prefLabel xml:lang="en">dark matter: lifetime</prefLabel>
+  <altLabel xml:lang="en">dynamic dark matter</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#darkmatter"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#lifetime"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.darkmatterstring">
+<prefLabel xml:lang="en">dark matter: string</prefLabel>
+  <altLabel xml:lang="en">dark string</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#darkmatter"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#string"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.decayweakinteraction">
+<prefLabel xml:lang="en">decay: weak interaction</prefLabel>
+  <altLabel xml:lang="en">weak decay</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decay"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#weakinteraction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.deepinelasticscatteringinclusivereaction">
+<prefLabel xml:lang="en">deep inelastic scattering: inclusive reaction</prefLabel>
+  <altLabel xml:lang="en">inclusive deep inelastic scattering</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#deepinelasticscattering"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#inclusivereaction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.deepinelasticscatteringsemi-inclusivereaction">
+<prefLabel xml:lang="en">deep inelastic scattering: semi-inclusive reaction</prefLabel>
+  <altLabel xml:lang="en">SIDIS</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#deepinelasticscattering"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#semi-inclusivereaction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.electricfieldlow">
+<prefLabel xml:lang="en">electric field: low</prefLabel>
+  <altLabel xml:lang="en">weak electric field</altLabel>
+  <altLabel xml:lang="en">small electric field</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electricfield"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#low"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.electromagneticfieldlow">
+<prefLabel xml:lang="en">electromagnetic field: low</prefLabel>
+  <altLabel xml:lang="en">weak electromagnetic field</altLabel>
+  <altLabel xml:lang="en">small electromagnetic field</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electromagneticfield"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#low"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.electronnucleoncollidingbeams">
+<prefLabel xml:lang="en">electron nucleon: colliding beams</prefLabel>
+  <altLabel xml:lang="en">electron ion collider</altLabel>
+  <altLabel xml:lang="en">ELIC</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electronnucleon"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#collidingbeams"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.electroweakinteractioncriticalphenomena">
+<prefLabel xml:lang="en">electroweak interaction: critical phenomena</prefLabel>
+  <altLabel xml:lang="en">electroweak phase transition</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electroweakinteraction"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#criticalphenomena"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.electroweakinteractionprecisionmeasurement">
+<prefLabel xml:lang="en">electroweak interaction: precision measurement</prefLabel>
+  <altLabel xml:lang="en">electroweak fit</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electroweakinteraction"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#precisionmeasurement"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.electroweakinteractionsymmetrybreaking">
+<prefLabel xml:lang="en">electroweak interaction: symmetry breaking</prefLabel>
+  <altLabel xml:lang="en">EWSB</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electroweakinteraction"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#symmetrybreaking"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fermiontechnicolor">
+<prefLabel xml:lang="en">fermion: technicolor</prefLabel>
+  <altLabel xml:lang="en">technifermion</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fermion"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#technicolor"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fieldequationsYang-Mills">
+<prefLabel xml:lang="en">field equations: Yang-Mills</prefLabel>
+  <altLabel xml:lang="en">Yang-Mills equations</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fieldequations"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Yang-Mills"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fieldtheoryquintessence">
+<prefLabel xml:lang="en">field theory: quintessence</prefLabel>
+  <altLabel xml:lang="en">Quintessence field</altLabel>
+  <altLabel xml:lang="en">Quintessence theory</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fieldtheory"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#quintessence"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fieldtheorytopological">
+<prefLabel xml:lang="en">field theory: topological</prefLabel>
+  <altLabel xml:lang="en">TQFT</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fieldtheory"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#topological"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.fundamentalconstantPlanck">
+<prefLabel xml:lang="en">fundamental constant: Planck</prefLabel>
+  <altLabel xml:lang="en">Planck constant</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#fundamentalconstant"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Planck"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.gaugefieldtheoryboson">
+<prefLabel xml:lang="en">gauge field theory: boson</prefLabel>
+  <altLabel xml:lang="en">bosonic field</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#gaugefieldtheory"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#boson"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.gluonRegge">
+<prefLabel xml:lang="en">gluon: Regge</prefLabel>
+  <altLabel xml:lang="en">reggeon</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#gluon"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Regge"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.gravitationalradiationplanewave">
+<prefLabel xml:lang="en">gravitational radiation: plane wave</prefLabel>
+  <altLabel xml:lang="en">plane gravitational wave</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#gravitationalradiation"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#planewave"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.gravitationelectromagnetic">
+<prefLabel xml:lang="en">gravitation: electromagnetic</prefLabel>
+  <altLabel xml:lang="en">gravitoelectromagnetism</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#gravitation"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electromagnetic"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.gravitationHorava-Lifshitz">
+<prefLabel xml:lang="en">gravitation: Horava-Lifshitz</prefLabel>
+  <altLabel xml:lang="en">Horava gravity</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#gravitation"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Horava-Lifshitz"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.gravitationmodel">
+<prefLabel xml:lang="en">gravitation: model</prefLabel>
+  <altLabel xml:lang="en">modified gravity</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#gravitation"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#model"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.gravitationtransverse">
+<prefLabel xml:lang="en">gravitation: transverse</prefLabel>
+  <altLabel xml:lang="en">transverse gravity</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#gravitation"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#transverse"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.hadronizationstatistical">
+<prefLabel xml:lang="en">hadronization: statistical</prefLabel>
+  <altLabel xml:lang="en">SHM</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadronization"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#statistical"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Higgsparticleboostedparticle">
+<prefLabel xml:lang="en">Higgs particle: boosted particle</prefLabel>
+  <altLabel xml:lang="en">boosted Higgs</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Higgsparticle"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#boostedparticle"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Higgsparticlechargedparticle">
+<prefLabel xml:lang="en">Higgs particle: charged particle</prefLabel>
+  <altLabel xml:lang="en">charged Higgs</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Higgsparticle"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#chargedparticle"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Higgsparticlemassdifference">
+<prefLabel xml:lang="en">Higgs particle: mass difference</prefLabel>
+  <altLabel xml:lang="en">doublet-triplet splitting</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Higgsparticle"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#massdifference"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Higgsparticlemass">
+<prefLabel xml:lang="en">Higgs particle: mass</prefLabel>
+  <altLabel xml:lang="en">Higgs mass</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Higgsparticle"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mass"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Higgsparticlemultiplet">
+<prefLabel xml:lang="en">Higgs particle: multiplet</prefLabel>
+  <altLabel xml:lang="en">Higgs multiplet</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Higgsparticle"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#multiplet"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Higgsparticletriplet">
+<prefLabel xml:lang="en">Higgs particle: triplet</prefLabel>
+  <altLabel xml:lang="en">Higgs triplet</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Higgsparticle"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#triplet"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.hydrogenmuonicatom">
+<prefLabel xml:lang="en">hydrogen: muonic atom</prefLabel>
+  <altLabel xml:lang="en">muonic hydrogen</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hydrogen"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#muonicatom"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.IceCubesurface">
+<prefLabel xml:lang="en">IceCube: surface</prefLabel>
+  <altLabel xml:lang="en">IceTop</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#IceCube"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#surface"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.inflatonHiggsparticle">
+<prefLabel xml:lang="en">inflaton: Higgs particle</prefLabel>
+  <altLabel xml:lang="en">Higgs inflation</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#inflaton"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Higgsparticle"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.jetbottom">
+<prefLabel xml:lang="en">jet: bottom</prefLabel>
+  <altLabel xml:lang="en">b-jet</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#jet"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bottom"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Jona-Lasinio-NambumodelPolyakovloop">
+<prefLabel xml:lang="en">Jona-Lasinio-Nambu model: Polyakov loop</prefLabel>
+  <altLabel xml:lang="en">PNJL</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Jona-Lasinio-Nambumodel"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Polyakovloop"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.latticefieldtheoryaction">
+<prefLabel xml:lang="en">lattice field theory: action</prefLabel>
+  <altLabel xml:lang="en">lattice action</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#latticefieldtheory"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#action"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.loopintegral0">
+<prefLabel xml:lang="en">loop integral: 0</prefLabel>
+  <altLabel xml:lang="en">vacuum integral</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#loopintegral"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#0"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.loopintegral1">
+<prefLabel xml:lang="en">loop integral: 1</prefLabel>
+  <altLabel xml:lang="en">tadpole integral</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#loopintegral"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#1"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.loopintegral3">
+<prefLabel xml:lang="en">loop integral: 3</prefLabel>
+  <altLabel xml:lang="en">triangle integral</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#loopintegral"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#3"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.loopintegral4">
+<prefLabel xml:lang="en">loop integral: 4</prefLabel>
+  <altLabel xml:lang="en">box integral</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#loopintegral"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#4"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.loopintegral5">
+<prefLabel xml:lang="en">loop integral: 5</prefLabel>
+  <altLabel xml:lang="en">pentagon integral</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#loopintegral"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#5"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.loopintegral6">
+<prefLabel xml:lang="en">loop integral: 6</prefLabel>
+  <altLabel xml:lang="en">hexagon integral</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#loopintegral"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#6"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.loopintegral8">
+<prefLabel xml:lang="en">loop integral: 8</prefLabel>
+  <altLabel xml:lang="en">octagon integral</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#loopintegral"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#8"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.matterstrangeness">
+<prefLabel xml:lang="en">matter: strangeness</prefLabel>
+  <altLabel xml:lang="en">strange quark matter</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#matter"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#strangeness"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.mesonhadronspectroscopy">
+<prefLabel xml:lang="en">meson: hadron spectroscopy</prefLabel>
+  <altLabel xml:lang="en">meson spectroscopy</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#meson"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hadronspectroscopy"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.mesonphotoproduction">
+<prefLabel xml:lang="en">meson: photoproduction</prefLabel>
+  <altLabel xml:lang="en">photomeson</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#meson"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#photoproduction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutralcurrentflavorchanging">
+<prefLabel xml:lang="en">neutral current: flavor changing</prefLabel>
+  <altLabel xml:lang="en">FCNC</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutralcurrent"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#flavorchanging"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.partondistributionfunction">
+<composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.nucleonpartondistributionfunction"/>
+<prefLabel xml:lang="en">parton: distribution function</prefLabel>
+  <altLabel xml:lang="en">parton distribution</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#parton"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#distributionfunction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.partoninteraction">
+<prefLabel xml:lang="en">parton: interaction</prefLabel>
+  <altLabel xml:lang="en">parton collision</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#parton"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#interaction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.phi**nmodel3">
+<prefLabel xml:lang="en">phi**n model: 3</prefLabel>
+  <altLabel xml:lang="en">phi**3</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#phi**nmodel"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#3"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.phi**nmodel4">
+<prefLabel xml:lang="en">phi**n model: 4</prefLabel>
+  <altLabel xml:lang="en">phi**4</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#phi**nmodel"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#4"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.phi**nmodel6">
+<prefLabel xml:lang="en">phi**n model: 6</prefLabel>
+  <altLabel xml:lang="en">phi**6</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#phi**nmodel"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#6"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.pi-mesicatom">
+<prefLabel xml:lang="en">pi-: mesic atom</prefLabel>
+  <altLabel xml:lang="en">pionic atom</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#pi-"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#mesicatom"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumchromodynamicsnonrelativistic">
+<prefLabel xml:lang="en">quantum chromodynamics: nonrelativistic</prefLabel>
+  <altLabel xml:lang="en">NRQCD</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#quantumchromodynamics"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#nonrelativistic"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumchromodynamicsperturbationtheory">
+<composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumchromodynamicsperturbationtheoryhigher-order"/>
+<prefLabel xml:lang="en">quantum chromodynamics: perturbation theory</prefLabel>
+  <altLabel xml:lang="en">perturbative QCD</altLabel>
+  <altLabel xml:lang="en">pQCD</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#quantumchromodynamics"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#perturbationtheory"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumchromodynamicsvacuumstate">
+<prefLabel xml:lang="en">quantum chromodynamics: vacuum state</prefLabel>
+  <altLabel xml:lang="en">QCD vacuum</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#quantumchromodynamics"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#vacuumstate"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumcosmologyloopspace">
+<prefLabel xml:lang="en">quantum cosmology: loop space</prefLabel>
+  <altLabel xml:lang="en">loop quantum cosmology</altLabel>
+  <altLabel xml:lang="en">LQC</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#quantumcosmology"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#loopspace"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumelectrodynamicssupersymmetry">
+<prefLabel xml:lang="en">quantum electrodynamics: supersymmetry</prefLabel>
+  <altLabel xml:lang="en">SQED</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#quantumelectrodynamics"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#supersymmetry"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumfieldtheoryDirac">
+<prefLabel xml:lang="en">quantum field theory: Dirac</prefLabel>
+  <altLabel xml:lang="en">Dirac field</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#quantumfieldtheory"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Dirac"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumfieldtheoryLiouville">
+<prefLabel xml:lang="en">quantum field theory: Liouville</prefLabel>
+  <altLabel xml:lang="en">Liouville theory</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#quantumfieldtheory"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Liouville"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumfieldtheoryProca">
+<prefLabel xml:lang="en">quantum field theory: Proca</prefLabel>
+  <altLabel xml:lang="en">Proca theory</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#quantumfieldtheory"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Proca"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumgravityloopspace">
+<prefLabel xml:lang="en">quantum gravity: loop space</prefLabel>
+  <altLabel xml:lang="en">loop quantum gravity</altLabel>
+  <altLabel xml:lang="en">loop gravity</altLabel>
+  <altLabel xml:lang="en">LQG</altLabel>
+  <altLabel xml:lang="en">QRLG</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#quantumgravity"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#loopspace"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.quarkgluonbagmodel">
+<prefLabel xml:lang="en">quark gluon: bag model</prefLabel>
+  <altLabel xml:lang="en">quark gluon bag</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#quarkgluon"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#bagmodel"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.radiationCherenkov">
+<prefLabel xml:lang="en">radiation: Cherenkov</prefLabel>
+  <altLabel xml:lang="en">Cherenkov light</altLabel>
+  <altLabel xml:lang="en">Cherenkov photon</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#radiation"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Cherenkov"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.scaleelectroweakinteraction">
+<prefLabel xml:lang="en">scale: electroweak interaction</prefLabel>
+  <altLabel xml:lang="en">weak scale</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#scale"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#electroweakinteraction"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.scalePlanck">
+<prefLabel xml:lang="en">scale: Planck</prefLabel>
+  <altLabel xml:lang="en">Planck mass</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#scale"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Planck"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.sneutrinoinflaton">
+<prefLabel xml:lang="en">sneutrino: inflaton</prefLabel>
+  <altLabel xml:lang="en">sneutrino inflation</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#sneutrino"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#inflaton"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.starstrangeness">
+<prefLabel xml:lang="en">star: strangeness</prefLabel>
+  <altLabel xml:lang="en">strange star</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#star"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#strangeness"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.stringdecay">
+<prefLabel xml:lang="en">string: decay</prefLabel>
+  <altLabel xml:lang="en">string breaking</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#string"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#decay"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.stringGreen-Schwarz">
+<prefLabel xml:lang="en">string: Green-Schwarz</prefLabel>
+  <altLabel xml:lang="en">Green-Schwarz action</altLabel>
+  <altLabel xml:lang="en">Green-Schwarz superstring</altLabel>
+  <altLabel xml:lang="en">H: 2010-11-18 Saul</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#string"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Green-Schwarz"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.stringmodelboson">
+<prefLabel xml:lang="en">string model: boson</prefLabel>
+  <altLabel xml:lang="en">bosonic string</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#stringmodel"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#boson"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.stringmodelheterotic">
+<prefLabel xml:lang="en">string model: heterotic</prefLabel>
+  <altLabel xml:lang="en">heterotic string</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#stringmodel"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#heterotic"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.stronginteractioncouplingconstant">
+<prefLabel xml:lang="en">strong interaction: coupling constant</prefLabel>
+  <altLabel xml:lang="en">strong coupling constant</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#stronginteraction"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#couplingconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.supergravityminimal">
+<prefLabel xml:lang="en">supergravity: minimal</prefLabel>
+  <altLabel xml:lang="en">mSUGRA</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#supergravity"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#minimal"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.supersymmetry1">
+<prefLabel xml:lang="en">supersymmetry: 1</prefLabel>
+  <altLabel xml:lang="en">N=1 SYM</altLabel>
+  <altLabel xml:lang="en">N=1 super</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#supersymmetry"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#1"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.supersymmetry2">
+<prefLabel xml:lang="en">supersymmetry: 2</prefLabel>
+  <altLabel xml:lang="en">N=2 SYM</altLabel>
+  <altLabel xml:lang="en">N=2 super</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#supersymmetry"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#2"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.supersymmetry4">
+<prefLabel xml:lang="en">supersymmetry: 4</prefLabel>
+  <altLabel xml:lang="en">N=4 SYM</altLabel>
+  <altLabel xml:lang="en">N=4 super</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#supersymmetry"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#4"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.supersymmetry6">
+<prefLabel xml:lang="en">supersymmetry: 6</prefLabel>
+  <altLabel xml:lang="en">N=6 SYM</altLabel>
+  <altLabel xml:lang="en">N=6 super</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#supersymmetry"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#6"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.supersymmetry8">
+<prefLabel xml:lang="en">supersymmetry: 8</prefLabel>
+  <altLabel xml:lang="en">N=8 SYM</altLabel>
+  <altLabel xml:lang="en">N=8 super</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#supersymmetry"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#8"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.supersymmetryalgebra">
+<prefLabel xml:lang="en">supersymmetry: algebra</prefLabel>
+  <altLabel xml:lang="en">superalgebra</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#supersymmetry"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#algebra"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.supersymmetryhiddensymmetry">
+<prefLabel xml:lang="en">supersymmetry: hidden symmetry</prefLabel>
+  <altLabel xml:lang="en">hidden supersymmetry</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#supersymmetry"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#hiddensymmetry"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.supersymmetryspontaneoussymmetrybreaking">
+<prefLabel xml:lang="en">supersymmetry: spontaneous symmetry breaking</prefLabel>
+  <altLabel xml:lang="en">spontaneous supersymmetry breaking</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#supersymmetry"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#spontaneoussymmetrybreaking"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.supersymmetrysymmetrybreaking">
+<prefLabel xml:lang="en">supersymmetry: symmetry breaking</prefLabel>
+  <altLabel xml:lang="en">supersymmetry breaking</altLabel>
+  <altLabel xml:lang="en">SUSY breaking</altLabel>
+  <altLabel xml:lang="en">broken supersymmetry</altLabel>
+  <altLabel xml:lang="en">broken SUSY</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#supersymmetry"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#symmetrybreaking"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.symmetryPeccei-Quinn">
+<prefLabel xml:lang="en">symmetry: Peccei-Quinn</prefLabel>
+  <altLabel xml:lang="en">PQ symmetry</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#symmetry"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Peccei-Quinn"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.topboostedparticle">
+<prefLabel xml:lang="en">top: boosted particle</prefLabel>
+  <altLabel xml:lang="en">boosted top</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#top"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#boostedparticle"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.weakinteractioncouplingconstant">
+<prefLabel xml:lang="en">weak interaction: coupling constant</prefLabel>
+  <altLabel xml:lang="en">Fermi constant</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#weakinteraction"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#couplingconstant"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.Z0boostedparticle">
+<prefLabel xml:lang="en">Z0: boosted particle</prefLabel>
+  <altLabel xml:lang="en">boosted Z</altLabel>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Z0"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#boostedparticle"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.approximationquasiparticlecoherence">
+<prefLabel xml:lang="en">approximation: quasiparticle: coherence </prefLabel>
+<compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#approximationquasiparticle"/>
+<compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#coherence"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinomasstimedependence">
+<prefLabel xml:lang="en">neutrino: mass: time dependence </prefLabel>
+<compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#neutrinomass"/>
+<compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#timedependence"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.nucleonpartondistributionfunction">
+<prefLabel xml:lang="en">nucleon: parton: distribution function </prefLabel>
+<compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#partondistributionfunction"/>
+<compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#nucleon"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.quantumchromodynamicsperturbationtheoryhigher-order">
+<prefLabel xml:lang="en">quantum chromodynamics: perturbation theory: higher-order </prefLabel>
+<compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#quantumchromodynamicsperturbationtheory"/>
+<compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#higher-order"/>
+</Concept>
+</rdf:RDF>

--- a/inspirehep/taxonomies/HEPontCore.rdf
+++ b/inspirehep/taxonomies/HEPontCore.rdf
@@ -5475,6 +5475,7 @@
 
 <Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#radiation">
   <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.radiationCherenkov"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.radiationHawking"/>
   <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.neutrinoradiation"/>
   <prefLabel xml:lang="en">radiation</prefLabel>
 </Concept>
@@ -6705,6 +6706,7 @@
   <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.flavorviolation"/>
   <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.CPTviolation"/>
   <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.CPviolation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.equivalenceprincipleviolation"/>
   <prefLabel xml:lang="en">violation</prefLabel>
 </Concept>
 
@@ -16039,4 +16041,49 @@
 <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#quantumchromodynamicsperturbationtheory"/>
 <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#higher-order"/>
 </Concept>
+
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.radiationHawking">
+<prefLabel xml:lang="en">radiation: Hawking</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#radiation"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Hawking"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Unruheffect">
+  <prefLabel xml:lang="en">Unruh effect</prefLabel>
+   <note xml:lang="en">core</note>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.equivalenceprinciplevaliditytest">
+<prefLabel xml:lang="en">equivalence principle: validity test</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#equivalenceprinciple"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#validitytest"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Composite.equivalenceprincipleviolation">
+<prefLabel xml:lang="en">equivalence principle: violation</prefLabel>
+   <note xml:lang="en">core</note>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#equivalenceprinciple"/>
+  <compositeOf rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#violation"/>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#equivalenceprinciple">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.equivalenceprincipleviolation"/>
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.equivalenceprinciplevaliditytest"/>
+  <prefLabel xml:lang="en">equivalence principle</prefLabel>
+  <altLabel xml:lang="en">SEP</altLabel>
+  <altLabel xml:lang="en">WEP</altLabel>
+  <altLabel xml:lang="en">principle of equivalence</altLabel>
+  <definition xml:lang="en">acceleration produces an artificial gravity and, conversely, gravity is indistinguishable from acceleration</definition>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Hawking">
+  <composite rdf:resource="http://cern.ch/thesauri/HEPontology.rdf#Composite.radiationHawking"/>
+  <prefLabel xml:lang="en">Hawking</prefLabel>
+  <note xml:lang="en">noautosingle</note>
+  <note xml:lang="en">nostandalone</note>
+</Concept>
+
 </rdf:RDF>

--- a/inspirehep/taxonomies/antiHEPont.rdf
+++ b/inspirehep/taxonomies/antiHEPont.rdf
@@ -1,0 +1,707 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- antiHEP ontology v.0.1 - Oct 2013 -->
+
+<rdf:RDF xmlns="http://www.w3.org/2004/02/skos/core#"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"> 
+
+<rdf:Property rdf:about="http://cern.ch/thesauri/HEPontology.rdf#compositeOf">
+  <rdfs:comment>Expresses a composite keyword relationship to broader concepts.</rdfs:comment>
+  <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#broader"/>
+</rdf:Property>
+
+<rdf:Property rdf:about="http://cern.ch/thesauri/HEPontology.rdf#composite">
+  <rdfs:comment>Expresses the relationship to a composite keyword</rdfs:comment>
+  <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#narrower"/>
+</rdf:Property>
+
+<ConceptScheme rdf:about="http://cern.ch/thesauri/HEPontology.rdf">
+        <dc:creator rdf:resource="http://ceres.ca.gov/"/>
+        <dc:description>This is an ontology or rather just a list of anti keywords 
+                        indicating non-relevance for High Energy Physics.</dc:description>
+        <dc:title>anti-HEP ontology</dc:title>
+</ConceptScheme>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#abdominal">
+  <prefLabel xml:lang="en">abdominal</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#ablation">
+  <prefLabel xml:lang="en">ablation</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#acid">
+  <prefLabel xml:lang="en">acid</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#alcohol">
+  <prefLabel xml:lang="en">alcohol</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#anatomic">
+  <prefLabel xml:lang="en">anatomic</prefLabel>
+  <altLabel xml:lang="en">anatomical</altLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#angiography">
+  <prefLabel xml:lang="en">angiography</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#animal">
+  <prefLabel xml:lang="en">animal</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#biology">
+  <prefLabel xml:lang="en">biology</prefLabel>
+  <altLabel xml:lang="en">biological</altLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#biomedical">
+  <prefLabel xml:lang="en">biomedical</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#biopsy">
+  <prefLabel xml:lang="en">biopsy</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#blood">
+  <prefLabel xml:lang="en">blood</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#bone">
+  <prefLabel xml:lang="en">bone</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#bragg">
+  <prefLabel xml:lang="en">bragg</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#brain">
+  <prefLabel xml:lang="en">brain</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#breast">
+  <prefLabel xml:lang="en">breast</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#breathing">
+  <prefLabel xml:lang="en">breathing</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Bridgman">
+  <prefLabel xml:lang="en">Bridgman</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Brillouin">
+  <prefLabel xml:lang="en">Brillouin</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#cancer">
+  <prefLabel xml:lang="en">cancer</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#capillary">
+  <prefLabel xml:lang="en">capillary</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#cardiac">
+  <prefLabel xml:lang="en">cardiac</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#ceramic">
+  <prefLabel xml:lang="en">ceramic</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#cerebral">
+  <prefLabel xml:lang="en">cerebral</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Cerebralcreatinedeficiencysyndromes">
+  <prefLabel xml:lang="en">Cerebral creatine deficiency syndromes</prefLabel>
+  <altLabel xml:lang="en">CCDS</altLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Chandra">
+  <prefLabel xml:lang="en">Chandra</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#chemistry">
+  <prefLabel xml:lang="en">chemistry</prefLabel>
+  <altLabel xml:lang="en">chemical</altLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#chromosome">
+  <prefLabel xml:lang="en">chromosome</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#circumstellar">
+  <prefLabel xml:lang="en">circumstellar</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#clinical">
+  <prefLabel xml:lang="en">clinical</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#clouds">
+  <prefLabel xml:lang="en">clouds</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#computedtomography">
+  <prefLabel xml:lang="en">computed tomography</prefLabel>
+  <altLabel xml:lang="en">CBCT</altLabel>
+  <altLabel xml:lang="en">CT imaging</altLabel>
+  <altLabel xml:lang="en">CT scan</altLabel>
+  <altLabel xml:lang="en">CT systems</altLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#corona">
+  <prefLabel xml:lang="en">corona</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#crack">
+  <prefLabel xml:lang="en">crack</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#crystallization">
+  <prefLabel xml:lang="en">crystallization</prefLabel>
+  <altLabel xml:lang="en">crystalline</altLabel>
+  <altLabel xml:lang="en">crystallographic</altLabel>
+  <altLabel xml:lang="en">inter-crystal</altLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#dioxide">
+  <prefLabel xml:lang="en">dioxide</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#disease">
+  <prefLabel xml:lang="en">disease</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#DNA">
+  <prefLabel xml:lang="en">DNA</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#doped">
+  <prefLabel xml:lang="en">doped</prefLabel>
+  <altLabel xml:lang="en">dopant</altLabel>
+  <altLabel xml:lang="en">doping</altLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#dwarfs">
+  <prefLabel xml:lang="en">dwarfs</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#dwarfs">
+  <prefLabel xml:lang="en">Dzyaloshinskii-Moriya</prefLabel>
+  <altLabel xml:lang="en">Dzyaloshinsky-Moriya</altLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#editorial">
+  <prefLabel xml:lang="en">editorial</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#electrochemical">
+  <prefLabel xml:lang="en">electrochemical</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#electronmicroscopy">
+  <prefLabel xml:lang="en">electron microscopy</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#epitaxial">
+  <prefLabel xml:lang="en">epitaxial</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#epoxy">
+  <prefLabel xml:lang="en">epoxy</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#extrasolar">
+  <prefLabel xml:lang="en">extrasolar</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Fibonacci">
+  <prefLabel xml:lang="en">Fibonacci</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#film">
+  <prefLabel xml:lang="en">film</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#finiteelement">
+  <prefLabel xml:lang="en">finite element</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#fission">
+  <prefLabel xml:lang="en">fission</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#flood">
+  <prefLabel xml:lang="en">flood</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#gantry">
+  <prefLabel xml:lang="en">gantry</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#geomagnetic">
+  <prefLabel xml:lang="en">geomagnetic</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#head">
+  <prefLabel xml:lang="en">head</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#health">
+  <prefLabel xml:lang="en">health</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#heart">
+  <prefLabel xml:lang="en">heart</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#heliosphere">
+  <prefLabel xml:lang="en">heliosphere</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Herschel">
+  <prefLabel xml:lang="en">Herschel</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#heterostructures">
+  <prefLabel xml:lang="en">heterostructures</prefLabel>
+  <altLabel xml:lang="en">heterostructured</altLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#homelandsecurity">
+  <prefLabel xml:lang="en">homeland security</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#imagequality">
+  <prefLabel xml:lang="en">image quality</prefLabel>
+  <altLabel xml:lang="en">imaging techniques</altLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#insitu">
+  <prefLabel xml:lang="en">in situ</prefLabel>
+  <altLabel xml:lang="en">in-situ</altLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#invivo">
+  <prefLabel xml:lang="en">in vivo</prefLabel>
+  <altLabel xml:lang="en">in-vivo</altLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#indiumarsenide">
+  <prefLabel xml:lang="en">indium arsenide</prefLabel>
+  <altLabel xml:lang="en">InAs</altLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#interplanetary">
+  <prefLabel xml:lang="en">interplanetary</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#interstellar">
+  <prefLabel xml:lang="en">interstellar</prefLabel>
+  <altLabel xml:lang="en">ISM molecules</altLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#iron">
+  <prefLabel xml:lang="en">iron</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Kepler">
+  <prefLabel xml:lang="en">Kepler</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#labpet">
+  <prefLabel xml:lang="en">labpet</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#lesions">
+  <prefLabel xml:lang="en">lesions</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#lettertotheeditor">
+  <prefLabel xml:lang="en">letter to the editor</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#LOFT">
+  <prefLabel xml:lang="en">LOFT</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#luminescence">
+  <prefLabel xml:lang="en">luminescence</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#lyso">
+  <prefLabel xml:lang="en">lyso</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#magnetron">
+  <prefLabel xml:lang="en">magnetron</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#mammography">
+  <prefLabel xml:lang="en">mammography</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#market">
+  <prefLabel xml:lang="en">market</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#medical">
+  <prefLabel xml:lang="en">medical</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#medicine">
+  <prefLabel xml:lang="en">medicine</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#metabolism">
+  <prefLabel xml:lang="en">metabolism</prefLabel>
+  <altLabel xml:lang="en">metabolic</altLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#metallic">
+  <prefLabel xml:lang="en">metallic</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#mice">
+  <prefLabel xml:lang="en">mice</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#microscope">
+  <prefLabel xml:lang="en">microscope</prefLabel>
+  <altLabel xml:lang="en">microscopy</altLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#mouse">
+  <prefLabel xml:lang="en">mouse</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#multipinhole">
+  <prefLabel xml:lang="en">multipinhole</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#myocardial">
+  <prefLabel xml:lang="en">myocardial</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#myocardium">
+  <prefLabel xml:lang="en">myocardium</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#nanoparticle">
+  <prefLabel xml:lang="en">nanoparticle</prefLabel>
+  <altLabel xml:lang="en">nanoribbon</altLabel>
+  <altLabel xml:lang="en">nanostructure</altLabel>
+  <altLabel xml:lang="en">nanotube</altLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Navier-Stokes">
+  <prefLabel xml:lang="en">Navier-Stokes</prefLabel>
+  <altLabel xml:lang="en">Navier Stokes</altLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#near-infrared">
+  <prefLabel xml:lang="en">near-infrared</prefLabel>
+  <altLabel xml:lang="en">infrared spectroscopy</altLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#networks">
+  <prefLabel xml:lang="en">networks</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#neuronal">
+  <prefLabel xml:lang="en">neuronal</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#nonarticle">
+  <prefLabel xml:lang="en">nonarticle</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#nuclearmedicine">
+  <prefLabel xml:lang="en">nuclear medicine</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#oncology">
+  <prefLabel xml:lang="en">oncology</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#organ">
+  <prefLabel xml:lang="en">organ</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#OSEM">
+  <prefLabel xml:lang="en">OSEM</prefLabel>
+  <altLabel xml:lang="en">ordered subset expectation maximization</altLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#oxide">
+  <prefLabel xml:lang="en">oxide</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#oxyorthosilicate">
+  <prefLabel xml:lang="en">oxyorthosilicate</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#para-Methoxymethamphetamine">
+  <prefLabel xml:lang="en">para-Methoxymethamphetamine</prefLabel>
+  <altLabel xml:lang="en">PMMA</altLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#patient">
+  <prefLabel xml:lang="en">patient</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#peltier">
+  <prefLabel xml:lang="en">peltier</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#photoemission">
+  <prefLabel xml:lang="en">photoemission</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#photonic">
+  <prefLabel xml:lang="en">photonic</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#photovoltaic">
+  <prefLabel xml:lang="en">photovoltaic</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#physiological">
+  <prefLabel xml:lang="en">physiological</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#piezoelectric">
+  <prefLabel xml:lang="en">piezoelectric</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#pinhole">
+  <prefLabel xml:lang="en">pinhole</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#planetary">
+  <prefLabel xml:lang="en">planetary</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#plastic">
+  <prefLabel xml:lang="en">plastic</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#population">
+  <prefLabel xml:lang="en">population</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#positioning">
+  <prefLabel xml:lang="en">positioning</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#positronemissiontomography">
+  <prefLabel xml:lang="en">positron emission tomography</prefLabel>
+  <altLabel xml:lang="en">511keV</altLabel>
+  <altLabel xml:lang="en">ECAT</altLabel>
+  <altLabel xml:lang="en">HRRT</altLabel>
+  <altLabel xml:lang="en">high-resolution research tomograph</altLabel>
+  <altLabel xml:lang="en">pet data</altLabel>
+  <altLabel xml:lang="en">pet scanner</altLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#powder">
+  <prefLabel xml:lang="en">powder</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#preclinical">
+  <prefLabel xml:lang="en">preclinical</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#price-change">
+  <prefLabel xml:lang="en">price-change</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#protein">
+  <prefLabel xml:lang="en">protein</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#protoplanetary">
+  <prefLabel xml:lang="en">protoplanetary</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#pyriolysis">
+  <prefLabel xml:lang="en">pyriolysis</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#radiography">
+  <prefLabel xml:lang="en">radiography</prefLabel>
+  <altLabel xml:lang="en">low dose</altLabel>
+  <altLabel xml:lang="en">radioisotopes</altLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Raman">
+  <prefLabel xml:lang="en">Raman</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#randomwalk">
+  <prefLabel xml:lang="en">random walk</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#rat">
+  <prefLabel xml:lang="en">rat</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Rayleigh">
+  <prefLabel xml:lang="en">Rayleigh</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#respiration">
+  <prefLabel xml:lang="en">respiration</prefLabel>
+  <altLabel xml:lang="en">respiratory</altLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Riemann-Liouville">
+  <prefLabel xml:lang="en">Riemann-Liouville</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#roughness">
+  <prefLabel xml:lang="en">roughness</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Schottky">
+  <prefLabel xml:lang="en">Schottky</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#sinogram">
+  <prefLabel xml:lang="en">sinogram</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#socioeconomic">
+  <prefLabel xml:lang="en">socioeconomic</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#solid-state">
+  <prefLabel xml:lang="en">solid-state</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#specimen">
+  <prefLabel xml:lang="en">specimen</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#SPECT">
+  <prefLabel xml:lang="en">SPECT</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#starformation">
+  <prefLabel xml:lang="en">star formation</prefLabel>
+  <altLabel xml:lang="en">star-forming</altLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#starburst">
+  <prefLabel xml:lang="en">starburst</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#stellarmass">
+  <prefLabel xml:lang="en">stellar mass</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#stockexchange">
+  <prefLabel xml:lang="en">stock exchange</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#substrates">
+  <prefLabel xml:lang="en">substrates</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#surgery">
+  <prefLabel xml:lang="en">surgery</prefLabel>
+  <altLabel xml:lang="en">surgical</altLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#tandemaccelerator">
+  <prefLabel xml:lang="en">tandem accelerator</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#temperaturerange">
+  <prefLabel xml:lang="en">temperature range</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#terahertz">
+  <prefLabel xml:lang="en">terahertz</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#terrestrial">
+  <prefLabel xml:lang="en">terrestrial</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#therapy">
+  <prefLabel xml:lang="en">therapy</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#thermalneutron">
+  <prefLabel xml:lang="en">thermal neutron</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#thermoluminescence">
+  <prefLabel xml:lang="en">thermoluminescence</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#thinfilms">
+  <prefLabel xml:lang="en">thin films</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#tokamak">
+  <prefLabel xml:lang="en">tokamak</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#tomography">
+  <prefLabel xml:lang="en">tomography</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#traffic">
+  <prefLabel xml:lang="en">traffic</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#train">
+  <prefLabel xml:lang="en">train</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#tumor">
+  <prefLabel xml:lang="en">tumor</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#ultrasonic">
+  <prefLabel xml:lang="en">ultrasonic</prefLabel>
+  <altLabel xml:lang="en">ultrasound</altLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#vascular">
+  <prefLabel xml:lang="en">vascular</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#vessels">
+  <prefLabel xml:lang="en">vessels</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#visual">
+  <prefLabel xml:lang="en">visual</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#voxel">
+  <prefLabel xml:lang="en">voxel</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#water">
+  <prefLabel xml:lang="en">water</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#wind">
+  <prefLabel xml:lang="en">wind</prefLabel>
+</Concept>
+
+<Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Zeeman">
+  <prefLabel xml:lang="en">Zeeman</prefLabel>
+</Concept>
+
+</rdf:RDF>


### PR DESCRIPTION
* Adds a reduced ontology with only the core HEP keywords.

* Adds an anti-HEP-ontology with keywords indicating irrelevance
  for HEP.

Signed-off-by: fschwenn <florian.schwennsen@desy.de>