### PR TITLE
mappings: add recids from refs to mappings

### DIFF
--- a/inspirehep/modules/records/mappings/records/authors.json
+++ b/inspirehep/modules/records/mappings/records/authors.json
@@ -72,6 +72,9 @@
                         "name": {
                             "type": "string"
                         },
+                        "recid": {
+                            "type": "integer"
+                        },
                         "record": {
                             "properties": {
                                 "$ref": {
@@ -110,6 +113,9 @@
                 "deleted": {
                     "type": "boolean"
                 },
+                "deleted_recids": {
+                    "type": "integer"
+                },
                 "deleted_records": {
                     "properties": {
                         "$ref": {
@@ -134,6 +140,9 @@
                         },
                         "name": {
                             "type": "string"
+                        },
+                        "recid": {
+                            "type": "integer"
                         },
                         "record": {
                             "properties": {
@@ -203,6 +212,9 @@
                 "native_name": {
                     "type": "string"
                 },
+                "new_recid": {
+                    "type": "integer"
+                },
                 "new_record": {
                     "properties": {
                         "$ref": {
@@ -239,6 +251,9 @@
                                 "name": {
                                     "copy_to": "facet_institution_name",
                                     "type": "string"
+                                },
+                                "recid": {
+                                    "type": "integer"
                                 },
                                 "record": {
                                     "properties": {
@@ -288,6 +303,9 @@
                         }
                     },
                     "type": "object"
+                },
+                "self_recid": {
+                    "type": "integer"
                 },
                 "source": {
                     "properties": {

--- a/inspirehep/modules/records/mappings/records/conferences.json
+++ b/inspirehep/modules/records/mappings/records/conferences.json
@@ -96,6 +96,9 @@
                 "deleted": {
                     "type": "boolean"
                 },
+                "deleted_recids": {
+                    "type": "integer"
+                },
                 "deleted_records": {
                     "properties": {
                         "$ref": {
@@ -140,6 +143,9 @@
                 "legacy_creation_date": {
                     "type": "string"
                 },
+                "new_recid": {
+                    "type": "integer"
+                },
                 "new_record": {
                     "properties": {
                         "$ref": {
@@ -175,6 +181,9 @@
                         }
                     },
                     "type": "object"
+                },
+                "self_recid": {
+                    "type": "integer"
                 },
                 "series": {
                     "properties": {

--- a/inspirehep/modules/records/mappings/records/experiments.json
+++ b/inspirehep/modules/records/mappings/records/experiments.json
@@ -35,6 +35,9 @@
                         "name": {
                             "type": "string"
                         },
+                        "recid": {
+                            "type": "integer"
+                        },
                         "record": {
                             "properties": {
                                 "$ref": {
@@ -86,6 +89,9 @@
                 },
                 "deleted": {
                     "type": "boolean"
+                },
+                "deleted_recids": {
+                    "type": "integer"
                 },
                 "deleted_records": {
                     "properties": {
@@ -151,6 +157,9 @@
                 "legacy_creation_date": {
                     "type": "string"
                 },
+                "new_recid": {
+                    "type": "integer"
+                },
                 "new_record": {
                     "properties": {
                         "$ref": {
@@ -192,6 +201,9 @@
                         "name": {
                             "type": "string"
                         },
+                        "recid": {
+                            "type": "integer"
+                        },
                         "record": {
                             "properties": {
                                 "$ref": {
@@ -213,6 +225,9 @@
                         }
                     },
                     "type": "object"
+                },
+                "self_recid": {
+                    "type": "integer"
                 },
                 "spokespersons": {
                     "properties": {
@@ -238,6 +253,9 @@
                         },
                         "name": {
                             "type": "string"
+                        },
+                        "recid": {
+                            "type": "integer"
                         },
                         "record": {
                             "properties": {

--- a/inspirehep/modules/records/mappings/records/hep.json
+++ b/inspirehep/modules/records/mappings/records/hep.json
@@ -142,6 +142,9 @@
                             "copy_to": "facet_experiment",
                             "type": "string"
                         },
+                        "recid": {
+                            "type": "integer"
+                        },
                         "record": {
                             "properties": {
                                 "$ref": {
@@ -204,6 +207,9 @@
                                 "curated_relation": {
                                     "type": "boolean"
                                 },
+                                "recid": {
+                                    "type": "integer"
+                                },
                                 "record": {
                                     "properties": {
                                         "$ref": {
@@ -263,6 +269,9 @@
                             },
                             "type": "object"
                         },
+                        "recid": {
+                            "type": "integer"
+                        },
                         "record": {
                             "properties": {
                                 "$ref": {
@@ -299,6 +308,9 @@
                 },
                 "collaborations": {
                     "properties": {
+                        "recid": {
+                            "type": "integer"
+                        },
                         "record": {
                             "properties": {
                                 "$ref": {
@@ -344,6 +356,9 @@
                 },
                 "deleted": {
                     "type": "boolean"
+                },
+                "deleted_recids": {
+                    "type": "integer"
                 },
                 "deleted_records": {
                     "properties": {
@@ -505,6 +520,9 @@
                     },
                     "type": "object"
                 },
+                "new_recid": {
+                    "type": "integer"
+                },
                 "new_record": {
                     "properties": {
                         "$ref": {
@@ -558,6 +576,9 @@
                         "conf_acronym": {
                             "type": "string"
                         },
+                        "conference_recid": {
+                            "type": "integer"
+                        },
                         "conference_record": {
                             "properties": {
                                 "$ref": {
@@ -571,6 +592,9 @@
                         },
                         "journal_issue": {
                             "type": "string"
+                        },
+                        "journal_recid": {
+                            "type": "integer"
                         },
                         "journal_record": {
                             "properties": {
@@ -597,6 +621,9 @@
                         },
                         "parent_isbn": {
                             "type": "string"
+                        },
+                        "parent_recid": {
+                            "type": "integer"
                         },
                         "parent_record": {
                             "properties": {
@@ -642,6 +669,9 @@
                                 }
                             },
                             "type": "object"
+                        },
+                        "recid": {
+                            "type": "integer"
                         },
                         "record": {
                             "properties": {
@@ -833,6 +863,9 @@
                     },
                     "type": "object"
                 },
+                "self_recid": {
+                    "type": "integer"
+                },
                 "special_collections": {
                     "type": "string"
                 },
@@ -840,6 +873,9 @@
                     "properties": {
                         "isbn": {
                             "type": "string"
+                        },
+                        "recid": {
+                            "type": "integer"
                         },
                         "record": {
                             "properties": {
@@ -876,6 +912,9 @@
                                 },
                                 "name": {
                                     "type": "string"
+                                },
+                                "recid": {
+                                    "type": "integer"
                                 },
                                 "record": {
                                     "properties": {

--- a/inspirehep/modules/records/mappings/records/institutions.json
+++ b/inspirehep/modules/records/mappings/records/institutions.json
@@ -70,6 +70,9 @@
                 "deleted": {
                     "type": "boolean"
                 },
+                "deleted_recids": {
+                    "type": "integer"
+                },
                 "deleted_records": {
                     "properties": {
                         "$ref": {
@@ -153,6 +156,9 @@
                     },
                     "type": "object"
                 },
+                "new_recid": {
+                    "type": "integer"
+                },
                 "new_record": {
                     "properties": {
                         "$ref": {
@@ -180,6 +186,9 @@
                         "name": {
                             "type": "string"
                         },
+                        "recid": {
+                            "type": "integer"
+                        },
                         "record": {
                             "properties": {
                                 "$ref": {
@@ -201,6 +210,9 @@
                         }
                     },
                     "type": "object"
+                },
+                "self_recid": {
+                    "type": "integer"
                 },
                 "time_zone": {
                     "type": "string"

--- a/inspirehep/modules/records/mappings/records/jobs.json
+++ b/inspirehep/modules/records/mappings/records/jobs.json
@@ -73,6 +73,9 @@
                 "deleted": {
                     "type": "boolean"
                 },
+                "deleted_recids": {
+                    "type": "integer"
+                },
                 "deleted_records": {
                     "properties": {
                         "$ref": {
@@ -91,6 +94,9 @@
                         },
                         "name": {
                             "type": "string"
+                        },
+                        "recid": {
+                            "type": "integer"
                         },
                         "record": {
                             "properties": {
@@ -133,6 +139,9 @@
                         "name": {
                             "type": "string"
                         },
+                        "recid": {
+                            "type": "integer"
+                        },
                         "record": {
                             "properties": {
                                 "$ref": {
@@ -146,6 +155,9 @@
                 },
                 "legacy_creation_date": {
                     "type": "string"
+                },
+                "new_recid": {
+                    "type": "integer"
                 },
                 "new_record": {
                     "properties": {
@@ -185,6 +197,9 @@
                         }
                     },
                     "type": "object"
+                },
+                "self_recid": {
+                    "type": "integer"
                 },
                 "urls": {
                     "properties": {

--- a/inspirehep/modules/records/mappings/records/journals.json
+++ b/inspirehep/modules/records/mappings/records/journals.json
@@ -99,6 +99,10 @@
                     },
                     "type": "object"
                 },
+                "lowercase_journal_titles": {
+                    "analyzer": "lowercase_analyzer",
+                    "type": "string"
+                },
                 "new_record": {
                     "properties": {
                         "$ref": {
@@ -106,10 +110,6 @@
                         }
                     },
                     "type": "object"
-                },
-                "lowercase_journal_titles": {
-                    "analyzer": "lowercase_analyzer",
-                    "type": "string"
                 },
                 "peer_reviewed": {
                     "type": "boolean"

--- a/inspirehep/modules/records/mappings/records/journals.json
+++ b/inspirehep/modules/records/mappings/records/journals.json
@@ -33,6 +33,9 @@
                 "deleted": {
                     "type": "boolean"
                 },
+                "deleted_recids": {
+                    "type": "integer"
+                },
                 "deleted_records": {
                     "properties": {
                         "$ref": {
@@ -103,6 +106,9 @@
                     "analyzer": "lowercase_analyzer",
                     "type": "string"
                 },
+                "new_recid": {
+                    "type": "integer"
+                },
                 "new_record": {
                     "properties": {
                         "$ref": {
@@ -136,6 +142,9 @@
                         "issn": {
                             "type": "string"
                         },
+                        "recid": {
+                            "type": "integer"
+                        },
                         "record": {
                             "properties": {
                                 "$ref": {
@@ -157,6 +166,9 @@
                         }
                     },
                     "type": "object"
+                },
+                "self_recid": {
+                    "type": "integer"
                 },
                 "short_titles": {
                     "properties": {


### PR DESCRIPTION
## Description

Since commit 8b0ecbe, when sending records to Elasticsearch we enrich
their JSON refs with the recid they are pointing to. This commit adds
those recids explicitly to the mappings. In fact, Elasticsearch could
easily generate their mappings from the data, but we prefer to state
this constraint explicitly so that in the future we may disallow the
automatic inference of mappings.

The only exception is the `conferences` key in the Authors collection:
this key is currently unused and might be removed in a future version
of the schema.

## Checklist:

- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.