### PR TITLE
docker: simplify database health check

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -227,7 +227,7 @@ services:
       retries: 5
       test:
         - "CMD-SHELL"
-        - "export PGPASSWORD=dbpass123 && psql --quiet --no-align --tuples-only --host 127.0.0.1 --username inspirehep --dbname inspirehep -c 'SELECT 1'"
+        - "pg_isready --dbname=inspirehep --host=localhost --username=inspirehep"
 
   selenium:
     image: selenium/standalone-firefox:2.53.1-beryllium

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ services:
       retries: 5
       test:
         - "CMD-SHELL"
-        - "export PGPASSWORD=dbpass123 && psql --quiet --no-align --tuples-only --host 127.0.0.1 --username inspirehep --dbname inspirehep -c 'SELECT 1'"
+        - "pg_isready --dbname=inspirehep --host=localhost --username=inspirehep"
 
   scrapyd:
     extends:


### PR DESCRIPTION
## Description
Since version 9.3, PostgreSQL ships with a utility to check the
connection status of a database. For more information, please see
https://www.postgresql.org/docs/9.3/static/app-pg-isready.html

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.