### PR TITLE
global: add missing with_debug_logging decorator

### DIFF
--- a/inspirehep/modules/authors/tasks.py
+++ b/inspirehep/modules/authors/tasks.py
@@ -35,6 +35,7 @@ from invenio_oauthclient.models import UserIdentity
 from inspire_dojson.utils import strip_empty_values
 from inspire_schemas.api import validate
 from inspirehep.modules.forms.utils import filter_empty_elements
+from inspirehep.modules.workflows.utils import with_debug_logging
 
 from .dojson.model import updateform
 
@@ -111,6 +112,7 @@ def formdata_to_model(obj, formdata):
     return data
 
 
+@with_debug_logging
 def curation_ticket_needed(obj, eng):
     """Check if the a curation ticket is needed."""
     return obj.extra_data.get("ticket", False)

--- a/inspirehep/modules/literaturesuggest/tasks.py
+++ b/inspirehep/modules/literaturesuggest/tasks.py
@@ -30,6 +30,7 @@ from idutils import is_arxiv_post_2007
 from inspire_schemas.api import LiteratureBuilder
 from inspire_utils.record import get_value
 from inspirehep.modules.forms.utils import filter_empty_elements
+from inspirehep.modules.workflows.utils import with_debug_logging
 from inspirehep.utils.helpers import force_list
 from inspirehep.utils.record import get_title
 
@@ -265,6 +266,7 @@ def curation_ticket_context(user, obj):
     )
 
 
+@with_debug_logging
 def curation_ticket_needed(obj, eng):
     """Check if the a curation ticket is needed."""
     return obj.extra_data.get("core", False)

--- a/inspirehep/modules/workflows/tasks/arxiv.py
+++ b/inspirehep/modules/workflows/tasks/arxiv.py
@@ -142,6 +142,7 @@ def arxiv_plot_extract(obj, eng):
         obj.log.info('Added {0} plots.'.format(len(plots)))
 
 
+@with_debug_logging
 def arxiv_derive_inspire_categories(obj, eng):
     """Derive ``inspire_categories`` from the arXiv categories.
 

--- a/inspirehep/modules/workflows/tasks/refextract.py
+++ b/inspirehep/modules/workflows/tasks/refextract.py
@@ -33,7 +33,10 @@ from inspire_schemas.utils import split_page_artid
 from inspire_utils.record import get_value
 from inspirehep.utils.helpers import force_list, maybe_int
 
+from ..utils import with_debug_logging
 
+
+@with_debug_logging
 def extract_journal_info(obj, eng):
     """Extract journal, volume etc. from any freetext publication info."""
     publication_info = get_value(obj.data, "publication_info")

--- a/inspirehep/modules/workflows/tasks/submission.py
+++ b/inspirehep/modules/workflows/tasks/submission.py
@@ -267,6 +267,7 @@ def send_robotupload(
     return _send_robotupload
 
 
+@with_debug_logging
 def wait_webcoll(obj, eng):
     if not in_production_mode():
         obj.log.debug("Would have wait for webcoll callback.")


### PR DESCRIPTION
## Description:
As I said a little while ago to @david-caro, some of our workflow tasks where missing the `@with_debug_logging` decorator.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.