### PR TITLE
workflows: make json_api_request fault-tolerant

### DIFF
--- a/inspirehep/modules/workflows/utils.py
+++ b/inspirehep/modules/workflows/utils.py
@@ -41,6 +41,7 @@ from .models import WorkflowsAudit
 LOGGER = logging.getLogger(__name__)
 
 
+@backoff.on_exception(backoff.expo, requests.packages.urllib3.exceptions.ConnectionError, base=4, max_tries=5)
 def json_api_request(url, data, headers=None):
     """Make JSON API request and return JSON response."""
     final_headers = {
@@ -57,7 +58,6 @@ def json_api_request(url, data, headers=None):
             url=url,
             headers=final_headers,
             data=json.dumps(data),
-            timeout=30
         )
     except requests.exceptions.RequestException as err:
         current_app.logger.exception(err)


### PR DESCRIPTION
## Related Issue
Sentry: https://sentry.cern.ch/inspire-sentry/inspire-labs/group/822046/

Closes #2355

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
