### PR TITLE
workflow: preserve references

### DIFF
--- a/inspirehep/modules/workflows/tasks/submission.py
+++ b/inspirehep/modules/workflows/tasks/submission.py
@@ -405,10 +405,3 @@ def prepare_files(obj, eng):
         obj.data['_fft'] = obj.data.get('_fft', []) + result
         obj.log.info('Non-user PDF files added to FFT.')
         obj.log.debug('Added PDF files: {}'.format(result))
-
-
-@with_debug_logging
-def remove_references(obj, eng):
-    obj.log.info(obj.data)
-    if 'references' in obj.data:
-        del obj.data['references']

--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -83,7 +83,6 @@ from inspirehep.modules.workflows.tasks.submission import (
     filter_keywords,
     prepare_files,
     prepare_keywords,
-    remove_references,
     reply_ticket,
     send_robotupload,
     wait_webcoll,
@@ -284,7 +283,6 @@ POSTENHANCE_RECORD = [
     add_note_entry,
     filter_keywords,
     prepare_keywords,
-    remove_references,
     prepare_files,
 ]
 

--- a/tests/unit/workflows/test_workflows_tasks_submission.py
+++ b/tests/unit/workflows/test_workflows_tasks_submission.py
@@ -41,7 +41,6 @@ from inspirehep.modules.workflows.tasks.submission import (
     filter_keywords,
     prepare_files,
     prepare_keywords,
-    remove_references,
     reply_ticket,
     send_robotupload,
     wait_webcoll,
@@ -1212,52 +1211,5 @@ def test_prepare_files_ignores_keys_not_ending_with_pdf():
 
     expected = ''
     result = obj.log._info.getvalue()
-
-    assert expected == result
-
-
-def test_remove_references():
-    schema = load_schema('hep')
-    subschema = schema['properties']['references']
-
-    data = {
-        'references': [
-            {
-                'reference': {
-                    'arxiv_eprint': 'hep-th/9710014',
-                    'authors': [
-                        {'full_name': 'Maldacena, J.'},
-                        {'full_name': 'Strominger, A.'},
-                    ],
-                    'label': '1',
-                },
-            },
-        ],
-    }
-    extra_data = {}
-    assert validate(data['references'], subschema) is None
-
-    obj = MockObj(data, extra_data)
-    eng = MockEng()
-
-    assert remove_references(obj, eng) is None
-
-    expected = {}
-    result = obj.data
-
-    assert expected == result
-
-
-def test_remove_references_does_nothing_when_there_are_no_references():
-    data = {}
-    extra_data = {}
-
-    obj = MockObj(data, extra_data)
-    eng = MockEng()
-
-    assert remove_references(obj, eng) is None
-
-    expected = {}
-    result = obj.data
 
     assert expected == result


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

<!--- Why is this change required? What problem does it solve? -->

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] *I have removed tests that covered the removed feature.*
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

* Now that refextract is using fresh journal information there's
  no more need to drop references before sending them to legacy.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>