### PR TITLE
config: default journal-titles.kb path

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -26,6 +26,7 @@ from __future__ import absolute_import, division, print_function
 
 import os
 import sys
+import pkg_resources
 
 from celery.schedules import crontab
 
@@ -172,7 +173,8 @@ RECORD_EDITOR_INDEX_TEMPLATE = 'inspirehep_theme/invenio_record_editor/index.htm
 RECORD_EDITOR_PREVIEW_TEMPLATE_FUNCTION = get_detailed_template_from_record
 
 # Path to where journal kb file is stored from `inspirehep.modules.refextract.tasks.create_journal_kb_file`
-REFEXTRACT_JOURNAL_KB_PATH = '/tmp/journal-titles.kb'
+# On production, if you enable celery beat change this path to point to a shared space.
+REFEXTRACT_JOURNAL_KB_PATH = pkg_resources.resource_filename('refextract', 'references/kbs/journal-titles.kb')
 
 INSPIRE_COLLECTIONS_DEFINITION = [
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

<!--- Why is this change required? What problem does it solve? -->

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

* Sets a good default for where to look an already built
  journal-titles.kb needed by refextract.

  NOTE: the REFEXTRACT_JOURNAL_KB_PATH configuration variable should
  be changed on production.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>