### PR TITLE
submission: fix crash when no reason

### DIFF
--- a/inspirehep/modules/workflows/tasks/submission.py
+++ b/inspirehep/modules/workflows/tasks/submission.py
@@ -155,7 +155,7 @@ def reply_ticket(template=None,
             )
         else:
             # Body already rendered in reason.
-            body = obj.extra_data.get("reason").strip()
+            body = obj.extra_data.get("reason", "").strip()
         if not body:
             obj.log.error("No body for ticket reply. Skipping reply.")
             return


### PR DESCRIPTION
* Fixes handling reporting a ticket where
  obj.extra_data.get("reason") is None.
  (closes #2348)

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>