### PR TITLE
travis: restore the permissions to the correct uid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ env:
   global:
     - DOCKER_DATA="$HOME/docker_data"
     - DOCKER_COMPOSE_VERSION=1.13.0
+    - BASE_USER_UID=2000
+    - BASE_USER_GID=2000
   matrix:
     - SUITE=workflows
     - SUITE=integration


### PR DESCRIPTION
Currently we are leaving the code directory as owned by id 1000,
though the travis runners use uid 2000. That prevents coverage from
reading the coverage file.

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

* This should fix the current coverage issues where the report does
  not show up.

Signed-off-by: David Caro <david@dcaro.es>