### PR TITLE
workflows: ignore max_score when rejecting

### DIFF
--- a/inspirehep/modules/workflows/tasks/actions.py
+++ b/inspirehep/modules/workflows/tasks/actions.py
@@ -134,16 +134,11 @@ def _is_auto_rejected(workflow_obj):
     if not relevance_prediction or not classification_results:
         return False
 
-    score = relevance_prediction.get('max_score')
     decision = relevance_prediction.get('decision')
     all_class_results = classification_results.get('complete_output')
     core_keywords = all_class_results.get('core_keywords')
 
-    return (
-        decision.lower() == 'rejected' and
-        score > 0 and
-        len(core_keywords) == 0
-    )
+    return decision.lower() == 'rejected' and len(core_keywords) == 0
 
 
 @with_debug_logging


### PR DESCRIPTION
## Description:
We don't need the `max_score` to be positive when rejecting a record:
it's enough that we couldn't find any CORE keywords in it and the ML
algorithm thinks it should be rejected.

## Related Issues:
Closes #2414 and Closes #2566 

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.