### PR TITLE
references: remove version from arxiv_eprint 

### DIFF
--- a/inspirehep/dojson/conferences/rules.py
+++ b/inspirehep/dojson/conferences/rules.py
@@ -36,6 +36,7 @@ from ..utils.geo import parse_conference_address
 
 
 @conferences.over('acronym', '^111..')
+@utils.flatten
 @utils.for_each_value
 def acronym(self, key, value):
     self['opening_date'] = value.get('x')
@@ -61,7 +62,7 @@ def acronym(self, key, value):
             address = parse_conference_address(raw_address)
             self['address'].append(address)
 
-    return value.get('e')
+    return force_list(value.get('e'))
 
 
 @conferences.over('contact_details', '^270..')

--- a/inspirehep/dojson/hep/rules/bd7xx.py
+++ b/inspirehep/dojson/hep/rules/bd7xx.py
@@ -39,27 +39,12 @@ from ...utils import (
 
 
 @hep.over('collaborations', '^710..')
-def collaboration(self, key, value):
-    value = force_list(value)
-
-    def get_value(value):
-        recid = None
-        if '0' in value:
-            try:
-                recid = int(value.get('0'))
-            except:
-                pass
-        return {
-            'value': value.get('g'),
-            'record': get_record_ref(recid, 'experiments')
-        }
-    collaboration = self.get('collaborations', [])
-
-    filtered_value = value
-    for element in filtered_value:
-        collaboration.append(get_value(element))
-
-    return collaboration
+@utils.for_each_value
+def collaborations(self, key, value):
+    return {
+        'record': get_record_ref(maybe_int(value.get('0')), 'experiments'),
+        'value': value.get('g'),
+    }
 
 
 @hep2marc.over('710', '^collaborations$')

--- a/inspirehep/modules/references/processors.py
+++ b/inspirehep/modules/references/processors.py
@@ -109,7 +109,7 @@ def _is_arxiv(obj):
 
 def _normalize_arxiv(obj):
     """Normalize arXiv report numbers accepted by _is_arxiv."""
-    return idutils.normalize_arxiv(obj.split()[0]).split(':')[-1]
+    return idutils.normalize_arxiv(obj.split()[0]).split(':')[-1].split('v')[0]
 
 
 class ReferenceBuilder(object):

--- a/tests/unit/dojson/test_dojson_conferences.py
+++ b/tests/unit/dojson/test_dojson_conferences.py
@@ -55,7 +55,6 @@ def test_acronym_from_111__a_c_e_g_x_y():
     assert expected == result['acronym']
 
 
-@pytest.mark.xfail(reason='tuple produced instead')
 def test_acronym_from_111__a_c_d_double_e_g_x_y():
     schema = load_schema('conferences')
     subschema = schema['properties']['acronym']
@@ -76,6 +75,32 @@ def test_acronym_from_111__a_c_d_double_e_g_x_y():
     expected = [
         'IVC-11',
         'ICSS-7',
+    ]
+    result = conferences.do(create_record(snippet))
+
+    assert validate(result['acronym'], subschema) is None
+    assert expected == result['acronym']
+
+
+def test_acronym_from_111__a_c_double_e_g_x_y():
+    schema = load_schema('conferences')
+    subschema = schema['properties']['acronym']
+
+    snippet = (
+        '<datafield tag="111" ind1=" " ind2=" ">'
+        '  <subfield code="a">2013 IEEE Nuclear Science Symposium and Medical Imaging Conference and Workshop on Room-Temperature Semiconductor Detectors</subfield>'
+        '  <subfield code="c">Seoul, Korea</subfield>'
+        '  <subfield code="e">NSS/MIC 2013</subfield>'
+        '  <subfield code="e">RTSD 2013</subfield>'
+        '  <subfield code="g">C13-10-26</subfield>'
+        '  <subfield code="x">2013-10-26</subfield>'
+        '  <subfield code="y">2013-11-02</subfield>'
+        '</datafield>'
+    )  # record/1218346
+
+    expected = [
+        'NSS/MIC 2013',
+        'RTSD 2013',
     ]
     result = conferences.do(create_record(snippet))
 

--- a/tests/unit/dojson/test_dojson_hep_bd9xx.py
+++ b/tests/unit/dojson/test_dojson_hep_bd9xx.py
@@ -1041,3 +1041,67 @@ def test_references_from_999C5k():
     result = hep2marc.do(result)
 
     assert expected == result['999C5']
+
+
+def test_references_from_999C5d_multiple_h_o_r_0_9():
+    schema = load_schema('hep')
+    subschema = schema['properties']['references']
+
+    snippet = (
+        '<datafield tag="999" ind1="C" ind2="5">'
+        '  <subfield code="0">568216</subfield>'
+        '  <subfield code="9">CURATOR</subfield>'
+        '  <subfield code="d">eprint</subfield>'
+        '  <subfield code="h">Y. Yan</subfield>'
+        '  <subfield code="h">R. Tegen</subfield>'
+        '  <subfield code="h">T. Gutsche</subfield>'
+        '  <subfield code="h">V. E. Lyubovitskij</subfield>'
+        '  <subfield code="h">A. Faessler</subfield>'
+        '  <subfield code="o">20</subfield>'
+        '  <subfield code="r">hep-ph/0112168v2</subfield>'
+        '</datafield>'
+    )  # record/1410105
+
+    expected = [
+        {
+            'curated_relation': False,
+            'record': {
+                '$ref': 'http://localhost:5000/api/literature/568216',
+            },
+            'reference': {
+                'arxiv_eprint': 'hep-ph/0112168',
+                'authors': [
+                    {'full_name': 'Yan, Y.'},
+                    {'full_name': 'Tegen, R.'},
+                    {'full_name': 'Gutsche, T.'},
+                    {'full_name': 'Lyubovitskij, V.E.'},
+                    {'full_name': 'Faessler, A.'},
+                ],
+                'label': '20',
+            },
+        },
+    ]
+    result = hep.do(create_record(snippet))
+
+    assert validate(result['references'], subschema) is None
+    assert expected == result['references']
+
+    expected = [
+        {
+            '0': 568216,
+            'h': [
+                'Yan, Y.',
+                'Tegen, R.',
+                'Gutsche, T.',
+                'Lyubovitskij, V.E.',
+                'Faessler, A.',
+            ],
+            'o': '20',
+            'r': [
+                'arXiv:hep-ph/0112168',
+            ],
+        },
+    ]
+    result = hep2marc.do(result)
+
+    assert expected == result['999C5']

--- a/tests/unit/references/test_references_processors.py
+++ b/tests/unit/references/test_references_processors.py
@@ -73,9 +73,58 @@ def test_is_arxiv_old_identifier():
     assert _is_arxiv('hep-th/0603001')
 
 
-def test_normalize_arxiv():
-    expected = '1501.00001v1'
+def test_normalize_arxiv_handles_new_identifiers_without_prefix_or_version():
+    expected = '1501.00001'
+    result = _normalize_arxiv('1501.00001')
+
+    assert expected == result
+
+
+def test_normalize_arxiv_handles_new_identifiers_with_prefix_and_without_version():
+    expected = '1501.00001'
+    result = _normalize_arxiv('arXiv:1501.00001')
+
+    assert expected == result
+
+
+def test_normalize_arxiv_handles_new_identifiers_without_prefix_and_with_version():
+    expected = '1501.00001'
+    result = _normalize_arxiv('1501.00001v1')
+
+    assert expected == result
+
+
+def test_normalize_arxiv_handles_new_identifiers_with_prefix_and_version():
+    expected = '1501.00001'
     result = _normalize_arxiv('arXiv:1501.00001v1')
+
+    assert expected == result
+
+
+def test_normalize_arxiv_handles_old_identifiers_without_prefix_or_version():
+    expected = 'math/0309136'
+    result = _normalize_arxiv('math.GT/0309136')
+
+    assert expected == result
+
+
+def test_normalize_arxiv_handles_old_identifiers_with_prefix_and_without_version():
+    expected = 'math/0309136'
+    result = _normalize_arxiv('arXiv:math.GT/0309136')
+
+    assert expected == result
+
+
+def test_normalize_arxiv_handles_old_identifiers_without_prefix_and_with_version():
+    expected = 'math/0309136'
+    result = _normalize_arxiv('math.GT/0309136v2')
+
+    assert expected == result
+
+
+def test_normalize_arxiv_handles_old_identifiers_with_prefix_and_version():
+    expected = 'math/0309136'
+    result = _normalize_arxiv('arXiv:math.GT/0309136v2')
 
     assert expected == result
 


### PR DESCRIPTION
Sentry: https://sentry.cern.ch/inspire-sentry/inspire-nightly/group/821839, https://sentry.cern.ch/inspire-sentry/inspire-nightly/group/618717

First commit simplifies some convoluted code that had so far escaped refactoring.

Second commit implements a small thing I need for HAL.

Third commit fixes a long-standing bug in `conferences`.