### PR TITLE
utils: is_pdf_link sanity check

### DIFF
--- a/inspirehep/utils/url.py
+++ b/inspirehep/utils/url.py
@@ -58,7 +58,10 @@ def is_pdf_link(url):
     except requests.exceptions.RequestException:
         return False
 
-    magic_number = next(response.iter_lines(1))
+    try:
+        magic_number = next(response.iter_lines(1))
+    except StopIteration:
+        return False
     correct_magic_number = magic_number.startswith('%PDF')
 
     return correct_magic_number

--- a/tests/unit/utils/test_utils_url.py
+++ b/tests/unit/utils/test_utils_url.py
@@ -22,10 +22,18 @@
 
 from __future__ import absolute_import, division, print_function
 
+import requests_mock
 from flask import current_app
 from mock import patch
 
-from inspirehep.utils.url import make_user_agent_string
+from inspirehep.utils.url import is_pdf_link, make_user_agent_string
+
+
+def test_is_pdf_link_handles_empty_requests():
+    with requests_mock.Mocker() as requests_mocker:
+        requests_mocker.register_uri('GET', 'http://example.org/empty-pdf', text='')
+
+        assert not is_pdf_link('http://example.org/empty-pdf')
 
 
 @patch('inspirehep.utils.url.__version__', '0.1.0')


### PR DESCRIPTION
* Avoid raising Stopiteration when response is empty. (closes #2589)

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
