### PR TITLE
setup: fix inspire-docker build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -162,7 +162,7 @@ extras_require = {
 
 extras_require['all'] = []
 for name, reqs in extras_require.items():
-    if name in ('postgresql', 'mysql', 'sqlite'):
+    if name in ('postgresql', 'mysql', 'sqlite', 'xrootd'):
         continue
     extras_require['all'].extend(reqs)
 


### PR DESCRIPTION
## Description
We need to exclude the `xrootd` extra from `all` otherwise the build of
`inspire-docker` will try to install it, but `xrootdpyfs` requires a
dependency which is not available on PyPI.

## Related Issue
https://travis-ci.org/inspirehep/inspire-docker/builds/243212256

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.