### PR TITLE
workflow: use nicer docstrings for mark and others

### DIFF
--- a/inspirehep/modules/workflows/tasks/actions.py
+++ b/inspirehep/modules/workflows/tasks/actions.py
@@ -42,20 +42,24 @@ from ..utils import download_file_to_workflow, with_debug_logging
 
 
 def mark(key, value):
-    """Mark a record by putting a value in a key in extra_data."""
+    """Mark the workflow object by putting a value in a key in extra_data."""
     @with_debug_logging
     @wraps(mark)
     def _mark(obj, eng):
         obj.extra_data[key] = value
+
+    _mark.__doc__ = 'Mark the workflow object with %s:%s.' % (key, value)
     return _mark
 
 
 def is_marked(key):
-    """Mark a record by putting a value in a key in extra_data."""
+    """Check if the workflow object has a specific mark."""
     @with_debug_logging
     @wraps(mark)
     def _mark(obj, eng):
         return key in obj.extra_data and obj.extra_data[key]
+
+    _mark.__doc__ = 'Check if the workflow object has the mark %s.' % key
     return _mark
 
 
@@ -92,6 +96,9 @@ def halt_record(action=None, message=None):
     def _halt_record(obj, eng):
         eng.halt(action=obj.extra_data.get("halt_action") or action,
                  msg=obj.extra_data.get("halt_message") or message)
+
+    _halt_record.__doc__ = (
+        'Halt the workflow object, action=%s, message=%s' % (action, message))
     return _halt_record
 
 
@@ -125,6 +132,8 @@ def reject_record(message):
         obj.extra_data["approved"] = False
         obj.extra_data["reason"] = message
         obj.log.info(message)
+
+    _reject_record.__doc__ = 'Reject the record, message=%s' % message
     return _reject_record
 
 
@@ -222,6 +231,9 @@ def prepare_update_payload(extra_data_key="update_payload"):
 
         # FIXME: Just update entire record for now
         obj.extra_data[extra_data_key] = obj.data
+
+    _prepare_update_payload.__doc__ = (
+        'Prepare the update payload, extra_data_key=%s.' % extra_data_key)
     return _prepare_update_payload
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

<!--- Why is this change required? What problem does it solve? -->

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

* This adds a nice docs (including the params they were called with)
  to the mark workflow step and other similar ones.

Signed-off-by: David Caro <david@dcaro.es>