### PR TITLE
docker: allow yellow status indexer

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -204,7 +204,7 @@ services:
       retries: 5
       test:
         - "CMD-SHELL"
-        - "curl http://localhost:9200/_cluster/health | grep '.status.:.green'"
+        - "curl http://localhost:9200/_cluster/health | grep '.status.:.\\(green\\|yellow\\)'"
 
   test-rabbitmq:
     image: rabbitmq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,7 @@ services:
       retries: 5
       test:
         - "CMD-SHELL"
-        - "curl http://localhost:9200/_cluster/health | grep '.status.:.green'"
+        - "curl http://localhost:9200/_cluster/health | grep '.status.:.\\(green\\|yellow\\)'"
 
   rabbitmq:
     image: rabbitmq


### PR DESCRIPTION
Sometimes the docker container for the indexer does not go fully to
the green state, and remains in yellow state, but that's good enough
for us.

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

It was being too strict in the health check, and not allowing the
indexer to be in yellow status.

Signed-off-by: David Caro <david@dcaro.es>