### PR TITLE
tests: wait until page load in author submission

### DIFF
--- a/inspirehep/bat/pages/create_author.py
+++ b/inspirehep/bat/pages/create_author.py
@@ -170,6 +170,7 @@ def submit_author(input_data):
     Arsenic().find_element_by_xpath('//input[@value="' + categories[0] + '"]').click()
     Arsenic().find_element_by_xpath('//input[@value="' + categories[1].strip() + '"]').click()
     Arsenic().find_element_by_xpath('//button[@class="btn btn-success form-submit"]').click()
+    WebDriverWait(Arsenic(), 10).until(EC.visibility_of_element_located((By.XPATH, '//div[@class="alert alert-success alert-form-success"]')))
     Arsenic().show_title_bar()
 
     return ArsenicResponse(_submit_author)


### PR DESCRIPTION
## Description
Fixing problem with acceptance tests, when some of the tests were getting stuck because it was trying to execute `show_title_bar()` in `submit_author()` when the page was not fully loaded

## Related Issue
Closes #2518 

## Motivation and Context
To avoid acceptance tests getting stuck.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
