### PR TITLE
docker: pin postgres to 9.4.5

### DIFF
--- a/services.yml
+++ b/services.yml
@@ -35,7 +35,7 @@ services:
     environment:
       - ES_HEAP_SIZE=2g
   database:
-    image: postgres
+    image: postgres:9.4.5
     environment:
       - POSTGRES_PASSWORD=dbpass123
       - POSTGRES_USER=inspirehep


### PR DESCRIPTION
## Description
Currently on production we are using this particular version, offered
by CERN's DB on Demand service. To ensure that we don't introduce code
that depends on future features of PostgreSQL, which would break on
production, this commit pins its Docker image to that specific version.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.