### PR TITLE
holdingpen: nicer halt message

### DIFF
--- a/inspirehep/modules/workflows/tasks/actions.py
+++ b/inspirehep/modules/workflows/tasks/actions.py
@@ -103,7 +103,7 @@ def halt_record(action=None, message=None):
     _halt_record.__doc__ = (
         'Halt the workflow object, action=%s, message=%s' % (action, message)
     )
-    _halt_record.nicename = '%s action' % (action or 'unspecified')
+    _halt_record.description = '"%s"' % (message or 'unspecified')
     return _halt_record
 
 


### PR DESCRIPTION
## Description:
Commit b4e496a didn't achieve its stated purpose as it was populating
the wrong attribute, and the message is anyway better suited for it.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.