### PR TITLE
tests: remove year validation tests

### DIFF
--- a/inspirehep/bat/pages/create_author.py
+++ b/inspirehep/bat/pages/create_author.py
@@ -65,23 +65,6 @@ def write_advisor(advisor, expected_data):
     return ArsenicResponse(_write_advisor)
 
 
-def write_year(input_id, error_message_id, year):
-    def _write_year():
-        return 'is not a valid year' in message_err
-
-    year_field = Arsenic().find_element_by_id(input_id)
-    year_field.send_keys(year)
-    try:
-        year_field.send_keys(Keys.TAB)
-        message_err = WebDriverWait(Arsenic(), 10).until(
-            GetText((By.ID, error_message_id)))
-    except (ElementNotVisibleException, WebDriverException):
-        message_err = ''
-    year_field.clear()
-
-    return ArsenicResponse(_write_year)
-
-
 def submit_empty_form(expected_data):
     def _submit_empty_form():
         return expected_data == output_data

--- a/tests/acceptance/test_author_creation.py
+++ b/tests/acceptance/test_author_creation.py
@@ -71,66 +71,6 @@ def test_advisors_typehead(login):
     assert create_author.write_advisor('alexe', 'Vorobyev, Alexey').has_error()
 
 
-def test_institutions_years(login):
-    create_author.go_to()
-
-    input_id = 'institution_history-0-start_year'
-    error_mess_id = 'state-institution_history-0-start_year'
-    assert create_author.write_year(
-        input_id,
-        error_mess_id,
-        'wrongyear',
-    ).has_error()
-    assert not create_author.write_year(
-        input_id,
-        error_mess_id,
-        '2016',
-    ).has_error()
-
-    input_id = 'institution_history-0-end_year'
-    error_mess_id = 'state-institution_history-0-end_year'
-    assert create_author.write_year(
-        input_id,
-        error_mess_id,
-        'wrongyear',
-    ).has_error()
-    assert not create_author.write_year(
-        input_id,
-        error_mess_id,
-        '2016',
-    ).has_error()
-
-
-def test_experiments_years(login):
-    create_author.go_to()
-
-    input_id = 'experiments-0-start_year'
-    error_mess_id = 'state-experiments-0-start_year'
-    assert create_author.write_year(
-        input_id,
-        error_mess_id,
-        'wrongyear',
-    ).has_error()
-    assert not create_author.write_year(
-        input_id,
-        error_mess_id,
-        '2016',
-    ).has_error()
-
-    input_id = 'experiments-0-end_year'
-    error_mess_id = 'state-experiments-0-end_year'
-    assert create_author.write_year(
-        input_id,
-        error_mess_id,
-        'wrongyear',
-    ).has_error()
-    assert not create_author.write_year(
-        input_id,
-        error_mess_id,
-        '2016',
-    ).has_error()
-
-
 def test_mandatory_fields(login):
     expected_data = {
         'given-name': 'This field is required.',


### PR DESCRIPTION
## Description:
Commit 1e571aa is already testing this logic and is much faster.

## Related Issue:
Addresses https://github.com/inspirehep/inspire-next/issues/1987.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.