### PR TITLE
records: add custom validators for hep records

### DIFF
--- a/inspirehep/modules/records/validators/__init__.py
+++ b/inspirehep/modules/records/validators/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function

--- a/inspirehep/modules/records/validators/helpers.py
+++ b/inspirehep/modules/records/validators/helpers.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+from collections import deque
+
+from jsonschema import ValidationError
+
+from invenio_db import db
+
+FIELD_REQUIRE_FIELD_VALUES_TEMPLATE = "'{field}' field requires '{required}' field to have " \
+                                      "at least one of the values {values}."
+FIELD_REQUIRE_FIELD_TEMPLATE = "'{field}' field requires '{required}' field to exist."
+FIELD_DUPLICATE_VALUES_FOUND_TEMPLATE = "'{field}' field with value '{value}' found in more than one record."
+FIELD_VALIDATION_TEMPLATE = "Field '{field}' with value '{value}' is not valid."
+
+
+def check_document_type_values_in_required_values_for_record(record, required_values):
+    document_type_values = record.get('document_type', [])
+    return len(set(document_type_values) & set(required_values)) > 0
+
+
+def check_if_field_exists_in_dict_list_x_times(field, dict_list, limit=1):
+    return len([1 for item in dict_list if field in item]) == limit
+
+
+def get_query_results(querystring, params={}):
+    res = db.session.execute(querystring, params)
+    return res
+
+
+def check_if_listfield_property_values_are_valid(record, field, prop, checker, errortype='Error'):
+    for i, item in enumerate(record.get(field, [])):
+        if prop in item:
+            for e in checker(field=field, prop=prop, value=item[prop], index=i, errortype=errortype):
+                yield e
+
+
+def query_db_for_duplicates_for_field_listitem_with_index(field, prop, value, index, errortype):
+    queryparams = dict(field=field, prop=prop, value=value)
+    querystring = "SELECT id FROM records_metadata as r, "\
+                  "json_array_elements(r.json -> :field) "\
+                  "as elem WHERE elem ->> :prop=:value"
+    results = get_query_results(querystring, queryparams)
+    if results.rowcount > 1:
+        yield ValidationError(path=deque(['{field}/{index}/{prop}'.format(field=field, index=index, prop=prop)]),
+                              message=FIELD_DUPLICATE_VALUES_FOUND_TEMPLATE.format(
+                                  field=field,
+                                  value=value
+                              ),
+                              cause=errortype)

--- a/inspirehep/modules/records/validators/rules.py
+++ b/inspirehep/modules/records/validators/rules.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import pycountry
+from jsonschema import ValidationError
+
+from idutils import is_isbn
+
+from .helpers import (
+    check_if_field_exists_in_dict_list_x_times,
+    check_document_type_values_in_required_values_for_record,
+    check_if_listfield_property_values_are_valid,
+    query_db_for_duplicates_for_field_listitem_with_index,
+    FIELD_REQUIRE_FIELD_VALUES_TEMPLATE,
+    FIELD_VALIDATION_TEMPLATE,
+    FIELD_REQUIRE_FIELD_TEMPLATE,
+)
+
+
+def check_for_author_or_corporate_author_to_exist(record):
+    if all(k not in record for k in ['authors', 'corporate_author']):
+        yield ValidationError(path=[''],
+                              message='Neither an author nor a corporate author found.',
+                              cause='Error')
+
+
+def check_document_type_if_book_series_exist(record):
+    if 'book_series' in record:
+        required_values = ['book', 'proceedings', 'thesis']
+        if not check_document_type_values_in_required_values_for_record(record, required_values):
+            yield ValidationError(path=[''],
+                                  message=FIELD_REQUIRE_FIELD_VALUES_TEMPLATE.format(
+                                      field='book_series',
+                                      required='document_type',
+                                      values=required_values),
+                                  cause='Error')
+
+
+def check_document_type_if_isbns_exist(record):
+    if 'isbns' in record:
+        required_values = ['book', 'proceedings', 'thesis']
+        if not check_document_type_values_in_required_values_for_record(record, required_values):
+            yield ValidationError(path=[''],
+                                  message=FIELD_REQUIRE_FIELD_VALUES_TEMPLATE.format(
+                                      field='isbns',
+                                      required='document_type',
+                                      values=required_values),
+                                  cause='Error')
+
+
+def check_document_type_if_cnum_exist(record):
+    if check_if_field_exists_in_dict_list_x_times('cnum', record.get('publication_info', [])):
+        required_values = ['proceedings', 'conference paper']
+        if not check_document_type_values_in_required_values_for_record(record, required_values):
+            yield ValidationError(path=[''],
+                                  message=FIELD_REQUIRE_FIELD_VALUES_TEMPLATE.format(
+                                      field='cnum',
+                                      required='document_type',
+                                      values=required_values),
+                                  cause='Error')
+
+
+def check_document_type_if_thesis_info_exist(record):
+    if 'thesis_info' in record:
+        required_values = ['thesis']
+        if not check_document_type_values_in_required_values_for_record(record, required_values):
+            yield ValidationError(path=[''],
+                                  message=FIELD_REQUIRE_FIELD_VALUES_TEMPLATE.format(
+                                      field='thesis_info',
+                                      required='document_type',
+                                      values=required_values),
+                                  cause='Error')
+
+
+def check_if_isbn_is_valid(record):
+    def _check_isbn_is_valid(field, value, prop, index, errortype):
+        if not is_isbn(value):
+            yield ValidationError(path=['{field}/{index}/{prop}'.format(field=field,
+                                                                        prop=prop,
+                                                                        index=index)],
+                                  message=FIELD_VALIDATION_TEMPLATE.format(
+                                      field='isbns',
+                                      value=value
+                                  ),
+                                  cause=errortype)
+
+    for error in check_if_listfield_property_values_are_valid(record=record,
+                                                          field='isbns',
+                                                          prop='value',
+                                                          checker=_check_isbn_is_valid):
+        yield error
+
+
+def check_if_isbn_exist_in_other_records(record):
+    for error in check_if_listfield_property_values_are_valid(record=record,
+                                                          field='isbns',
+                                                          prop='value',
+                                                          checker=query_db_for_duplicates_for_field_listitem_with_index):
+        yield error
+
+
+def check_if_languages_are_valid_iso(record):
+    def _check_language(language, index):
+        try:
+            pycountry.languages.lookup(language)
+        except LookupError:
+            yield ValidationError(path=['languages/{index}'.format(index=index)],
+                                  message=FIELD_VALIDATION_TEMPLATE.format(
+                                      field='languages',
+                                      value=language
+                                  ),
+                                  cause='Error')
+    for i, item in enumerate(record.get('languages', [])):
+        for error in _check_language(item, i):
+            yield error
+
+
+def check_languages_if_title_translations_exist(record):
+    def _check_if_language_exist(translated_title, index):
+        if 'language' not in translated_title:
+            yield ValidationError(path=['title_translations/{index}'.format(index=index)],
+                                  message=FIELD_REQUIRE_FIELD_TEMPLATE.format(
+                                      field='title_translations',
+                                      required='language'
+                                  ),
+                                  cause='Error')
+
+    for i, item in enumerate(record.get('title_translations', [])):
+        for error in _check_if_language_exist(item, i):
+            yield error

--- a/inspirehep/modules/records/validators/validator.py
+++ b/inspirehep/modules/records/validators/validator.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+from jsonschema import Draft4Validator
+from jsonschema.validators import extend, RefResolver
+
+from inspire_schemas.utils import load_schema
+
+from .rules import (
+    check_for_author_or_corporate_author_to_exist,
+    check_if_isbn_exist_in_other_records,
+    check_if_isbn_is_valid,
+    check_document_type_if_book_series_exist,
+    check_document_type_if_isbns_exist,
+    check_document_type_if_cnum_exist,
+    check_document_type_if_thesis_info_exist,
+    check_if_languages_are_valid_iso
+)
+
+LITERATURE_VALIDATORS_LIST = [
+    check_for_author_or_corporate_author_to_exist,
+    check_if_isbn_exist_in_other_records,
+    check_if_isbn_is_valid,
+    check_document_type_if_book_series_exist,
+    check_document_type_if_isbns_exist,
+    check_document_type_if_cnum_exist,
+    check_document_type_if_thesis_info_exist,
+    check_if_languages_are_valid_iso
+]
+
+
+def inspire_validator_dispatcher(validator, value, instance, schema):
+    if 'hep.json' in schema.get('$schema'):
+        for validator in LITERATURE_VALIDATORS_LIST:
+            for error in validator(instance):
+                yield error
+
+
+class InspireResolver(RefResolver):
+
+    def resolve_remote(self, uri):
+        """Resolve a uri or relative path to a schema."""
+        resolved = load_schema(uri.rsplit('.json', 1)[0])
+        resolved['inspire_validator'] = 'Inspire validator extending Draft4Validator for hep records.'
+
+        return resolved
+
+
+InspireValidator = extend(Draft4Validator, {'inspire_validator': inspire_validator_dispatcher})

--- a/tests/integration/test_hep_records_inspire_validators.py
+++ b/tests/integration/test_hep_records_inspire_validators.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+from invenio_db import db
+
+from inspirehep.modules.records.api import InspireRecord
+from inspirehep.modules.records.validators.helpers import (
+    FIELD_DUPLICATE_VALUES_FOUND_TEMPLATE
+)
+from inspirehep.modules.records.validators.rules import (
+    check_if_isbn_exist_in_other_records
+)
+
+
+@pytest.fixture(scope='function')
+def test_record(app):
+    sample_record = {
+        '$schema': 'http://localhost:5000/schemas/records/hep.json',
+        'control_number': 111,
+        'document_type': [
+            'article',
+        ],
+        'isbns': [
+            {'value': '9783598215001'},
+        ],
+        'report_numbers': [
+            {'value': '11111'}
+        ],
+        'titles': [
+            {'title': 'sample'},
+        ],
+        'self': {
+            '$ref': 'http://localhost:5000/schemas/records/hep.json',
+        }
+    }
+    dupl_isbn_sample_record = {
+        '$schema': 'http://localhost:5000/schemas/records/hep.json',
+        'control_number': 222,
+        'document_type': [
+            'article',
+        ],
+        'isbns': [
+            {'value': '9783598215001'},
+        ],
+        'report_numbers': [
+            {'value': '11111'}
+        ],
+        'titles': [
+            {'title': 'another_sample'},
+        ],
+        'self': {
+            '$ref': 'http://localhost:5000/schemas/records/hep.json',
+        }
+    }
+
+    record_id = InspireRecord.create(sample_record).id
+    dupl_record_id = InspireRecord.create(dupl_isbn_sample_record).id
+
+    db.session.commit()
+
+    yield
+
+    InspireRecord.get_record(record_id)._delete(force=True)
+    InspireRecord.get_record(dupl_record_id)._delete(force=True)
+
+    db.session.commit()
+
+
+def format_error(_error):
+    path = '/' + '/'.join(str(el) for el in _error.path)
+    if path == '/':
+        path = 'globalErrors'
+    return {
+        path: [{
+            'message': _error.message,
+            'type': _error.cause or 'Error'
+        }]
+    }
+
+
+def test_check_if_isbn_exist_in_other_records(app, test_record):
+    sample_record = {
+        '$schema': 'http://localhost:5000/schemas/records/hep.json',
+        'control_number': 333,
+        'document_type': [
+            'book',
+        ],
+        'isbns': [
+            {'value': '9783598215001'},
+        ],
+        'titles': [
+            {'title': 'sample_record_title'},
+        ],
+        'self': {
+            '$ref': 'http://localhost:5000/schemas/records/hep.json',
+        }
+    }
+
+    expected = [{
+        '/isbns/0/value': [{
+            'message': FIELD_DUPLICATE_VALUES_FOUND_TEMPLATE.format(
+                field='isbns',
+                value='9783598215001'
+            ),
+            'type': 'Error'
+        }]
+    }]
+
+    result = [format_error(e) for e in check_if_isbn_exist_in_other_records(sample_record)]
+    assert expected == result

--- a/tests/integration/test_permissions.py
+++ b/tests/integration/test_permissions.py
@@ -58,6 +58,9 @@ def _create_and_index_record(record):
 def sample_record(app):
     record = {
         '$schema': 'http://localhost:5000/schemas/records/hep.json',
+        'authors': [{
+            'full_name': 'Dummy name'
+        }],
         '_collections': [
             'Literature',
         ],
@@ -99,6 +102,9 @@ def restricted_record(app):
 
     record = {
         '$schema': 'http://localhost:5000/schemas/records/hep.json',
+        'authors': [{
+            'full_name': 'Dummy name'
+        }],
         '_collections': [
             'Literature',
             'Restricted Collection',

--- a/tests/integration/test_records.py
+++ b/tests/integration/test_records.py
@@ -83,7 +83,9 @@ def deleted_record(app):
     with app.app_context():
         record = hep.do(create_record(snippet))
         record['$schema'] = 'http://localhost:5000/schemas/records/hep.json'
-
+        record['authors'] = [{
+            'full_name': 'Dummy name'
+        }]
         with db.session.begin_nested():
             record_upsert(record)
         db.session.commit()
@@ -99,6 +101,9 @@ def not_yet_deleted_record(app):
     record = {
         '$schema': 'http://localhost:5000/schemas/records/hep.json',
         'control_number': 111,
+        'authors': [{
+            'full_name': 'Dummy name'
+        }],
         'document_type': [
             'article',
         ],
@@ -214,6 +219,9 @@ def not_yet_merged_records(app):
 def records_to_be_merged(app):
     merged_record = {
         '$schema': 'http://localhost:5000/schemas/records/hep.json',
+        'authors': [{
+            'full_name': 'Dummy name'
+        }],
         'control_number': 111,
         'document_type': [
             'article',
@@ -229,6 +237,9 @@ def records_to_be_merged(app):
     deleted_record = {
         '$schema': 'http://localhost:5000/schemas/records/hep.json',
         'control_number': 222,
+        'authors': [{
+            'full_name': 'Dummy name'
+        }],
         'document_type': [
             'article',
         ],
@@ -242,6 +253,9 @@ def records_to_be_merged(app):
 
     pointing_record = {
         '$schema': 'http://localhost:5000/schemas/records/hep.json',
+        'authors': [{
+            'full_name': 'Dummy name'
+        }],
         'accelerator_experiments': [
             {
                 'record': {

--- a/tests/integration/test_records_receivers.py
+++ b/tests/integration/test_records_receivers.py
@@ -34,6 +34,9 @@ def test_that_db_changes_are_mirrored_in_es(app):
     search = LiteratureSearch()
     json = {
         '$schema': 'http://localhost:5000/schemas/records/hep.json',
+        'authors': [{
+            'full_name': 'Dummy name'
+        }],
         'document_type': [
             'article',
         ],

--- a/tests/unit/records/test_records_validators_rules.py
+++ b/tests/unit/records/test_records_validators_rules.py
@@ -1,0 +1,229 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+from collections import defaultdict
+
+from inspirehep.modules.records.validators.helpers import (
+    FIELD_REQUIRE_FIELD_VALUES_TEMPLATE,
+    FIELD_VALIDATION_TEMPLATE,
+    FIELD_REQUIRE_FIELD_TEMPLATE
+)
+from inspirehep.modules.records.validators.rules import (
+    check_for_author_or_corporate_author_to_exist,
+    check_if_isbn_is_valid,
+    check_document_type_if_book_series_exist,
+    check_document_type_if_isbns_exist,
+    check_document_type_if_cnum_exist,
+    check_document_type_if_thesis_info_exist,
+    check_if_languages_are_valid_iso,
+    check_languages_if_title_translations_exist
+)
+
+
+def format_error(_error):
+    return [{
+        'message': _error.message,
+        'type': _error.cause or 'Error'
+    }]
+
+
+def json_pointer_format(path):
+    path = '/' + '/'.join(str(el) for el in path)
+    if path == '/':
+        path = 'globalErrors'
+    return path
+
+
+def validate(validator_fn, record):
+    result = defaultdict(list)
+    for e in validator_fn(record):
+        result[json_pointer_format(e.path)].extend(format_error(e))
+    return result
+
+
+def test_check_for_author_or_corporate_author_to_exist():
+    sample_record = {
+        'no_authors': {},
+        'no_corporate_author': {}
+    }
+
+    expected = {
+        'globalErrors': [{
+            'message': 'Neither an author nor a corporate author found.',
+            'type': 'Error'
+        }]
+    }
+    result = validate(check_for_author_or_corporate_author_to_exist, sample_record)
+    assert expected == result
+
+
+def test_check_document_type_if_book_series_exist():
+    sample_record = {
+        'book_series': [{
+            'key': 'value'
+        }],
+        'document_type': ['not_one_of_required_values']
+    }
+    required_values = ['book', 'proceedings', 'thesis']
+    expected = {
+        'globalErrors': [{
+            'message': FIELD_REQUIRE_FIELD_VALUES_TEMPLATE.format(
+                            field='book_series',
+                            required='document_type',
+                            values=required_values),
+            'type': 'Error'
+        }]
+    }
+    result = validate(check_document_type_if_book_series_exist, sample_record)
+    assert expected == result
+
+
+def test_check_document_type_if_isbns_exist():
+    sample_record = {
+        'isbns': [{
+            'key': 'value'
+        }],
+        'document_type': ['not_one_of_required_values']
+    }
+    required_values = ['book', 'proceedings', 'thesis']
+    expected = {
+        'globalErrors': [{
+            'message': FIELD_REQUIRE_FIELD_VALUES_TEMPLATE.format(
+                field='isbns',
+                required='document_type',
+                values=required_values),
+            'type': 'Error'
+        }]
+    }
+    result = validate(check_document_type_if_isbns_exist, sample_record)
+    assert expected == result
+
+
+def test_check_document_type_if_cnum_exist():
+    sample_record = {
+        'publication_info': [{
+            'cnum': 'cnum_value'
+        }],
+        'document_type': ['not_one_of_required_values']
+    }
+    required_values = ['proceedings', 'conference paper']
+    expected = {
+        'globalErrors': [{
+            'message': FIELD_REQUIRE_FIELD_VALUES_TEMPLATE.format(
+                field='cnum',
+                required='document_type',
+                values=required_values),
+            'type': 'Error'
+        }]
+    }
+    result = validate(check_document_type_if_cnum_exist, sample_record)
+    assert expected == result
+
+
+def test_check_document_type_if_thesis_info_exist():
+    sample_record = {
+        'thesis_info': {
+            'key': 'value'
+        },
+        'document_type': ['not_one_of_required_values']
+    }
+    required_values = ['thesis']
+    expected = {
+        'globalErrors': [{
+            'message': FIELD_REQUIRE_FIELD_VALUES_TEMPLATE.format(
+                field='thesis_info',
+                required='document_type',
+                values=required_values),
+            'type': 'Error'
+        }]
+    }
+    result = validate(check_document_type_if_thesis_info_exist, sample_record)
+    assert expected == result
+
+
+def test_check_if_isbn_is_valid():
+    sample_record = {
+        'isbns': [
+            {
+                'value': '978-3-319-15000-0'
+            },
+            {
+                'value': '8267411'
+            }
+        ]
+    }
+    expected = {
+        '/isbns/1/value': [{
+            'message': FIELD_VALIDATION_TEMPLATE.format(
+                field='isbns',
+                value='8267411'),
+            'type': 'Error'
+        }]
+    }
+    result = validate(check_if_isbn_is_valid, sample_record)
+    assert expected == result
+
+
+def test_check_if_languages_are_valid_iso():
+    sample_record = {
+        'languages': [
+            'kr',
+            'z2'
+        ]
+    }
+    expected = {
+        '/languages/1': [{
+            'message': FIELD_VALIDATION_TEMPLATE.format(
+                field='languages',
+                value='z2'
+            ),
+            'type': 'Error'
+        }]
+    }
+    result = validate(check_if_languages_are_valid_iso, sample_record)
+    assert expected == result
+
+
+def test_check_languages_if_title_translations_exist():
+    sample_record = {
+        'title_translations': [
+            {
+                'language': 'kr'
+            },
+            {
+                'not_langauge_field': 'value'
+            }
+        ]
+    }
+    expected = {
+        '/title_translations/1': [{
+            'message': FIELD_REQUIRE_FIELD_TEMPLATE.format(
+                field='title_translations',
+                required='language'
+            ),
+            'type': 'Error'
+        }]
+    }
+    result = validate(check_languages_if_title_translations_exist, sample_record)
+    assert expected == result


### PR DESCRIPTION
## Description
Runs custom validators on `commit`. Currently only Literature records
have custom validators defined on them, enforcing business rules that
are impossible to express in a schema, such as the fact that ISBNs are
unique, or that a record has either an `author` or a `corporate_author`.

## Related Issues
Closes #2306

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.