### PR TITLE
authors: fix the signature_block assignment 

### DIFF
--- a/inspirehep/modules/authors/receivers.py
+++ b/inspirehep/modules/authors/receivers.py
@@ -87,12 +87,6 @@ def assign_phonetic_block(sender, *args, **kwargs):
             authors[authors_map[full_name]].update(
                 {"signature_block": signature_block})
 
-        # # For missing phonetic blocks (not valid full names) add None.
-        for full_name in list(
-                set(authors_map.keys()) - set(signatures_blocks.keys())):
-            authors[authors_map[full_name]].update(
-                {"signature_block": None})
-
 
 @before_record_insert.connect
 @before_record_update.connect

--- a/tests/unit/authors/test_authors_receivers.py
+++ b/tests/unit/authors/test_authors_receivers.py
@@ -27,6 +27,8 @@ import mock
 import pytest
 from flask import current_app
 
+from inspire_schemas.utils import load_schema
+from inspirehep.dojson.utils import validate
 from inspirehep.modules.authors import receivers
 
 
@@ -96,6 +98,9 @@ def test_phonetic_block_generation_ascii():
 
 @pytest.mark.httpretty
 def test_phonetic_block_generation_broken():
+    schema = load_schema('hep')
+    subschema = schema['properties']['authors']
+
     extra_config = {
         "BEARD_API_URL": "http://example.com/beard",
     }
@@ -117,7 +122,8 @@ def test_phonetic_block_generation_broken():
 
         receivers.assign_phonetic_block(json_dict)
 
-        assert json_dict['authors'][0]['signature_block'] is None
+        assert validate(json_dict['authors'], subschema) is None
+        assert json_dict['authors'][0].get('signature_block') is None
 
 
 @pytest.mark.httpretty


### PR DESCRIPTION
## Description        
The function `assign_phonetic_block` is handling the case missing phonetic blocks putting `None`. This kind of behavior is not schema compatible

## Related Issue
Closes https://github.com/inspirehep/inspire-next/issues/2462
