### PR TITLE
migrator: lock continuous_migration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,7 @@ install_requires = [
     'elasticsearch-dsl<2.2.0',
     'pycountry>=17.1.8',
     'Flask_CeleryExt>=0.3.0',
+    'python-redis-lock~=3.2',
 ]
 
 tests_require = [


### PR DESCRIPTION
* Introduces a redis-based lock to continuous_migration() so that
  no two continuous_migration() tasks are executed at the same time.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>