### PR TITLE
workflows: remove references before legacy export

### DIFF
--- a/inspirehep/modules/workflows/tasks/submission.py
+++ b/inspirehep/modules/workflows/tasks/submission.py
@@ -364,3 +364,10 @@ def prepare_files(obj, eng):
         obj.data['_fft'] = obj.data.get('_fft', []) + result
         obj.log.info('Non-user PDF files added to FFT.')
         obj.log.debug('Added PDF files: {}'.format(result))
+
+
+@with_debug_logging
+def remove_references(obj, eng):
+    obj.log.info(obj.data)
+    if 'references' in obj.data:
+        del obj.data['references']

--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -83,6 +83,7 @@ from inspirehep.modules.workflows.tasks.submission import (
     filter_keywords,
     prepare_files,
     prepare_keywords,
+    remove_references,
     reply_ticket,
     send_robotupload,
     wait_webcoll,
@@ -283,6 +284,7 @@ POSTENHANCE_RECORD = [
     add_note_entry,
     filter_keywords,
     prepare_keywords,
+    remove_references,
     prepare_files,
 ]
 

--- a/tests/unit/workflows/test_workflows_tasks_submission.py
+++ b/tests/unit/workflows/test_workflows_tasks_submission.py
@@ -37,6 +37,7 @@ from inspirehep.modules.workflows.tasks.submission import (
     filter_keywords,
     prepare_files,
     prepare_keywords,
+    remove_references,
     reply_ticket,
     send_robotupload,
     wait_webcoll,
@@ -890,5 +891,52 @@ def test_prepare_files_ignores_keys_not_ending_with_pdf():
 
     expected = ''
     result = obj.log._info.getvalue()
+
+    assert expected == result
+
+
+def test_remove_references():
+    schema = load_schema('hep')
+    subschema = schema['properties']['references']
+
+    data = {
+        'references': [
+            {
+                'reference': {
+                    'arxiv_eprint': 'hep-th/9710014',
+                    'authors': [
+                        {'full_name': 'Maldacena, J.'},
+                        {'full_name': 'Strominger, A.'},
+                    ],
+                    'label': '1',
+                },
+            },
+        ],
+    }
+    extra_data = {}
+    assert validate(data['references'], subschema) is None
+
+    obj = MockObj(data, extra_data)
+    eng = MockEng()
+
+    assert remove_references(obj, eng) is None
+
+    expected = {}
+    result = obj.data
+
+    assert expected == result
+
+
+def test_remove_references_does_nothing_when_there_are_no_references():
+    data = {}
+    extra_data = {}
+
+    obj = MockObj(data, extra_data)
+    eng = MockEng()
+
+    assert remove_references(obj, eng) is None
+
+    expected = {}
+    result = obj.data
 
     assert expected == result


### PR DESCRIPTION
This reverts commit 25501fba66bdffbdb72e338591f7467b263944e7.
We need to properly handle the journal letter issue and be able to match
references before we can export reliable reference lists to legacy.

Signed-off-by: Micha Moskovic <michamos@gmail.com>