### PR TITLE
utils: use first line to get magic number

### DIFF
--- a/inspirehep/utils/url.py
+++ b/inspirehep/utils/url.py
@@ -58,7 +58,7 @@ def is_pdf_link(url):
     except requests.exceptions.RequestException:
         return False
 
-    magic_number = next(response.iter_content(4))
+    magic_number = next(response.iter_lines(1))
     correct_magic_number = magic_number.startswith('%PDF')
 
     return correct_magic_number


### PR DESCRIPTION
Uses the first line instead of the first four bytes because,
sometimes, the server might reply with fewer bytes than four.

In particular this happens for the following PDF: http://edok01.tib.uni-hannover.de/edoks/e01dh15/815761511.pdf, as reported by one of our users: https://rt.inspirehep.net/Ticket/Display.html?id=717918

We have the following curious behavior:
```python
>>> from requests import get
>>> response = get('http://edok01.tib.uni-hannover.de/edoks/e01dh15/815761511.pdf', stream=True)
>>> next(response.iter_content(4))
'%PD'
```

Note also, quite perplexingly, that:
```python
>>> from requests import get
>>> response = get('http://edok01.tib.uni-hannover.de/edoks/e01dh15/815761511.pdf', stream=True)
>>> iter = response.iter_content(1)
>>> next(iter)
'%'
>>> next(iter)
'P'
>>> next(iter)
'D'
>>> next(iter)
'F'
```