### PR TITLE
global: handle files between records and workflows

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -1202,6 +1202,11 @@ ARXIV_CATEGORIES_ALREADY_HARVESTED_ON_LEGACY = [
     'physics.acc-ph',
     'physics.ins-det',
 ]
+RECORDS_DEFAULT_FILE_LOCATION_NAME = "records"
+"""Name of default records Location reference."""
+
+RECORDS_DEFAULT_STORAGE_CLASS = "S"
+"""Default storage class for record files."""
 
 WORKFLOWS_DEFAULT_FILE_LOCATION_NAME = "holdingpen"
 """Name of default workflow Location reference."""

--- a/inspirehep/modules/fixtures/files.py
+++ b/inspirehep/modules/fixtures/files.py
@@ -71,7 +71,30 @@ def init_workflows_storage_path(default=False):
         raise
 
 
+def init_records_files_storage_path(default=False):
+    """Init records file store location."""
+    try:
+        uri = os.path.join(
+            current_app.config['BASE_FILES_LOCATION'],
+            "records", "files"
+        )
+        if uri.startswith('/') and not os.path.exists(uri):
+            os.makedirs(uri)
+        loc = Location(
+            name=current_app.config["RECORDS_DEFAULT_FILE_LOCATION_NAME"],
+            uri=uri,
+            default=False
+        )
+        db.session.add(loc)
+        db.session.commit()
+        return loc
+    except Exception:
+        db.session.rollback()
+        raise
+
+
 def init_all_storage_paths():
     """Init all storage paths."""
     init_default_storage_path()
     init_workflows_storage_path()
+    init_records_files_storage_path()

--- a/inspirehep/modules/records/api.py
+++ b/inspirehep/modules/records/api.py
@@ -28,10 +28,12 @@ from datetime import datetime
 
 import arrow
 from elasticsearch.exceptions import NotFoundError
+from flask import current_app
 
+from invenio_files_rest.models import Bucket
 from invenio_pidstore.errors import PIDDoesNotExistError
 from invenio_pidstore.models import PersistentIdentifier
-from invenio_records.api import Record
+from invenio_records_files.api import Record
 from invenio_db import db
 
 from inspirehep.utils.record_getter import (
@@ -70,6 +72,23 @@ class InspireRecord(Record):
 
     def _delete(self, *args, **kwargs):
         super(InspireRecord, self).delete(*args, **kwargs)
+
+    def _create_bucket(self, location=None, storage_class=None):
+        """Create file bucket for workflow object."""
+        if location is None:
+            location = current_app.config[
+                'RECORDS_DEFAULT_FILE_LOCATION_NAME'
+            ]
+        if storage_class is None:
+            storage_class = current_app.config[
+                'RECORDS_DEFAULT_STORAGE_CLASS'
+            ]
+
+        bucket = Bucket.create(
+            location=location,
+            storage_class=storage_class
+        )
+        return bucket
 
 
 class ESRecord(InspireRecord):

--- a/inspirehep/modules/workflows/tasks/actions.py
+++ b/inspirehep/modules/workflows/tasks/actions.py
@@ -30,6 +30,7 @@ from flask import current_app
 from werkzeug import secure_filename
 from timeout_decorator import TimeoutError
 
+from inspire_schemas.builders import LiteratureBuilder
 from inspire_utils.record import get_value
 from inspirehep.modules.workflows.utils import (
     get_pdf_in_workflow,
@@ -211,6 +212,14 @@ def submission_fulltext_download(obj, eng):
         )
 
         if pdf:
+            lb = LiteratureBuilder(source=obj.data['acquisition_source']['source'], record=obj.data)
+            lb.add_document(
+                filename,
+                fulltext=True,
+                original_url=submission_pdf,
+                url='/api/files/{bucket}/{key}'.format(bucket=obj.files[filename].bucket_id, key=filename)
+            )
+            obj.data = lb.record
             obj.log.info('PDF provided by user from %s', submission_pdf)
             return obj.files[filename].file.uri
         else:

--- a/inspirehep/modules/workflows/tasks/submission.py
+++ b/inspirehep/modules/workflows/tasks/submission.py
@@ -40,7 +40,7 @@ from inspirehep.utils.robotupload import make_robotupload_marcxml
 from inspirehep.utils import tickets
 from inspirehep.utils.proxies import rt_instance
 
-from .actions import in_production_mode, is_arxiv_paper
+from .actions import in_production_mode
 from ..utils import with_debug_logging
 
 
@@ -311,44 +311,6 @@ def prepare_keywords(obj, eng):
     obj.data['keywords'] = keywords
 
     obj.log.debug('Finally got keywords: \n%s', pformat(keywords))
-
-
-@with_debug_logging
-def prepare_files(obj, eng):
-    """Adds to the _fft field (files) the extracted pdfs if any"""
-    def _get_fft(url, name):
-        def _get_filename(obj, filename):
-            if is_arxiv_paper(obj):
-                return 'arxiv:' + filename
-
-            return filename
-
-        filename, filetype = os.path.splitext(name)
-
-        return {
-            'path': os.path.realpath(url),
-            'type': is_arxiv_paper(obj) and 'arXiv' or 'INSPIRE-PUBLIC',
-            'filename': _get_filename(obj, filename),
-            'format': filetype,
-        }
-
-    if not obj.files:
-        return
-
-    pdf_file_objs = []
-    for key in obj.files.keys:
-        if key.endswith('.pdf'):
-            pdf_file_objs.append((key, obj.files[key]))
-
-    result = []
-    for filename, pdf_file_obj in pdf_file_objs:
-        if pdf_file_obj:
-            result.append(_get_fft(pdf_file_obj.obj.file.uri, filename))
-
-    if result:
-        obj.data['_fft'] = obj.data.get('_fft', []) + result
-        obj.log.info('Non-user PDF files added to FFT.')
-        obj.log.debug('Added PDF files: {}'.format(result))
 
 
 @with_debug_logging

--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -80,7 +80,6 @@ from inspirehep.modules.workflows.tasks.submission import (
     close_ticket,
     create_ticket,
     filter_keywords,
-    prepare_files,
     prepare_keywords,
     remove_references,
     reply_ticket,
@@ -281,7 +280,6 @@ POSTENHANCE_RECORD = [
     filter_keywords,
     prepare_keywords,
     remove_references,
-    prepare_files,
 ]
 
 

--- a/tests/integration/test_records.py
+++ b/tests/integration/test_records.py
@@ -23,6 +23,7 @@
 from __future__ import absolute_import, division, print_function
 
 import pytest
+import StringIO
 
 from dojson.contrib.marc21.utils import create_record
 from invenio_db import db
@@ -347,3 +348,22 @@ def test_get_es_records_accepts_lists_of_strings(app):
     records = get_es_records('lit', ['4328'])
 
     assert len(records) == 1
+
+
+def test_records_files_attached_correctly(app):
+    json = {
+        '$schema': 'http://localhost:5000/schemas/records/hep.json',
+        'document_type': [
+            'article',
+        ],
+        'titles': [
+            {'title': 'foo'},
+        ],
+        '_collections': ['Literature']
+    }
+
+    record = InspireRecord.create(json)
+    record.files['fulltext.pdf'] = StringIO.StringIO()
+    record.commit()
+
+    assert 'fulltext.pdf' in record.files

--- a/tests/unit/helpers/mocks.py
+++ b/tests/unit/helpers/mocks.py
@@ -85,6 +85,7 @@ class MockFileObject(object):
 
     def __init__(self, key):
         self.obj = {'key': key}
+        self.bucket_id = '0b9dd5d1-feae-4ba5-809d-3a029b0bc110'
 
     def __eq__(self, other):
         return self.obj['key'] == other.obj['key']

--- a/tests/unit/workflows/test_workflows_tasks_arxiv.py
+++ b/tests/unit/workflows/test_workflows_tasks_arxiv.py
@@ -161,6 +161,50 @@ def test_arxiv_fulltext_download_retries_on_error():
         assert expected == result
 
 
+def test_arxiv_fulltext_download_polulates_documents():
+    with requests_mock.Mocker() as requests_mocker:
+        requests_mocker.register_uri(
+            'GET', 'http://export.arxiv.org/pdf/1605.03844',
+            content=pkg_resources.resource_string(
+                __name__, os.path.join('fixtures', '1605.03844.pdf')),
+        )
+
+        schema = load_schema('hep')
+        subschema = schema['properties']['arxiv_eprints']
+
+        data = {
+            'arxiv_eprints': [
+                {
+                    'categories': [
+                        'physics.ins-det',
+                    ],
+                    'value': '1605.03844',
+                },
+            ],
+        }  # literature/1458302
+        extra_data = {}
+        files = MockFiles({})
+        assert validate(data['arxiv_eprints'], subschema) is None
+
+        obj = MockObj(data, extra_data, files=files)
+        eng = MockEng()
+
+        assert arxiv_fulltext_download(obj, eng) is None
+
+        expected = [{
+            'fulltext': True,
+            'original_url': 'http://export.arxiv.org/pdf/1605.03844',
+            'url': '/api/files/0b9dd5d1-feae-4ba5-809d-3a029b0bc110/1605.03844.pdf',
+            'material': 'preprint',
+            'source': 'arxiv',
+            'key': '1605.03844.pdf',
+            'hidden': True
+        }]
+        result = obj.data['documents']
+
+        assert expected == result
+
+
 def test_arxiv_package_download_logs_on_success():
     with requests_mock.Mocker() as requests_mocker:
         requests_mocker.register_uri(
@@ -271,12 +315,14 @@ def test_arxiv_plot_extract_populates_files_with_plots(mock_os):
 
         assert arxiv_plot_extract(obj, eng) is None
 
-        expected = obj.files['figure1']['description']
-        result = (
-            '00000 Difference (in MeV) between the theoretical and '
-            'experimental masses for the 2027 selected nuclei as a '
-            'function of the mass number.'
-        )
+        expected = [{
+            'url': '/api/files/0b9dd5d1-feae-4ba5-809d-3a029b0bc110/figure1',
+            'source': 'arxiv',
+            'material': 'preprint',
+            'key': 'figure1',
+            'caption': 'Difference (in MeV) between the theoretical and experimental masses for the 2027 selected nuclei as a function of the mass number.'
+        }]
+        result = obj.data['figures']
 
         assert expected == result
 


### PR DESCRIPTION
## Description:
Adds the ``files`` property to ``InspireRecord`` by inheriting from the
``Record`` of ``invenio_records_files``. This allows us to attach plots
and documents to records (closes #2551 and closes #2552).

Also modifies those workflows tasks that deal with records so that they
use builder methods to populate the ``documents`` and ``figures`` keys,
and those will then be converted by DoJSON to the ``FFT`` fields that
Legacy understands.

## Related Issues:
Closes #2551 and closes #2552.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.