### PR TITLE
literaturesuggest: add year validation

### DIFF
--- a/inspirehep/modules/forms/validators/simple_fields.py
+++ b/inspirehep/modules/forms/validators/simple_fields.py
@@ -33,6 +33,8 @@ from wtforms.validators import ValidationError, StopValidation
 
 from idutils import is_arxiv
 
+from inspire_schemas.utils import load_schema
+from inspirehep.utils.record import get_value
 from inspirehep.utils.url import is_pdf_link
 
 
@@ -185,3 +187,15 @@ def date_validator(form, field):
                 break
         else:
             raise StopValidation(message)
+
+
+def year_validator(form, field):
+    """Validate that the field contains an year in an acceptable range."""
+    hep = load_schema('hep')
+    min_year = get_value(hep, 'properties.publication_info.items.properties.year.minimum')
+    max_year = get_value(hep, 'properties.publication_info.items.properties.year.maximum')
+
+    message = 'Please, provide an year between {} and {}.'.format(min_year, max_year)
+
+    if field.data and not min_year <= int(field.data) <= max_year:
+        raise StopValidation(message)

--- a/inspirehep/modules/literaturesuggest/forms.py
+++ b/inspirehep/modules/literaturesuggest/forms.py
@@ -51,6 +51,7 @@ from inspirehep.modules.forms.validators.simple_fields import (
     duplicated_doi_validator,
     no_pdf_validator,
     pdf_validator,
+    year_validator,
 )
 from inspirehep.modules.literaturesuggest.fields.arxiv_id import ArXivField
 
@@ -530,7 +531,8 @@ class LiteratureForm(INSPIREForm):
 
     year = fields.TextField(
         label=_('Year'),
-        widget_classes="form-control" + ARTICLE_CLASS
+        widget_classes="form-control" + ARTICLE_CLASS,
+        validators=[year_validator],
     )
 
     issue = fields.TextField(

--- a/tests/unit/forms/test_forms_validators_simple_fields.py
+++ b/tests/unit/forms/test_forms_validators_simple_fields.py
@@ -29,6 +29,7 @@ from wtforms.validators import StopValidation
 from inspirehep.modules.forms.validators.simple_fields import (
     no_pdf_validator,
     pdf_validator,
+    year_validator,
 )
 
 
@@ -93,3 +94,23 @@ def test_no_pdf_validator_raises_on_link_to_a_pdf():
 
     with pytest.raises(StopValidation):
         no_pdf_validator(None, field)
+
+
+def test_year_validator_accepts_a_valid_year():
+    field = MockField(u'1993')
+
+    assert year_validator(None, field) is None
+
+
+def test_year_validator_raises_on_year_invalid_because_too_early():
+    field = MockField(u'999')
+
+    with pytest.raises(StopValidation):
+        year_validator(None, field)
+
+
+def test_year_validator_raises_on_year_invalid_because_too_late():
+    field = MockField(u'2051')
+
+    with pytest.raises(StopValidation):
+        year_validator(None, field)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I introduced some validation for the "year" field in the Article/Conference paper submission form.

## Description
<!--- Describe your changes in detail -->
I implementing a validator for the "year" field. So, right now the UI complains when the introduced year is invalid and displays a warning field asking the user for a valid year instead.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/inspirehep/inspire-next/issues/2591

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When submitting an Article/Conference paper with an invalid year (i.e. not 1000 - 2050),
the user was redirected to an error message that did not specify the cause.  The user found it hard to understand what was wrong and has to go back and complete the form again.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
