### PR TITLE
dojson: fix deleted in experiments

### DIFF
--- a/inspirehep/dojson/common/rules.py
+++ b/inspirehep/dojson/common/rules.py
@@ -404,7 +404,6 @@ def new_record2marc(self, key, value):
 
 @conferences.over('deleted', '^980..')
 @institutions.over('deleted', '^980..')
-@experiments.over('deleted', '^980..')
 @jobs.over('deleted', '^980..')
 @journals.over('deleted', '^980..')
 def deleted(self, key, value):

--- a/inspirehep/dojson/experiments/rules.py
+++ b/inspirehep/dojson/experiments/rules.py
@@ -157,7 +157,20 @@ def collaboration(self, key, value):
 
 @experiments.over('core', '^980..')
 def core(self, key, value):
-    if not self.get('core'):
-        return value.get('a', '').upper() == 'CORE'
+    """Populate the ``core`` key.
 
-    return self.get('core')
+    Also populates the ``deleted`` key through side effects.
+    """
+    core = self.get('core')
+    deleted = self.get('deleted')
+
+    if not core:
+        normalized_a_values = [el.upper() for el in force_list(value.get('a'))]
+        core = 'CORE' in normalized_a_values
+
+    if not deleted:
+        normalized_c_values = [el.upper() for el in force_list(value.get('c'))]
+        deleted = 'DELETED' in normalized_c_values
+
+    self['deleted'] = deleted
+    return core

--- a/tests/unit/dojson/test_dojson_experiments.py
+++ b/tests/unit/dojson/test_dojson_experiments.py
@@ -22,8 +22,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import pytest
-
 from dojson.contrib.marc21.utils import create_record
 
 from inspire_schemas.utils import load_schema
@@ -498,7 +496,7 @@ def test_collaboration_from_710__g_0():
     assert expected == result['collaboration']
 
 
-def test_core_from_multiple_980__a():
+def test_core_from_double_980__a():
     schema = load_schema('experiments')
     subschema = schema['properties']['core']
 
@@ -518,3 +516,33 @@ def test_core_from_multiple_980__a():
 
     assert validate(result['core'], subschema) is None
     assert expected == result['core']
+
+
+def test_core_and_deleted_from_multiple_980__a():
+    schema = load_schema('experiments')
+    core_schema = schema['properties']['core']
+    deleted_schema = schema['properties']['deleted']
+
+    snippet = (
+        '<record>'
+        '  <datafield tag="980" ind1=" " ind2=" ">'
+        '    <subfield code="a">CORE</subfield>'
+        '  </datafield>'
+        '  <datafield tag="980" ind1=" " ind2=" ">'
+        '    <subfield code="a">EXPERIMENT</subfield>'
+        '  </datafield>'
+        '  <datafield tag="980" ind1=" " ind2=" ">'
+        '    <subfield code="c">DELETED</subfield>'
+        '  </datafield>'
+        '</record>'
+    )  # record/1400948
+
+    expected_core = True
+    expected_deleted = True
+    result = experiments.do(create_record(snippet))
+
+    assert validate(result['core'], core_schema) is None
+    assert expected_core == result['core']
+
+    assert validate(result['deleted'], deleted_schema) is None
+    assert expected_deleted == result['deleted']


### PR DESCRIPTION
## Description:
DoJSON doesn't allow to have two rules defined on the same regular
expression, so the rule for `core` was hiding the rule for `deleted`.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.