### PR TITLE
global: bump inspire-schemas to version ~36.0

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -198,12 +198,24 @@ INSPIRE_COLLECTIONS_DEFINITION = [
         'name': 'Journals',
     },
     {
+        'query': 'special_collections:BABAR-ANALYSIS-DOCUMENT',
+        'name': 'BABAR Analysis Documents',
+    },
+    {
+        'query': 'special_collections:BABAR-INTERNAL-NOTE',
+        'name': 'BABAR Internal Notes',
+    },
+    {
         'query': 'special_collections:CDF-INTERNAL-NOTE',
         'name': 'CDF Internal Notes',
     },
     {
         'query': 'special_collections:CDF-NOTE',
         'name': 'CDF Notes',
+    },
+    {
+        'query': 'special_collections:CDSHIDDEN',
+        'name': 'CDS Hidden',
     },
     {
         'query': 'special_collections:D0-INTERNAL-NOTE',

--- a/inspirehep/dojson/hep/rules/bd6xx.py
+++ b/inspirehep/dojson/hep/rules/bd6xx.py
@@ -24,12 +24,28 @@
 
 from __future__ import absolute_import, division, print_function
 
+import six
+
 from dojson import utils
 
-from inspirehep.utils.helpers import force_list, maybe_int
+from inspirehep.utils.helpers import force_list
 
 from ..model import hep, hep2marc
 from ...utils import force_single_element, get_record_ref
+
+
+ENERGY_RANGES_MAP = {
+    '1': '0-3 GeV',
+    '2': '3-10 GeV',
+    '3': '10-30 GeV',
+    '4': '30-100 GeV',
+    '5': '100-300 GeV',
+    '6': '300-1000 GeV',
+    '7': '1-10 TeV',
+    '8': '> 10 TeV',
+}
+
+REVERSE_ENERGY_RANGES_MAP = {v: k for k, v in six.iteritems(ENERGY_RANGES_MAP)}
 
 
 @hep.over('accelerator_experiments', '^693..')
@@ -84,7 +100,7 @@ def keywords(self, key, values):
                 })
 
         if value.get('e'):
-            energy_ranges.append(maybe_int(value.get('e')))
+            energy_ranges.append(ENERGY_RANGES_MAP.get(value.get('e')))
 
     self['energy_ranges'] = energy_ranges
     return keywords
@@ -95,10 +111,11 @@ def energy_ranges2marc(self, key, values):
     result_695 = self.get('695', [])
 
     for value in values:
-        result_695.append({
-            '2': 'INSPIRE',
-            'e': value,
-        })
+        if value in REVERSE_ENERGY_RANGES_MAP:
+            result_695.append({
+                '2': 'INSPIRE',
+                'e': REVERSE_ENERGY_RANGES_MAP.get(value),
+            })
 
     return result_695
 
@@ -133,6 +150,12 @@ def keywords2marc(self, key, values):
         elif schema == 'INSPIRE':
             result_695.append({
                 '2': 'INSPIRE',
+                '9': source,
+                'a': keyword,
+            })
+        elif schema == 'INIS':
+            result_695.append({
+                '2': 'INIS',
                 '9': source,
                 'a': keyword,
             })

--- a/inspirehep/dojson/hep/rules/bd9xx.py
+++ b/inspirehep/dojson/hep/rules/bd9xx.py
@@ -50,9 +50,11 @@ def document_type(self, key, value):
     ]
 
     special_collections = [
+        # XXX: BABAR-AnalysisDocument is treated as a special case below.
+        'babar-internal-note',
         'cdf-internal-note',
         'cdf-note',
-        'cds',
+        'cdshidden',
         'd0-internal-note',
         'd0-preliminary-note',
         'h1-internal-note',
@@ -95,6 +97,8 @@ def document_type(self, key, value):
             self['withdrawn'] = True
         elif normalized_a_value in publication_types:
             publication_type.append(normalized_a_value)
+        elif normalized_a_value == 'babar-analysisdocument':
+            self.setdefault('special_collections', []).append('BABAR-ANALYSIS-DOCUMENT')
         elif normalized_a_value in special_collections:
             self.setdefault('special_collections', []).append(normalized_a_value.upper())
         elif normalized_a_value == 'activityreport':
@@ -162,6 +166,9 @@ def publication_type2marc(self, key, value):
 @hep2marc.over('980', '^special_collections$')
 @utils.for_each_value
 def special_collections2marc(self, key, value):
+    if value == 'BABAR-ANALYSIS-DOCUMENT':
+        return {'a': 'BABAR-AnalysisDocument'}
+
     return {'a': value}
 
 

--- a/inspirehep/modules/records/mappings/records/experiments.json
+++ b/inspirehep/modules/records/mappings/records/experiments.json
@@ -159,7 +159,7 @@
                 "inspire_classification": {
                     "type": "string"
                 },
-                "institution": {
+                "institutions": {
                     "properties": {
                         "curated_relation": {
                             "type": "boolean"

--- a/inspirehep/modules/records/mappings/records/hep.json
+++ b/inspirehep/modules/records/mappings/records/hep.json
@@ -399,7 +399,7 @@
                     "type": "string"
                 },
                 "energy_ranges": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "external_system_identifiers": {
                     "properties": {

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ install_requires = [
     'invenio-utils==0.2.0',  # Not fully Invenio 3 ready
     'invenio>=3.0.0a1,<3.1.0',
     'inspire-crawler~=0.0,>=0.2.7',
-    'inspire-schemas~=35.0,>=35.0.1',
+    'inspire-schemas~=36.0,>=36.0.1',
     'dojson>=1.3.0',
     'Flask>=0.11.1',
     'Flask-Breadcrumbs>=0.3.0',

--- a/tests/unit/dojson/test_dojson_hep_bd6xx.py
+++ b/tests/unit/dojson/test_dojson_hep_bd6xx.py
@@ -290,6 +290,42 @@ def test_keywords_from_695__a_2():
     assert '6531' not in result
 
 
+def test_keywords_from_695__a_2_inis():
+    schema = load_schema('hep')
+    subschema = schema['properties']['keywords']
+
+    snippet = (
+        '<datafield tag="695" ind1=" " ind2=" ">'
+        '  <subfield code="a">Accelerators</subfield>'
+        '  <subfield code="2">INIS</subfield>'
+        '</datafield>'
+    )  # record/1493738
+
+    expected = [
+        {
+            'schema': 'INIS',
+            'value': 'Accelerators',
+        },
+    ]
+    result = hep.do(create_record(snippet))
+
+    assert validate(result['keywords'], subschema) is None
+    assert expected == result['keywords']
+    assert 'energy_ranges' not in result
+
+    expected = [
+        {
+            'a': 'Accelerators',
+            '2': 'INIS',
+        },
+    ]
+    result = hep2marc.do(result)
+
+    assert expected == result['695']
+    assert '084' not in result
+    assert '6531' not in result
+
+
 def test_energy_ranges_from_695__e_2():
     schema = load_schema('hep')
     subschema = schema['properties']['energy_ranges']
@@ -301,7 +337,9 @@ def test_energy_ranges_from_695__e_2():
         '</datafield>'
     )  # record/1124337
 
-    expected = [7]
+    expected = [
+        '1-10 TeV',
+    ]
     result = hep.do(create_record(snippet))
 
     assert validate(result['energy_ranges'], subschema) is None
@@ -311,7 +349,7 @@ def test_energy_ranges_from_695__e_2():
     expected = [
         {
             '2': 'INSPIRE',
-            'e': 7,
+            'e': '7',
         },
     ]
     result = hep2marc.do(result)

--- a/tests/unit/dojson/test_dojson_hep_bd9xx.py
+++ b/tests/unit/dojson/test_dojson_hep_bd9xx.py
@@ -157,6 +157,32 @@ def test_special_collections_from_980__a():
     assert expected == result['980']
 
 
+def test_special_collections_from_980__a_babar_analysis_document():
+    schema = load_schema('hep')
+    subschema = schema['properties']['special_collections']
+
+    snippet = (
+        '<datafield tag="980" ind1=" " ind2=" ">'
+        '  <subfield code="a">BABAR-AnalysisDocument</subfield>'
+        '</datafield>'
+    )  # record/1598316
+
+    expected = [
+        'BABAR-ANALYSIS-DOCUMENT',
+    ]
+    result = hep.do(create_record(snippet))
+
+    assert validate(result['special_collections'], subschema) is None
+    assert expected == result['special_collections']
+
+    expected = [
+        {'a': 'BABAR-AnalysisDocument'},
+    ]
+    result = hep2marc.do(result)
+
+    assert expected == result['980']
+
+
 def test_refereed_from_980__a_published():
     schema = load_schema('hep')
     subschema = schema['properties']['refereed']


### PR DESCRIPTION
## Description
INCOMPATIBLE `energy_ranges` changes mapping type from `integer`
to `string`, so this commit will require a reindex.

CC: @ammirate @david-caro @jmartinm @kaplun 

## Related Issue
Closes https://github.com/inspirehep/inspire-next/issues/2429

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.