### PR TITLE
holdingpen: number of classifier results display fix

### DIFF
--- a/inspirehep/modules/workflows/static/js/inspire_workflows_ui/templates/results.html
+++ b/inspirehep/modules/workflows/static/js/inspire_workflows_ui/templates/results.html
@@ -122,7 +122,7 @@
                 allKeywords = (record._source._extra_data.classifier_results.complete_output | unifyKeywords)"
               ng-if="record._source._extra_data.classifier_results.complete_output" class="small-text">
               <p ng-class="{'accept_core_keyword': filteredKeywords.length > 1,
-                'accept_keyword': filteredKeywords.length < 1}">
+                'accept_keyword': filteredKeywords.length < 2}">
                 {{filteredKeywords.length}} Filtered core keywords
               </p>
               <span


### PR DESCRIPTION
* Fixes off-by-one error when styling the number of core keywords.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
