### PR TITLE
dojson: ignore name_variants with DESY source

### DIFF
--- a/inspirehep/dojson/institutions/rules.py
+++ b/inspirehep/dojson/institutions/rules.py
@@ -160,7 +160,6 @@ def field_activity(self, key, value):
 @institutions.over('name_variants', '^410..')
 def name_variants(self, key, value):
     valid_sources = [
-        'DESY_AFF',
         'ADS',
         'INSPIRE'
     ]

--- a/tests/unit/dojson/test_dojson_institutions.py
+++ b/tests/unit/dojson/test_dojson_institutions.py
@@ -281,14 +281,14 @@ def test_name_variants_from_410__a_9():
     snippet = (
         '<datafield tag="410" ind1=" " ind2=" ">'
         '  <subfield code="9">INSPIRE</subfield>'
-        '  <subfield code="a">Aachen Tech. Hochsch.</subfield>'
+        '  <subfield code="a">University of Chile</subfield>'
         '</datafield>'
-    )  # record/902624
+    )  # record/1496423
 
     expected = [
         {
             'source': 'INSPIRE',
-            'value': 'Aachen Tech. Hochsch.',
+            'value': 'University of Chile',
         },
     ]
     result = institutions.do(create_record(snippet))
@@ -297,7 +297,33 @@ def test_name_variants_from_410__a_9():
     assert expected == result['name_variants']
 
 
-def test_name_variants_from_410__9_with_invalid_source():
+def test_name_variants_from_410__a_9_discards_desy_source():
+    snippet = (
+        '<datafield tag="410" ind1=" " ind2=" ">'
+        '  <subfield code="9">DESY</subfield>'
+        '  <subfield code="a">Aachen Tech. Hochsch.</subfield>'
+        '</datafield>'
+    )  # record/902624
+
+    result = institutions.do(create_record(snippet))
+
+    assert 'name_variants' not in result
+
+
+def test_name_variants_from_410__a_9_discards_desy_aff_source():
+    snippet = (
+        '<datafield tag="410" ind1=" " ind2=" ">'
+        '  <subfield code="9">DESY_AFF</subfield>'
+        '  <subfield code="a">AARHUS UNIV</subfield>'
+        '</datafield>'
+    )  # record/902626
+
+    result = institutions.do(create_record(snippet))
+
+    assert 'name_variants' not in result
+
+
+def test_name_variants_from_410__9_discards_other_sources():
     snippet = (
         '<datafield tag="410" ind1=" " ind2=" ">'
         '  <subfield code="9">Tech</subfield>'
@@ -306,10 +332,9 @@ def test_name_variants_from_410__9_with_invalid_source():
         '</datafield>'
     )  # record/1338296
 
-    expected = {}
     result = institutions.do(create_record(snippet))
 
-    assert expected == result.get('name_variants', {})
+    assert 'name_variants' not in result
 
 
 def test_name_variants_from_410__double_a():


### PR DESCRIPTION
## Related Issue
Closes #2442 

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.