### PR TITLE
utils/normalizers: normalize_journal_title proper search

### DIFF
--- a/inspirehep/modules/records/mappings/records/journals.json
+++ b/inspirehep/modules/records/mappings/records/journals.json
@@ -70,7 +70,10 @@
                             "type": "string"
                         },
                         "title": {
-                            "copy_to": "journalautocomplete",
+                            "copy_to": [
+                                "journalautocomplete",
+                                "lowercase_titles"
+                            ],
                             "type": "string"
                         }
                     },
@@ -103,6 +106,10 @@
                         }
                     },
                     "type": "object"
+                },
+                "lowercase_journal_titles": {
+                    "analyzer": "lowercase_analyzer",
+                    "type": "string"
                 },
                 "peer_reviewed": {
                     "type": "boolean"
@@ -175,6 +182,7 @@
                             "type": "string"
                         },
                         "title": {
+                            "copy_to": "lowercase_titles",
                             "type": "string"
                         }
                     },
@@ -190,6 +198,17 @@
                         }
                     },
                     "type": "object"
+                }
+            }
+        }
+    },
+    "settings": {
+        "analysis": {
+            "analyzer": {
+                "lowercase_analyzer": {
+                    "filter": "lowercase",
+                    "tokenizer": "keyword",
+                    "type": "custom"
                 }
             }
         }

--- a/inspirehep/utils/normalizers.py
+++ b/inspirehep/utils/normalizers.py
@@ -22,12 +22,13 @@
 
 from __future__ import absolute_import, division, print_function
 
-from flask import current_app
+import logging
 
 from inspirehep.modules.search.api import JournalsSearch
 
 
 def normalize_journal_title(journal_title):
+    logger = logging.getLogger(__name__)
     normalized_journal_title = journal_title
     hits = JournalsSearch().query(
         'match',
@@ -38,5 +39,5 @@ def normalize_journal_title(journal_title):
         try:
             normalized_journal_title = hits[0].short_titles[0].title
         except (AttributeError, IndexError) as e:
-            current_app.logger.debug("Failed to access normalized journal title: {}".format(e))
+            logger.debug("Failed to access normalized journal title: %s", e)
     return normalized_journal_title

--- a/inspirehep/utils/normalizers.py
+++ b/inspirehep/utils/normalizers.py
@@ -22,6 +22,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+from flask import current_app
+
 from inspirehep.modules.search.api import JournalsSearch
 
 
@@ -29,12 +31,12 @@ def normalize_journal_title(journal_title):
     normalized_journal_title = journal_title
     hits = JournalsSearch().query(
         'match',
-        title_variants__title__lowercased=journal_title
+        lowercase_titles=journal_title.lower()
     ).execute()
 
     if hits:
         try:
             normalized_journal_title = hits[0].short_titles[0].title
-        except (AttributeError, IndexError):
-            pass
+        except (AttributeError, IndexError) as e:
+            current_app.logger.debug("Failed to access normalized journal title: {}".format(e))
     return normalized_journal_title

--- a/tests/integration/utils/test_normalizers.py
+++ b/tests/integration/utils/test_normalizers.py
@@ -1,21 +1,24 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of Invenio.
-# Copyright (C) 2014, 2015 CERN.
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
 #
-# Invenio is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License as
-# published by the Free Software Foundation; either version 2 of the
-# License, or (at your option) any later version.
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-# Invenio is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Invenio; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
 
 from __future__ import absolute_import, division, print_function
 
@@ -26,7 +29,7 @@ def test_normalize_journal_title(app):
     journal_title = 'Physical Review'
     abbreviated_journal_title = 'Phys.Rev.'
 
-    with app.test_client() as client:
+    with app.test_client():
         normalized_journal_title = normalize_journal_title(journal_title)
 
     assert abbreviated_journal_title == normalized_journal_title

--- a/tests/integration/utils/test_normalizers.py
+++ b/tests/integration/utils/test_normalizers.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2014, 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+from __future__ import absolute_import, division, print_function
+
+from inspirehep.utils.normalizers import normalize_journal_title
+
+
+def test_normalize_journal_title(app):
+    journal_title = 'Physical Review'
+    abbreviated_journal_title = 'Phys.Rev.'
+
+    with app.test_client() as client:
+        normalized_journal_title = normalize_journal_title(journal_title)
+
+    assert abbreviated_journal_title == normalized_journal_title


### PR DESCRIPTION
* Update journals mapping with lowercase analyzer.
* Add `lowercase_titles` field for searching the abbreviated journal
  name.

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>
Co-Authored-By: George Lignos <glignos93@gmail.com>

Addresses #2120 (1st comment)