### PR TITLE
records-journals: add journal title suggester

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -945,6 +945,11 @@ RECORDS_REST_ENDPOINTS = dict(
                 ':json_v1_search'
             ),
         },
+        suggesters=dict(
+            journal_title=dict(completion=dict(
+                field='title_suggest'
+            ))
+        ),
         list_route='/journals/',
         item_route='/journals/<pid(jou,record_class="inspirehep.modules.records.api:InspireRecord"):pid_value>',
         default_media_type='application/json',

--- a/inspirehep/modules/forms/static/js/forms/journals_typeahead.js
+++ b/inspirehep/modules/forms/static/js/forms/journals_typeahead.js
@@ -30,9 +30,9 @@ define([
     this.dataEngine = new Bloodhound({
       name: 'journals',
       remote: {
-        url: '/api/journals?q=journalautocomplete:%QUERY*',
+        url: '/api/journals/_suggest?journal_title=%QUERY',
         filter: function(response) {
-          return $.map(response.hits.hits, function(el) { return el });
+          return $.map(response.journal_title[0].options, function(el) { return el });
         }
       },
       datumTokenizer: function() {},
@@ -63,16 +63,17 @@ define([
         }.bind(this));
       }.bind(this),
       displayKey: function(data) {
-        return data.metadata.journal_titles[0].title;
+        return data.text;
       },
       templates: {
         empty: function(data) {
           return 'Cannot find this journal in our database.';
         },
         suggestion: function(data) {
-          data.metadata.title = data.metadata.journal_titles[0].title;
-          data.metadata.short_title = data.metadata.short_titles[0].title;
-          return suggestionTemplate.render.call(suggestionTemplate, data.metadata);
+          var metadata = {};
+          metadata['title'] = data.payload.full_title;
+          metadata['short_title'] = data.text;
+          return suggestionTemplate.render.call(suggestionTemplate, metadata);
         }.bind(this)
       }
     });

--- a/inspirehep/modules/records/mappings/records/journals.json
+++ b/inspirehep/modules/records/mappings/records/journals.json
@@ -166,6 +166,10 @@
                     },
                     "type": "object"
                 },
+                "title_suggest": {
+                    "payloads": true,
+                    "type": "completion"
+                },
                 "title_variants": {
                     "properties": {
                         "source": {

--- a/inspirehep/modules/records/receivers.py
+++ b/inspirehep/modules/records/receivers.py
@@ -67,6 +67,7 @@ def enhance_record(sender, json, *args, **kwargs):
     populate_experiment_suggest(sender, json, *args, **kwargs)
     populate_abstract_source_suggest(sender, json, *args, **kwargs)
     populate_affiliation_suggest(sender, json, *args, **kwargs)
+    populate_title_suggest(sender, json, *args, **kwargs)
     after_record_enhanced.send(json)
 
 
@@ -304,6 +305,38 @@ def populate_affiliation_suggest(sender, json, *args, **kwargs):
                     'legacy_ICN': legacy_ICN,
                 },
             },
+        })
+
+
+def populate_title_suggest(sender, json, *args, **kwargs):
+    """Populate title_suggest field of Journals records."""
+    if 'journals.json' in json.get('$schema'):
+        input = []
+
+        journal_titles = get_value(json, 'journal_titles.title')
+        first_journal_title = ''
+        if journal_titles:
+            input.extend(journal_titles)
+            first_journal_title = journal_titles[0]
+
+        short_titles = get_value(json, 'short_titles.title')
+        first_short_title = ''
+        if short_titles:
+            first_short_title = short_titles[0]
+            input.extend(short_titles)
+
+        title_variants = get_value(json, 'title_variants.title')
+        if title_variants:
+            input.extend(title_variants)
+
+        json.update({
+            'title_suggest': {
+                'input': input,
+                'output': first_short_title,
+                'payload': {
+                    'full_title': first_journal_title
+                }
+            }
         })
 
 

--- a/tests/acceptance/test_literature_suggestion_form.py
+++ b/tests/acceptance/test_literature_suggestion_form.py
@@ -167,7 +167,7 @@ def test_journal_info_autocomplete_title(login):
     create_literature.go_to()
     assert create_literature.write_journal_title(
         'Nuc',
-        'Nuclear Physics',
+        'Nucl.Phys.',
     ).has_error()
 
 


### PR DESCRIPTION
* Add suggester for journal title in journal-records. Input is the full
  title, title variants and short titles. Output is the first short
  title and payload is full journal title.

Closes #2120.

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>
Co-authored-by: George Lignos glignos93@gmail.com