### PR TITLE
dojson: make publication_info2marc handle unicode

### DIFF
--- a/inspirehep/dojson/hep/rules/bd7xx.py
+++ b/inspirehep/dojson/hep/rules/bd7xx.py
@@ -114,7 +114,7 @@ def publication_info2marc(self, key, values):
         elif value.get('page_start'):
             page_artid.append('{page_start}'.format(**value))
         if value.get('artid'):
-            page_artid.append('{artid}'.format(**value))
+            page_artid.append(u'{artid}'.format(**value))
 
         result = {
             '0': get_recid_from_ref(value.get('parent_record')),

--- a/tests/unit/dojson/test_dojson_hep_bd7xx.py
+++ b/tests/unit/dojson/test_dojson_hep_bd7xx.py
@@ -401,3 +401,36 @@ def test_publication_info_from_7731_c_p_v_y():
     result = hep2marc.do(result)
 
     assert expected == result['7731']
+
+
+def test_publication_info2marc_handles_unicode():
+    schema = load_schema('hep')
+    subschema = schema['properties']['publication_info']
+
+    record = {
+        'publication_info': [
+            {
+                'artid': u'207–214',
+                'journal_issue': '36',
+                'journal_title': 'Electronic Journal of Theoretical Physics',
+                'journal_volume': '13',
+                'year': 2016,
+            },
+        ],
+    }  # holdingpen/650664
+    assert validate(record['publication_info'], subschema) is None
+
+    expected = [
+        {
+            'c': [
+                u'207–214',
+            ],
+            'n': '36',
+            'p': 'Electronic Journal of Theoretical Physics',
+            'v': '13',
+            'y': 2016,
+        },
+    ]
+    result = hep2marc.do(record)
+
+    assert expected == result['773']


### PR DESCRIPTION
## Related Issue
https://sentry.cern.ch/inspire-sentry/inspire-labs/group/822408/

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.