### PR TITLE
records-journals: add journal title suggester

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -945,6 +945,11 @@ RECORDS_REST_ENDPOINTS = dict(
                 ':json_v1_search'
             ),
         },
+        suggesters=dict(
+            journal_title=dict(completion=dict(
+                field='title_suggest'
+            ))
+        ),
         list_route='/journals/',
         item_route='/journals/<pid(jou,record_class="inspirehep.modules.records.api:InspireRecord"):pid_value>',
         default_media_type='application/json',

--- a/inspirehep/modules/forms/static/js/forms/journals_typeahead.js
+++ b/inspirehep/modules/forms/static/js/forms/journals_typeahead.js
@@ -30,9 +30,9 @@ define([
     this.dataEngine = new Bloodhound({
       name: 'journals',
       remote: {
-        url: '/api/journals?q=journalautocomplete:%QUERY*',
+        url: '/api/journals/_suggest?journal_title=%QUERY',
         filter: function(response) {
-          return $.map(response.hits.hits, function(el) { return el });
+          return $.map(response.journal_title[0].options, function(el) { return el });
         }
       },
       datumTokenizer: function() {},
@@ -63,16 +63,17 @@ define([
         }.bind(this));
       }.bind(this),
       displayKey: function(data) {
-        return data.metadata.journal_titles[0].title;
+        return data.text;
       },
       templates: {
         empty: function(data) {
           return 'Cannot find this journal in our database.';
         },
         suggestion: function(data) {
-          data.metadata.title = data.metadata.journal_titles[0].title;
-          data.metadata.short_title = data.metadata.short_titles[0].title;
-          return suggestionTemplate.render.call(suggestionTemplate, data.metadata);
+          var metadata = {};
+          metadata['title'] = data.payload.full_title;
+          metadata['short_title'] = data.text;
+          return suggestionTemplate.render.call(suggestionTemplate, metadata);
         }.bind(this)
       }
     });

--- a/inspirehep/modules/records/mappings/records/journals.json
+++ b/inspirehep/modules/records/mappings/records/journals.json
@@ -166,6 +166,10 @@
                     },
                     "type": "object"
                 },
+                "title_suggest": {
+                    "payloads": true,
+                    "type": "completion"
+                },
                 "title_variants": {
                     "properties": {
                         "source": {

--- a/inspirehep/modules/records/receivers.py
+++ b/inspirehep/modules/records/receivers.py
@@ -67,6 +67,7 @@ def enhance_record(sender, json, *args, **kwargs):
     populate_experiment_suggest(sender, json, *args, **kwargs)
     populate_abstract_source_suggest(sender, json, *args, **kwargs)
     populate_affiliation_suggest(sender, json, *args, **kwargs)
+    populate_title_suggest(sender, json, *args, **kwargs)
     after_record_enhanced.send(json)
 
 
@@ -304,6 +305,29 @@ def populate_affiliation_suggest(sender, json, *args, **kwargs):
                     'legacy_ICN': legacy_ICN,
                 },
             },
+        })
+
+
+def populate_title_suggest(sender, json, *args, **kwargs):
+    """Populate title_suggest field of Journals records."""
+    if 'journals.json' in json.get('$schema'):
+        input_values = []
+
+        journal_titles = get_value(json, 'journal_titles.title', [])
+        short_titles = get_value(json, 'short_titles.title', [])
+        title_variants = get_value(json, 'title_variants.title', [])
+        input_values.extend(journal_titles)
+        input_values.extend(short_titles)
+        input_values.extend(title_variants)
+
+        json.update({
+            'title_suggest': {
+                'input': input_values,
+                'output': short_titles[0] if short_titles else '',
+                'payload': {
+                    'full_title': journal_titles[0] if journal_titles else ''
+                }
+            }
         })
 
 

--- a/tests/acceptance/test_literature_suggestion_form.py
+++ b/tests/acceptance/test_literature_suggestion_form.py
@@ -168,7 +168,7 @@ def test_journal_info_autocomplete_title(login):
     create_literature.go_to()
     assert create_literature.write_journal_title(
         'Nuc',
-        'Nuclear Physics',
+        'Nucl.Phys.',
     ).has_error()
 
 


### PR DESCRIPTION
* Add suggester for journal title in journal-records. Input is the full
  title, title variants and short titles. Output is the first short
  title and payload is full journal title. (closes #2120)

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>
Co-authored-by: George Lignos <glignos93@gmail.com>
Co-authored-by: Javier Martin Montull <javier.martin.montull@cern.ch>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/master/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
