### PR TITLE
setup: remove pin on coverage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ install_requires = [
 
 tests_require = [
     'check-manifest>=0.25',
-    'coverage==4.4b1',
+    'coverage>=4.4',
     'flake8-future-import>=0.4.3',
     'isort>=4.2.2',
     'pep257>=0.7.0',


### PR DESCRIPTION
Closes #2319 

As detailed in inspirehep/inspire-next#2319, we can now remove
this pin as it was a workaround to avoid a bad wheel that we
were caching in the Docker image.