### PR TITLE
workflows: catch the right exception

### DIFF
--- a/inspirehep/modules/workflows/utils.py
+++ b/inspirehep/modules/workflows/utils.py
@@ -156,7 +156,7 @@ def get_pdf_in_workflow(obj):
     obj.log.info('No PDF available')
 
 
-@backoff.on_exception(backoff.expo, urllib3.exceptions.ProtocolError, max_tries=5)
+@backoff.on_exception(backoff.expo, requests.packages.urllib3.exceptions.ProtocolError, max_tries=5)
 def download_file_to_workflow(workflow, name, url):
     """Download a file to a specified workflow.
 

--- a/tests/unit/workflows/test_workflows_utils.py
+++ b/tests/unit/workflows/test_workflows_utils.py
@@ -25,8 +25,8 @@ from __future__ import absolute_import, division, print_function
 import os
 
 import pkg_resources
+import requests
 import requests_mock
-import urllib3
 
 from inspirehep.modules.workflows.utils import download_file_to_workflow
 
@@ -40,7 +40,7 @@ def test_download_file_to_workflow_retries_on_protocol_error():
 
         requests_mocker.register_uri(
             'GET', 'http://export.arxiv.org/pdf/1605.03844', [
-                {'exc': urllib3.exceptions.ProtocolError},
+                {'exc': requests.packages.urllib3.exceptions.ProtocolError},
                 {'body': filename, 'status_code': 200},
             ])
 


### PR DESCRIPTION
Addresses #2337 

The `requests` library rewraps all `urllib3` exceptions with their own classes.