### PR TITLE
setup: bump invenio-workflows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ install_requires = [
     'invenio-trends-ui>=1.0.0a1',
     'elasticsearch<3.0.0',
     'Flask-Login<0.4.0',
-    'invenio-workflows~=6.0.2',
+    'invenio-workflows~=6.0.2,>=6.0.5',
     'invenio-workflows-files~=0.0.4',
     'invenio-workflows-ui~=1.0.31',
     'elasticsearch-dsl<2.2.0',


### PR DESCRIPTION
#2238 was fixed by inveniosoftware-contrib/invenio-workflows#40,
but the latest version of `invenio-workflows` must be installed
in order to fix the problem in production as well.

CC: @jmartinm 