### PR TITLE
setup: pin requests and docutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -126,6 +126,7 @@ extras_require = {
         'mock',
         'Sphinx<1.6',
         'sphinxcontrib-napoleon>=0.6.1',
+        'docutils~=0.13.1',
     ],
     'postgresql': [
         'invenio-db[postgresql,versioning]>=1.0.0b2',

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ install_requires = [
     'Flask_CeleryExt>=0.3.0',
     'python-redis-lock~=3.2',
     'backoff~=1.4.2',
+    'requests~=2.15.1',
 ]
 
 tests_require = [


### PR DESCRIPTION
This build broke because `requests==2.15.0` was a bad version: https://travis-ci.org/inspirehep/inspire-next/builds/236661038

The [current build](https://travis-ci.org/inspirehep/inspire-next/builds/236879618) instead breaks because `requests~=2.16.5` has changed significantly how exception handling happens in `requests`.