### PR TITLE
records: remove experiment_suggest receiver

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -886,11 +886,6 @@ RECORDS_REST_ENDPOINTS = dict(
                 ':json_v1_search'
             ),
         },
-        suggesters=dict(
-            experiment=dict(completion=dict(
-                field='experiment_suggest'
-            ))
-        ),
         list_route='/experiments/',
         item_route='/experiments/<pid(exp,record_class="inspirehep.modules.records.api:InspireRecord"):pid_value>',
         default_media_type='application/json',

--- a/inspirehep/modules/records/mappings/records/experiments.json
+++ b/inspirehep/modules/records/mappings/records/experiments.json
@@ -127,10 +127,6 @@
                     },
                     "type": "object"
                 },
-                "experiment_suggest": {
-                    "payloads": true,
-                    "type": "completion"
-                },
                 "experimentautocomplete": {
                     "type": "string"
                 },

--- a/inspirehep/modules/records/receivers.py
+++ b/inspirehep/modules/records/receivers.py
@@ -64,7 +64,6 @@ def enhance_record(sender, json, *args, **kwargs):
     match_valid_experiments(sender, json, *args, **kwargs)
     dates_validator(sender, json, *args, **kwargs)
     add_recids_and_validate(sender, json, *args, **kwargs)
-    populate_experiment_suggest(sender, json, *args, **kwargs)
     populate_abstract_source_suggest(sender, json, *args, **kwargs)
     populate_affiliation_suggest(sender, json, *args, **kwargs)
     populate_title_suggest(sender, json, *args, **kwargs)
@@ -222,23 +221,6 @@ def add_recids_and_validate(sender, json, *args, **kwargs):
     """Ensure that recids are generated before being validated."""
     populate_recid_from_ref(sender, json, *args, **kwargs)
     references_validator(sender, json, *args, **kwargs)
-
-
-def populate_experiment_suggest(sender, json, *args, **kwargs):
-    """Populates experiment_suggest field of experiment records."""
-
-    # FIXME: Use a dedicated method when #1355 will be resolved.
-    if 'experiments.json' in json.get('$schema'):
-        long_name = force_list(json.get('long_name'))
-        name_variants = force_list(json.get('name_variants'))
-
-        json.update({
-            'experiment_suggest': {
-                'input': long_name + name_variants,
-                'output': long_name[0],
-                'payload': {'$ref': get_value(json, 'self.$ref')},
-            },
-        })
 
 
 def populate_abstract_source_suggest(sender, json, *args, **kwargs):

--- a/tests/unit/records/test_records_receivers.py
+++ b/tests/unit/records/test_records_receivers.py
@@ -33,7 +33,6 @@ from inspirehep.modules.records.receivers import (
     populate_inspire_document_type,
     populate_recid_from_ref,
     references_validator,
-    populate_experiment_suggest,
     populate_abstract_source_suggest,
     populate_affiliation_suggest,
     populate_title_suggest
@@ -508,34 +507,6 @@ def test_references_validator_removes_and_warns_on_non_numerical_recids(warning)
         {},
         {'recid': 456},
     ]
-
-
-def test_populate_experiment_suggest_populates_if_record_is_experiment():
-    json_dict = {
-        '$schema': 'http://foo/experiments.json',
-        'self': {'$ref': 'http://foo/$ref'},
-        'long_name': 'foo',
-        'name_variants': [
-            'bar',
-            'baz',
-        ],
-    }
-
-    populate_experiment_suggest(None, json_dict)
-
-    assert json_dict['experiment_suggest']['input'] == ['foo', 'bar', 'baz']
-    assert json_dict['experiment_suggest']['output'] == 'foo'
-    assert json_dict['experiment_suggest']['payload']['$ref'] == 'http://foo/$ref'
-
-
-def test_populate_experiment_suggest_does_nothing_if_record_is_not_experiment():
-    json_dict = {
-        '$schema': 'http://foo/bar.json',
-    }
-
-    populate_experiment_suggest(None, json_dict)
-
-    assert 'experiment_suggest' not in json_dict
 
 
 def test_populate_abstract_source_suggest():


### PR DESCRIPTION
## Description
This receiver was briefly needed for a demo, but now is causing trouble
during migration because some experiments don't have a `long_name`.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.