### PR TITLE
search: prevent error when no documents found in mget

### DIFF
--- a/inspirehep/modules/search/api.py
+++ b/inspirehep/modules/search/api.py
@@ -22,9 +22,12 @@
 
 from __future__ import absolute_import, division, print_function
 
+import logging
+
 from flask import request
 from flask_security import current_user
 
+from elasticsearch import RequestError
 from elasticsearch_dsl.query import Q
 
 from invenio_search.api import DefaultFilter, RecordsSearch
@@ -37,7 +40,7 @@ from inspirehep.modules.records.permissions import (
 
 from .query_factory import inspire_query_factory
 
-
+logger = logging.getLogger(__name__)
 IQ = inspire_query_factory()
 
 
@@ -77,14 +80,20 @@ class SearchMixin(object):
         :type uuids: list of strings representing uuids
         :returns: list of JSON documents
         """
-        documents = current_search_client.mget(
-            index=self.Meta.index,
-            doc_type=self.Meta.doc_types,
-            body={'ids': uuids},
-            **kwargs
-        )
+        results = []
 
-        return [document['_source'] for document in documents['docs']]
+        try:
+            documents = current_search_client.mget(
+                index=self.Meta.index,
+                doc_type=self.Meta.doc_types,
+                body={'ids': uuids},
+                **kwargs
+            )
+            results = [document['_source'] for document in documents['docs']]
+        except RequestError as e:
+            logger.warning('%s', e)
+
+        return results
 
 
 def inspire_filter():

--- a/tests/integration/search/test_search_api.py
+++ b/tests/integration/search/test_search_api.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import mock
+
+from inspirehep.modules.search.api import LiteratureSearch
+
+
+@mock.patch('inspirehep.modules.search.api.logger')
+def test_mget_warns_when_no_documents_to_get(l, app):
+    search = LiteratureSearch()
+    search.mget([])
+    l.warning.assert_called()

--- a/tests/integration/test_records.py
+++ b/tests/integration/test_records.py
@@ -334,12 +334,6 @@ def test_references_can_be_updated(app, records_to_be_merged):
     assert expected == result
 
 
-def test_get_es_records_raises_on_empty_list(app):
-    with app.app_context():
-        with pytest.raises(RequestError):
-            get_es_records('lit', [])
-
-
 def test_get_es_records_accepts_lists_of_integers(app):
     with app.app_context():
         records = get_es_records('lit', [4328])


### PR DESCRIPTION
* Catch ES RequestError exception to prevent the application from
  crashing when no documents are found in mget request. (addresses #2300)

* Log with warning level when this situation happens.

* Adds tests for to assert the new behaviour.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>