### PR TITLE
workflow: fix extracting keywords from PDF

### DIFF
--- a/inspirehep/modules/forms/validators/simple_fields.py
+++ b/inspirehep/modules/forms/validators/simple_fields.py
@@ -31,6 +31,8 @@ from flask.ext.login import current_user
 from idutils import is_arxiv, is_isbn
 from wtforms.validators import ValidationError, StopValidation
 
+from inspirehep.utils.url import is_pdf_link
+
 
 def _get_current_user_roles():
     return [r.name for r in current_user.roles]
@@ -62,7 +64,6 @@ def does_exist_in_inspirehep(query, collection=None):
     :param collection: collection to search in; by default searches in
         the default collection
     """
-    import requests
     from json import loads
 
     params = {
@@ -161,7 +162,7 @@ def pdf_validator(form, field):
     """Validate that the field contains a link to a PDF."""
     message = 'Please, provide an accessible direct link to a PDF document.'
 
-    if field.data and not _is_pdf_link(field.data):
+    if field.data and not is_pdf_link(field.data):
         raise StopValidation(message)
 
 
@@ -169,7 +170,7 @@ def no_pdf_validator(form, field):
     """Validate that the field does not contain a link to a PDF."""
     message = 'Please, use the field above to link to a PDF.'
 
-    if field.data and _is_pdf_link(field.data):
+    if field.data and is_pdf_link(field.data):
         raise StopValidation(message)
 
 
@@ -186,30 +187,3 @@ def date_validator(form, field):
                 break
         else:
             raise StopValidation(message)
-
-
-def _is_pdf_link(url):
-    """Return ``True`` if ``url`` points to a PDF.
-
-    Returns ``True`` if either the server replies with the correct
-    ``Content-Type`` or the first few bytes of the response are ``%PDF``.
-
-    Args:
-        url (string): a URL.
-
-    Returns:
-        bool: whether the url points to a PDF.
-
-    """
-    try:
-        response = requests.get(url, allow_redirects=True, stream=True)
-    except requests.exceptions.RequestException:
-        return False
-
-    content_type = response.headers.get('Content-Type', '')
-    correct_content_type = content_type.startswith('application/pdf')
-
-    magic_number = next(response.iter_content(4))
-    correct_magic_number = magic_number.startswith('%PDF')
-
-    return correct_content_type or correct_magic_number

--- a/inspirehep/modules/workflows/tasks/actions.py
+++ b/inspirehep/modules/workflows/tasks/actions.py
@@ -27,12 +27,15 @@ from __future__ import absolute_import, division, print_function
 from functools import wraps
 
 from flask import current_app
+from werkzeug import secure_filename
 
-from inspirehep.modules.workflows.utils import log_workflows_action
+from inspirehep.modules.workflows.utils import log_workflows_action, get_pdf_in_workflow
 
 from inspirehep.utils.record import get_arxiv_id, get_value
+from inspirehep.utils.url import is_pdf_link
 
-from ..utils import with_debug_logging
+from ..utils import download_file_to_workflow, with_debug_logging
+from .refextract import extract_references
 
 
 def mark(key, value):
@@ -194,6 +197,24 @@ def is_submission(obj, eng):
     return False
 
 
+@with_debug_logging
+def submission_fulltext_download(obj, eng):
+    submission_pdf = obj.extra_data.get('submission_pdf')
+    if submission_pdf and is_pdf_link(submission_pdf):
+        filename = secure_filename("fulltext.pdf")
+        pdf = download_file_to_workflow(
+            workflow=obj,
+            name=filename,
+            url=submission_pdf
+        )
+        if pdf:
+            pdf['doctype'] = 'main'
+            obj.log.info("PDF provided by user from {0}".format(submission_pdf))
+            return obj.files[filename].file.uri
+        else:
+            obj.log.info("Cannot fetch PDF provided by user from {0}".format(submission_pdf))
+
+
 def prepare_update_payload(extra_data_key="update_payload"):
     @with_debug_logging
     @wraps(prepare_update_payload)
@@ -204,3 +225,24 @@ def prepare_update_payload(extra_data_key="update_payload"):
         # FIXME: Just update entire record for now
         obj.extra_data[extra_data_key] = obj.data
     return _prepare_update_payload
+
+
+@with_debug_logging
+def refextract(obj, eng):
+    """Extract references from PDF.
+
+    :param obj: Workflow Object to process
+    :param eng: Workflow Engine processing the object
+    """
+    uri = get_pdf_in_workflow(obj)
+    if uri:
+        mapped_references = extract_references(uri)
+        if mapped_references:
+            obj.data["references"] = mapped_references
+            obj.log.info("Extracted {0} references".format(
+                len(mapped_references)
+            ))
+        else:
+            obj.log.info("No references extracted")
+    else:
+        obj.log.error("Not able to download and process the PDF")

--- a/inspirehep/modules/workflows/tasks/actions.py
+++ b/inspirehep/modules/workflows/tasks/actions.py
@@ -208,7 +208,6 @@ def submission_fulltext_download(obj, eng):
             url=submission_pdf
         )
         if pdf:
-            pdf['doctype'] = 'main'
             obj.log.info("PDF provided by user from {0}".format(submission_pdf))
             return obj.files[filename].file.uri
         else:

--- a/inspirehep/modules/workflows/tasks/arxiv.py
+++ b/inspirehep/modules/workflows/tasks/arxiv.py
@@ -74,7 +74,6 @@ def arxiv_fulltext_download(obj, eng):
             arxiv_id=arxiv_id
         )
     )
-    pdf['doctype'] = "arXiv"
     obj.log.info("PDF retrieved from arXiv for {0}".format(arxiv_id))
 
 
@@ -95,7 +94,6 @@ def arxiv_package_download(obj, eng):
         )
     )
     if tarball:
-        tarball['doctype'] = "package"
         obj.log.info("Tarball retrieved from arXiv for {0}".format(arxiv_id))
     else:
         obj.log.error("Cannot retrieve tarball from arXiv for {0}".format(arxiv_id))
@@ -129,7 +127,6 @@ def arxiv_plot_extract(obj, eng):
 
         for idx, plot in enumerate(plots):
             obj.files[plot.get('name')] = BytesIO(open(plot.get('url')))
-            obj.files[plot.get('name')]["doctype"] = "Plot"
             obj.files[plot.get('name')]["description"] = u"{0:05d} {1}".format(
                 idx, "".join(plot.get('captions', []))
             )

--- a/inspirehep/modules/workflows/tasks/arxiv.py
+++ b/inspirehep/modules/workflows/tasks/arxiv.py
@@ -37,7 +37,6 @@ from dojson.contrib.marc21.utils import create_record
 
 from inspirehep.dojson.hep import hep
 from inspirehep.dojson.utils import classify_field
-from inspirehep.utils.helpers import download_file_to_workflow
 from inspirehep.utils.record import (
     get_arxiv_categories,
     get_arxiv_id,
@@ -48,8 +47,7 @@ from plotextractor.api import process_tarball
 from plotextractor.converter import untar
 from plotextractor.errors import InvalidTarball, NoTexFilesFound
 
-from .refextract import extract_references
-from ..utils import with_debug_logging
+from ..utils import download_file_to_workflow, get_pdf_in_workflow, with_debug_logging
 
 
 REGEXP_AUTHLIST = re.compile(
@@ -68,15 +66,39 @@ def arxiv_fulltext_download(obj, eng):
     """
     arxiv_id = get_arxiv_id(obj.data)
     filename = secure_filename("{0}.pdf".format(arxiv_id))
-    if filename not in obj.files:
-        pdf = download_file_to_workflow(
-            workflow=obj,
-            name=filename,
-            url=current_app.config['ARXIV_PDF_URL'].format(
-                arxiv_id=arxiv_id
-            )
+    # We fetch if on the fly if needed
+    pdf = download_file_to_workflow(
+        workflow=obj,
+        name=filename,
+        url=current_app.config['ARXIV_PDF_URL'].format(
+            arxiv_id=arxiv_id
         )
-        pdf['doctype'] = "arXiv"
+    )
+    pdf['doctype'] = "arXiv"
+    obj.log.info("PDF retrieved from arXiv for {0}".format(arxiv_id))
+
+
+@with_debug_logging
+def arxiv_package_download(obj, eng):
+    """Perform the fulltext download step for arXiv records.
+
+    :param obj: Workflow Object to process
+    :param eng: Workflow Engine processing the object
+    """
+    arxiv_id = get_arxiv_id(obj.data)
+    filename = secure_filename("{0}.tar.gz".format(arxiv_id))
+    tarball = download_file_to_workflow(
+        workflow=obj,
+        name=filename,
+        url=current_app.config['ARXIV_TARBALL_URL'].format(
+            arxiv_id=arxiv_id
+        )
+    )
+    if tarball:
+        tarball['doctype'] = "package"
+        obj.log.info("Tarball retrieved from arXiv for {0}".format(arxiv_id))
+    else:
+        obj.log.error("Cannot retrieve tarball from arXiv for {0}".format(arxiv_id))
 
 
 @with_debug_logging
@@ -90,68 +112,28 @@ def arxiv_plot_extract(obj, eng):
 
     arxiv_id = get_arxiv_id(obj.data)
     filename = secure_filename("{0}.tar.gz".format(arxiv_id))
-    if filename not in obj.files:
-        tarball = download_file_to_workflow(
-            workflow=obj,
-            name=filename,
-            url=current_app.config['ARXIV_TARBALL_URL'].format(
-                arxiv_id=arxiv_id
+    tarball = obj.files[filename]
+
+    if tarball:
+        try:
+            plots = process_tarball(tarball.file.uri)
+        except (InvalidTarball, NoTexFilesFound):
+            obj.log.error(
+                'Invalid tarball {0}'.format(tarball.file.uri)
             )
-        )
-    else:
-        tarball = obj.files[filename]
+            return
+        except DelegateError as err:
+            obj.log.error("Error extracting plots. Report and skip.")
+            current_app.logger.exception(err)
+            return
 
-    try:
-        plots = process_tarball(tarball.file.uri)
-    except (InvalidTarball, NoTexFilesFound):
-        obj.log.error(
-            'Invalid tarball {0}'.format(tarball.file.uri)
-        )
-        return
-    except DelegateError as err:
-        obj.log.error("Error extracting plots. Report and skip.")
-        current_app.logger.exception(err)
-        return
-
-    for idx, plot in enumerate(plots):
-        obj.files[plot.get('name')] = BytesIO(open(plot.get('url')))
-        obj.files[plot.get('name')]["doctype"] = "Plot"
-        obj.files[plot.get('name')]["description"] = u"{0:05d} {1}".format(
-            idx, "".join(plot.get('captions', []))
-        )
-    obj.log.info("Added {0} plots.".format(len(plots)))
-
-
-@with_debug_logging
-def arxiv_refextract(obj, eng):
-    """Extract references from arXiv PDF.
-
-    :param obj: Workflow Object to process
-    :param eng: Workflow Engine processing the object
-    """
-    arxiv_id = get_arxiv_id(obj.data)
-    filename = secure_filename("{0}.pdf".format(arxiv_id))
-    if filename not in obj.files:
-        pdf = download_file_to_workflow(
-            workflow=obj,
-            name=filename,
-            url=current_app.config['ARXIV_PDF_URL'].format(
-                arxiv_id=arxiv_id
+        for idx, plot in enumerate(plots):
+            obj.files[plot.get('name')] = BytesIO(open(plot.get('url')))
+            obj.files[plot.get('name')]["doctype"] = "Plot"
+            obj.files[plot.get('name')]["description"] = u"{0:05d} {1}".format(
+                idx, "".join(plot.get('captions', []))
             )
-        )
-    else:
-        pdf = obj.files[filename]
-    if pdf:
-        mapped_references = extract_references(pdf.file.uri)
-        if mapped_references:
-            obj.data["references"] = mapped_references
-            obj.log.info("Extracted {0} references".format(
-                len(mapped_references)
-            ))
-        else:
-            obj.log.info("No references extracted")
-    else:
-        obj.log.error("Not able to download and process the PDF")
+        obj.log.info("Added {0} plots.".format(len(plots)))
 
 
 def arxiv_derive_inspire_categories(obj, eng):
@@ -195,47 +177,39 @@ def arxiv_author_list(stylesheet="authorlist2marcxml.xsl"):
 
         arxiv_id = get_arxiv_id(obj.data)
         filename = secure_filename("{0}.tar.gz".format(arxiv_id))
-        if filename not in obj.files:
-            tarball = download_file_to_workflow(
-                workflow=obj,
-                name=filename,
-                url=current_app.config['ARXIV_TARBALL_URL'].format(
-                    arxiv_id=arxiv_id
-                )
-            )
-        else:
-            tarball = obj.files[filename]
+        tarball = obj.files[filename]
 
-        sub_dir = os.path.abspath("{0}_files".format(tarball.file.uri))
-        try:
-            file_list = untar(tarball.file.uri, sub_dir)
-        except InvalidTarball:
-            obj.log.error("Invalid tarball {0}".format(tarball.file.uri))
-            return
-        obj.log.info("Extracted tarball to: {0}".format(sub_dir))
+        if tarball:
+            sub_dir = os.path.abspath("{0}_files".format(tarball.file.uri))
+            try:
+                file_list = untar(tarball.file.uri, sub_dir)
+            except InvalidTarball:
+                obj.log.error("Invalid tarball {0}".format(tarball.file.uri))
+                return
+            obj.log.info("Extracted tarball to: {0}".format(sub_dir))
 
-        xml_files_list = [path for path in file_list
-                          if path.endswith(".xml")]
-        obj.log.info("Found xmlfiles: {0}".format(xml_files_list))
+            xml_files_list = [path for path in file_list
+                            if path.endswith(".xml")]
+            obj.log.info("Found xmlfiles: {0}".format(xml_files_list))
 
-        for xml_file in xml_files_list:
-            with open(xml_file, 'r') as xml_file_fd:
-                xml_content = xml_file_fd.read()
+            for xml_file in xml_files_list:
+                with open(xml_file, 'r') as xml_file_fd:
+                    xml_content = xml_file_fd.read()
 
-            match = REGEXP_AUTHLIST.findall(xml_content)
-            if match:
-                obj.log.info("Found a match for author extraction")
-                try:
-                    authors_xml = convert(xml_content, stylesheet)
-                except XMLSyntaxError:
-                    # Probably the %auto-ignore comment exists, so we skip the
-                    # first line. See: inspirehep/inspire-next/issues/2195
-                    authors_xml = convert(
-                        xml_content.split('\n', 1)[1],
-                        stylesheet,
-                    )
-                authors_rec = create_record(authors_xml)
-                authorlist_record = hep.do(authors_rec)
-                obj.data.update(authorlist_record)
-                break
+                match = REGEXP_AUTHLIST.findall(xml_content)
+                if match:
+                    obj.log.info("Found a match for author extraction")
+                    try:
+                        authors_xml = convert(xml_content, stylesheet)
+                    except XMLSyntaxError:
+                        # Probably the %auto-ignore comment exists, so we skip the
+                        # first line. See: inspirehep/inspire-next/issues/2195
+                        authors_xml = convert(
+                            xml_content.split('\n', 1)[1],
+                            stylesheet,
+                        )
+                    authors_rec = create_record(authors_xml)
+                    authorlist_record = hep.do(authors_rec)
+                    obj.data.update(authorlist_record)
+                    break
     return _author_list

--- a/inspirehep/modules/workflows/tasks/classifier.py
+++ b/inspirehep/modules/workflows/tasks/classifier.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import, division, print_function
 from functools import wraps
 
 from ..proxies import antihep_keywords
-from ..utils import with_debug_logging
+from ..utils import with_debug_logging, get_pdf_in_workflow
 
 
 @with_debug_logging
@@ -75,11 +75,9 @@ def classify_paper(taxonomy, rebuild_cache=False, no_cache=False,
 
         fast_mode = False
         try:
-            # FIXME: May need to find another canonical way of getting PDF
-            if "pdf" in obj.extra_data:
-                result = get_keywords_from_local_file(
-                    obj.extra_data["pdf"], **params
-                )
+            uri = get_pdf_in_workflow(obj)
+            if uri:
+                result = get_keywords_from_local_file(uri, **params)
             else:
                 data = []
                 titles = obj.data.get('titles')

--- a/inspirehep/modules/workflows/tasks/submission.py
+++ b/inspirehep/modules/workflows/tasks/submission.py
@@ -374,19 +374,6 @@ def prepare_keywords(obj, eng):
 
 
 @with_debug_logging
-def user_pdf_get(obj, eng):
-    """Upload user PDF file, if requested."""
-    if obj.extra_data.get('pdf_upload', False):
-        fft = {'path': obj.extra_data.get('submission_pdf'),
-               'type': 'INSPIRE-PUBLIC'}
-        if obj.data.get('_fft'):
-            obj.data['_fft'].append(fft)
-        else:
-            obj.data['_fft'] = [fft]
-        obj.log.info("User PDF file added to FFT.")
-
-
-@with_debug_logging
 def prepare_files(obj, eng):
     """Adds to the _fft field (files) the extracted pdfs if any"""
     def _get_fft(url, name):

--- a/inspirehep/modules/workflows/utils.py
+++ b/inspirehep/modules/workflows/utils.py
@@ -27,10 +27,13 @@ from __future__ import absolute_import, division, print_function
 import json
 import logging
 import traceback
-from functools import wraps
-
 import requests
+
+from contextlib import closing
+from functools import wraps
 from flask import current_app
+
+from inspirehep.utils.record import get_arxiv_id
 
 from .models import WorkflowsAudit
 
@@ -141,3 +144,32 @@ def with_debug_logging(func):
         return res
 
     return _decorator
+
+
+@with_debug_logging
+def get_pdf_in_workflow(obj):
+    """Return the fullpath to the PDF attached to a workflow object"""
+
+    for filename in obj.files.keys:
+        if filename.endswith('.pdf'):
+            # There's a PDF already attached
+            return obj.files[filename].file.uri
+
+    obj.log.info("No PDF available")
+
+
+def download_file_to_workflow(workflow, name, url):
+    """Download a file to a specified workflow.
+
+    The ``workflow.files`` property is actually a method, which returns a
+    ``WorkflowFilesIterator``. This class inherits a custom ``__setitem__``
+    method from its parent, ``FilesIterator``, which ends up calling ``save``
+    on an ``invenio_files_rest.storage.pyfs.PyFSFileStorage`` instance
+    through ``ObjectVersion`` and ``FileObject``. This method consumes the
+    stream passed to it and saves in its place a ``FileObject`` with the
+    details of the downloaded file.
+    """
+    with closing(requests.get(url=url, stream=True)) as req:
+        if req.status_code == 200:
+            workflow.files[name] = req.raw
+            return workflow.files[name]

--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -36,8 +36,8 @@ from inspirehep.modules.workflows.tasks.refextract import extract_journal_info
 from inspirehep.modules.workflows.tasks.arxiv import (
     arxiv_author_list,
     arxiv_fulltext_download,
+    arxiv_package_download,
     arxiv_plot_extract,
-    arxiv_refextract,
     arxiv_derive_inspire_categories,
 )
 from inspirehep.modules.workflows.tasks.actions import (
@@ -52,7 +52,9 @@ from inspirehep.modules.workflows.tasks.actions import (
     is_submission,
     is_arxiv_paper,
     mark,
-    prepare_update_payload
+    prepare_update_payload,
+    refextract,
+    submission_fulltext_download,
 )
 
 from inspirehep.modules.workflows.tasks.classifier import (
@@ -85,7 +87,6 @@ from inspirehep.modules.workflows.tasks.submission import (
     remove_references,
     reply_ticket,
     send_robotupload,
-    user_pdf_get,
     wait_webcoll,
 )
 
@@ -180,10 +181,18 @@ ENHANCE_RECORD = [
         is_arxiv_paper,
         [
             arxiv_fulltext_download,
+            arxiv_package_download,
             arxiv_plot_extract,
-            arxiv_refextract,
+            refextract,
             arxiv_derive_inspire_categories,
             arxiv_author_list("authorlist2marcxml.xsl"),
+        ]
+    ),
+    IF(
+        is_submission,
+        [
+            submission_fulltext_download,
+            refextract,
         ]
     ),
     extract_journal_info,
@@ -278,7 +287,6 @@ POSTENHANCE_RECORD = [
     add_note_entry,
     filter_keywords,
     prepare_keywords,
-    user_pdf_get,
     remove_references,
     prepare_files,
 ]

--- a/inspirehep/utils/helpers.py
+++ b/inspirehep/utils/helpers.py
@@ -24,8 +24,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-from contextlib import closing
-
 import requests
 
 
@@ -40,23 +38,6 @@ def download_file(url, output_file=None, chunk_size=1024):
             for chunk in r.iter_content(chunk_size):
                 f.write(chunk)
     return output_file
-
-
-def download_file_to_workflow(workflow, name, url):
-    """Download a file to a specified workflow.
-
-    The ``workflow.files`` property is actually a method, which returns a
-    ``WorkflowFilesIterator``. This class inherits a custom ``__setitem__``
-    method from its parent, ``FilesIterator``, which ends up calling ``save``
-    on an ``invenio_files_rest.storage.pyfs.PyFSFileStorage`` instance
-    through ``ObjectVersion`` and ``FileObject``. This method consumes the
-    stream passed to it and saves in its place a ``FileObject`` with the
-    details of the downloaded file.
-    """
-    with closing(requests.get(url=url, stream=True)) as req:
-        if req.status_code == 200:
-            workflow.files[name] = req.raw
-            return workflow.files[name]
 
 
 def force_list(data):

--- a/inspirehep/utils/url.py
+++ b/inspirehep/utils/url.py
@@ -24,6 +24,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+import requests
+
 from flask import current_app
 
 from inspirehep import __version__
@@ -38,3 +40,26 @@ def make_user_agent_string(component=""):
     if component:
         ret += " [{}]".format(component)
     return ret
+
+
+def is_pdf_link(url):
+    """Return ``True`` if ``url`` points to a PDF.
+
+    Returns ``True`` if the first few bytes of the response are ``%PDF``.
+
+    Args:
+        url (string): a URL.
+
+    Returns:
+        bool: whether the url points to a PDF.
+
+    """
+    try:
+        response = requests.get(url, allow_redirects=True, stream=True)
+    except requests.exceptions.RequestException:
+        return False
+
+    magic_number = next(response.iter_content(4))
+    correct_magic_number = magic_number.startswith('%PDF')
+
+    return correct_magic_number

--- a/tests/integration/workflows/test_arxiv_workflow.py
+++ b/tests/integration/workflows/test_arxiv_workflow.py
@@ -377,7 +377,7 @@ def get_halted_workflow(app, record, extra_config=None):
 
 
 @mock.patch(
-    'inspirehep.modules.workflows.tasks.arxiv.download_file_to_workflow',
+    'inspirehep.modules.workflows.utils.download_file_to_workflow',
     side_effect=fake_download_file,
 )
 @mock.patch(
@@ -440,7 +440,7 @@ def test_harvesting_arxiv_workflow_manual_rejected(
 
 
 @mock.patch(
-    'inspirehep.modules.workflows.tasks.arxiv.download_file_to_workflow',
+    'inspirehep.modules.workflows.utils.download_file_to_workflow',
     side_effect=fake_download_file,
 )
 @mock.patch(
@@ -494,6 +494,10 @@ def test_harvesting_arxiv_workflow_already_on_legacy(
     side_effect=fake_download_file,
 )
 @mock.patch(
+    'inspirehep.modules.workflows.utils.download_file_to_workflow',
+    side_effect=fake_download_file,
+)
+@mock.patch(
     'inspirehep.modules.workflows.tasks.beard.json_api_request',
     side_effect=fake_beard_api_request,
 )
@@ -519,7 +523,8 @@ def test_harvesting_arxiv_workflow_manual_accepted(
     mocked_api_request_beard_block,
     mocked_api_request_magpie,
     mocked_api_request_beard,
-    mocked_download,
+    mocked_download_utils,
+    mocked_download_arxiv,
     workflow_app,
     record,
 ):


### PR DESCRIPTION
* Fixes extracting keywords from PDFs. (Closes #2255)

* Refactors retrieval of PDF unifying arXiv and submitter sources.
  Now PDFs are looked into the obj.files attribute.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>