### PR TITLE
docs: generate the api docs at conf.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,7 +81,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
-docs/_source/
+docs/_api/
 
 # PyBuilder
 target/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,8 +6,7 @@ SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
-SOURCEDIR     = _source
-CODEDIR       = ../inspirehep
+APIDIR        = _api
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
@@ -20,7 +19,6 @@ PAPEROPT_letter = -D latex_paper_size=letter
 ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
-SPHINXAPIDOC    = sphinx-apidoc -f -o $(SOURCEDIR) $(CODEDIR)
 
 .PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest coverage gettext
 
@@ -63,11 +61,9 @@ endef
 
 
 clean:
-	rm -rf $(BUILDDIR) $(SOURCEDIR) documentation_errors.log
+	rm -rf $(BUILDDIR) $(APIDIR) documentation_errors.log
 
 html:
-	$(SPHINXAPIDOC); \
-	rm -f $(SOURCEDIR)/modules.rst; \
 	$(SPHINXBUILD) -w documentation_errors.log -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@$(call report_result_html,$$?)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,7 +37,7 @@ Contents
    tests
    howtos
    building_the_docs
-   _source/inspirehep
+   _api/inspirehep
 
 *Happy hacking!*
 


### PR DESCRIPTION
Moves the generation of the api rst files to the conf.py file, as
readthedocs.io does not run the makefile.


Closes #2438

The api docs were not being generated.

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Signed-off-by: David Caro <david@dcaro.es>