### PR TITLE
workflows: fix arxiv_plot_extract

### DIFF
--- a/inspirehep/modules/workflows/tasks/arxiv.py
+++ b/inspirehep/modules/workflows/tasks/arxiv.py
@@ -122,7 +122,8 @@ def arxiv_plot_extract(obj, eng):
             return
 
         for idx, plot in enumerate(plots):
-            obj.files[plot.get('name')] = BytesIO(open(plot.get('url')))
+            with open(plot['url']) as plot_file:
+                obj.files[plot.get('name')] = plot_file
             obj.files[plot.get('name')]['description'] = u'{0:05d} {1}'.format(
                 idx, ''.join(plot.get('captions', []))
             )


### PR DESCRIPTION
* Do actually save plots rather than their name.
  (closes #2371)

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>