### PR TITLE
tests: unit tests for workflows/tasks/submission

### DIFF
--- a/inspirehep/modules/workflows/tasks/submission.py
+++ b/inspirehep/modules/workflows/tasks/submission.py
@@ -34,9 +34,12 @@ from retrying import retry
 
 from invenio_accounts.models import User
 
-from ..utils import with_debug_logging
-from ....utils.tickets import get_instance, retry_if_connection_problems
+from inspirehep.dojson.utils import legacy_export_as_marc
+from inspirehep.utils.robotupload import make_robotupload_marcxml
+from inspirehep.utils.tickets import get_instance, retry_if_connection_problems
+
 from .actions import in_production_mode, is_arxiv_paper
+from ..utils import with_debug_logging
 
 
 LOGGER = logging.getLogger(__name__)
@@ -131,8 +134,6 @@ def reply_ticket(template=None,
     @with_debug_logging
     @wraps(reply_ticket)
     def _reply_ticket(obj, eng):
-        from inspirehep.utils.tickets import get_instance
-
         ticket_id = obj.extra_data.get("ticket_id", "")
         if not ticket_id:
             obj.log.error("No ticket ID found!")
@@ -194,8 +195,6 @@ def close_ticket(ticket_id_key="ticket_id"):
     @with_debug_logging
     @wraps(close_ticket)
     def _close_ticket(obj, eng):
-        from inspirehep.utils.tickets import get_instance
-
         ticket_id = obj.extra_data.get(ticket_id_key, "")
         if not ticket_id:
             obj.log.error("No ticket ID found!")
@@ -241,9 +240,6 @@ def send_robotupload(
     @with_debug_logging
     @wraps(send_robotupload)
     def _send_robotupload(obj, eng):
-        from inspirehep.dojson.utils import legacy_export_as_marc
-        from inspirehep.utils.robotupload import make_robotupload_marcxml
-
         combined_callback_url = ''
         if callback_url:
             combined_callback_url = os.path.join(

--- a/tests/unit/helpers/mocks.py
+++ b/tests/unit/helpers/mocks.py
@@ -124,8 +124,32 @@ class MockLog(object):
 
 
 class MockRT(object):
+    def __init__(self):
+        self.last_id = 0
+        self.tickets = {}
+
     def create_ticket(self, **kwargs):
-        return 1
+        self.last_id += 1
+        kwargs.update({'ticket_id': self.last_id})
+        self.tickets[self.last_id] = kwargs
+        return self.last_id
+
+    def edit_ticket(self, ticket_id, **kwargs):
+        try:
+            ticket = self.tickets[ticket_id]
+            if ticket['Status'] == 'resolved':
+                raise KeyError
+        except KeyError:
+            raise IndexError
+
+        ticket.update(kwargs)
+
+    def get_ticket(self, ticket_id):
+        return self.tickets[ticket_id]
+
+    def reply(self, ticket_id, **kwargs):
+        kwargs.update({'Status': 'acknowledged'})
+        self.tickets[ticket_id].update(kwargs)
 
 
 class MockUser(object):

--- a/tests/unit/helpers/mocks.py
+++ b/tests/unit/helpers/mocks.py
@@ -29,9 +29,9 @@ class MockEng(object):
     def __init__(self, data_type='hep'):
         self.workflow_definition = AttrDict(data_type=data_type)
 
-    def halt(self, action, msg):
-        self.action = action
+    def halt(self, msg='', action=None):
         self.msg = msg
+        self.action = action
 
 
 class MockObj(object):

--- a/tests/unit/helpers/mocks.py
+++ b/tests/unit/helpers/mocks.py
@@ -123,6 +123,11 @@ class MockLog(object):
         self._warning.write(msg % args if args else msg)
 
 
+class MockRT(object):
+    def create_ticket(self, **kwargs):
+        return 1
+
+
 class MockUser(object):
     def __init__(self, email, roles=[]):
         self.email = email

--- a/tests/unit/helpers/mocks.py
+++ b/tests/unit/helpers/mocks.py
@@ -110,13 +110,13 @@ class MockLog(object):
         self._info = StringIO()
 
     def debug(self, msg, *args, **kwargs):
-        self._debug.write(msg % args)
+        self._debug.write(msg % args if args else msg)
 
     def error(self, msg, *args, **kwargs):
-        self._error.write(msg % args)
+        self._error.write(msg % args if args else msg)
 
     def info(self, msg, *args, **kwargs):
-        self._info.write(msg % args)
+        self._info.write(msg % args if args else msg)
 
 
 class MockUser(object):

--- a/tests/unit/helpers/mocks.py
+++ b/tests/unit/helpers/mocks.py
@@ -108,6 +108,7 @@ class MockLog(object):
         self._debug = StringIO()
         self._error = StringIO()
         self._info = StringIO()
+        self._warning = StringIO()
 
     def debug(self, msg, *args, **kwargs):
         self._debug.write(msg % args if args else msg)
@@ -117,6 +118,9 @@ class MockLog(object):
 
     def info(self, msg, *args, **kwargs):
         self._info.write(msg % args if args else msg)
+
+    def warning(self, msg, *args, **kwargs):
+        self._warning.write(msg % args if args else msg)
 
 
 class MockUser(object):

--- a/tests/unit/workflows/test_workflows_tasks_submission.py
+++ b/tests/unit/workflows/test_workflows_tasks_submission.py
@@ -22,13 +22,29 @@
 
 from __future__ import absolute_import, division, print_function
 
+import httpretty
+import pytest
 from flask import current_app
 from mock import patch
 
+from inspire_schemas.utils import load_schema
+from inspirehep.dojson.hep import hep2marc
+from inspirehep.dojson.hepnames import hepnames2marc
+from inspirehep.dojson.utils import validate
+from inspirehep.modules.literaturesuggest.tasks import (
+    reply_ticket_context as literaturesuggest_reply_ticket_context,
+)
 from inspirehep.modules.workflows.tasks.submission import (
     add_note_entry,
+    close_ticket,
     create_ticket,
+    filter_keywords,
     prepare_files,
+    prepare_keywords,
+    remove_references,
+    reply_ticket,
+    send_robotupload,
+    wait_webcoll,
 )
 
 from mocks import AttrDict, MockEng, MockFiles, MockObj, MockUser, MockRT
@@ -36,9 +52,9 @@ from mocks import AttrDict, MockEng, MockFiles, MockObj, MockUser, MockRT
 
 @patch('inspirehep.modules.workflows.tasks.submission.User')
 @patch('inspirehep.modules.workflows.tasks.submission.render_template')
-def test_create_ticket_handles_unicode_when_not_in_production_mode(r_t, user):
-    user.query.get.return_value = MockUser('user@example.com')
-    r_t.return_value = u'φοο'
+def test_create_ticket_handles_unicode_when_not_in_production_mode(mock_render_template, mock_user):
+    mock_user.query.get.return_value = MockUser('user@example.com')
+    mock_render_template.return_value = u'φοο'
 
     config = {'PRODUCTION_MODE': False}
 
@@ -51,22 +67,24 @@ def test_create_ticket_handles_unicode_when_not_in_production_mode(r_t, user):
 
         _create_ticket = create_ticket(None)
 
+        assert _create_ticket(obj, eng) is None
+
         expected = (
             u'Was going to create ticket: None\n\nφοο\n\n'
             u'To: user@example.com Queue: Test'
         )
+        result = obj.log._info.getvalue()
 
-        assert _create_ticket(obj, eng) is None
-        assert expected == obj.log._info.getvalue()
+        assert expected == result
 
 
 @patch('inspirehep.modules.workflows.tasks.submission.User')
 @patch('inspirehep.modules.workflows.tasks.submission.render_template')
 @patch('inspirehep.modules.workflows.tasks.submission.get_instance')
-def test_create_ticket_handles_unicode_when_in_production_mode(g_i, r_t, user):
-    user.query.get.return_value = MockUser('user@example.com')
-    r_t.return_value = u'φοο'
-    g_i.return_value = MockRT()
+def test_create_ticket_handles_unicode_when_in_production_mode(mock_get_instance, mock_render_template, mock_user):
+    mock_user.query.get.return_value = MockUser('user@example.com')
+    mock_render_template.return_value = u'φοο'
+    mock_get_instance.return_value = MockRT()
 
     config = {'PRODUCTION_MODE': True}
 
@@ -80,30 +98,953 @@ def test_create_ticket_handles_unicode_when_in_production_mode(g_i, r_t, user):
         _create_ticket = create_ticket(None)
 
         assert _create_ticket(obj, eng) is None
-        assert obj.extra_data == {'ticket_id': 1}
-        assert u'Ticket 1 created:\nφοο' in obj.log._info.getvalue()
+
+        expected = {'ticket_id': 1}
+        result = obj.extra_data
+
+        assert expected == result
+
+        expected = u'Ticket 1 created:\nφοο'
+        result = obj.log._info.getvalue()
+
+        assert expected == result
+
+
+@patch('inspirehep.modules.workflows.tasks.submission.User')
+@patch('inspirehep.modules.workflows.tasks.submission.get_instance')
+def test_reply_ticket_thanks_the_user_when_their_literature_submission_is_received(mock_get_instance, mock_user):
+    mock_rt = MockRT()
+    mock_rt.create_ticket(Queue='Test', Status='new')
+    mock_get_instance.return_value = mock_rt
+    mock_user.query.get.return_value = MockUser('user@example.com')
+
+    schema = load_schema('hep')
+    subschema = schema['properties']['titles']
+
+    data = {
+        'titles': [
+            {'title': 'Partial Symmetries of Weak Interactions'},
+        ],
+    }
+    extra_data = {'ticket_id': 1}
+    assert validate(data['titles'], subschema) is None
+
+    obj = MockObj(data, extra_data)
+    eng = MockEng()
+
+    _reply_ticket = reply_ticket(
+        template='literaturesuggest/tickets/user_submitted.html',
+        context_factory=literaturesuggest_reply_ticket_context,
+        keep_new=True,
+    )
+
+    assert _reply_ticket(obj, eng) is None
+
+    expected = (
+        'Dear user@example.com,\n '
+        '\n '
+        'Thank you very much for suggesting "Partial Symmetries of Weak Interactions" '
+        'to INSPIRE. It has been received and will be reviewed by our staff as '
+        'soon as possible. You will hear back from us shortly.\n '
+        '\n '
+        'Thank you for sharing with INSPIRE!'
+    )
+    result = mock_rt.get_ticket(1)
+
+    assert expected == result['text']
+
+    expected = 'new'
+    result = mock_rt.get_ticket(1)
+
+    assert expected == result['Status']
+
+
+@patch('inspirehep.modules.workflows.tasks.submission.User')
+@patch('inspirehep.modules.workflows.tasks.submission.get_instance')
+def test_reply_ticket_thanks_user_when_their_literature_submission_is_accepted(mock_get_instance, mock_user):
+    mock_rt = MockRT()
+    mock_rt.create_ticket(Queue='Test', Status='new')
+    mock_get_instance.return_value = mock_rt
+    mock_user.query.get.return_value = MockUser('user@example.com')
+
+    schema = load_schema('hep')
+    subschema = schema['properties']['titles']
+
+    data = {
+        'titles': [
+            {'title': 'Partial Symmetries of Weak Interactions'},
+        ],
+    }
+    extra_data = {'ticket_id': 1}
+    assert validate(data['titles'], subschema) is None
+
+    obj = MockObj(data, extra_data)
+    eng = MockEng()
+
+    _reply_ticket = reply_ticket(
+        template='literaturesuggest/tickets/user_accepted.html',
+        context_factory=literaturesuggest_reply_ticket_context,
+    )
+
+    assert _reply_ticket(obj, eng) is None
+
+    expected = (
+        'Dear user@example.com,\n '
+        '\n '
+        'Thank you very much again for your suggestion "Partial Symmetries of Weak Interactions". '
+        'It has been reviewed by our curators and is now in INSPIRE.\n '
+        '\n '
+        "If you have any further questions, don't hesitate to contact us.\n "
+        '\n '
+        'Thanks again for your submission!'
+    )
+    result = mock_rt.get_ticket(1)
+
+    assert expected == result['text']
+
+    expected = 'acknowledged'
+    result = mock_rt.get_ticket(1)
+
+    assert expected == result['Status']
+
+
+def test_reply_ticket_logs_an_error_when_there_is_no_ticket_id():
+    data = {}
+    extra_data = {}
+
+    obj = MockObj(data, extra_data)
+    eng = MockEng()
+
+    _reply_ticket = reply_ticket()
+
+    assert _reply_ticket(obj, eng) is None
+
+    expected = 'No ticket ID found!'
+    result = obj.log._error.getvalue()
+
+    assert expected == result
+
+
+@patch('inspirehep.modules.workflows.tasks.submission.User')
+def test_reply_ticket_logs_an_error_when_there_is_no_user(mock_user):
+    mock_user.query.get.return_value = None
+
+    data = {}
+    extra_data = {'ticket_id': 1}
+
+    obj = MockObj(data, extra_data, id=1, id_user=1)
+    eng = MockEng()
+
+    _reply_ticket = reply_ticket()
+
+    assert _reply_ticket(obj, eng) is None
+
+    expected = 'No user found for object 1, skipping ticket creation'
+    result = obj.log._error.getvalue()
+
+    assert expected == result
+
+
+@patch('inspirehep.modules.workflows.tasks.submission.User')
+def test_reply_ticket_falls_back_to_reason_when_there_is_no_template(mock_user):
+    mock_user.query.get.return_value = MockUser('user@example.com')
+
+    data = {}
+    extra_data = {
+        'reason': 'reason',
+        'ticket_id': 1,
+    }
+
+    obj = MockObj(data, extra_data, id=1, id_user=1)
+    eng = MockEng()
+
+    _reply_ticket = reply_ticket()
+
+    assert _reply_ticket(obj, eng) is None
+
+
+@patch('inspirehep.modules.workflows.tasks.submission.User')
+def test_reply_ticket_logs_an_error_when_the_fallback_is_an_empty_string(mock_user):
+    mock_user.query.get.return_value = MockUser('user@example.com')
+
+    data = {}
+    extra_data = {
+        'reason': '',
+        'ticket_id': 1,
+    }
+
+    obj = MockObj(data, extra_data, id=1, id_user=1)
+    eng = MockEng()
+
+    _reply_ticket = reply_ticket()
+
+    assert _reply_ticket(obj, eng) is None
+
+    expected = 'No body for ticket reply. Skipping reply.'
+    result = obj.log._error.getvalue()
+
+    assert expected == result
+
+
+@patch('inspirehep.modules.workflows.tasks.submission.User')
+@patch('inspirehep.modules.workflows.tasks.submission.render_template')
+@patch('inspirehep.modules.workflows.tasks.submission.get_instance')
+def test_reply_ticket_logs_when_there_is_no_rt_instance(mock_get_instance, mock_render_template, mock_user):
+    mock_get_instance.return_value = None
+    mock_render_template.return_value = 'foo'
+    mock_user.query.get.return_value = MockUser('user@example.com')
+
+    data = {}
+    extra_data = {'ticket_id': 1}
+
+    obj = MockObj(data, extra_data, id=1, id_user=1)
+    eng = MockEng()
+
+    _reply_ticket = reply_ticket(template='foo')
+
+    assert _reply_ticket(obj, eng) is None
+
+    expected = 'No RT instance available. Skipping!'
+    result = obj.log._error.getvalue()
+
+    assert expected == result
+
+    expected = 'Was going to reply to 1\n\nfoo\n\n'
+    result = obj.log._info.getvalue()
+
+    assert expected == result
+
+
+@pytest.mark.xfail
+@patch('inspirehep.modules.workflows.tasks.submission.User')
+@patch('inspirehep.modules.workflows.tasks.submission.render_template')
+@patch('inspirehep.modules.workflows.tasks.submission.get_instance')
+def test_reply_ticket_handles_unicode_when_there_is_no_rt_instance(mock_get_instance, mock_render_template, mock_user):
+    mock_get_instance.return_value = None
+    mock_render_template.return_value = u'φοο'
+    mock_user.query.get.return_value = MockUser('user@example.com')
+
+    data = {}
+    extra_data = {'ticket_id': 1}
+
+    obj = MockObj(data, extra_data, id=1, id_user=1)
+    eng = MockEng()
+
+    _reply_ticket = reply_ticket(template='foo')
+
+    assert _reply_ticket(obj, eng) is None
+
+    expected = 'No RT instance available. Skipping!'
+    result = obj.log._error.getvalue()
+
+    assert expected == result
+
+    expected = u'Was going to reply to 1\n\nφοο\n\n'
+    result = obj.log._info.getvalue()
+
+    assert expected == result
+
+
+@patch('inspirehep.modules.workflows.tasks.submission.User')
+@patch('inspirehep.modules.workflows.tasks.submission.render_template')
+@patch('inspirehep.modules.workflows.tasks.submission.get_instance')
+def test_reply_ticket_keeps_new_status_when_requested(mock_get_instance, mock_render_template, mock_user):
+    mock_rt = MockRT()
+    mock_rt.create_ticket(Queue='Test', Status='new')
+    mock_get_instance.return_value = mock_rt
+    mock_render_template.return_value = 'foo'
+    mock_user.query.get.return_value = MockUser('user@example.com')
+
+    data = {}
+    extra_data = {'ticket_id': 1}
+
+    obj = MockObj(data, extra_data, id=1, id_user=1)
+    eng = MockEng()
+
+    _reply_ticket = reply_ticket(keep_new=True, template='foo')
+
+    assert _reply_ticket(obj, eng) is None
+
+    expected = 'foo'
+    result = mock_rt.get_ticket(1)
+
+    assert expected == result['text']
+
+    expected = 'new'
+    result = mock_rt.get_ticket(1)
+
+    assert expected == result['Status']
+
+
+@patch('inspirehep.modules.workflows.tasks.submission.get_instance')
+def test_close_ticket_marks_a_ticket_as_resolved(mock_get_instance):
+    mock_rt = MockRT()
+    mock_rt.create_ticket(Queue='Test', Status='new')
+    mock_get_instance.return_value = mock_rt
+
+    data = {}
+    extra_data = {'ticket_id': 1}
+
+    obj = MockObj(data, extra_data)
+    eng = MockEng()
+
+    _close_ticket = close_ticket()
+
+    assert _close_ticket(obj, eng) is None
+
+    expected = 'resolved'
+    result = mock_rt.get_ticket(1)
+
+    assert expected == result['Status']
+
+
+def test_close_ticket_logs_an_error_when_there_is_no_ticket_id():
+    data = {}
+    extra_data = {}
+
+    obj = MockObj(data, extra_data)
+    eng = MockEng()
+
+    _close_ticket = close_ticket()
+
+    assert _close_ticket(obj, eng) is None
+
+    expected = 'No ticket ID found!'
+    result = obj.log._error.getvalue()
+
+    assert expected == result
+
+
+def test_close_ticket_logs_when_there_is_no_rt_instance():
+    data = {}
+    extra_data = {'ticket_id': 1}
+
+    obj = MockObj(data, extra_data)
+    eng = MockEng()
+
+    _close_ticket = close_ticket()
+
+    assert _close_ticket(obj, eng) is None
+
+    expected = 'No RT instance available. Skipping!'
+    result = obj.log._error.getvalue()
+
+    assert expected == result
+
+    expected = 'Was going to close ticket 1'
+    result = obj.log._info.getvalue()
+
+    assert expected == result
+
+
+@patch('inspirehep.modules.workflows.tasks.submission.get_instance')
+def test_close_ticket_logs_a_warning_if_the_ticket_is_already_resolved(mock_get_instance):
+    mock_rt = MockRT()
+    mock_rt.create_ticket(Queue='Test', Status='resolved')
+    mock_get_instance.return_value = mock_rt
+
+    data = {}
+    extra_data = {'ticket_id': 1}
+
+    obj = MockObj(data, extra_data)
+    eng = MockEng()
+
+    _close_ticket = close_ticket()
+
+    assert _close_ticket(obj, eng) is None
+
+    expected = 'Ticket is already resolved.'
+    result = obj.log._warning.getvalue()
+
+    assert expected == result
+
+
+@pytest.mark.httpretty
+def test_send_robotupload_works_with_mode_correct_and_extra_data_key():
+    httpretty.HTTPretty.allow_net_connect = False
+    httpretty.register_uri(
+        httpretty.POST, 'http://inspirehep.net/batchuploader/robotupload/correct',
+        body='[INFO] foo bar baz')
+
+    config = {
+        'LEGACY_ROBOTUPLOAD_URL': 'http://inspirehep.net',
+        'PRODUCTION_MODE': True,
+    }
+
+    with patch.dict(current_app.config, config):
+        data = {}
+        extra_data = {
+            'update_payload': {
+                'arxiv_eprints': [
+                    {
+                        'categories': [
+                            'hep-th',
+                        ],
+                        'value': 'hep-th/9711200',
+                    },
+                ],
+            },
+        }
+
+        obj = MockObj(data, extra_data)
+        eng = MockEng()
+
+        _send_robotupload = send_robotupload(
+            marcxml_processor=hep2marc,
+            mode='correct',
+            extra_data_key='update_payload',
+        )
+
+        assert _send_robotupload(obj, eng) is None
+
+        expected = (
+            'Robotupload sent!'
+            '[INFO] foo bar baz'
+            'end of upload'
+        )
+        result = obj.log._info.getvalue()
+
+        assert expected == result
+
+        expected = 'Waiting for robotupload: [INFO] foo bar baz'
+        result = eng.msg
+
+        assert expected == result
+
+    httpretty.HTTPretty.allow_net_connect = True
+
+
+@pytest.mark.httpretty
+def test_send_robotupload_works_with_hep2marc_and_mode_insert():
+    httpretty.HTTPretty.allow_net_connect = False
+    httpretty.register_uri(
+        httpretty.POST, 'http://inspirehep.net/batchuploader/robotupload/insert',
+        body='[INFO] foo bar baz')
+
+    schema = load_schema('hep')
+    subschema = schema['properties']['arxiv_eprints']
+
+    config = {
+        'LEGACY_ROBOTUPLOAD_URL': 'http://inspirehep.net',
+        'PRODUCTION_MODE': True,
+    }
+
+    with patch.dict(current_app.config, config):
+        data = {
+            'arxiv_eprints': [
+                {
+                    'categories': [
+                        'hep-th',
+                    ],
+                    'value': 'hep-th/9711200',
+                },
+            ],
+        }
+        extra_data = {}
+        assert validate(data['arxiv_eprints'], subschema) is None
+
+        obj = MockObj(data, extra_data)
+        eng = MockEng()
+
+        _send_robotupload = send_robotupload(
+            marcxml_processor=hep2marc,
+            mode='insert',
+        )
+
+        assert _send_robotupload(obj, eng) is None
+
+        expected = (
+            'Robotupload sent!'
+            '[INFO] foo bar baz'
+            'end of upload'
+        )
+        result = obj.log._info.getvalue()
+
+        assert expected == result
+
+        expected = 'Waiting for robotupload: [INFO] foo bar baz'
+        result = eng.msg
+
+        assert expected == result
+
+    httpretty.HTTPretty.allow_net_connect = True
+
+
+@pytest.mark.httpretty
+def test_send_robotupload_works_with_hepnames2marc_and_mode_insert():
+    httpretty.HTTPretty.allow_net_connect = False
+    httpretty.register_uri(
+        httpretty.POST, 'http://inspirehep.net/batchuploader/robotupload/insert',
+        body='[INFO] foo bar baz')
+
+    schema = load_schema('authors')
+    subschema = schema['properties']['arxiv_categories']
+
+    config = {
+        'LEGACY_ROBOTUPLOAD_URL': 'http://inspirehep.net',
+        'PRODUCTION_MODE': True,
+    }
+
+    with patch.dict(current_app.config, config):
+        data = {
+            'arxiv_categories': [
+                'hep-th',
+            ],
+        }
+        extra_data = {}
+        assert validate(data['arxiv_categories'], subschema) is None
+
+        obj = MockObj(data, extra_data)
+        eng = MockEng()
+
+        _send_robotupload = send_robotupload(
+            marcxml_processor=hepnames2marc,
+            mode='insert',
+        )
+
+        assert _send_robotupload(obj, eng) is None
+
+        expected = (
+            'Robotupload sent!'
+            '[INFO] foo bar baz'
+            'end of upload'
+        )
+        result = obj.log._info.getvalue()
+
+        assert expected == result
+
+        expected = 'Waiting for robotupload: [INFO] foo bar baz'
+        result = eng.msg
+
+        assert expected == result
+
+    httpretty.HTTPretty.allow_net_connect = True
+
+
+@pytest.mark.httpretty
+def test_send_robotupload_works_with_mode_holdingpen_and_without_callback_url():
+    httpretty.HTTPretty.allow_net_connect = False
+    httpretty.register_uri(
+        httpretty.POST, 'http://inspirehep.net/batchuploader/robotupload/holdingpen',
+        body='[INFO] foo bar baz')
+
+    schema = load_schema('authors')
+    subschema = schema['properties']['arxiv_categories']
+
+    config = {
+        'LEGACY_ROBOTUPLOAD_URL': 'http://inspirehep.net',
+        'PRODUCTION_MODE': True,
+    }
+
+    with patch.dict(current_app.config, config):
+        data = {
+            'arxiv_categories': [
+                'hep-th',
+            ],
+        }
+        extra_data = {}
+        assert validate(data['arxiv_categories'], subschema) is None
+
+        obj = MockObj(data, extra_data)
+        eng = MockEng()
+
+        _send_robotupload = send_robotupload(
+            marcxml_processor=hepnames2marc,
+            mode='holdingpen',
+            callback_url=None,
+        )
+
+        assert _send_robotupload(obj, eng) is None
+
+        expected = (
+            'Robotupload sent!'
+            '[INFO] foo bar baz'
+            'end of upload'
+        )
+        result = obj.log._info.getvalue()
+
+        assert expected == result
+
+    httpretty.HTTPretty.allow_net_connect = True
+
+
+@pytest.mark.httpretty
+def test_send_robotupload_logs_on_error_response():
+    httpretty.HTTPretty.allow_net_connect = False
+    httpretty.register_uri(
+        httpretty.POST, 'http://inspirehep.net/batchuploader/robotupload/insert',
+        body='[ERROR] cannot use the service')
+
+    schema = load_schema('hep')
+    subschema = schema['properties']['arxiv_eprints']
+
+    config = {
+        'LEGACY_ROBOTUPLOAD_URL': 'http://inspirehep.net',
+        'PRODUCTION_MODE': True,
+    }
+
+    with patch.dict(current_app.config, config):
+        data = {
+            'arxiv_eprints': [
+                {
+                    'categories': [
+                        'hep-th',
+                    ],
+                    'value': 'hep-th/9711200',
+                },
+            ],
+        }
+        extra_data = {}
+        assert validate(data['arxiv_eprints'], subschema) is None
+
+        obj = MockObj(data, extra_data)
+        eng = MockEng()
+
+        _send_robotupload = send_robotupload(
+            marcxml_processor=hep2marc,
+            mode='insert',
+        )
+
+        with pytest.raises(Exception) as excinfo:
+            _send_robotupload(obj, eng)
+
+        expected = (
+            'Error while submitting robotupload: '
+            '[ERROR] cannot use the service'
+        )
+        result = str(excinfo.value)
+
+        assert expected == result
+
+        expected = (
+            'Your IP is not in app.config_BATCHUPLOADER_WEB_ROBOT_RIGHTS on host'
+            '[ERROR] cannot use the service'
+        )
+        result = obj.log._error.getvalue()
+
+        assert expected == result
+
+    httpretty.HTTPretty.allow_net_connect = True
+
+
+@pytest.mark.httpretty
+def test_send_robotupload_does_nothing_when_not_in_production_mode():
+    httpretty.HTTPretty.allow_net_connect = False
+
+    schema = load_schema('hep')
+    subschema = schema['properties']['arxiv_eprints']
+
+    config = {
+        'LEGACY_ROBOTUPLOAD_URL': 'http://inspirehep.net',
+        'PRODUCTION_MODE': False,
+    }
+
+    with patch.dict(current_app.config, config):
+        data = {
+            'arxiv_eprints': [
+                {
+                    'categories': [
+                        'hep-th',
+                    ],
+                    'value': 'hep-th/9711200',
+                },
+            ],
+        }
+        extra_data = {}
+        assert validate(data['arxiv_eprints'], subschema) is None
+
+        obj = MockObj(data, extra_data)
+        eng = MockEng()
+
+        _send_robotupload = send_robotupload(
+            marcxml_processor=hep2marc,
+            mode='insert',
+        )
+
+        assert _send_robotupload(obj, eng) is None
+
+    httpretty.HTTPretty.allow_net_connect = True
+
+
+def test_wait_webcoll_halts_the_workflow_engine_when_in_production_mode():
+    config = {'PRODUCTION_MODE': True}
+
+    with patch.dict(current_app.config, config):
+        data = {}
+        extra_data = {}
+
+        obj = MockObj(data, extra_data)
+        eng = MockEng()
+
+        assert wait_webcoll(obj, eng) is None
+
+        expected = 'Waiting for webcoll.'
+        result = eng.msg
+
+        assert expected == result
+
+
+def test_wait_webcoll_does_nothing_otherwise():
+    config = {'PRODUCTION_MODE': False}
+
+    with patch.dict(current_app.config, config):
+        data = {}
+        extra_data = {}
+
+        obj = MockObj(data, extra_data)
+        eng = MockEng()
+
+        assert wait_webcoll(obj, eng) is None
+
+
+def test_add_note_entry():
+    schema = load_schema('hep')
+    subschema = schema['properties']['public_notes']
+
+    data = {
+        'public_notes': [
+            {'value': 'Reprinted in *Duff, M.J. (ed.): The world in eleven dimensions* 492-513'},
+        ],
+    }
+    extra_data = {}
+    assert validate(data['public_notes'], subschema) is None
+
+    obj = MockObj(data, extra_data)
+    eng = MockEng()
+
+    assert add_note_entry(obj, eng) is None
+
+    expected = [
+        {'value': 'Reprinted in *Duff, M.J. (ed.): The world in eleven dimensions* 492-513'},
+        {'value': '*Brief entry*'},
+    ]
+    result = obj.data
+
+    assert validate(result['public_notes'], subschema) is None
+    assert expected == result['public_notes']
+
+
+def test_add_note_entry_creates_public_notes_if_not_present():
+    schema = load_schema('hep')
+    subschema = schema['properties']['public_notes']
+
+    data = {}
+    extra_data = {}
+
+    obj = MockObj(data, extra_data)
+    eng = MockEng()
+
+    assert add_note_entry(obj, eng) is None
+
+    expected = [
+        {'value': '*Brief entry*'},
+    ]
+    result = obj.data
+
+    assert validate(result['public_notes'], subschema) is None
+    assert expected == result['public_notes']
 
 
 def test_add_note_entry_does_not_add_value_that_is_already_present():
+    schema = load_schema('hep')
+    subschema = schema['properties']['public_notes']
+
     data = {
         'public_notes': [
             {'value': '*Temporary entry*'},
         ],
     }
     extra_data = {'core': 'something'}
+    assert validate(data['public_notes'], subschema) is None
 
     obj = MockObj(data, extra_data)
     eng = MockEng()
 
     assert add_note_entry(obj, eng) is None
-    assert obj.data == {
-        'public_notes': [
-            {'value': '*Temporary entry*'},
+
+    expected = [
+        {'value': '*Temporary entry*'},
+    ]
+    result = obj.data
+
+    assert validate(result['public_notes'], subschema) is None
+    assert expected == result['public_notes']
+
+
+def test_filter_keywords():
+    data = {}
+    extra_data = {
+        'keywords_prediction': {
+            'keywords': [
+                {
+                    'accept': True,
+                    'label': 'galaxy',
+                },
+                {
+                    'accept': True,
+                    'label': 'numerical calculations',
+                },
+                {
+                    'accept': False,
+                    'label': 'numerical calculations: interpretation of experiments',
+                },
+            ],
+        },
+    }
+
+    obj = MockObj(data, extra_data)
+    eng = MockEng()
+
+    assert filter_keywords(obj, eng) is None
+
+    expected = [
+        {
+            'accept': True,
+            'label': 'galaxy',
+        },
+        {
+            'accept': True,
+            'label': 'numerical calculations',
+        },
+    ]
+    result = obj.extra_data['keywords_prediction']
+
+    assert expected == result['keywords']
+
+
+def test_filter_keywords_does_nothing_if_no_keywords_were_predicted():
+    data = {}
+    extra_data = {}
+
+    obj = MockObj(data, extra_data)
+    eng = MockEng()
+
+    assert filter_keywords(obj, eng) is None
+
+    expected = {}
+    result = obj.extra_data
+
+    assert expected == result
+
+
+def test_prepare_keywords():
+    schema = load_schema('hep')
+    subschema = schema['properties']['keywords']
+
+    data = {}
+    extra_data = {
+        'keywords_prediction': {
+            'keywords': [
+                {'label': 'galaxy'},
+                {'label': 'numerical calculations'},
+            ],
+        },
+    }
+
+    obj = MockObj(data, extra_data)
+    eng = MockEng()
+
+    assert prepare_keywords(obj, eng) is None
+
+    expected = [
+        {
+            'source': 'magpie',
+            'value': 'galaxy',
+        },
+        {
+            'source': 'magpie',
+            'value': 'numerical calculations',
+        },
+    ]
+    result = obj.data
+
+    assert validate(result['keywords'], subschema) is None
+    assert expected == result['keywords']
+
+
+def test_prepare_keywords_appends_to_existing_keywords():
+    schema = load_schema('hep')
+    subschema = schema['properties']['keywords']
+
+    data = {
+        'keywords': [
+            {
+                'schema': 'INSPIRE',
+                'value': 'field theory: conformal',
+            },
         ],
     }
+    extra_data = {
+        'keywords_prediction': {
+            'keywords': [
+                {'label': 'expansion 1/N'},
+                {'label': 'supergravity'},
+            ],
+        },
+    }
+    assert validate(data['keywords'], subschema) is None
+
+    obj = MockObj(data, extra_data)
+    eng = MockEng()
+
+    assert prepare_keywords(obj, eng) is None
+
+    expected = [
+        {
+            'schema': 'INSPIRE',
+            'value': 'field theory: conformal',
+        },
+        {
+            'source': 'magpie',
+            'value': 'expansion 1/N',
+        },
+        {
+            'source': 'magpie',
+            'value': 'supergravity',
+        },
+    ]
+    result = obj.data
+
+    assert validate(result['keywords'], subschema) is None
+    assert expected == result['keywords']
+
+
+def test_prepare_keywords_does_nothing_if_no_keywords_were_predicted():
+    schema = load_schema('hep')
+    subschema = schema['properties']['keywords']
+
+    data = {
+        'keywords': [
+            {
+                'schema': 'INSPIRE',
+                'value': 'field theory: conformal',
+            },
+        ],
+    }
+    extra_data = {}
+    assert validate(data['keywords'], subschema) is None
+
+    obj = MockObj(data, extra_data)
+    eng = MockEng()
+
+    assert prepare_keywords(obj, eng) is None
+
+    expected = [
+        {
+            'schema': 'INSPIRE',
+            'value': 'field theory: conformal',
+        },
+    ]
+    result = obj.data
+
+    assert validate(result['keywords'], subschema) is None
+    assert expected == result['keywords']
 
 
 def test_prepare_files():
+    schema = load_schema('hep')
+    subschema = schema['properties']['_fft']
+
     data = {}
     extra_data = {}
     files = MockFiles({
@@ -120,23 +1061,39 @@ def test_prepare_files():
     eng = MockEng()
 
     assert prepare_files(obj, eng) is None
-    assert obj.data == {
-        '_fft': [
-            {
-                'path': '/data/foo.pdf',
-                'type': 'INSPIRE-PUBLIC',
-                'filename': 'foo',
-                'format': '.pdf',
-            },
-        ],
-    }
-    assert 'Non-user PDF files added to FFT.' == obj.log._info.getvalue()
+
+    expected = [
+        {
+            'path': '/data/foo.pdf',
+            'type': 'INSPIRE-PUBLIC',
+            'filename': 'foo',
+            'format': '.pdf',
+        },
+    ]
+    result = obj.data
+
+    assert validate(result['_fft'], subschema) is None
+    assert expected == result['_fft']
+
+    expected = 'Non-user PDF files added to FFT.'
+    result = obj.log._info.getvalue()
+
+    assert expected == result
 
 
 def test_prepare_files_annotates_files_from_arxiv():
+    schema = load_schema('hep')
+    _fft_schema = schema['properties']['_fft']
+    arxiv_eprints_schema = schema['properties']['arxiv_eprints']
+
     data = {
         'arxiv_eprints': [
-            {'categories': 'hep-th'},
+            {
+                'categories': [
+                    'hep-th'
+                ],
+                'value': 'hep-th/9711200',
+            },
         ],
     }
     extra_data = {}
@@ -149,25 +1106,41 @@ def test_prepare_files_annotates_files_from_arxiv():
             }),
         }),
     })
+    assert validate(data['arxiv_eprints'], arxiv_eprints_schema) is None
 
     obj = MockObj(data, extra_data, files=files)
     eng = MockEng()
 
     assert prepare_files(obj, eng) is None
-    assert obj.data == {
-        'arxiv_eprints': [
-            {'categories': 'hep-th'},
-        ],
-        '_fft': [
-            {
-                'path': '/data/foo.pdf',
-                'type': 'arXiv',
-                'filename': 'arxiv:foo',
-                'format': '.pdf',
-            },
-        ],
-    }
-    assert 'Non-user PDF files added to FFT.' == obj.log._info.getvalue()
+
+    expected_fft = [
+        {
+            'path': '/data/foo.pdf',
+            'type': 'arXiv',
+            'filename': 'arxiv:foo',
+            'format': '.pdf',
+        },
+    ]
+    expected_arxiv_eprints = [
+        {
+            'categories': [
+                'hep-th',
+            ],
+            'value': 'hep-th/9711200',
+        },
+    ]
+    result = obj.data
+
+    assert validate(result['_fft'], _fft_schema) is None
+    assert expected_fft == result['_fft']
+
+    assert validate(result['arxiv_eprints'], arxiv_eprints_schema) is None
+    assert expected_arxiv_eprints == result['arxiv_eprints']
+
+    expected = 'Non-user PDF files added to FFT.'
+    result = obj.log._info.getvalue()
+
+    assert expected == result
 
 
 def test_prepare_files_skips_empty_files():
@@ -181,8 +1154,16 @@ def test_prepare_files_skips_empty_files():
     eng = MockEng()
 
     assert prepare_files(obj, eng) is None
-    assert obj.data == {}
-    assert '' == obj.log._info.getvalue()
+
+    expected = {}
+    result = obj.data
+
+    assert expected == result
+
+    expected = ''
+    result = obj.log._info.getvalue()
+
+    assert expected == result
 
 
 def test_prepare_files_does_nothing_when_obj_has_no_files():
@@ -194,8 +1175,16 @@ def test_prepare_files_does_nothing_when_obj_has_no_files():
     eng = MockEng()
 
     assert prepare_files(obj, eng) is None
-    assert obj.data == {}
-    assert '' == obj.log._info.getvalue()
+
+    expected = {}
+    result = obj.data
+
+    assert expected == result
+
+    expected = ''
+    result = obj.log._info.getvalue()
+
+    assert expected == result
 
 
 def test_prepare_files_ignores_keys_not_ending_with_pdf():
@@ -215,5 +1204,60 @@ def test_prepare_files_ignores_keys_not_ending_with_pdf():
     eng = MockEng()
 
     assert prepare_files(obj, eng) is None
-    assert obj.data == {}
-    assert '' == obj.log._info.getvalue()
+
+    expected = {}
+    result = obj.data
+
+    assert expected == result
+
+    expected = ''
+    result = obj.log._info.getvalue()
+
+    assert expected == result
+
+
+def test_remove_references():
+    schema = load_schema('hep')
+    subschema = schema['properties']['references']
+
+    data = {
+        'references': [
+            {
+                'reference': {
+                    'arxiv_eprint': 'hep-th/9710014',
+                    'authors': [
+                        {'full_name': 'Maldacena, J.'},
+                        {'full_name': 'Strominger, A.'},
+                    ],
+                    'label': '1',
+                },
+            },
+        ],
+    }
+    extra_data = {}
+    assert validate(data['references'], subschema) is None
+
+    obj = MockObj(data, extra_data)
+    eng = MockEng()
+
+    assert remove_references(obj, eng) is None
+
+    expected = {}
+    result = obj.data
+
+    assert expected == result
+
+
+def test_remove_references_does_nothing_when_there_are_no_references():
+    data = {}
+    extra_data = {}
+
+    obj = MockObj(data, extra_data)
+    eng = MockEng()
+
+    assert remove_references(obj, eng) is None
+
+    expected = {}
+    result = obj.data
+
+    assert expected == result

--- a/tests/unit/workflows/test_workflows_tasks_submission.py
+++ b/tests/unit/workflows/test_workflows_tasks_submission.py
@@ -31,12 +31,7 @@ from inspirehep.modules.workflows.tasks.submission import (
     prepare_files,
 )
 
-from mocks import AttrDict, MockEng, MockFiles, MockObj, MockUser
-
-
-class StubRTInstance(object):
-    def create_ticket(self, **kwargs):
-        return 1
+from mocks import AttrDict, MockEng, MockFiles, MockObj, MockUser, MockRT
 
 
 @patch('inspirehep.modules.workflows.tasks.submission.User')
@@ -71,7 +66,7 @@ def test_create_ticket_handles_unicode_when_not_in_production_mode(r_t, user):
 def test_create_ticket_handles_unicode_when_in_production_mode(g_i, r_t, user):
     user.query.get.return_value = MockUser('user@example.com')
     r_t.return_value = u'φοο'
-    g_i.return_value = StubRTInstance()
+    g_i.return_value = MockRT()
 
     config = {'PRODUCTION_MODE': True}
 


### PR DESCRIPTION
Addresses #1773 

- [x] `add_note_entry`
- [x] `close_ticket`
- [ ] `create_ticket`
- [x] `filter_keywords`
- [x] `prepare_files`
- [x] `prepare_keywords`
- [x] `remove_references`
- [x] `reply_ticket`
- [ ] `submit_rt_ticket`
- [x] `send_robotupload`
- [x] `wait_webcoll`