### PR TITLE
migrator: shorten the validation errors for Sentry

### DIFF
--- a/inspirehep/modules/migrator/tasks/records.py
+++ b/inspirehep/modules/migrator/tasks/records.py
@@ -337,10 +337,8 @@ def migrate_and_insert_record(raw_record):
             record = record_upsert(json_record)
     except ValidationError as e:
         # Aggregate logs by part of schema being validated.
-        pattern = u'Migrator Validation Error: {} on {}: Value: %r, Record: %r'
-        logger.error(pattern.format('.'.join(e.schema_path),
-                                    e.validator_value),
-                     e.instance, recid)
+        pattern = u'Migrator Validator Error: {}, Value: %r, Record: %r'
+        logger.error(pattern.format('.'.join(e.schema_path), e.instance, recid))
         error = e
     except Exception as e:
         # Receivers can always cause exceptions and we could dump the entire


### PR DESCRIPTION
Closes #2262 

Sentry 6 has trouble clustering log messages that are too long.
Now that the schema contains descriptions we hit this limit, so
we need to shorten the string we log when encountering an error.