### PR TITLE
global: set extra_data when creating a workflow

### DIFF
--- a/inspirehep/modules/authors/views/holdingpen.py
+++ b/inspirehep/modules/authors/views/holdingpen.py
@@ -272,6 +272,7 @@ def submitupdate():
 
     workflow_object = workflow_object_class.create(
         data={},
+        extra_data={},
         id_user=current_user.get_id(),
         data_type="authors"
     )
@@ -302,6 +303,7 @@ def submitnew():
 
     workflow_object = workflow_object_class.create(
         data={},
+        extra_data={},
         id_user=current_user.get_id(),
         data_type="authors"
     )

--- a/inspirehep/modules/literaturesuggest/views.py
+++ b/inspirehep/modules/literaturesuggest/views.py
@@ -83,6 +83,7 @@ def submit():
 
     workflow_object = workflow_object_class.create(
         data={},
+        extra_data={},
         id_user=current_user.get_id(),
         data_type="hep"
     )


### PR DESCRIPTION
* NOTE: When creating a workflow if data or extra_data are not set
  the next workflow created will share the same data or extra_data
  instance. (closes #2238)

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>