### PR TITLE
logging: backoff not in Sentry

### DIFF
--- a/inspirehep/celery.py
+++ b/inspirehep/celery.py
@@ -24,9 +24,14 @@
 
 from __future__ import absolute_import, division, print_function
 
+import logging
+
 from flask_celeryext import create_celery_app
 
 from .factory import create_app
 
 
 celery = create_celery_app(create_app())
+
+# We don't want to log to Sentry backoff errors
+logging.getLogger('backoff').propagate = 0

--- a/inspirehep/cli.py
+++ b/inspirehep/cli.py
@@ -24,9 +24,14 @@
 
 from __future__ import absolute_import, division, print_function
 
+import logging
+
 from invenio_base.app import create_cli
 
 from .factory import create_app
 
 
 cli = create_cli(create_app=create_app)
+
+# We don't want to log to Sentry backoff errors
+logging.getLogger('backoff').propagate = 0

--- a/inspirehep/wsgi.py
+++ b/inspirehep/wsgi.py
@@ -24,6 +24,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+import logging
+
 from inspirehep.factory import create_app
 
 
@@ -31,3 +33,6 @@ application = create_app()
 if application.debug:
     from werkzeug.debug import DebuggedApplication
     application = DebuggedApplication(application, evalex=True)
+
+# We don't want to log to Sentry backoff errors
+logging.getLogger('backoff').propagate = 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

<!--- Why is this change required? What problem does it solve? -->

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

* Disable backoff log propagation up to Sentry, not to pollute
  Sentry log aggregation.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>