### PR TITLE
search: prevent error when no documents found in mget

### DIFF
--- a/tests/integration/test_records.py
+++ b/tests/integration/test_records.py
@@ -334,10 +334,8 @@ def test_references_can_be_updated(app, records_to_be_merged):
     assert expected == result
 
 
-def test_get_es_records_raises_on_empty_list(app):
-    with app.app_context():
-        with pytest.raises(RequestError):
-            get_es_records('lit', [])
+def test_get_es_records_handles_empty_lists(app):
+    get_es_records('lit', [])  # Does not raise.
 
 
 def test_get_es_records_accepts_lists_of_integers(app):


### PR DESCRIPTION
Closes #2302 

Catch `RequestError` from ES to prevent the application from crashing
when no documents are found in an `mget` request, but log this
exception when it happens (addresses #2300).