### PR TITLE
config: use export.arxiv.org instead of arxiv.org

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -1368,8 +1368,8 @@ MAGPIE_API_URL = "http://magpie.inspirehep.net/api"
 
 # Harvesting and Workflows
 # ========================
-ARXIV_PDF_URL = "http://arxiv.org/pdf/{arxiv_id}"
-ARXIV_TARBALL_URL = "http://arxiv.org/e-print/{arxiv_id}"
+ARXIV_PDF_URL = "http://export.arxiv.org/pdf/{arxiv_id}"
+ARXIV_TARBALL_URL = "http://export.arxiv.org/e-print/{arxiv_id}"
 
 ARXIV_CATEGORIES_ALREADY_HARVESTED_ON_LEGACY = [
     'astro-ph.CO',

--- a/tests/integration/workflows/test_arxiv_workflow.py
+++ b/tests/integration/workflows/test_arxiv_workflow.py
@@ -247,7 +247,7 @@ def _do_webcoll_callback(app, recids, server_name='http://fake.na.me'):
 
 def fake_download_file(workflow, name, url):
     """Mock download_file_to_workflow func."""
-    if url == 'http://arxiv.org/e-print/1407.7587':
+    if url == 'http://export.arxiv.org/e-print/1407.7587':
         workflow.files[name] = pkg_resources.resource_stream(
             __name__,
             os.path.join(
@@ -256,7 +256,7 @@ def fake_download_file(workflow, name, url):
             )
         )
         return workflow.files[name]
-    elif url == 'http://arxiv.org/pdf/1407.7587':
+    elif url == 'http://export.arxiv.org/pdf/1407.7587':
         workflow.files[name] = pkg_resources.resource_stream(
             __name__,
             os.path.join(

--- a/tests/unit/workflows/test_workflows_tasks_arxiv.py
+++ b/tests/unit/workflows/test_workflows_tasks_arxiv.py
@@ -49,7 +49,7 @@ from mocks import AttrDict, MockEng, MockFiles, MockObj
 @pytest.mark.httpretty
 def test_arxiv_fulltext_download_logs_on_success():
     httpretty.register_uri(
-        httpretty.GET, 'http://arxiv.org/pdf/1605.03844',
+        httpretty.GET, 'http://export.arxiv.org/pdf/1605.03844',
         body=pkg_resources.resource_string(
             __name__, os.path.join('fixtures', '1605.03844.pdf')))
 
@@ -84,7 +84,7 @@ def test_arxiv_fulltext_download_logs_on_success():
 @pytest.mark.httpretty
 def test_arxiv_fulltext_download_logs_on_error():
     httpretty.register_uri(
-        httpretty.GET, 'http://arxiv.org/pdf/1605.03814', status=500)
+        httpretty.GET, 'http://export.arxiv.org/pdf/1605.03814', status=500)
 
     schema = load_schema('hep')
     subschema = schema['properties']['arxiv_eprints']
@@ -117,7 +117,7 @@ def test_arxiv_fulltext_download_logs_on_error():
 @pytest.mark.httpretty
 def test_arxiv_package_download_logs_on_success():
     httpretty.register_uri(
-        httpretty.GET, 'http://arxiv.org/e-print/1605.03959',
+        httpretty.GET, 'http://export.arxiv.org/e-print/1605.03959',
         body=pkg_resources.resource_string(
             __name__, os.path.join('fixtures', '1605.03959.tar.gz')))
 
@@ -154,7 +154,7 @@ def test_arxiv_package_download_logs_on_success():
 @pytest.mark.httpretty
 def test_arxiv_package_download_logs_on_error():
     httpretty.register_uri(
-        httpretty.GET, 'http://arxiv.org/e-print/1605.03951', status=500)
+        httpretty.GET, 'http://export.arxiv.org/e-print/1605.03951', status=500)
 
     schema = load_schema('hep')
     subschema = schema['properties']['arxiv_eprints']
@@ -259,7 +259,7 @@ def test_arxiv_plot_extract_logs_when_tarball_is_invalid(mock_process_tarball):
     files = MockFiles({
         '1612.00626.tar.gz': AttrDict({
             'file': AttrDict({
-                'uri': 'https://arxiv.org/e-print/1612.00626',
+                'uri': 'http://export.arxiv.org/e-print/1612.00626',
             })
         })
     })
@@ -270,7 +270,7 @@ def test_arxiv_plot_extract_logs_when_tarball_is_invalid(mock_process_tarball):
 
     assert arxiv_plot_extract(obj, eng) is None
 
-    expected = 'Invalid tarball https://arxiv.org/e-print/1612.00626'
+    expected = 'Invalid tarball http://export.arxiv.org/e-print/1612.00626'
     result = obj.log._error.getvalue()
 
     assert expected == result
@@ -297,7 +297,7 @@ def test_arxiv_plot_extract_logs_when_images_are_invalid(mock_process_tarball):
     files = MockFiles({
         '1612.00624.tar.gz': AttrDict({
             'file': AttrDict({
-                'uri': 'https://arxiv.org/e-print/1612.00624',
+                'uri': 'http://export.arxiv.org/e-print/1612.00624',
             })
         })
     })
@@ -501,7 +501,7 @@ def test_arxiv_author_list_logs_on_error(mock_os, mock_untar):
     files = MockFiles({
         '1605.07707.tar.gz': AttrDict({
             'file': AttrDict({
-                'uri': 'https://arxiv.org/e-print/1605.07707',
+                'uri': 'http://export.arxiv.org/e-print/1605.07707',
             })
         })
     })
@@ -518,7 +518,7 @@ def test_arxiv_author_list_logs_on_error(mock_os, mock_untar):
 
         assert default_arxiv_author_list(obj, eng) is None
 
-        expected = 'Invalid tarball https://arxiv.org/e-print/1605.07707'
+        expected = 'Invalid tarball http://export.arxiv.org/e-print/1605.07707'
         result = obj.log._error.getvalue()
 
         assert expected == result


### PR DESCRIPTION
Closes #2338 

We have a verbal agreement with arXiv that we should use the
former instead of the latter to avoid throttling.