### PR TITLE
workflows: refactor file handling

### DIFF
--- a/inspirehep/modules/workflows/tasks/actions.py
+++ b/inspirehep/modules/workflows/tasks/actions.py
@@ -27,12 +27,17 @@ from __future__ import absolute_import, division, print_function
 from functools import wraps
 
 from flask import current_app
+from werkzeug import secure_filename
 
-from inspirehep.modules.workflows.utils import log_workflows_action
-
+from inspirehep.modules.workflows.utils import (
+    get_pdf_in_workflow,
+    log_workflows_action,
+)
 from inspirehep.utils.record import get_arxiv_id, get_value
+from inspirehep.utils.url import is_pdf_link
 
-from ..utils import with_debug_logging
+from .refextract import extract_references
+from ..utils import download_file_to_workflow, with_debug_logging
 
 
 def mark(key, value):
@@ -194,6 +199,24 @@ def is_submission(obj, eng):
     return False
 
 
+@with_debug_logging
+def submission_fulltext_download(obj, eng):
+    submission_pdf = obj.extra_data.get('submission_pdf')
+    if submission_pdf and is_pdf_link(submission_pdf):
+        filename = secure_filename('fulltext.pdf')
+        pdf = download_file_to_workflow(
+            workflow=obj,
+            name=filename,
+            url=submission_pdf,
+        )
+
+        if pdf:
+            obj.log.info('PDF provided by user from %s', submission_pdf)
+            return obj.files[filename].file.uri
+        else:
+            obj.log.info('Cannot fetch PDF provided by user from %s', submission_pdf)
+
+
 def prepare_update_payload(extra_data_key="update_payload"):
     @with_debug_logging
     @wraps(prepare_update_payload)
@@ -204,3 +227,17 @@ def prepare_update_payload(extra_data_key="update_payload"):
         # FIXME: Just update entire record for now
         obj.extra_data[extra_data_key] = obj.data
     return _prepare_update_payload
+
+
+@with_debug_logging
+def refextract(obj, eng):
+    uri = get_pdf_in_workflow(obj)
+    if uri:
+        mapped_references = extract_references(uri)
+        if mapped_references:
+            obj.data['references'] = mapped_references
+            obj.log.info('Extracted %d references', len(mapped_references))
+        else:
+            obj.log.info('No references extracted')
+    else:
+        obj.log.error('Not able to download and process the PDF')

--- a/inspirehep/modules/workflows/tasks/classifier.py
+++ b/inspirehep/modules/workflows/tasks/classifier.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import, division, print_function
 from functools import wraps
 
 from ..proxies import antihep_keywords
-from ..utils import with_debug_logging
+from ..utils import with_debug_logging, get_pdf_in_workflow
 
 
 @with_debug_logging
@@ -75,11 +75,9 @@ def classify_paper(taxonomy, rebuild_cache=False, no_cache=False,
 
         fast_mode = False
         try:
-            # FIXME: May need to find another canonical way of getting PDF
-            if "pdf" in obj.extra_data:
-                result = get_keywords_from_local_file(
-                    obj.extra_data["pdf"], **params
-                )
+            uri = get_pdf_in_workflow(obj)
+            if uri:
+                result = get_keywords_from_local_file(uri, **params)
             else:
                 data = []
                 titles = obj.data.get('titles')

--- a/inspirehep/modules/workflows/tasks/submission.py
+++ b/inspirehep/modules/workflows/tasks/submission.py
@@ -374,19 +374,6 @@ def prepare_keywords(obj, eng):
 
 
 @with_debug_logging
-def user_pdf_get(obj, eng):
-    """Upload user PDF file, if requested."""
-    if obj.extra_data.get('pdf_upload', False):
-        fft = {'path': obj.extra_data.get('submission_pdf'),
-               'type': 'INSPIRE-PUBLIC'}
-        if obj.data.get('_fft'):
-            obj.data['_fft'].append(fft)
-        else:
-            obj.data['_fft'] = [fft]
-        obj.log.info("User PDF file added to FFT.")
-
-
-@with_debug_logging
 def prepare_files(obj, eng):
     """Adds to the _fft field (files) the extracted pdfs if any"""
     def _get_fft(url, name):

--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -36,8 +36,8 @@ from inspirehep.modules.workflows.tasks.refextract import extract_journal_info
 from inspirehep.modules.workflows.tasks.arxiv import (
     arxiv_author_list,
     arxiv_fulltext_download,
+    arxiv_package_download,
     arxiv_plot_extract,
-    arxiv_refextract,
     arxiv_derive_inspire_categories,
 )
 from inspirehep.modules.workflows.tasks.actions import (
@@ -52,7 +52,9 @@ from inspirehep.modules.workflows.tasks.actions import (
     is_submission,
     is_arxiv_paper,
     mark,
-    prepare_update_payload
+    prepare_update_payload,
+    refextract,
+    submission_fulltext_download,
 )
 
 from inspirehep.modules.workflows.tasks.classifier import (
@@ -85,7 +87,6 @@ from inspirehep.modules.workflows.tasks.submission import (
     remove_references,
     reply_ticket,
     send_robotupload,
-    user_pdf_get,
     wait_webcoll,
 )
 
@@ -180,10 +181,18 @@ ENHANCE_RECORD = [
         is_arxiv_paper,
         [
             arxiv_fulltext_download,
+            arxiv_package_download,
             arxiv_plot_extract,
-            arxiv_refextract,
+            refextract,
             arxiv_derive_inspire_categories,
             arxiv_author_list("authorlist2marcxml.xsl"),
+        ]
+    ),
+    IF(
+        is_submission,
+        [
+            submission_fulltext_download,
+            refextract,
         ]
     ),
     extract_journal_info,
@@ -278,7 +287,6 @@ POSTENHANCE_RECORD = [
     add_note_entry,
     filter_keywords,
     prepare_keywords,
-    user_pdf_get,
     remove_references,
     prepare_files,
 ]

--- a/inspirehep/utils/helpers.py
+++ b/inspirehep/utils/helpers.py
@@ -24,8 +24,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-from contextlib import closing
-
 import requests
 
 
@@ -40,23 +38,6 @@ def download_file(url, output_file=None, chunk_size=1024):
             for chunk in r.iter_content(chunk_size):
                 f.write(chunk)
     return output_file
-
-
-def download_file_to_workflow(workflow, name, url):
-    """Download a file to a specified workflow.
-
-    The ``workflow.files`` property is actually a method, which returns a
-    ``WorkflowFilesIterator``. This class inherits a custom ``__setitem__``
-    method from its parent, ``FilesIterator``, which ends up calling ``save``
-    on an ``invenio_files_rest.storage.pyfs.PyFSFileStorage`` instance
-    through ``ObjectVersion`` and ``FileObject``. This method consumes the
-    stream passed to it and saves in its place a ``FileObject`` with the
-    details of the downloaded file.
-    """
-    with closing(requests.get(url=url, stream=True)) as req:
-        if req.status_code == 200:
-            workflow.files[name] = req.raw
-            return workflow.files[name]
 
 
 def force_list(data):

--- a/inspirehep/utils/url.py
+++ b/inspirehep/utils/url.py
@@ -24,6 +24,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import requests
 from flask import current_app
 
 from inspirehep import __version__
@@ -38,3 +39,26 @@ def make_user_agent_string(component=""):
     if component:
         ret += " [{}]".format(component)
     return ret
+
+
+def is_pdf_link(url):
+    """Return ``True`` if ``url`` points to a PDF.
+
+    Returns ``True`` if the first few bytes of the response are ``%PDF``.
+
+    Args:
+        url (string): a URL.
+
+    Returns:
+        bool: whether the url points to a PDF.
+
+    """
+    try:
+        response = requests.get(url, allow_redirects=True, stream=True)
+    except requests.exceptions.RequestException:
+        return False
+
+    magic_number = next(response.iter_content(4))
+    correct_magic_number = magic_number.startswith('%PDF')
+
+    return correct_magic_number

--- a/tests/integration/workflows/test_arxiv_workflow.py
+++ b/tests/integration/workflows/test_arxiv_workflow.py
@@ -377,7 +377,7 @@ def get_halted_workflow(app, record, extra_config=None):
 
 
 @mock.patch(
-    'inspirehep.modules.workflows.tasks.arxiv.download_file_to_workflow',
+    'inspirehep.modules.workflows.utils.download_file_to_workflow',
     side_effect=fake_download_file,
 )
 @mock.patch(
@@ -440,7 +440,7 @@ def test_harvesting_arxiv_workflow_manual_rejected(
 
 
 @mock.patch(
-    'inspirehep.modules.workflows.tasks.arxiv.download_file_to_workflow',
+    'inspirehep.modules.workflows.utils.download_file_to_workflow',
     side_effect=fake_download_file,
 )
 @mock.patch(
@@ -494,6 +494,10 @@ def test_harvesting_arxiv_workflow_already_on_legacy(
     side_effect=fake_download_file,
 )
 @mock.patch(
+    'inspirehep.modules.workflows.utils.download_file_to_workflow',
+    side_effect=fake_download_file,
+)
+@mock.patch(
     'inspirehep.modules.workflows.tasks.beard.json_api_request',
     side_effect=fake_beard_api_request,
 )
@@ -519,7 +523,8 @@ def test_harvesting_arxiv_workflow_manual_accepted(
     mocked_api_request_beard_block,
     mocked_api_request_magpie,
     mocked_api_request_beard,
-    mocked_download,
+    mocked_download_utils,
+    mocked_download_arxiv,
     workflow_app,
     record,
 ):


### PR DESCRIPTION
Closes #2283 

Uniformizes the handling of PDFs within workflows between user
submissions and arXiv harvesting (closes #2255).

Consistently checks if PDFs are PDFs by centralizing the usage
of `is_pdf_link` (and basing the check only on the file's magic
number rather than on the mimetype reported by the server).