### PR TITLE
tests: get rid of es waits by adding health checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ services:
 env:
   global:
     - DOCKER_DATA="$HOME/docker_data"
-    - DOCKER_COMPOSE_VERSION=1.9.0
+    - DOCKER_COMPOSE_VERSION=1.13.0
   matrix:
     - SUITE=workflows
     - SUITE=integration

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -35,68 +35,92 @@ services:
       - APP_CACHE_REDIS_URL=redis://test-redis:6379/0
       - APP_ACCOUNTS_SESSION_REDIS_URL=redis://test-redis:6379/2
       - APP_SEARCH_ELASTIC_HOSTS=test-indexer
+
   unit:
     extends:
       service: test-service_base
     volumes_from:
       - test-static
     command: bash -c "py.test inspirehep tests/unit && make -C docs html"
+
   disambiguation:
     extends:
       service: test-service_base
     command: py.test tests/integration/disambiguation
     volumes_from:
       - test-static
-    links:
-      - test-database
-      - test-indexer
-      - test-rabbitmq
-      - test-redis
     depends_on:
-      - test-worker
+      test-database:
+        condition: service_healthy
+      test-indexer:
+        condition: service_healthy
+      test-rabbitmq:
+        condition: service_healthy
+      test-redis:
+        condition: service_healthy
+      test-worker:
+        condition: service_started
+
   workflows:
     extends:
       service: test-service_base
     command: py.test tests/integration/workflows
     volumes_from:
       - test-static
-    links:
-      - test-database
-      - test-indexer
-      - test-rabbitmq
-      - test-redis
     depends_on:
-      - test-worker
+      test-database:
+        condition: service_healthy
+      test-indexer:
+        condition: service_healthy
+      test-rabbitmq:
+        condition: service_healthy
+      test-redis:
+        condition: service_healthy
+      test-worker:
+        condition: service_started
+
   integration:
     extends:
       service: test-service_base
     command: py.test tests/integration --ignore tests/integration/disambiguation --ignore tests/integration/workflows
     volumes_from:
       - test-static
-    links:
-      - test-database
-      - test-indexer
-      - test-rabbitmq
-      - test-redis
     depends_on:
-      - test-worker
+      test-database:
+        condition: service_healthy
+      test-indexer:
+        condition: service_healthy
+      test-rabbitmq:
+        condition: service_healthy
+      test-redis:
+        condition: service_healthy
+      test-worker:
+        condition: service_started
+
   acceptance:
     extends:
       service: test-service_base
     command: py.test --driver Remote --host selenium --port 4444 --capability browserName firefox --html=selenium-report.html tests/acceptance
     volumes_from:
       - test-static
-    links:
-      - test-database
-      - test-indexer
-      - test-rabbitmq
-      - test-redis
-      - selenium
     depends_on:
-      - test-web
-      - test-worker
+      test-database:
+        condition: service_healthy
+      test-indexer:
+        condition: service_healthy
+      test-rabbitmq:
+        condition: service_healthy
+      test-redis:
+        condition: service_healthy
+      test-worker:
+        condition: service_started
+      selenium:
+        condition: service_started
+      test-web:
+        condition: service_started
     environment:
       - SERVER_NAME=test-web:5000
+
   visible_acceptance:
     extends:
       service: test-service_base
@@ -105,56 +129,109 @@ services:
       - /tmp/.X11-unix:/tmp/.X11-unix
     volumes_from:
       - test-static
-    links:
-      - test-database
-      - test-indexer
-      - test-rabbitmq
-      - test-redis
-      - selenium
     depends_on:
-      - test-web
-      - test-worker
+      test-database:
+        condition: service_healthy
+      test-indexer:
+        condition: service_healthy
+      test-rabbitmq:
+        condition: service_healthy
+      test-redis:
+        condition: service_healthy
+      test-worker:
+        condition: service_started
+      selenium:
+        condition: service_started
+      test-web:
+        condition: service_started
     environment:
       - SERVER_NAME=test-web:5000
       - DISPLAY=$DISPLAY
+
   test-web:
     extends:
       service: test-service_base
     command: gunicorn -b 0.0.0.0:5000 -t 3600 -w 1 --access-logfile "-" inspirehep.wsgi_with_coverage:application
     volumes_from:
       - test-static
-    links:
-      - test-database
-      - test-indexer
-      - test-rabbitmq
-      - test-redis
+    depends_on:
+      test-database:
+        condition: service_healthy
+      test-indexer:
+        condition: service_healthy
+      test-rabbitmq:
+        condition: service_healthy
+      test-redis:
+        condition: service_healthy
     environment:
       - APP_SERVER_NAME=test-web:5000
+
   test-worker:
     extends:
       service: test-service_base
     command: celery worker -E -A inspirehep.celery --loglevel=INFO --purge
     volumes_from:
       - test-static
-    links:
-      - test-database
-      - test-indexer
-      - test-rabbitmq
-      - test-redis
+    depends_on:
+      test-database:
+        condition: service_healthy
+      test-indexer:
+        condition: service_healthy
+      test-rabbitmq:
+        condition: service_healthy
+      test-redis:
+        condition: service_healthy
+
   test-redis:
     image: redis:3.2.3
+    healthcheck:
+      timeout: 5s
+      interval: 5s
+      retries: 5
+      test:
+        - "CMD"
+        - "bash"
+        - "-c"
+        - "exec 3<> /dev/tcp/127.0.0.1/6379 && echo PING >&3 && head -1 <&3 | grep PONG"
+
   test-indexer:
     extends:
       file: services.yml
       service: indexer
+    healthcheck:
+      timeout: 5s
+      interval: 5s
+      retries: 5
+      test:
+        - "CMD-SHELL"
+        - "curl http://localhost:9200/_cluster/health | grep '.status.:.green'"
+
   test-rabbitmq:
     image: rabbitmq
+    healthcheck:
+      timeout: 5s
+      interval: 5s
+      retries: 5
+      test:
+        - "CMD"
+        - "rabbitmqctl"
+        - "status"
+
   test-database:
     extends:
       file: services.yml
       service: database
+    healthcheck:
+      timeout: 5s
+      interval: 5s
+      retries: 5
+      test:
+        - "CMD-SHELL"
+        - "export PGPASSWORD=dbpass123 && psql --quiet --no-align --tuples-only --host 127.0.0.1 --username inspirehep --dbname inspirehep -c 'SELECT 1'"
+
   selenium:
     image: selenium/standalone-firefox:2.53.1-beryllium
+
   test-static:
     extends:
       file: services.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,29 +49,48 @@ services:
       - static
     ports:
       - "5000:5000"
-    links:
-      - database
-      - indexer
-      - rabbitmq
-      - redis
+    depends_on:
+      database:
+        condition: service_healthy
+      indexer:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     environment:
       - APP_DEBUG=True
       - APP_ASSETS_DEBUG=True
+
   worker:
     extends:
       service: service_base
     command: celery worker -E -A inspirehep.celery --loglevel=INFO --purge
     volumes_from:
       - static
-    links:
-      - database
-      - indexer
-      - rabbitmq
-      - redis
+    depends_on:
+      database:
+        condition: service_healthy
+      indexer:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
 
   # Services needed for inspirehep to run.
   redis:
     image: redis:3.2.3
+    healthcheck:
+      timeout: 5s
+      interval: 5s
+      retries: 5
+      test:
+        - "CMD"
+        - "bash"
+        - "-c"
+        - "exec 3<> /dev/tcp/127.0.0.1/6379 && echo PING >&3 && head -1 <&3 | grep PONG"
+
   indexer:
     extends:
       file: services.yml
@@ -81,14 +100,38 @@ services:
     volumes:
       - "${DOCKER_DATA}/tmp/inspirehep_elastic/data:/usr/share/elasticsearch/data"
       - "${DOCKER_DATA}/tmp/inspirehep_elastic/log:/usr/share/elasticsearch/log"
+    healthcheck:
+      timeout: 5s
+      interval: 5s
+      retries: 5
+      test:
+        - "CMD-SHELL"
+        - "curl http://localhost:9200/_cluster/health | grep '.status.:.green'"
+
   rabbitmq:
     image: rabbitmq
+    healthcheck:
+      timeout: 5s
+      interval: 5s
+      retries: 5
+      test:
+        - "CMD"
+        - "rabbitmqctl"
+        - "status"
+
   database:
     extends:
       file: services.yml
       service: database
     volumes:
       - "${DOCKER_DATA}/tmp/inspirehep_db/data:/var/lib/postgresql/data/pgdata"
+    healthcheck:
+      timeout: 5s
+      interval: 5s
+      retries: 5
+      test:
+        - "CMD-SHELL"
+        - "export PGPASSWORD=dbpass123 && psql --quiet --no-align --tuples-only --host 127.0.0.1 --username inspirehep --dbname inspirehep -c 'SELECT 1'"
 
   scrapyd:
     extends:
@@ -106,11 +149,15 @@ services:
     command: flower -A inspirehep.celery --broker=amqp://guest:guest@rabbitmq:5672//
     volumes_from:
       - static
-    links:
-      - database
-      - indexer
-      - rabbitmq
-      - redis
+    depends_on:
+      database:
+        condition: service_healthy
+      indexer:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
 
   # Static volume config for service_base.
   static:

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -59,7 +59,6 @@ def app(request):
         db.drop_all()
         db.create_all()
 
-        sleep(10)
         _es = app.extensions['invenio-search']
         list(_es.delete(ignore=[404]))
         list(_es.create(ignore=[400]))

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -22,8 +22,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-from time import sleep
-
 import pytest
 
 from invenio_db import db
@@ -57,7 +55,6 @@ def app():
         db.drop_all()
         db.create_all()
 
-        sleep(10)  # Makes sure that ES is up.
         _es = app.extensions['invenio-search']
         list(_es.delete(ignore=[404]))
         list(_es.create(ignore=[400]))
@@ -91,7 +88,6 @@ def small_app():
         db.drop_all()
         db.create_all()
 
-        sleep(10)
         _es = app.extensions['invenio-search']
         list(_es.delete(ignore=[404]))
         list(_es.create(ignore=[400]))


### PR DESCRIPTION
* This requires getting docker-compose > 1.10
* This makes the dependent containers wait for the dependencies to be
  in a healthy state before starting.
* As we are sure now that ES is already healthy before running the
  tests, there's no point on doing a sleep to wait for it to be up.