### PR TITLE
records: fix hep & authors search facets

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -1053,12 +1053,11 @@ RECORDS_UI_ENDPOINTS = dict(
 RECORDS_REST_FACETS = {
     "records-hep": {
         "filters": {
-            "author": terms_filter('exactauthor.raw'),
+            "author": terms_filter('facet_author_name'),
             "subject": terms_filter('facet_inspire_subjects'),
+            "arxiv_categories": terms_filter('facet_arxiv_categories'),
             "doc_type": terms_filter('facet_inspire_doc_type'),
-            "formulas": terms_filter('facet_formulas'),
-            "experiment": terms_filter(
-                'accelerator_experiments.facet_experiment'),
+            "experiment": terms_filter('facet_experiment'),
             "earliest_date": range_filter(
                 'earliest_date',
                 format='yyyy',
@@ -1071,27 +1070,27 @@ RECORDS_REST_FACETS = {
                     "size": 20
                 }
             },
+            "arxiv_categories": {
+                "terms": {
+                    "field": "facet_arxiv_categories",
+                    "size": 20
+                }
+            },
             "doc_type": {
                 "terms": {
                     "field": "facet_inspire_doc_type",
                     "size": 20
                 }
             },
-            "formulas": {
-                "terms": {
-                    "field": "facet_formulas",
-                    "size": 20
-                }
-            },
             "author": {
                 "terms": {
-                    "field": "facet_authors",
+                    "field": "facet_author_name",
                     "size": 20
                 }
             },
             "experiment": {
                 "terms": {
-                    "field": "accelerator_experiments.facet_experiment",
+                    "field": "facet_experiment",
                     "size": 20
                 }
             },
@@ -1108,19 +1107,20 @@ RECORDS_REST_FACETS = {
     },
     "records-authors": {
         "filters": {
-            "arxiv_categories": terms_filter('arxiv_categories'),
-            "institution": terms_filter('positions.institution.name')
+            "arxiv_categories": terms_filter('facet_arxiv_categories'),
+            "inspire_categories": terms_filter('facet_inspire_categories'),
+            "institution": terms_filter('facet_institution_name')
         },
         "aggs": {
-            "inspire_categories": {
+            "arxiv_categories": {
                 "terms": {
-                    "field": "inspire_categories.term",
+                    "field": "facet_arxiv_categories",
                     "size": 20
                 }
             },
             "institution": {
                 "terms": {
-                    "field": "positions.institution.name",
+                    "field": "facet_institution_name",
                     "size": 20
                 }
             }

--- a/inspirehep/modules/records/mappings/records/authors.json
+++ b/inspirehep/modules/records/mappings/records/authors.json
@@ -84,6 +84,7 @@
                     "type": "object"
                 },
                 "arxiv_categories": {
+                    "copy_to": "facet_arxiv_categories",
                     "type": "string"
                 },
                 "authorautocomplete": {
@@ -147,6 +148,14 @@
                         }
                     },
                     "type": "object"
+                },
+                "facet_arxiv_categories": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "facet_institution_name": {
+                    "index": "not_analyzed",
+                    "type": "string"
                 },
                 "ids": {
                     "properties": {
@@ -228,6 +237,7 @@
                                     "type": "boolean"
                                 },
                                 "name": {
+                                    "copy_to": "facet_institution_name",
                                     "type": "string"
                                 },
                                 "record": {

--- a/inspirehep/modules/records/mappings/records/hep.json
+++ b/inspirehep/modules/records/mappings/records/hep.json
@@ -139,6 +139,7 @@
                             "type": "string"
                         },
                         "legacy_name": {
+                            "copy_to": "facet_experiment",
                             "type": "string"
                         },
                         "record": {
@@ -181,6 +182,7 @@
                 "arxiv_eprints": {
                     "properties": {
                         "categories": {
+                            "copy_to": "facet_arxiv_categories",
                             "type": "string"
                         },
                         "value": {
@@ -223,6 +225,7 @@
                             "type": "string"
                         },
                         "full_name": {
+                            "copy_to": "facet_author_name",
                             "type": "string"
                         },
                         "ids": {
@@ -382,6 +385,26 @@
                     },
                     "type": "object"
                 },
+                "facet_arxiv_categories": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "facet_author_name": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "facet_experiment": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "facet_inspire_doc_type": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
+                "facet_inspire_subjects": {
+                    "index": "not_analyzed",
+                    "type": "string"
+                },
                 "funding_info": {
                     "properties": {
                         "agency": {
@@ -416,6 +439,7 @@
                             "type": "string"
                         },
                         "term": {
+                            "copy_to": "facet_inspire_subjects",
                             "type": "string"
                         }
                     },

--- a/inspirehep/modules/records/receivers.py
+++ b/inspirehep/modules/records/receivers.py
@@ -60,7 +60,6 @@ def receive_after_model_commit(sender, changes):
 def enhance_record(sender, json, *args, **kwargs):
     """Runs all the record enhancers and fires the after_record_enhanced signals
        to allow receivers work with a fully populated record."""
-    populate_inspire_subjects(sender, json, *args, **kwargs)
     populate_inspire_document_type(sender, json, *args, **kwargs)
     match_valid_experiments(sender, json, *args, **kwargs)
     dates_validator(sender, json, *args, **kwargs)
@@ -69,15 +68,6 @@ def enhance_record(sender, json, *args, **kwargs):
     populate_abstract_source_suggest(sender, json, *args, **kwargs)
     populate_affiliation_suggest(sender, json, *args, **kwargs)
     after_record_enhanced.send(json)
-
-
-def populate_inspire_subjects(sender, json, *args, **kwargs):
-    """Populate the INSPIRE subjects before indexing.
-
-    Adds the `facet_inspire_subjects` key to the record, to be used for
-    faceting in the search interface.
-    """
-    json['facet_inspire_subjects'] = get_value(json, 'inspire_categories.term')
 
 
 def populate_inspire_document_type(sender, json, *args, **kwargs):

--- a/inspirehep/modules/search/bundles.py
+++ b/inspirehep/modules/search/bundles.py
@@ -33,6 +33,6 @@ js = NpmBundle(
     npm={
         'invenio-search-js': '~0.2.1',
         'angular-loading-bar': '~0.9.0',
-        'inspirehep-search-js': '~0.4.0'
+        'inspirehep-search-js': '~0.6.0'
     },
 )

--- a/tests/unit/records/test_records_receivers.py
+++ b/tests/unit/records/test_records_receivers.py
@@ -31,7 +31,6 @@ from inspirehep.modules.records.receivers import (
     earliest_date,
     match_valid_experiments,
     populate_inspire_document_type,
-    populate_inspire_subjects,
     populate_recid_from_ref,
     references_validator,
     populate_experiment_suggest,
@@ -425,19 +424,6 @@ def test_populate_inspire_document_type_doc_type_from_publication_type_lectures(
         'article',
         'lectures',
     ]
-
-
-def test_populate_inspire_subjects_preserves_terms():
-    json_dict = {
-        'inspire_categories': [
-            {'term': 'foo'},
-            {'not-term': 'bar'},
-        ],
-    }
-
-    populate_inspire_subjects(None, json_dict)
-
-    assert json_dict['facet_inspire_subjects'] == ['foo']
 
 
 def test_populate_recid_from_ref_naming():


### PR DESCRIPTION
* Create mapping fields especially for search-facets (with 'no_analyzed',
  stemmed versions aren't useful for user-facing text) and ensure naming
  consistency for fields used in 'config.py' (i.e. 'facet_X').

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>
Co-authored-by: Javier Martin Montull <javier.martin.montull@cern.ch>