### PR TITLE
editor: affilition suggester

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -803,6 +803,11 @@ RECORDS_REST_ENDPOINTS = dict(
                 ':json_v1_search'
             ),
         },
+        suggesters=dict(
+            affiliation=dict(completion=dict(
+                field='affiliation_suggest'
+            ))
+        ),
         list_route='/institutions/',
         item_route='/institutions/<pid(ins,record_class="inspirehep.modules.records.api:InspireRecord"):pid_value>',
         default_media_type='application/json',

--- a/inspirehep/modules/records/mappings/records/institutions.json
+++ b/inspirehep/modules/records/mappings/records/institutions.json
@@ -58,9 +58,7 @@
                     "type": "string"
                 },
                 "affiliation_suggest": {
-                    "analyzer": "simple",
                     "payloads": true,
-                    "search_analyzer": "simple",
                     "type": "completion"
                 },
                 "control_number": {

--- a/inspirehep/modules/records/mappings/records/institutions.json
+++ b/inspirehep/modules/records/mappings/records/institutions.json
@@ -57,6 +57,12 @@
                 "affautocomplete": {
                     "type": "string"
                 },
+                "affiliation_suggest": {
+                    "analyzer": "simple",
+                    "payloads": true,
+                    "search_analyzer": "simple",
+                    "type": "completion"
+                },
                 "control_number": {
                     "type": "integer"
                 },

--- a/inspirehep/modules/records/receivers.py
+++ b/inspirehep/modules/records/receivers.py
@@ -67,6 +67,7 @@ def enhance_record(sender, json, *args, **kwargs):
     add_recids_and_validate(sender, json, *args, **kwargs)
     populate_experiment_suggest(sender, json, *args, **kwargs)
     populate_abstract_source_suggest(sender, json, *args, **kwargs)
+    populate_affiliation_suggest(sender, json, *args, **kwargs)
     after_record_enhanced.send(json)
 
 
@@ -265,6 +266,55 @@ def populate_abstract_source_suggest(sender, json, *args, **kwargs):
                         'output': source,
                     },
                 })
+
+
+def populate_affiliation_suggest(sender, json, *args, **kwargs):
+    """Populates affiliation_suggest field of institution records."""
+
+    # FIXME: Use a dedicated method when #1355 will be resolved.
+    if 'institutions.json' in json.get('$schema'):
+        institution = json.get('institution')
+        institution_acronym = json.get('institution_acronym')
+        ICN = json.get('ICN')
+        legacy_ICN = json.get('legacy_ICN')
+        name_variants = force_list(
+            get_value(json, 'name_variants.value'))
+        postal_codes = force_list(
+            get_value(json, 'address.postal_code'))
+
+        inputs = []
+        if institution:
+            inputs.extend(institution)
+
+        if institution_acronym:
+            inputs.append(institution_acronym)
+
+        if ICN:
+            inputs.extend(ICN)
+
+        if legacy_ICN:
+            inputs.append(legacy_ICN)
+
+        if name_variants:
+            inputs.extend(name_variants)
+
+        if postal_codes:
+            inputs.extend(postal_codes)
+
+        json.update({
+            'affiliation_suggest': {
+                'input': inputs,
+                'output': legacy_ICN,
+                'payload': {
+                    'institution': institution,
+                    'institution_acronym': institution_acronym,
+                    'ICN': ICN,
+                    'legacy_ICN': legacy_ICN,
+                    'department': json.get('department'),
+                    '$ref': get_value(json, 'self.$ref')
+                },
+            },
+        })
 
 
 @before_record_index.connect

--- a/inspirehep/modules/records/receivers.py
+++ b/inspirehep/modules/records/receivers.py
@@ -311,7 +311,7 @@ def populate_affiliation_suggest(sender, json, *args, **kwargs):
                     'ICN': ICN,
                     'legacy_ICN': legacy_ICN,
                     'department': json.get('department'),
-                    '$ref': get_value(json, 'self.$ref')
+                    '$ref': get_value(json, 'self.$ref'),
                 },
             },
         })

--- a/tests/unit/records/test_records_receivers.py
+++ b/tests/unit/records/test_records_receivers.py
@@ -36,7 +36,7 @@ from inspirehep.modules.records.receivers import (
     references_validator,
     populate_experiment_suggest,
     populate_abstract_source_suggest,
-    populate_affiliation_suggest
+    populate_affiliation_suggest,
 )
 
 
@@ -542,8 +542,7 @@ def test_populate_experiment_suggest_populates_if_record_is_experiment():
     assert json_dict['experiment_suggest']['input'] == \
         ['foo', 'bar', 'foo_var', 'bar_var']
     assert json_dict['experiment_suggest']['output'] == 'foo'
-    assert json_dict['experiment_suggest'][
-        'payload']['$ref'] == 'http://foo/$ref'
+    assert json_dict['experiment_suggest']['payload']['$ref'] == 'http://foo/$ref'
 
 
 def test_populate_experiment_suggest_does_nothing_if_record_is_not_experiment():
@@ -699,12 +698,10 @@ def test_populate_affiliation_suggest():
 def test_populate_affiliation_suggest_does_nothing_if_record_is_not_institution():
     json_dict = {
         '$schema': 'http://localhost:5000/schemas/records/other.json',
-        'other': 'foo'
     }
 
     populate_affiliation_suggest(None, json_dict)
 
     assert json_dict == {
         '$schema': 'http://localhost:5000/schemas/records/other.json',
-        'other': 'foo'
     }

--- a/tests/unit/records/test_records_receivers.py
+++ b/tests/unit/records/test_records_receivers.py
@@ -36,6 +36,7 @@ from inspirehep.modules.records.receivers import (
     references_validator,
     populate_experiment_suggest,
     populate_abstract_source_suggest,
+    populate_affiliation_suggest
 )
 
 
@@ -541,7 +542,8 @@ def test_populate_experiment_suggest_populates_if_record_is_experiment():
     assert json_dict['experiment_suggest']['input'] == \
         ['foo', 'bar', 'foo_var', 'bar_var']
     assert json_dict['experiment_suggest']['output'] == 'foo'
-    assert json_dict['experiment_suggest']['payload']['$ref'] == 'http://foo/$ref'
+    assert json_dict['experiment_suggest'][
+        'payload']['$ref'] == 'http://foo/$ref'
 
 
 def test_populate_experiment_suggest_does_nothing_if_record_is_not_experiment():
@@ -598,3 +600,111 @@ def test_populate_abstract_source_suggest_does_nothing_if_record_is_not_hep():
         {'source': 'foo'},
         {'source': 'bar'},
     ]
+
+
+def test_populate_affiliation_suggest():
+    json_dict = {
+        '$schema': 'http://localhost:5000/schemas/records/institutions.json',
+        'self': {
+            '$ref': 'http://foo/bar',
+        },
+        'institution': [
+            'foo',
+            'bar',
+        ],
+        'institution_acronym': 'foo-bar',
+        'ICN': [
+            'foo-ICN',
+            'bar-ICN'
+        ],
+        'legacy_ICN': 'foo-bar-legacy_ICN',
+        'department': [
+            'foo-department',
+            'bar-department',
+        ],
+        'name_variants': [
+            {'value': 'foo-name_variant'},
+            {'value': 'bar-name_variant'},
+        ],
+        'address': [
+            {'postal_code': 'foo-postal_code'},
+            {'postal_code': 'bar-postal_code'},
+        ],
+    }
+
+    populate_affiliation_suggest(None, json_dict)
+
+    assert json_dict == {
+        '$schema': 'http://localhost:5000/schemas/records/institutions.json',
+        'self': {
+            '$ref': 'http://foo/bar',
+        },
+        'institution': [
+            'foo',
+            'bar',
+        ],
+        'institution_acronym': 'foo-bar',
+        'ICN': [
+            'foo-ICN',
+            'bar-ICN'
+        ],
+        'legacy_ICN': 'foo-bar-legacy_ICN',
+        'department': [
+            'foo-department',
+            'bar-department',
+        ],
+        'name_variants': [
+            {'value': 'foo-name_variant'},
+            {'value': 'bar-name_variant'},
+        ],
+        'address': [
+            {'postal_code': 'foo-postal_code'},
+            {'postal_code': 'bar-postal_code'},
+        ],
+        'affiliation_suggest': {
+            'input': [
+                'foo',
+                'bar',
+                'foo-bar',
+                'foo-ICN',
+                'bar-ICN',
+                'foo-bar-legacy_ICN',
+                'foo-name_variant',
+                'bar-name_variant',
+                'foo-postal_code',
+                'bar-postal_code',
+            ],
+            'output': 'foo-bar-legacy_ICN',
+            'payload': {
+                'institution': [
+                    'foo',
+                    'bar',
+                ],
+                'institution_acronym': 'foo-bar',
+                'ICN': [
+                    'foo-ICN',
+                    'bar-ICN'
+                ],
+                'legacy_ICN': 'foo-bar-legacy_ICN',
+                'department': [
+                    'foo-department',
+                    'bar-department',
+                ],
+                '$ref': 'http://foo/bar',
+            },
+        }
+    }
+
+
+def test_populate_affiliation_suggest_does_nothing_if_record_is_not_institution():
+    json_dict = {
+        '$schema': 'http://localhost:5000/schemas/records/other.json',
+        'other': 'foo'
+    }
+
+    populate_affiliation_suggest(None, json_dict)
+
+    assert json_dict == {
+        '$schema': 'http://localhost:5000/schemas/records/other.json',
+        'other': 'foo'
+    }


### PR DESCRIPTION
* Adds a suggester for instititution which suggestet based on
institution names and institution_acronym and returns results with
payload that is populated with necessary fields for UI.

Signed-off-by: harunurhan <harunurhan17@gmail.com>


@jmartinm  please check if the output and input make sense for the case. And I am assuming `institution_acronym` is present all the time, is it OK?