### PR TITLE
mappings: add raw fields to some external ids

### DIFF
--- a/inspirehep/modules/records/mappings/records/hep.json
+++ b/inspirehep/modules/records/mappings/records/hep.json
@@ -186,6 +186,12 @@
                             "type": "string"
                         },
                         "value": {
+                            "fields": {
+                                "raw": {
+                                    "index": "not_analyzed",
+                                    "type": "string"
+                                }
+                            },
                             "type": "string"
                         }
                     },
@@ -359,6 +365,12 @@
                             "type": "string"
                         },
                         "value": {
+                            "fields": {
+                                "raw": {
+                                    "index": "not_analyzed",
+                                    "type": "string"
+                                }
+                            },
                             "type": "string"
                         }
                     },
@@ -642,6 +654,12 @@
                         "reference": {
                             "properties": {
                                 "arxiv_eprint": {
+                                    "fields": {
+                                        "raw": {
+                                            "index": "not_analyzed",
+                                            "type": "string"
+                                        }
+                                    },
                                     "type": "string"
                                 },
                                 "authors": {
@@ -673,6 +691,12 @@
                                     "type": "string"
                                 },
                                 "dois": {
+                                    "fields": {
+                                        "raw": {
+                                            "index": "not_analyzed",
+                                            "type": "string"
+                                        }
+                                    },
                                     "type": "string"
                                 },
                                 "imprint": {


### PR DESCRIPTION
## Description

Fields that contain external identifiers need to have a raw variant
to support aggregations and exact searches. This commit adds it to
`arxiv_eprints` and `dois`, but not to other fields (notably, `isbns`
and `report_numbers`) because the data contained in them contains
small typos and irregularities that we need to account for.

## Checklist:

- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

