### PR TITLE
robotupload: treat the errors before checking dups

### DIFF
--- a/inspirehep/modules/workflows/views/callback.py
+++ b/inspirehep/modules/workflows/views/callback.py
@@ -242,6 +242,14 @@ def _parse_robotupload_result(result, workflow_id):
     response = {}
     recid = int(result.get('recid'))
 
+    result_has_error, error_message = _robotupload_has_error(result)
+    if result_has_error:
+        response = {
+            'success': False,
+            'message': error_message,
+        }
+        return response
+
     already_pending_ones = WorkflowsPendingRecord.query.filter_by(
         record_id=recid,
     ).all()
@@ -253,14 +261,6 @@ def _parse_robotupload_result(result, workflow_id):
         response = {
             'success': False,
             'message': 'Recid %s already in pending list.' % recid,
-        }
-        return response
-
-    result_has_error, error_message = _robotupload_has_error(result)
-    if result_has_error:
-        response = {
-            'success': False,
-            'message': error_message,
         }
         return response
 


### PR DESCRIPTION
* Instead of checking if the record id returned is already in the
  pending list first thing when getting the robotupload results, check
  first if there were any errors, as on some errors the id returned is
  invalid.

Just saw on labs a record that had the error 'record already exists
in the pending list', when the underlying error was that the record
already exists on inspire itself (returning id -1), so it should not
be masked.

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->


Signed-off-by: David Caro <david@dcaro.es>