### PR TITLE
workflows: timeouts refextract

### DIFF
--- a/inspirehep/modules/workflows/tasks/refextract.py
+++ b/inspirehep/modules/workflows/tasks/refextract.py
@@ -26,6 +26,8 @@ from __future__ import absolute_import, division, print_function
 
 import json
 
+from timeout_decorator import timeout
+
 from refextract import extract_journal_reference, extract_references_from_file
 
 from inspirehep.utils.helpers import maybe_int
@@ -84,6 +86,7 @@ def extract_journal_info(obj, eng):
     obj.data["publication_info"] = new_publication_info
 
 
+@timeout(5 * 60)
 def extract_references(filepath):
     """Extract references from PDF and return in INSPIRE format."""
     references = extract_references_from_file(

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ install_requires = [
     'python-redis-lock~=3.2',
     'backoff~=1.0,>=1.4.2',
     'requests~=2.0,>=2.15.1',
+    'timeout-decorator~=0.0,>=0.3.3',
 ]
 
 tests_require = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


<!--- Why is this change required? What problem does it solve? -->

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Worksaround inspirehep/refextract#26 by interrupting the running away
refextract process.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>