### PR TITLE
xrootd: first commit

### DIFF
--- a/inspirehep/modules/xrootd/__init__.py
+++ b/inspirehep/modules/xrootd/__init__.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""XRootD integration of INSPIRE."""
+
+from __future__ import absolute_import, division, print_function
+
+from .ext import INSPIREXRootD

--- a/inspirehep/modules/xrootd/ext.py
+++ b/inspirehep/modules/xrootd/ext.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""INSPIRE XRootD extension."""
+
+from __future__ import absolute_import, division, print_function
+
+from pkg_resources import DistributionNotFound, get_distribution
+
+try:
+    # Import XRootDPyFS if available so that its
+    # opener gets registered on PyFilesystem.
+    get_distribution('xrootdpyfs')
+    import xrootdpyfs
+    XROOTD_ENABLED = True
+except DistributionNotFound:
+    XROOTD_ENABLED = False
+    xrootdpyfs = None
+
+
+class INSPIREXRootD(object):
+
+    """INSPIRE XRootD extension."""
+
+    def __init__(self, app=None):
+        """Extension initialization."""
+        if app:
+            self.init_app(app)
+
+    def init_app(self, app):
+        """Extension registration and configuration."""
+        app.config['XROOTD_ENABLED'] = XROOTD_ENABLED
+        if XROOTD_ENABLED:
+            # Overwrite reported checksum from CERN EOS due to XRootD 3.3.6.
+            app.config['XROOTD_CHECKSUM_ALGO'] = 'md5'
+            app.config['FILES_REST_STORAGE_FACTORY'] = 'invenio_xrootd:eos_storage_factory'
+        app.extensions['inspire-xrootd'] = self

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,11 @@ extras_require = {
         'kwalitee',
         'honcho',
         'gunicorn',
-    ]
+    ],
+    'xrootd': [
+        'invenio-xrootd>=1.0.0a4',
+        'xrootdpyfs>=0.1.3',
+    ],
 }
 
 extras_require['all'] = []
@@ -224,6 +228,7 @@ setup(
             'inspire_search = inspirehep.modules.search:INSPIRESearch',
             'inspire_workflows = inspirehep.modules.workflows:INSPIREWorkflows',
             'invenio_collections = invenio_collections:InvenioCollections',
+            'inspire_xrootd = inspirehep.modules.xrootd:INSPIREXRootD',
         ],
         'invenio_base.apps': [
             'inspire_cache = inspirehep.modules.cache.ext:INSPIRECache',
@@ -240,6 +245,7 @@ setup(
             'inspire_orcid = inspirehep.modules.orcid:INSPIREOrcid',
             'inspire_disambiguation = inspirehep.modules.disambiguation:InspireDisambiguation',
             'inspire_tools = inspirehep.modules.tools:INSPIRETools',
+            'inspire_xrootd = inspirehep.modules.xrootd:INSPIREXRootD',
         ],
         'invenio_assets.bundles': [
             'inspirehep_theme_css = inspirehep.modules.theme.bundles:css',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Copies from Zenodo the XRootD integration. Unfortunately this is not testable on Travis. However by default, mocking XRootD is equivalent to having it disabled. So the real test will happen hopefully on QA.


Closes #1086

Currently we are using Fuse-mounted EOS on production and this has many stability and performance issues. Hopefully by switching to XRootD (which is the
native interface of EOS) will allow INSPIRE to use EOS following its original design, i.e. a blob-store, rather than a POSIX filesystem. This should, hopefully improve performance issue (if not also stability issues), at least within the workflow files.

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

* Copies from Zenodo the integration with XRootD, to be used as
  storage, instead of Fuse-mounted EOS.
  (closes #1086)

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>