### PR TITLE
workflows: create ticket for core arXiv records

### DIFF
--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -253,29 +253,27 @@ NOTIFY_ALREADY_EXISTING = [
 ]
 
 
-NOTIFY_ACCEPTED = [
+NOTIFY_USER_OR_CURATOR = [
     IF(
         is_submission,
         [
-            IF(
-                curation_ticket_needed,
-                [
-                    create_ticket(
-                        template=(
-                            "literaturesuggest/tickets/curation_core.html"
-                        ),
-                        queue="HEP_curation",
-                        context_factory=curation_ticket_context,
-                        ticket_id_key="curation_ticket_id"
-                    )
-                ]
-            ),
             reply_ticket(
-                template="literaturesuggest/tickets/user_accepted.html",
-                context_factory=reply_ticket_context
-            )
-        ]
-    )
+                template='literaturesuggest/tickets/user_accepted.html',
+                context_factory=reply_ticket_context,
+            ),
+        ],
+    ),
+    IF(
+        curation_ticket_needed,
+        [
+            create_ticket(
+                template='literaturesuggest/tickets/curation_core.html',
+                queue='HEP_curation',
+                context_factory=curation_ticket_context,
+                ticket_id_key='curation_ticket_id',
+            ),
+        ],
+    ),
 ]
 
 
@@ -370,7 +368,7 @@ class Article(object):
                 (
                     POSTENHANCE_RECORD +
                     SEND_TO_LEGACY_AND_WAIT +
-                    NOTIFY_ACCEPTED +
+                    NOTIFY_USER_OR_CURATOR +
                     [
                         # TODO: once legacy is out, this should become
                         # unconditional, and remove the SEND_TO_LEGACY_AND_WAIT


### PR DESCRIPTION
Changed the workflow for harvested arXiv records to generate a RT curation ticket
when selected as 'core'.

## Description
Previously, a RT curation ticket was generated only for 'core' submissions.

## Related Issue
Closes https://github.com/inspirehep/inspire-next/issues/2584

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.