### PR TITLE
workflows.callbacks: handle robotupload errors

### DIFF
--- a/inspirehep/modules/workflows/ext.py
+++ b/inspirehep/modules/workflows/ext.py
@@ -45,8 +45,12 @@ class INSPIREWorkflows(object):
 
     def init_config(self, app):
         """Initialize configuration."""
+        server_name = app.config["SERVER_NAME"]
+        if not server_name.startswith('http'):
+            server_name = 'http://' + server_name
+
         app.config.setdefault("WORKFLOWS_MATCH_REMOTE_SERVER_URL",
-                              app.config["SERVER_NAME"])
+                              server_name)
         app.config.setdefault("WORKFLOWS_PENDING_RECORDS_CACHE_TIMEOUT",
                               2629743)
         app.config.setdefault("HOLDING_PEN_MATCH_MAPPING", dict(


### PR DESCRIPTION
Now the errors from the callback results from legacy are properly
handled (at least, more usefully).

*NOTE*: The tests will come after the workflow tests refactor.
        See #2466

When we receive an error from legacy, now the workflow is set to
'ERROR' status and the callback error message is added to the
`_error_message` so it gets shown in the holdingpen.

Closes #2083 and closes #2397.

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Now it will set the workflow in error state and put the message of the
robotupload error on it so it can be viewed from the ui and restarted
if needed.
Also avoids using the recid `-1` completely, leaving the pending
records table coherent.

Signed-off-by: David Caro <david@dcaro.es>