### PR TITLE
holdingpen: pass unique categories to ng-repeat

### DIFF
--- a/inspirehep/modules/workflows/static/js/inspire_workflows_ui/holdingpen/holdingpen.filters.js
+++ b/inspirehep/modules/workflows/static/js/inspire_workflows_ui/holdingpen/holdingpen.filters.js
@@ -78,7 +78,10 @@
         }
       }
 
-      return categories;
+      var uniqueCategories = categories.filter(function (value, index, self) {
+        return self.indexOf(value) === index;
+      });
+      return uniqueCategories;
     }
   }
 


### PR DESCRIPTION
## Description

Prevents an error that happens when `ng-repeat` is passed the same
category multiple times (closes #2383).

## Related Issues

Closes #2383 
Closes #2399 

## Checklist:

- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.