### PR TITLE
tests: unit tests for workflows/tasks/upload

### DIFF
--- a/tests/unit/helpers/mocks.py
+++ b/tests/unit/helpers/mocks.py
@@ -26,16 +26,20 @@ from six import StringIO
 
 
 class MockEng(object):
+    def __init__(self, data_type='hep'):
+        self.workflow_definition = AttrDict(data_type=data_type)
+
     def halt(self, action, msg):
         self.action = action
         self.msg = msg
 
 
 class MockObj(object):
-    def __init__(self, data, extra_data, files=None, id=1, id_user=1):
+    def __init__(self, data, extra_data, data_type='hep', files=None, id=1, id_user=1):
         self.data = data
         self.extra_data = extra_data
 
+        self.data_type = data_type
         self.files = files
         self.id = id
         self.id_user = id_user

--- a/tests/unit/workflows/test_workflows_tasks_arxiv.py
+++ b/tests/unit/workflows/test_workflows_tasks_arxiv.py
@@ -70,7 +70,7 @@ def test_arxiv_fulltext_download_logs_on_success():
     files = MockFiles({})
     assert validate(data['arxiv_eprints'], subschema) is None
 
-    obj = MockObj(data, extra_data, files)
+    obj = MockObj(data, extra_data, files=files)
     eng = MockEng()
 
     assert arxiv_fulltext_download(obj, eng) is None
@@ -103,7 +103,7 @@ def test_arxiv_fulltext_download_logs_on_error():
     files = MockFiles({})
     assert validate(data['arxiv_eprints'], subschema) is None
 
-    obj = MockObj(data, extra_data, files)
+    obj = MockObj(data, extra_data, files=files)
     eng = MockEng()
 
     assert arxiv_fulltext_download(obj, eng) is None
@@ -140,7 +140,7 @@ def test_arxiv_package_download_logs_on_success():
     files = MockFiles({})
     assert validate(data['arxiv_eprints'], subschema) is None
 
-    obj = MockObj(data, extra_data, files)
+    obj = MockObj(data, extra_data, files=files)
     eng = MockEng()
 
     assert arxiv_package_download(obj, eng) is None
@@ -173,7 +173,7 @@ def test_arxiv_package_download_logs_on_error():
     files = MockFiles({})
     assert validate(data['arxiv_eprints'], subschema) is None
 
-    obj = MockObj(data, extra_data, files)
+    obj = MockObj(data, extra_data, files=files)
     eng = MockEng()
 
     assert arxiv_package_download(obj, eng) is None
@@ -212,7 +212,7 @@ def test_arxiv_plot_extract_populates_files_with_plots(mock_os):
     })
     assert validate(data['arxiv_eprints'], subschema) is None
 
-    obj = MockObj(data, extra_data, files)
+    obj = MockObj(data, extra_data, files=files)
     eng = MockEng()
 
     try:
@@ -265,7 +265,7 @@ def test_arxiv_plot_extract_logs_when_tarball_is_invalid(mock_process_tarball):
     })
     assert validate(data['arxiv_eprints'], subschema) is None
 
-    obj = MockObj(data, extra_data, files)
+    obj = MockObj(data, extra_data, files=files)
     eng = MockEng()
 
     assert arxiv_plot_extract(obj, eng) is None
@@ -303,7 +303,7 @@ def test_arxiv_plot_extract_logs_when_images_are_invalid(mock_process_tarball):
     })
     assert validate(data['arxiv_eprints'], subschema) is None
 
-    obj = MockObj(data, extra_data, files)
+    obj = MockObj(data, extra_data, files=files)
     eng = MockEng()
 
     assert arxiv_plot_extract(obj, eng) is None
@@ -465,7 +465,7 @@ def test_arxiv_author_list_handles_auto_ignore_comment(mock_os):
     })
     assert validate(data['arxiv_eprints'], subschema) is None
 
-    obj = MockObj(data, extra_data, files)
+    obj = MockObj(data, extra_data, files=files)
     eng = MockEng()
 
     default_arxiv_author_list = arxiv_author_list()
@@ -507,7 +507,7 @@ def test_arxiv_author_list_logs_on_error(mock_os, mock_untar):
     })
     assert validate(data['arxiv_eprints'], subschema) is None
 
-    obj = MockObj(data, extra_data, files)
+    obj = MockObj(data, extra_data, files=files)
     eng = MockEng()
 
     default_arxiv_author_list = arxiv_author_list()

--- a/tests/unit/workflows/test_workflows_tasks_submission.py
+++ b/tests/unit/workflows/test_workflows_tasks_submission.py
@@ -50,9 +50,8 @@ def test_create_ticket_handles_unicode_when_not_in_production_mode(r_t, user):
     with patch.dict(current_app.config, config):
         data = {}
         extra_data = {}
-        files = MockFiles({})
 
-        obj = MockObj(data, extra_data, files)
+        obj = MockObj(data, extra_data)
         eng = MockEng()
 
         _create_ticket = create_ticket(None)
@@ -79,9 +78,8 @@ def test_create_ticket_handles_unicode_when_in_production_mode(g_i, r_t, user):
     with patch.dict(current_app.config, config):
         data = {}
         extra_data = {}
-        files = MockFiles({})
 
-        obj = MockObj(data, extra_data, files)
+        obj = MockObj(data, extra_data)
         eng = MockEng()
 
         _create_ticket = create_ticket(None)
@@ -98,9 +96,8 @@ def test_add_note_entry_does_not_add_value_that_is_already_present():
         ],
     }
     extra_data = {'core': 'something'}
-    files = MockFiles({})
 
-    obj = MockObj(data, extra_data, files)
+    obj = MockObj(data, extra_data)
     eng = MockEng()
 
     assert add_note_entry(obj, eng) is None
@@ -124,7 +121,7 @@ def test_prepare_files():
         }),
     })
 
-    obj = MockObj(data, extra_data, files)
+    obj = MockObj(data, extra_data, files=files)
     eng = MockEng()
 
     assert prepare_files(obj, eng) is None
@@ -158,7 +155,7 @@ def test_prepare_files_annotates_files_from_arxiv():
         }),
     })
 
-    obj = MockObj(data, extra_data, files)
+    obj = MockObj(data, extra_data, files=files)
     eng = MockEng()
 
     assert prepare_files(obj, eng) is None
@@ -185,7 +182,7 @@ def test_prepare_files_skips_empty_files():
         'foo.pdf': AttrDict({}),
     })
 
-    obj = MockObj(data, extra_data, files)
+    obj = MockObj(data, extra_data, files=files)
     eng = MockEng()
 
     assert prepare_files(obj, eng) is None
@@ -198,7 +195,7 @@ def test_prepare_files_does_nothing_when_obj_has_no_files():
     extra_data = {}
     files = MockFiles({})
 
-    obj = MockObj(data, extra_data, files)
+    obj = MockObj(data, extra_data, files=files)
     eng = MockEng()
 
     assert prepare_files(obj, eng) is None
@@ -219,7 +216,7 @@ def test_prepare_files_ignores_keys_not_ending_with_pdf():
         }),
     })
 
-    obj = MockObj(data, extra_data, files)
+    obj = MockObj(data, extra_data, files=files)
     eng = MockEng()
 
     assert prepare_files(obj, eng) is None

--- a/tests/unit/workflows/test_workflows_tasks_upload.py
+++ b/tests/unit/workflows/test_workflows_tasks_upload.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+from inspire_schemas.utils import load_schema
+from inspirehep.dojson.utils import validate
+from inspirehep.modules.workflows.tasks.upload import set_schema
+
+from mocks import MockObj, MockEng
+
+
+def test_set_schema_adds_a_schema_from_the_obj_data_type():
+    schema = load_schema('hep')
+    subschema = schema['properties']['$schema']
+
+    data = {}
+    extra_data = {}
+
+    obj = MockObj(data, extra_data, data_type='hep')
+    eng = MockEng()
+
+    assert set_schema(obj, eng) is None
+
+    expected = 'http://localhost:5000/schemas/records/hep.json'
+    result = obj.data
+
+    assert validate(result['$schema'], subschema) is None
+    assert expected == result['$schema']
+
+
+def test_set_schema_adds_a_schema_from_the_eng_data_type():
+    schema = load_schema('hep')
+    subschema = schema['properties']['$schema']
+
+    data = {}
+    extra_data = {}
+
+    obj = MockObj(data, extra_data)
+    eng = MockEng(data_type='hep')
+
+    assert set_schema(obj, eng) is None
+
+    expected = 'http://localhost:5000/schemas/records/hep.json'
+    result = obj.data
+
+    assert validate(result['$schema'], subschema) is None
+    assert expected == result['$schema']
+
+
+def test_set_schema_builds_a_full_url_for_the_schema():
+    schema = load_schema('hep')
+    subschema = schema['properties']['$schema']
+
+    data = {'$schema': 'hep.json'}
+    extra_data = {}
+    assert validate(data['$schema'], subschema) is None
+
+    obj = MockObj(data, extra_data)
+    eng = MockEng()
+
+    assert set_schema(obj, eng) is None
+
+    expected = 'http://localhost:5000/schemas/records/hep.json'
+    result = obj.data
+
+    assert validate(result['$schema'], subschema) is None
+    assert expected == result['$schema']
+
+
+def test_set_schema_does_nothing_when_the_schema_url_is_already_full():
+    schema = load_schema('hep')
+    subschema = schema['properties']['$schema']
+
+    data = {'$schema': 'http://localhost:5000/schemas/records/hep.json'}
+    extra_data = {}
+    assert validate(data['$schema'], subschema) is None
+
+    obj = MockObj(data, extra_data)
+    eng = MockEng()
+
+    assert set_schema(obj, eng) is None
+
+    expected = 'http://localhost:5000/schemas/records/hep.json'
+    result = obj.data
+
+    assert validate(result['$schema'], subschema) is None
+    assert expected == result['$schema']


### PR DESCRIPTION
Addresses #1773 

It makes little sense to unit test [`store_record`](https://github.com/inspirehep/inspire-next/blob/5fdbd8bf4ac6bd984406719b6a3d0c91b0b4cf77/inspirehep/modules/workflows/tasks/upload.py#L39-L62), so I skipped that.

- [x] `set_schema`