### PR TITLE
holdingpen: no indexing of classifier_results

### DIFF
--- a/inspirehep/modules/workflows/mappings/holdingpen/hep.json
+++ b/inspirehep/modules/workflows/mappings/holdingpen/hep.json
@@ -23,6 +23,9 @@
                                 }
                             },
                             "type": "object"
+                        },
+                        "classifier_results": {
+                            "enabled": false
                         }
                     },
                     "type": "object"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

<!--- Why is this change required? What problem does it solve? -->

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

The output of `invenio-classifier`, currently put inside
`obj.extra_data['classifier_results']` is not in a ES-friendly
structure, due to using keywords as key in a dictionary (rather than
as value).

Temporary fixes this issue by disabling entirely indexing of
`classifier_results` in holdingpen.
(closes #2456)

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>