### PR TITLE
Put specific version of urllib3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ install_requires = [
     'backoff~=1.0,>=1.4.2',
     'requests~=2.0,>=2.15.1',
     'timeout-decorator~=0.0,>=0.3.3',
+    'urllib3<1.22,>=1.21.1',  # TODO: remove once requests change dep version
 ]
 
 tests_require = [


### PR DESCRIPTION
## Description
Added suitable version of *urllib3* to *setup.py*

## Motivation and Context
When installing all the dependencies I was getting:
```python
Traceback (most recent call last):
  File "/virtualenv/bin/inspirehep", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/virtualenv/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3038, in <module>
    @_call_aside
  File "/virtualenv/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3022, in _call_aside
    f(*args, **kwargs)
  File "/virtualenv/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3051, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/virtualenv/lib/python2.7/site-packages/pkg_resources/__init__.py", line 659, in _build_master
    return cls._build_from_requirements(__requires__)
  File "/virtualenv/lib/python2.7/site-packages/pkg_resources/__init__.py", line 672, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "/virtualenv/lib/python2.7/site-packages/pkg_resources/__init__.py", line 857, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'urllib3<1.22,>=1.21.1' distribution was not found and is required by requests
```

While *urllib3<1.22,>=1.21.1* is required by requests it's firstly installing the latest *urllib3* as dependency for *elasticsearch* (which has *urllib3<2.0,>=1.8* requirements)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
