### PR TITLE
arxiv: Fix wrong mimetype for arxiv pdfs

### DIFF
--- a/inspirehep/modules/workflows/tasks/arxiv.py
+++ b/inspirehep/modules/workflows/tasks/arxiv.py
@@ -40,6 +40,7 @@ from inspire_dojson.hep import hep
 from inspire_dojson.utils.arxiv import classify_field
 from inspirehep.modules.converter import convert
 from inspirehep.utils.record import get_arxiv_categories, get_arxiv_id
+from inspirehep.utils.url import is_pdf_link
 
 from plotextractor.api import process_tarball
 from plotextractor.converter import untar
@@ -66,20 +67,19 @@ def arxiv_fulltext_download(obj, eng):
     """
     arxiv_id = get_arxiv_id(obj.data)
     filename = secure_filename('{0}.pdf'.format(arxiv_id))
+    url = current_app.config['ARXIV_PDF_URL'].format(arxiv_id=arxiv_id)
+
+    if not is_pdf_link(url):
+        raise DownloadError("{url} is not serving a PDF file.".format(url=url))
+
     pdf = download_file_to_workflow(
         workflow=obj,
         name=filename,
-        url=current_app.config['ARXIV_PDF_URL'].format(arxiv_id=arxiv_id),
+        url=url,
     )
 
-    if pdf and pdf.get_version().mimetype == 'application/pdf':
+    if pdf:
         obj.log.info('PDF retrieved from arXiv for %s', arxiv_id)
-    elif pdf:
-        # We need to delete the failed download as otherwise it would
-        # create a new version instead of replacing the previous one.
-        del obj.files[filename]
-        pdf.delete()
-        raise DownloadError()
     else:
         obj.log.error('Cannot retrieve PDF from arXiv for %s', arxiv_id)
 

--- a/tests/integration/workflows/test_arxiv_workflow.py
+++ b/tests/integration/workflows/test_arxiv_workflow.py
@@ -322,12 +322,22 @@ def fake_magpie_api_request(url, data):
         }
 
 
+def fake_is_pdf_link(url):
+    """Mock is_pdf_link func"""
+    return True
+
+
 def fake_refextract_extract_references_from_file(*args, **kwargs):
     """Mock refextract extract_references_from_file func."""
     return []
 
 
-def get_halted_workflow(app, record, extra_config=None):
+@mock.patch(
+    'inspirehep.modules.workflows.tasks.arxiv.is_pdf_link'
+)
+def get_halted_workflow(mocked_is_pdf_link, app, record, extra_config=None):
+    mocked_is_pdf_link.return_value = True
+
     extra_config = extra_config or {}
     with mock.patch.dict(app.config, extra_config):
         workflow_uuid = start('article', [record])

--- a/tests/unit/workflows/test_workflows_tasks_arxiv.py
+++ b/tests/unit/workflows/test_workflows_tasks_arxiv.py
@@ -41,6 +41,7 @@ from inspirehep.modules.workflows.tasks.arxiv import (
     arxiv_package_download,
     arxiv_plot_extract,
 )
+from inspirehep.modules.workflows.errors import DownloadError
 from plotextractor.errors import InvalidTarball
 
 from mocks import AttrDict, MockEng, MockFiles, MockObj
@@ -106,10 +107,11 @@ def test_arxiv_fulltext_download_logs_on_error():
     obj = MockObj(data, extra_data, files=files)
     eng = MockEng()
 
-    assert arxiv_fulltext_download(obj, eng) is None
+    with pytest.raises(DownloadError) as excinfo:
+        arxiv_fulltext_download(obj, eng)
 
-    expected = 'Cannot retrieve PDF from arXiv for 1605.03814'
-    result = obj.log._error.getvalue()
+    expected = 'http://export.arxiv.org/pdf/1605.03814 is not serving a PDF file.'
+    result = str(excinfo.value)
 
     assert expected == result
 


### PR DESCRIPTION
Downloaded pdf files from arxiv, sometimes were wrong recognized by
`invenio-files-rest` as mimetype 'application/pdf' but the content
was html. Therefore, `refextract` was correctly raising an exception.
For this reason, the check of mimetype was made more strict before
downloading the file.

(Closes #2523)
Signed-off-by: Zacharias Zacharodimos <zacharias.zacharodimos@cern.ch>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
#2523 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
