### PR TITLE
docs: use Sphinx-bundled Napoleon

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,7 +84,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.viewcode',
     'sphinx.ext.todo',
-    'sphinxcontrib.napoleon',
+    'sphinx.ext.napoleon',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/dev_flow.rst
+++ b/docs/dev_flow.rst
@@ -258,7 +258,7 @@ Documentation will be required though for some parts of the code meant to be
 reused several times, like apis, utility functions, etc.
 
 The format of the docstrings that we use is the Google style one defined in the
-`napoleon Sphinx plugin page`_.
+`Napoleon Sphinx extension page`_.
 
 
 More details
@@ -279,4 +279,4 @@ Some useful links are listed bellow:
 .. _github settings page for keys: https://github.com/settings/keys
 .. _the hub tool git repo: https://github.com/github/hub
 .. _Invenio commit guideline: http://invenio.readthedocs.io/en/latest/technology/git.html#r2-remarks-on-commit-log-messages
-.. _napoleon Sphinx plugin page: http://sphinxcontrib-napoleon.readthedocs.io/en/latest/index.html
+.. _Napoleon Sphinx extension page: http://www.sphinx-doc.org/en/stable/ext/napoleon.html

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,6 @@ extras_require = {
         'six',
         'mock',
         'Sphinx~=1.0,>=1.6.2',
-        'sphinxcontrib-napoleon>=0.6.1',
     ],
     'postgresql': [
         'invenio-db[postgresql,versioning]>=1.0.0b2',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Napoleon is a Sphinx extension since Sphinx 1.3, so that can be used
instead of the `sphinxcontrib-napoleon` external dependency.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have checked that the documentation is correctly generated, including the Google-style docstrings.
<!--- After this you can move the PR to `Needs Review` -->
