### PR TITLE
setup: unpin urllib3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,6 @@ install_requires = [
     'backoff~=1.0,>=1.4.2',
     'requests~=2.0,>=2.15.1',
     'timeout-decorator~=0.0,>=0.3.3',
-    'urllib3<1.22,>=1.21.1',  # TODO: remove once requests change dep version
 ]
 
 tests_require = [


### PR DESCRIPTION
## Description:
Reverts 81d5b1e because `requests==2.18.3` now allows `urllib==1.22`.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.