### PR TITLE
Acceptance: remove has_error functions from all the tests  

### DIFF
--- a/inspirehep/bat/arsenic.py
+++ b/inspirehep/bat/arsenic.py
@@ -72,7 +72,24 @@ class Arsenic(object):
 
 
 class ArsenicResponse(object):
-    has_error = None
+    statement = None
+    negative_statement = None
 
-    def __init__(self, has_error):
-        self.has_error = has_error
+    def __init__(self, statement, negative_statement=None):
+        """Init method.
+
+        :param statement: sets the function that will
+        be called to verify that a given event occured
+        :type source: function
+        :param negative_statement: sets the function that will
+        be called to verify that a given event did not occur
+        :type record: function
+        """
+        self.statement = statement
+        self.negative_statement = negative_statement
+
+    def assert_no_errors(self):
+        self.statement()
+
+    def assert_errors(self):
+        self.negative_statement()

--- a/inspirehep/bat/pages/create_author.py
+++ b/inspirehep/bat/pages/create_author.py
@@ -43,7 +43,7 @@ def go_to():
 
 def write_institution(institution, expected_data):
     def _write_institution():
-        return expected_data in Arsenic().write_in_autocomplete_field(
+        assert expected_data in Arsenic().write_in_autocomplete_field(
             'institution_history-0-name', institution)
 
     return ArsenicResponse(_write_institution)
@@ -51,7 +51,7 @@ def write_institution(institution, expected_data):
 
 def write_experiment(experiment, expected_data):
     def _write_experiment():
-        return expected_data in Arsenic().write_in_autocomplete_field(
+        assert expected_data in Arsenic().write_in_autocomplete_field(
             'experiments-0-name', experiment)
 
     return ArsenicResponse(_write_experiment)
@@ -59,15 +59,18 @@ def write_experiment(experiment, expected_data):
 
 def write_advisor(advisor, expected_data):
     def _write_advisor():
-        return expected_data in Arsenic().write_in_autocomplete_field(
+        assert expected_data in Arsenic().write_in_autocomplete_field(
             'advisors-0-name', advisor)
 
     return ArsenicResponse(_write_advisor)
 
 
 def write_mail(mail):
+    def _negative_write_mail():
+        assert 'Invalid email address.' not in message_err
+
     def _write_mail():
-        return 'Invalid email address.' in message_err
+        assert 'Invalid email address.' in message_err
 
     mail_field = Arsenic().find_element_by_id('public_emails-0-email')
     mail_field.send_keys(mail)
@@ -79,12 +82,15 @@ def write_mail(mail):
         message_err = ''
     mail_field.clear()
 
-    return ArsenicResponse(_write_mail)
+    return ArsenicResponse(_write_mail, negative_statement=_negative_write_mail)
 
 
 def write_orcid(orcid):
+    def _negative_write_orcid():
+        assert 'A valid ORCID iD consists of 16 digits separated by dashes.' not in message_err
+
     def _write_orcid():
-        return 'A valid ORCID iD consists of 16 digits separated by dashes.' in message_err
+        assert 'A valid ORCID iD consists of 16 digits separated by dashes.' in message_err
 
     ORCID_field = Arsenic().find_element_by_id('orcid')
     ORCID_field.send_keys(orcid)
@@ -96,12 +102,15 @@ def write_orcid(orcid):
         message_err = ''
     ORCID_field.clear()
 
-    return ArsenicResponse(_write_orcid)
+    return ArsenicResponse(_write_orcid, negative_statement=_negative_write_orcid)
 
 
 def write_year(input_id, error_message_id, year):
+    def _negative_write_year():
+        assert 'is not a valid year' not in message_err
+
     def _write_year():
-        return 'is not a valid year' in message_err
+        assert 'is not a valid year' in message_err
 
     year_field = Arsenic().find_element_by_id(input_id)
     year_field.send_keys(year)
@@ -113,12 +122,12 @@ def write_year(input_id, error_message_id, year):
         message_err = ''
     year_field.clear()
 
-    return ArsenicResponse(_write_year)
+    return ArsenicResponse(_write_year, negative_statement=_negative_write_year)
 
 
 def submit_empty_form(expected_data):
     def _submit_empty_form():
-        return expected_data == output_data
+        assert expected_data == output_data
 
     Arsenic().find_element_by_xpath('//button[@class="btn btn-success form-submit"]').click()
     try:
@@ -138,7 +147,7 @@ def submit_empty_form(expected_data):
 
 def submit_author(input_data):
     def _submit_author():
-        return 'Thank you for adding new profile information!' in WebDriverWait(Arsenic(), 10).until(
+        assert 'Thank you for adding new profile information!' in WebDriverWait(Arsenic(), 10).until(
             GetText((By.XPATH, '(//div[@class="alert alert-success alert-form-success"])')))
 
     Arsenic().hide_title_bar()

--- a/inspirehep/bat/pages/create_literature.py
+++ b/inspirehep/bat/pages/create_literature.py
@@ -43,7 +43,7 @@ def go_to():
 
 def submit_thesis(input_data):
     def _submit_thesis():
-        return (
+        assert (
             'The INSPIRE staff will review it and your changes will be added '
             'to INSPIRE.'
         ) in WebDriverWait(Arsenic(), 10).until(
@@ -72,7 +72,7 @@ def submit_thesis(input_data):
 
 def submit_journal_article_with_proceeding(input_data):
     def _submit_journal_article_with_proceeding():
-        return (
+        assert (
             'The INSPIRE staff will review it and your changes will be added '
             'to INSPIRE.'
         ) in WebDriverWait(Arsenic(), 10).until(
@@ -101,7 +101,7 @@ def submit_journal_article_with_proceeding(input_data):
 
 def submit_journal_article(input_data):
     def _submit_journal_article():
-        return (
+        assert (
             'The INSPIRE staff will review it and your changes will be added '
             'to INSPIRE.'
         ) in WebDriverWait(Arsenic(), 10).until(
@@ -245,8 +245,13 @@ def _references_comment_population(input_data):
 
 
 def write_pdf_link(pdf_link):
+    def _negative_write_pdf_link():
+        assert (
+            'Please, provide an accessible direct link to a PDF document.'
+        ) not in message_err
+
     def _write_pdf_link():
-        return (
+        assert (
             'Please, provide an accessible direct link to a PDF document.'
         ) in message_err
 
@@ -271,7 +276,7 @@ def write_pdf_link(pdf_link):
     Arsenic().show_title_bar()
     field.clear()
 
-    return ArsenicResponse(_write_pdf_link)
+    return ArsenicResponse(_write_pdf_link, negative_statement=_negative_write_pdf_link)
 
 
 def write_date_thesis(date_field, error_message_id, date):
@@ -297,18 +302,24 @@ def write_date_thesis(date_field, error_message_id, date):
     Arsenic().show_title_bar()
     field.clear()
 
-    def _has_error():
-        return (
+    def _negative_has_error_message():
+        assert (
             'Please, provide a valid date in the format YYYY-MM-DD, YYYY-MM '
             'or YYYY.'
         ) in error_message
 
-    return ArsenicResponse(_has_error)
+    def _has_error_message():
+        assert (
+            'Please, provide a valid date in the format YYYY-MM-DD, YYYY-MM '
+            'or YYYY.'
+        ) not in error_message
+
+    return ArsenicResponse(_has_error_message, negative_statement=_negative_has_error_message)
 
 
 def write_institution_thesis(institution, expected_data):
     def _write_institution_thesis():
-        return expected_data == Arsenic().write_in_autocomplete_field(
+        assert expected_data == Arsenic().write_in_autocomplete_field(
             'supervisors-0-affiliation', institution)
 
     _skip_import_data()
@@ -321,7 +332,7 @@ def write_institution_thesis(institution, expected_data):
 
 def write_conference(conference_title, expected_data):
     def _write_conference():
-        return expected_data in Arsenic().write_in_autocomplete_field(
+        assert expected_data in Arsenic().write_in_autocomplete_field(
             'conf_name', conference_title)
 
     _skip_import_data()
@@ -330,7 +341,7 @@ def write_conference(conference_title, expected_data):
 
 def write_journal_title(journal_title, expected_data):
     def _write_journal_title():
-        return expected_data in Arsenic().write_in_autocomplete_field(
+        assert expected_data in Arsenic().write_in_autocomplete_field(
             'journal_title', journal_title)
 
     _skip_import_data()
@@ -339,7 +350,7 @@ def write_journal_title(journal_title, expected_data):
 
 def write_affiliation(affiliation, expected_data):
     def _write_affiliation():
-        return expected_data == Arsenic().write_in_autocomplete_field(
+        assert expected_data == Arsenic().write_in_autocomplete_field(
             'authors-0-affiliation', affiliation)
 
     _skip_import_data()
@@ -347,8 +358,13 @@ def write_affiliation(affiliation, expected_data):
 
 
 def write_arxiv_id(arxiv_id):
+    def _negative_write_arxiv_id():
+        assert (
+            'The provided ArXiv ID is invalid - it should look'
+        ) not in message_err
+
     def _write_arxiv_id():
-        return (
+        assert (
             'The provided ArXiv ID is invalid - it should look'
         ) in message_err
 
@@ -362,12 +378,15 @@ def write_arxiv_id(arxiv_id):
     except (ElementNotVisibleException, WebDriverException):
         message_err = ''
 
-    return ArsenicResponse(_write_arxiv_id)
+    return ArsenicResponse(_write_arxiv_id, negative_statement=_negative_write_arxiv_id)
 
 
 def write_doi_id(doi):
+    def _negative_write_doi_id():
+        assert 'The provided DOI is invalid - it should look' not in message_err
+
     def _write_doi_id():
-        return 'The provided DOI is invalid - it should look' in message_err
+        assert 'The provided DOI is invalid - it should look' in message_err
 
     Arsenic().find_element_by_id('doi').clear()
     Arsenic().find_element_by_id('doi').send_keys(doi)
@@ -379,12 +398,15 @@ def write_doi_id(doi):
     except (ElementNotVisibleException, WebDriverException):
         message_err = ''
 
-    return ArsenicResponse(_write_doi_id)
+    return ArsenicResponse(_write_doi_id, negative_statement=_negative_write_doi_id)
 
 
 def submit_arxiv_id(arxiv_id, expected_data):
+    def _negative_submit_arxiv_id():
+        assert expected_data != output_data
+
     def _submit_arxiv_id():
-        return expected_data == output_data
+        assert expected_data == output_data
 
     Arsenic().find_element_by_id('arxiv_id').send_keys(arxiv_id)
     WebDriverWait(Arsenic(), 10).until(
@@ -420,12 +442,12 @@ def submit_arxiv_id(arxiv_id, expected_data):
         ).get_attribute('value')
     }
 
-    return ArsenicResponse(_submit_arxiv_id)
+    return ArsenicResponse(_submit_arxiv_id, negative_statement=_submit_arxiv_id)
 
 
 def submit_doi_id(doi_id, expected_data):
     def _submit_doi_id():
-        return expected_data == output_data
+        assert expected_data == output_data
 
     Arsenic().find_element_by_id('doi').send_keys(doi_id)
     Arsenic().find_element_by_id('importData').click()

--- a/inspirehep/bat/pages/holding_panel_author_detail.py
+++ b/inspirehep/bat/pages/holding_panel_author_detail.py
@@ -45,7 +45,7 @@ def go_to():
 
 def load_submitted_record(input_data):
     def _load_submitted_record():
-        res = (
+        assert (
             'M. Twain' in record and
             'Twain, Mark' in record and
             'retired' in record and
@@ -65,8 +65,6 @@ def load_submitted_record(input_data):
             '2000' in record and
             '2001' in record
         )
-        assert res
-        return res
 
     try:
         record = WebDriverWait(Arsenic(), 10).until(GetText((By.ID, 'hp-panel-detailed-info')))
@@ -86,7 +84,7 @@ def load_submitted_record(input_data):
 
 def accept_record():
     def _accept_record():
-        return 'Accepted as Non-CORE' in WebDriverWait(Arsenic(), 10).until(
+        assert 'Accepted as Non-CORE' in WebDriverWait(Arsenic(), 10).until(
             GetText((By.XPATH, '//div[@class="alert ng-scope alert-accept"]')))
 
     Arsenic().find_element_by_id('btn-accept').click()
@@ -95,7 +93,7 @@ def accept_record():
 
 def reject_record():
     def _reject_record():
-        return 'Rejected' in WebDriverWait(Arsenic(), 10).until(
+        assert 'Rejected' in WebDriverWait(Arsenic(), 10).until(
             GetText((By.XPATH, '//div[@class="alert ng-scope alert-reject"]')))
 
     Arsenic().find_element_by_id('btn-reject-submission').click()
@@ -104,7 +102,7 @@ def reject_record():
 
 def curation_record():
     def _curation_record():
-        return 'Accepted with Curation' in WebDriverWait(Arsenic(), 10).until(
+        assert 'Accepted with Curation' in WebDriverWait(Arsenic(), 10).until(
             GetText((By.XPATH, '//span[@ng-switch-when="accept_curate"]')))
 
     Arsenic().find_element_by_id('btn-accept-curation').click()
@@ -115,9 +113,9 @@ def review_record(input_data):
     def _review_record():
         def _text_in_element(element_id, text):
             try:
-                return text in Arsenic().find_element_by_id(element_id).get_attribute('value')
+                assert text in Arsenic().find_element_by_id(element_id).get_attribute('value')
             except TypeError:
-                return text in Arsenic().find_element_by_id(element_id).text
+                assert text in Arsenic().find_element_by_id(element_id).text
         return (
             WebDriverWait(Arsenic(), 10).until(EC.visibility_of_element_located((By.ID, 'inspireid'))) and
             WebDriverWait(Arsenic(), 10).until(EC.visibility_of_element_located((By.ID, 'bai'))) and

--- a/inspirehep/bat/pages/holding_panel_literature_detail.py
+++ b/inspirehep/bat/pages/holding_panel_literature_detail.py
@@ -41,7 +41,7 @@ def go_to():
 
 def load_submitted_record(input_data):
     def _load_submitted_record():
-        return (
+        assert (
             'Lorem ipsum dolor sit amet, consetetur sadipscing elitr.' in record and
             'Submitted by admin@inspirehep.net\non' in record and
             'Wisconsin U., Madison' in record and
@@ -75,7 +75,7 @@ def load_submitted_record(input_data):
 
 def accept_record():
     def _accept_record():
-        return 'Accepted as Non-CORE' in WebDriverWait(Arsenic(), 10).until(
+        assert 'Accepted as Non-CORE' in WebDriverWait(Arsenic(), 10).until(
             GetText((By.XPATH, '//div[@class="alert ng-scope alert-accept"]'))
         )
 

--- a/inspirehep/bat/pages/holding_panel_literature_list.py
+++ b/inspirehep/bat/pages/holding_panel_literature_list.py
@@ -77,7 +77,7 @@ def click_first_record():
 
 def load_submitted_record():
     def _load_submitted_record():
-        return (
+        assert (
             'Computing' in record and
             'Accelerators' in record and
             'My Title For Test' in record and
@@ -92,7 +92,7 @@ def load_submitted_record():
 
 def load_completed_record():
     def _load_completed_record():
-        return 'Completed' in record
+        assert 'Completed' in record
 
     record = force_load_record('//div[@class="row hp-item ng-scope"][1]/div/div/div[2]/holding-pen-template-handler/div[4]/a')
     return ArsenicResponse(_load_completed_record)

--- a/inspirehep/bat/pages/top_navigation_page.py
+++ b/inspirehep/bat/pages/top_navigation_page.py
@@ -28,7 +28,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
-from ..arsenic import Arsenic
+from ..arsenic import Arsenic, ArsenicResponse
 
 
 def log_in(user_id, password):
@@ -38,13 +38,16 @@ def log_in(user_id, password):
     Arsenic().find_element_by_xpath("//button[@type='submit']").click()
 
 
-def am_i_logged():
+def log_in_user():
+    def _logged_check():
+        assert log_in_info == 'My account'
+
     Arsenic().get(environ['SERVER_NAME'])
-    return (
-        WebDriverWait(Arsenic(), 10).until(
-            EC.visibility_of_element_located((By.ID, 'user-info'))
-        ).text == 'My account'
-    )
+    log_in_info = WebDriverWait(Arsenic(), 10).until(
+        EC.visibility_of_element_located((By.ID, 'user-info'))
+    ).text
+
+    return ArsenicResponse(_logged_check)
 
 
 def ping():

--- a/tests/acceptance/test_author_creation.py
+++ b/tests/acceptance/test_author_creation.py
@@ -58,29 +58,29 @@ INPUT_AUTHOR_DATA = {
 
 def test_institutions_typeahead(login):
     create_author.go_to()
-    assert create_author.write_institution('cer', 'CERN').has_error()
+    create_author.write_institution('cer', 'CERN').assert_no_errors()
 
 
 def test_experiments_typehead(login):
     create_author.go_to()
-    assert create_author.write_experiment('atl', 'ATLAS').has_error()
+    create_author.write_experiment('atl', 'ATLAS').assert_no_errors()
 
 
 def test_advisors_typehead(login):
     create_author.go_to()
-    assert create_author.write_advisor('alexe', 'Vorobyev, Alexey').has_error()
+    create_author.write_advisor('alexe', 'Vorobyev, Alexey').assert_no_errors()
 
 
 def test_mail_format(login):
     create_author.go_to()
-    assert create_author.write_mail('wrong.mail').has_error()
-    assert not create_author.write_mail('me@me.com').has_error()
+    create_author.write_mail('wrong.mail').assert_no_errors()
+    create_author.write_mail('me@me.com').assert_errors()
 
 
 def test_ORCID_format(login):
     create_author.go_to()
-    assert create_author.write_orcid('wrong.ORCID').has_error()
-    assert not create_author.write_orcid('1111-1111-1111-1111').has_error()
+    create_author.write_orcid('wrong.ORCID').assert_no_errors()
+    create_author.write_orcid('1111-1111-1111-1111').assert_errors()
 
 
 def test_institutions_years(login):
@@ -88,29 +88,29 @@ def test_institutions_years(login):
 
     input_id = 'institution_history-0-start_year'
     error_mess_id = 'state-institution_history-0-start_year'
-    assert create_author.write_year(
+    create_author.write_year(
         input_id,
         error_mess_id,
         'wrongyear',
-    ).has_error()
-    assert not create_author.write_year(
+    ).assert_no_errors()
+    create_author.write_year(
         input_id,
         error_mess_id,
         '2016',
-    ).has_error()
+    ).assert_errors()
 
     input_id = 'institution_history-0-end_year'
     error_mess_id = 'state-institution_history-0-end_year'
-    assert create_author.write_year(
+    create_author.write_year(
         input_id,
         error_mess_id,
         'wrongyear',
-    ).has_error()
-    assert not create_author.write_year(
+    ).assert_no_errors()
+    create_author.write_year(
         input_id,
         error_mess_id,
         '2016',
-    ).has_error()
+    ).assert_errors()
 
 
 def test_experiments_years(login):
@@ -118,29 +118,29 @@ def test_experiments_years(login):
 
     input_id = 'experiments-0-start_year'
     error_mess_id = 'state-experiments-0-start_year'
-    assert create_author.write_year(
+    create_author.write_year(
         input_id,
         error_mess_id,
         'wrongyear',
-    ).has_error()
-    assert not create_author.write_year(
+    ).assert_no_errors()
+    create_author.write_year(
         input_id,
         error_mess_id,
         '2016',
-    ).has_error()
+    ).assert_errors()
 
     input_id = 'experiments-0-end_year'
     error_mess_id = 'state-experiments-0-end_year'
-    assert create_author.write_year(
+    create_author.write_year(
         input_id,
         error_mess_id,
         'wrongyear',
-    ).has_error()
-    assert not create_author.write_year(
+    ).assert_no_errors()
+    create_author.write_year(
         input_id,
         error_mess_id,
         '2016',
-    ).has_error()
+    ).assert_errors()
 
 
 def test_mandatory_fields(login):
@@ -151,22 +151,22 @@ def test_mandatory_fields(login):
     }
 
     create_author.go_to()
-    assert create_author.submit_empty_form(expected_data).has_error()
+    create_author.submit_empty_form(expected_data).assert_no_errors()
 
 
 def test_submit_author(login):
     create_author.go_to()
-    assert create_author.submit_author(INPUT_AUTHOR_DATA).has_error()
+    create_author.submit_author(INPUT_AUTHOR_DATA).assert_no_errors()
 
     holding_panel_author_list.go_to()
-    assert holding_panel_author_list.load_submission_record(
+    holding_panel_author_list.load_submission_record(
         INPUT_AUTHOR_DATA
-    ).has_error()
+    ).assert_no_errors()
 
     holding_panel_author_detail.go_to()
-    assert holding_panel_author_detail.load_submitted_record(
+    holding_panel_author_detail.load_submitted_record(
         INPUT_AUTHOR_DATA
-    ).has_error()
+    ).assert_no_errors()
     holding_panel_author_detail.reject_record()
 
 
@@ -177,7 +177,7 @@ def test_accept_author(login):
     holding_panel_author_list.load_submission_record(INPUT_AUTHOR_DATA)
     holding_panel_author_detail.go_to()
     holding_panel_author_detail.load_submitted_record(INPUT_AUTHOR_DATA)
-    assert holding_panel_author_detail.accept_record().has_error()
+    holding_panel_author_detail.accept_record().assert_no_errors()
 
 
 def test_reject_author(login):
@@ -187,7 +187,7 @@ def test_reject_author(login):
     holding_panel_author_list.load_submission_record(INPUT_AUTHOR_DATA)
     holding_panel_author_detail.go_to()
     holding_panel_author_detail.load_submitted_record(INPUT_AUTHOR_DATA)
-    assert holding_panel_author_detail.reject_record().has_error()
+    holding_panel_author_detail.reject_record().assert_no_errors()
 
 
 def test_curation_author(login):
@@ -197,7 +197,7 @@ def test_curation_author(login):
     holding_panel_author_list.load_submission_record(INPUT_AUTHOR_DATA)
     holding_panel_author_detail.go_to()
     holding_panel_author_detail.load_submitted_record(INPUT_AUTHOR_DATA)
-    assert holding_panel_author_detail.curation_record().has_error()
+    holding_panel_author_detail.curation_record().assert_no_errors()
 
 
 def test_review_submission_author(login):
@@ -207,4 +207,4 @@ def test_review_submission_author(login):
     holding_panel_author_list.load_submission_record(INPUT_AUTHOR_DATA)
     holding_panel_author_detail.go_to()
     holding_panel_author_detail.load_submitted_record(INPUT_AUTHOR_DATA)
-    assert holding_panel_author_detail.review_record(INPUT_AUTHOR_DATA).has_error()
+    holding_panel_author_detail.review_record(INPUT_AUTHOR_DATA).assert_no_errors()

--- a/tests/acceptance/test_literature_suggestion_form.py
+++ b/tests/acceptance/test_literature_suggestion_form.py
@@ -59,7 +59,7 @@ def test_literature_create_thesis_manually(login):
     }
 
     create_literature.go_to()
-    assert create_literature.submit_thesis(input_data).has_error()
+    create_literature.submit_thesis(input_data).assert_no_errors()
     _check_back_office(input_data)
 
 
@@ -91,7 +91,7 @@ def test_literature_create_article_journal_manually(login):
     }
 
     create_literature.go_to()
-    assert create_literature.submit_journal_article(input_data).has_error()
+    create_literature.submit_journal_article(input_data).assert_no_errors()
     _check_back_office(input_data)
 
 
@@ -124,30 +124,30 @@ def test_literature_create_article_journal_with_proceeding_manually(login):
     }
 
     create_literature.go_to()
-    assert create_literature.submit_journal_article_with_proceeding(
+    create_literature.submit_journal_article_with_proceeding(
         input_data
-    ).has_error()
+    ).assert_no_errors()
     _check_back_office(input_data)
 
 
 def _check_back_office(input_data):
     holding_panel_literature_list.go_to()
-    assert holding_panel_literature_list.load_submitted_record().has_error()
+    holding_panel_literature_list.load_submitted_record().assert_no_errors()
 
     holding_panel_literature_detail.go_to()
-    assert holding_panel_literature_detail.load_submitted_record(
+    holding_panel_literature_detail.load_submitted_record(
         input_data
-    ).has_error()
-    assert holding_panel_literature_detail.accept_record().has_error()
+    ).assert_no_errors()
+    holding_panel_literature_detail.accept_record().assert_no_errors()
 
     holding_panel_literature_list.go_to()
-    assert holding_panel_literature_list.load_completed_record().has_error()
+    holding_panel_literature_list.load_completed_record().assert_no_errors()
 
 
 def test_pdf_link(login):
     create_literature.go_to()
-    assert create_literature.write_pdf_link('pdf_url_wrong').has_error()
-    assert not create_literature.write_pdf_link('pdf_url_correct').has_error()
+    create_literature.write_pdf_link('pdf_url_wrong').assert_no_errors()
+    create_literature.write_pdf_link('pdf_url_correct').assert_errors()
 
 
 def test_thesis_info_date(login):
@@ -158,31 +158,31 @@ def test_thesis_info_date(login):
 
 def test_thesis_info_autocomplete_supervisor_institution(login):
     create_literature.go_to()
-    assert create_literature.write_institution_thesis(
+    create_literature.write_institution_thesis(
         'CER',
         'CERN',
-    ).has_error()
+    ).assert_no_errors()
 
 
 def test_journal_info_autocomplete_title(login):
     create_literature.go_to()
-    assert create_literature.write_journal_title(
+    create_literature.write_journal_title(
         'Nuc',
         'Nucl.Phys.',
-    ).has_error()
+    ).assert_no_errors()
 
 
 def test_conference_info_autocomplete_title(login):
     create_literature.go_to()
-    assert create_literature.write_conference(
+    create_literature.write_conference(
         'autrans',
         'IN2P3 School of Statistics, 2012-05-28, Autrans, France',
-    ).has_error()
+    ).assert_no_errors()
 
 
 def test_basic_info_autocomplete_affiliation(login):
     create_literature.go_to()
-    assert create_literature.write_affiliation('oxf', 'Oxford U.').has_error()
+    create_literature.write_affiliation('oxf', 'Oxford U.').assert_no_errors()
 
 
 def test_import_from_arXiv(login):
@@ -205,10 +205,10 @@ def test_import_from_arXiv(login):
     }
 
     create_literature.go_to()
-    assert create_literature.submit_arxiv_id(
+    create_literature.submit_arxiv_id(
         'hep-th/9711200',
         expected_data,
-    ).has_error()
+    ).assert_no_errors()
 
 
 def test_import_from_doi(login):
@@ -228,24 +228,24 @@ def test_import_from_doi(login):
     }
 
     create_literature.go_to()
-    assert create_literature.submit_doi_id(
+    create_literature.submit_doi_id(
         '10.1086/305772',
         expected_data,
-    ).has_error()
+    ).assert_no_errors()
 
 
 def test_format_input_arXiv(login):
     create_literature.go_to()
-    assert not create_literature.write_arxiv_id('1001.4538').has_error()
-    assert create_literature.write_arxiv_id('hep-th.9711200').has_error()
-    assert not create_literature.write_arxiv_id('hep-th/9711200').has_error()
+    create_literature.write_arxiv_id('1001.4538').assert_errors()
+    create_literature.write_arxiv_id('hep-th.9711200').assert_no_errors()
+    create_literature.write_arxiv_id('hep-th/9711200').assert_errors()
 
 
 def test_format_input_doi(login):
     create_literature.go_to()
-    assert create_literature.write_doi_id('dummy:10.1086/305772').has_error()
-    assert not create_literature.write_doi_id('10.1086/305772').has_error()
-    assert create_literature.write_doi_id('state-doi').has_error()
+    create_literature.write_doi_id('dummy:10.1086/305772').assert_no_errors()
+    create_literature.write_doi_id('10.1086/305772').assert_errors()
+    create_literature.write_doi_id('state-doi').assert_no_errors()
 
 
 def _test_date_format(field_id, field_err_id):
@@ -254,9 +254,9 @@ def _test_date_format(field_id, field_err_id):
         field_id,
         field_err_id,
     )
-    assert not write_date_thesis('').has_error()
-    assert write_date_thesis('wrong').has_error()
-    assert not write_date_thesis('2016-01').has_error()
-    assert write_date_thesis('2016-02-30').has_error()
-    assert not write_date_thesis('2016').has_error()
-    assert write_date_thesis('2016-13').has_error()
+    write_date_thesis('').assert_no_errors()
+    write_date_thesis('wrong').assert_errors()
+    write_date_thesis('2016-01').assert_no_errors()
+    write_date_thesis('2016-02-30').assert_errors()
+    write_date_thesis('2016').assert_no_errors()
+    write_date_thesis('2016-13').assert_errors()

--- a/tests/acceptance/test_login.py
+++ b/tests/acceptance/test_login.py
@@ -26,4 +26,4 @@ from inspirehep.bat.pages import top_navigation_page
 
 
 def test_login(login):
-    assert top_navigation_page.am_i_logged()
+    top_navigation_page.log_in_user().assert_no_errors()


### PR DESCRIPTION
## Description
This PR wants to remove the `has_error` function that we used in the acceptance test.

## Motivation and Context
The has_error function was confusing because was not used in the proper way. With this change in the `ArsenicResponse` class we are able to decide which kind of assertion we want to test plus the naming with this change is going to be more meaningful

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
