### PR TITLE
dojson: fix conferences

### DIFF
--- a/inspirehep/dojson/conferences/rules.py
+++ b/inspirehep/dojson/conferences/rules.py
@@ -123,7 +123,12 @@ def short_description(self, key, value):
 @utils.flatten
 @utils.for_each_value
 def alternative_titles(self, key, value):
-    return [
-        {'title': value.get('a')},
-        {'title': value.get('b')},
-    ]
+    result = []
+
+    for a_value in force_list(value.get('a')):
+        result.append({'title': a_value})
+
+    for b_value in force_list(value.get('b')):
+        result.append({'title': b_value})
+
+    return result

--- a/inspirehep/dojson/conferences/rules.py
+++ b/inspirehep/dojson/conferences/rules.py
@@ -64,16 +64,29 @@ def acronyms(self, key, value):
 
 
 @conferences.over('contact_details', '^270..')
-@utils.for_each_value
 def contact_details(self, key, value):
     if value.get('b'):
         self.setdefault('address', [])
         self['address'].append({'place_name': value.get('b')})
 
-    return {
-        'name': value.get('p'),
-        'email': value.get('m'),
-    }
+    result = []
+
+    m_values = force_list(value.get('m'))
+    p_values = force_list(value.get('p'))
+
+    # XXX: we zip only when they have the same length, otherwise
+    #      we might match an email with the wrong name.
+    if len(m_values) == len(p_values):
+        for m_value, p_value in zip(m_values, p_values):
+            result.append({
+                'email': m_value,
+                'name': p_value,
+            })
+    else:
+        for m_value in m_values:
+            result.append({'email': m_value})
+
+    return result
 
 
 @conferences.over('series', '^411..')

--- a/tests/unit/dojson/test_dojson_conferences.py
+++ b/tests/unit/dojson/test_dojson_conferences.py
@@ -360,6 +360,29 @@ def test_contact_details_from_270__m_p():
     assert expected == result['contact_details']
 
 
+def test_contact_details_from_270__triple_m():
+    schema = load_schema('conferences')
+    subschema = schema['properties']['contact_details']
+
+    snippet = (
+        '<datafield tag="270" ind1=" " ind2=" ">'
+        '  <subfield code="m">mborn37@ift.uni.wroc.pl</subfield>'
+        '  <subfield code="m">mb37_wg3@ift.uni.wroc.pl</subfield>'
+        '  <subfield code="m">andrzej.borowiec@ift.uni.wroc.pl</subfield>'
+        '</datafield>'
+    )  # record/1436421
+
+    expected = [
+        {'email': 'mborn37@ift.uni.wroc.pl'},
+        {'email': 'mb37_wg3@ift.uni.wroc.pl'},
+        {'email': 'andrzej.borowiec@ift.uni.wroc.pl'},
+    ]
+    result = conferences.do(create_record(snippet))
+
+    assert validate(result['contact_details'], subschema) is None
+    assert expected == result['contact_details']
+
+
 def test_series_from_411__a():
     schema = load_schema('conferences')
     subschema = schema['properties']['series']

--- a/tests/unit/dojson/test_dojson_conferences.py
+++ b/tests/unit/dojson/test_dojson_conferences.py
@@ -778,3 +778,24 @@ def test_alternative_titles_from_711__a_b():
 
     assert validate(result['alternative_titles'], subschema) is None
     assert expected == result['alternative_titles']
+
+
+def test_alternative_titles_from_711__double_b():
+    schema = load_schema('conferences')
+    subschema = schema['properties']['alternative_titles']
+
+    snippet = (
+        '<datafield tag="711" ind1=" " ind2=" ">'
+        '  <subfield code="b">high energy</subfield>'
+        '  <subfield code="b">ACAT</subfield>'
+        '</datafield>'
+    )  # record/967859
+
+    expected = [
+        {'title': 'high energy'},
+        {'title': 'ACAT'},
+    ]
+    result = conferences.do(create_record(snippet))
+
+    assert validate(result['alternative_titles'], subschema) is None
+    assert expected == result['alternative_titles']


### PR DESCRIPTION
## Description
First commit fixes a bug in `alternative_titles`, second commit fixes a bug in `contact_details`. All the remaining problems in this collection are tracked in https://github.com/inspirehep/inspire/issues/304.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.