### PR TITLE
tests: use the right fixtures almost everywhere

### DIFF
--- a/tests/integration/api/v1/test_authors.py
+++ b/tests/integration/api/v1/test_authors.py
@@ -27,7 +27,7 @@ import json
 from jsonschema import validate
 
 
-def test_api_v1_authors_citesummary(app):
+def test_api_v1_authors_citesummary(api_client):
     schema = {
         'items': {
             'additionalProperties': False,
@@ -88,13 +88,12 @@ def test_api_v1_authors_citesummary(app):
         'type': 'array',
     }
 
-    with app.test_client() as client:
-        response = client.get('/api/authors/1061000/citesummary')
+    response = api_client.get('/authors/1061000/citesummary')
 
-        assert response.status_code == 200
+    assert response.status_code == 200
 
-        response_json = json.loads(response.data)
+    response_json = json.loads(response.data)
 
-        assert validate(response_json, schema) is None
+    assert validate(response_json, schema) is None
 
-        assert len(response_json) == 2
+    assert len(response_json) == 2

--- a/tests/integration/api/v1/test_experiments.py
+++ b/tests/integration/api/v1/test_experiments.py
@@ -27,7 +27,7 @@ import json
 from jsonschema import validate
 
 
-def test_api_v1_experiments_citesummary(app):
+def test_api_v1_experiments_citesummary(api_client):
     schema = {
         'items': {
             'additionalProperties': False,
@@ -88,13 +88,12 @@ def test_api_v1_experiments_citesummary(app):
         'type': 'array',
     }
 
-    with app.test_client() as client:
-        response = client.get('/api/experiments/1108642/citesummary')
+    response = api_client.get('/experiments/1108642/citesummary')
 
-        assert response.status_code == 200
+    assert response.status_code == 200
 
-        response_json = json.loads(response.data)
+    response_json = json.loads(response.data)
 
-        assert validate(response_json, schema) is None
+    assert validate(response_json, schema) is None
 
-        assert len(response_json) == 2
+    assert len(response_json) == 2

--- a/tests/integration/api/v1/test_institutions.py
+++ b/tests/integration/api/v1/test_institutions.py
@@ -27,7 +27,7 @@ import json
 from jsonschema import validate
 
 
-def test_api_v1_institutions_citesummary(app):
+def test_api_v1_institutions_citesummary(api_client):
     schema = {
         'items': {
             'additionalProperties': False,
@@ -88,13 +88,12 @@ def test_api_v1_institutions_citesummary(app):
         'type': 'array',
     }
 
-    with app.test_client() as client:
-        response = client.get('/api/institutions/902725/citesummary')
+    response = api_client.get('/institutions/902725/citesummary')
 
-        assert response.status_code == 200
+    assert response.status_code == 200
 
-        response_json = json.loads(response.data)
+    response_json = json.loads(response.data)
 
-        assert validate(response_json, schema) is None
+    assert validate(response_json, schema) is None
 
-        assert len(response_json) == 4
+    assert len(response_json) == 4

--- a/tests/integration/api/v1/test_journals.py
+++ b/tests/integration/api/v1/test_journals.py
@@ -27,7 +27,7 @@ import json
 from jsonschema import validate
 
 
-def test_api_v1_journals_citesummary(app):
+def test_api_v1_journals_citesummary(api_client):
     schema = {
         'items': {
             'additionalProperties': False,
@@ -88,13 +88,12 @@ def test_api_v1_journals_citesummary(app):
         'type': 'array',
     }
 
-    with app.test_client() as client:
-        response = client.get('/api/journals/1213103/citesummary')
+    response = api_client.get('/journals/1213103/citesummary')
 
-        assert response.status_code == 200
+    assert response.status_code == 200
 
-        response_json = json.loads(response.data)
+    response_json = json.loads(response.data)
 
-        assert validate(response_json, schema) is None
+    assert validate(response_json, schema) is None
 
-        assert len(response_json) == 1
+    assert len(response_json) == 1

--- a/tests/integration/api/v1/test_literature.py
+++ b/tests/integration/api/v1/test_literature.py
@@ -27,7 +27,7 @@ import json
 from jsonschema import validate
 
 
-def test_api_v1_literature_citesummary(app):
+def test_api_v1_literature_citesummary(api_client):
     schema = {
         'items': {
             'additionalProperties': False,
@@ -90,14 +90,13 @@ def test_api_v1_literature_citesummary(app):
         'type': 'array',
     }
 
-    with app.test_client() as client:
-        response = client.get('/api/literature/712925/citesummary')
+    response = api_client.get('/literature/712925/citesummary')
 
-        assert response.status_code == 200
+    assert response.status_code == 200
 
-        response_json = json.loads(response.data)
+    response_json = json.loads(response.data)
 
-        assert validate(response_json, schema) is None
+    assert validate(response_json, schema) is None
 
-        assert len(response_json) == 1
-        assert len(response_json[0]['citations']) == 2
+    assert len(response_json) == 1
+    assert len(response_json[0]['citations']) == 2

--- a/tests/integration/test_author_api.py
+++ b/tests/integration/test_author_api.py
@@ -27,18 +27,17 @@ import json
 from jsonschema import validate
 
 
-def test_api_authors_root(app):
-    with app.test_client() as client:
-        response = client.get('/api/authors/983220')
+def test_api_authors_root(api_client):
+    response = api_client.get('/authors/983220')
 
-        assert response.status_code == 200
+    assert response.status_code == 200
 
-        response_json = json.loads(response.data)
+    response_json = json.loads(response.data)
 
-        assert response_json['id'] == 983220
+    assert response_json['id'] == 983220
 
 
-def test_api_authors_citations(app):
+def test_api_authors_citations(api_client):
     schema = {
         'items': {
             'properties': {
@@ -82,18 +81,17 @@ def test_api_authors_citations(app):
         'type': 'array'
     }
 
-    with app.test_client() as client:
-        response = client.get('/api/authors/1061000/citations')
+    response = api_client.get('/authors/1061000/citations')
 
-        assert response.status_code == 200
+    assert response.status_code == 200
 
-        response_json = json.loads(response.data)
+    response_json = json.loads(response.data)
 
-        assert validate(response_json, schema) is None
-        assert len(response_json) == 2
+    assert validate(response_json, schema) is None
+    assert len(response_json) == 2
 
 
-def test_api_authors_coauthors(app):
+def test_api_authors_coauthors(api_client):
     schema = {
         'items': {
             'properties': {
@@ -110,18 +108,17 @@ def test_api_authors_coauthors(app):
         'type': 'array'
     }
 
-    with app.test_client() as client:
-        response = client.get('/api/authors/1061000/coauthors')
+    response = api_client.get('/authors/1061000/coauthors')
 
-        assert response.status_code == 200
+    assert response.status_code == 200
 
-        response_json = json.loads(response.data)
+    response_json = json.loads(response.data)
 
-        assert validate(response_json, schema) is None
-        assert len(response_json) == 10
+    assert validate(response_json, schema) is None
+    assert len(response_json) == 10
 
 
-def test_api_authors_publications(app):
+def test_api_authors_publications(api_client):
     schema = {
         'items': {
             'properties': {
@@ -154,18 +151,17 @@ def test_api_authors_publications(app):
         'type': 'array'
     }
 
-    with app.test_client() as client:
-        response = client.get('/api/authors/1061000/publications')
+    response = api_client.get('/authors/1061000/publications')
 
-        assert response.status_code == 200
+    assert response.status_code == 200
 
-        response_json = json.loads(response.data)
+    response_json = json.loads(response.data)
 
-        assert validate(response_json, schema) is None
-        assert len(response_json) == 2
+    assert validate(response_json, schema) is None
+    assert len(response_json) == 2
 
 
-def test_api_author_stats(app):
+def test_api_author_stats(api_client):
     schema = {
         'properties': {
             'citations': {'type': 'integer'},
@@ -191,12 +187,11 @@ def test_api_author_stats(app):
         'type': 'object'
     }
 
-    with app.test_client() as client:
-        response = client.get('/api/authors/1061000/stats')
+    response = api_client.get('/authors/1061000/stats')
 
-        assert response.status_code == 200
+    assert response.status_code == 200
 
-        response_json = json.loads(response.data)
+    response_json = json.loads(response.data)
 
-        assert validate(response_json, schema) is None
-        assert len(response_json['keywords']) == 12
+    assert validate(response_json, schema) is None
+    assert len(response_json['keywords']) == 12

--- a/tests/integration/test_citation_counts.py
+++ b/tests/integration/test_citation_counts.py
@@ -32,9 +32,8 @@ def test_citation_counts_are_correct(app):
 
         return citation_count
 
-    with app.app_context():
-        assert get_citation_count(712925) == 2
-        assert get_citation_count(451647) == 2
-        assert get_citation_count(1430091) == 1
-        assert get_citation_count(452060) == 1
-        assert get_citation_count(1496635) == 1
+    assert get_citation_count(712925) == 2
+    assert get_citation_count(451647) == 2
+    assert get_citation_count(1430091) == 1
+    assert get_citation_count(452060) == 1
+    assert get_citation_count(1496635) == 1

--- a/tests/integration/test_datatable_citations.py
+++ b/tests/integration/test_datatable_citations.py
@@ -25,8 +25,7 @@ from __future__ import absolute_import, division, print_function
 import json
 
 
-def test_citations(app):
+def test_citations(app_client):
     """Tests if citation datatables work for records."""
-    with app.test_client() as client:
-        response = client.get('/ajax/citations?recid=712925&endpoint=literature')
-        assert response.status_code == 200
+    response = app_client.get('/ajax/citations?recid=712925&endpoint=literature')
+    assert response.status_code == 200

--- a/tests/integration/test_datatable_references.py
+++ b/tests/integration/test_datatable_references.py
@@ -23,8 +23,7 @@
 from __future__ import absolute_import, division, print_function
 
 
-def test_references(app):
+def test_references(app_client):
     """Tests if reference datatables work for records."""
-    with app.test_client() as client:
-        response = client.get('/ajax/references?recid=712925&endpoint=literature')
-        assert response.status_code == 200
+    response = app_client.get('/ajax/references?recid=712925&endpoint=literature')
+    assert response.status_code == 200

--- a/tests/integration/test_detailed_records.py
+++ b/tests/integration/test_detailed_records.py
@@ -43,18 +43,17 @@ def test_all_records_are_valid(app):
     assert recids == []
 
 
-def test_all_records_are_there(app):
-    with app.test_client() as client:
-        failed = []
+def test_all_records_are_there(app_client):
+    failed = []
 
-        for record in [record.json for record in RecordMetadata.query.all()]:
-            try:
-                absolute_url = record['self']['$ref']
-                relative_url = absolute_url.partition('api')[2]
-                response = client.get(relative_url)
+    for record in [record.json for record in RecordMetadata.query.all()]:
+        try:
+            absolute_url = record['self']['$ref']
+            relative_url = absolute_url.partition('api')[2]
+            response = app_client.get(relative_url)
 
-                assert response.status_code == 200
-            except Exception:
-                failed.append(record['control_number'])
+            assert response.status_code == 200
+        except Exception:
+            failed.append(record['control_number'])
 
-        assert failed == []
+    assert failed == []

--- a/tests/integration/test_impact_graphs.py
+++ b/tests/integration/test_impact_graphs.py
@@ -27,15 +27,14 @@ from __future__ import absolute_import, division, print_function
 import json
 
 
-def test_impact_graphs_api(app):
+def test_impact_graphs_api(api_client):
     """Test response of impact graph API."""
-    with app.test_client() as client:
-        result = client.get(
-            "/api/literature/712925",
-            headers={"Accept": "application/x-impact.graph+json"}
-        )
+    result = api_client.get(
+        "/literature/712925",
+        headers={"Accept": "application/x-impact.graph+json"}
+    )
 
-        result = json.loads(result.data)
-        assert result['title'] == u'PYTHIA 6.4 Physics and Manual'
-        assert result['year'] == u'2006'
-        assert len(result['citations']) == 2
+    result = json.loads(result.data)
+    assert result['title'] == u'PYTHIA 6.4 Physics and Manual'
+    assert result['year'] == u'2006'
+    assert len(result['citations']) == 2

--- a/tests/integration/test_other_conferences.py
+++ b/tests/integration/test_other_conferences.py
@@ -23,20 +23,19 @@
 from __future__ import absolute_import, division, print_function
 
 
-def test_other_conferences(app):
+def test_other_conferences(app_client):
     """Tests if citation datatables work for records."""
-    with app.test_client() as client:
-        response = client.get('/ajax/conferences/series?recid=1331207&seriesname=Rencontres%20de%20Moriond')
-        assert response.status_code == 200
+    response = app_client.get('/ajax/conferences/series?recid=1331207&seriesname=Rencontres%20de%20Moriond')
+    assert response.status_code == 200
 
-        response = client.get('/ajax/conferences/series?recid=1346335&seriesname=EDS')
-        assert response.status_code == 200
+    response = app_client.get('/ajax/conferences/series?recid=1346335&seriesname=EDS')
+    assert response.status_code == 200
 
-        response = client.get('/ajax/conferences/series?recid=1320036&seriesname=Quarks')
-        assert response.status_code == 200
+    response = app_client.get('/ajax/conferences/series?recid=1320036&seriesname=Quarks')
+    assert response.status_code == 200
 
-        response = client.get('/ajax/conferences/series?recid=976391&seriesname=LCWS')
-        assert response.status_code == 200
+    response = app_client.get('/ajax/conferences/series?recid=976391&seriesname=LCWS')
+    assert response.status_code == 200
 
-        response = client.get('/ajax/conferences/series?recid=977661&seriesname=NSS')
-        assert response.status_code == 200
+    response = app_client.get('/ajax/conferences/series?recid=977661&seriesname=NSS')
+    assert response.status_code == 200

--- a/tests/integration/test_pidstore.py
+++ b/tests/integration/test_pidstore.py
@@ -25,6 +25,7 @@ from __future__ import absolute_import, division, print_function
 import httpretty
 import mock
 import pytest
+from flask import current_app
 
 from inspirehep.modules.pidstore.providers import InspireRecordIdProvider
 
@@ -35,21 +36,20 @@ def test_getting_next_recid_from_legacy(app):
         'LEGACY_PID_PROVIDER': 'http://server/batchuploader/allocaterecord',
     }
 
-    with app.app_context():
-        with mock.patch.dict(app.config, extra_config):
-            httpretty.register_uri(
-                httpretty.GET,
-                'http://server/batchuploader/allocaterecord',
-                content_type='application/json',
-                body='3141592',
-                status=200,
-            )
+    with mock.patch.dict(current_app.config, extra_config):
+        httpretty.register_uri(
+            httpretty.GET,
+            'http://server/batchuploader/allocaterecord',
+            content_type='application/json',
+            body='3141592',
+            status=200,
+        )
 
-            args = dict(
-                object_type='rec',
-                object_uuid='7753a30b-4c4b-469c-8d8d-d5020069b3ab',
-                pid_type='lit'
-            )
-            provider = InspireRecordIdProvider.create(**args)
+        args = dict(
+            object_type='rec',
+            object_uuid='7753a30b-4c4b-469c-8d8d-d5020069b3ab',
+            pid_type='lit'
+        )
+        provider = InspireRecordIdProvider.create(**args)
 
-            assert str(provider.pid.pid_value) == "3141592"
+        assert str(provider.pid.pid_value) == "3141592"

--- a/tests/integration/test_search_views.py
+++ b/tests/integration/test_search_views.py
@@ -27,48 +27,40 @@ import json
 from mock import patch
 
 
-def test_search_conferences_is_there(app):
-    with app.test_client() as client:
-        assert client.get('/search?cc=conferences').status_code == 200
+def test_search_conferences_is_there(app_client):
+    assert app_client.get('/search?cc=conferences').status_code == 200
 
 
-def test_search_authors_is_there(app):
-    with app.test_client() as client:
-        assert client.get('/search?cc=authors').status_code == 200
+def test_search_authors_is_there(app_client):
+    assert app_client.get('/search?cc=authors').status_code == 200
 
 
-def test_search_data_is_there(app):
-    with app.test_client() as client:
-        assert client.get('/search?cc=data').status_code == 200
+def test_search_data_is_there(app_client):
+    assert app_client.get('/search?cc=data').status_code == 200
 
 
-def test_search_experiments_is_there(app):
-    with app.test_client() as client:
-        assert client.get('/search?cc=experiments').status_code == 200
+def test_search_experiments_is_there(app_client):
+    assert app_client.get('/search?cc=experiments').status_code == 200
 
 
-def test_search_institutions_is_there(app):
-    with app.test_client() as client:
-        assert client.get('/search?cc=institutions').status_code == 200
+def test_search_institutions_is_there(app_client):
+    assert app_client.get('/search?cc=institutions').status_code == 200
 
 
-def test_search_journals_is_there(app):
-    with app.test_client() as client:
-        assert client.get('/search?cc=journals').status_code == 200
+def test_search_journals_is_there(app_client):
+    assert app_client.get('/search?cc=journals').status_code == 200
 
 
-def test_search_jobs_is_there(app):
-    with app.test_client() as client:
-        assert client.get('/search?cc=jobs').status_code == 200
+def test_search_jobs_is_there(app_client):
+    assert app_client.get('/search?cc=jobs').status_code == 200
 
 
-def test_search_falls_back_to_hep(app):
-    with app.test_client() as client:
-        assert client.get('/search').status_code == 200
+def test_search_falls_back_to_hep(app_client):
+    assert app_client.get('/search').status_code == 200
 
 
 @patch('inspirehep.modules.search.query.current_app')
-def test_search_logs(current_app_mock, app):
+def test_search_logs(current_app_mock, api_client):
     def _debug(log_output):
         query = {
             'query': {
@@ -93,5 +85,4 @@ def test_search_logs(current_app_mock, app):
         assert query == json.loads(log_output)
 
     current_app_mock.logger.debug.side_effect = _debug
-    with app.test_client() as client:
-        client.get('/api/literature/')
+    api_client.get('/literature/')

--- a/tests/integration/test_serializers.py
+++ b/tests/integration/test_serializers.py
@@ -39,5 +39,4 @@ def test_impact_graph_serializer_does_not_raise_maximum_recursion_error(app):
         ]
     }
 
-    with app.app_context():
-        serializer.serialize(111, record)
+    serializer.serialize(111, record)

--- a/tests/integration/test_theme_views.py
+++ b/tests/integration/test_theme_views.py
@@ -23,113 +23,96 @@
 from __future__ import absolute_import, division, print_function
 
 
-def test_literature_is_there(app):
-    with app.test_client() as client:
-        assert client.get('/literature').status_code == 200
-        assert client.get('/collection/literature').status_code == 200
-        assert client.get('/').status_code == 200
+def test_literature_is_there(app_client):
+    assert app_client.get('/literature').status_code == 200
+    assert app_client.get('/collection/literature').status_code == 200
+    assert app_client.get('/').status_code == 200
 
 
-def test_authors_is_there(app):
-    with app.test_client() as client:
-        assert client.get('/authors').status_code == 200
-        assert client.get('/collection/authors').status_code == 200
+def test_authors_is_there(app_client):
+    assert app_client.get('/authors').status_code == 200
+    assert app_client.get('/collection/authors').status_code == 200
 
 
-def test_conferences_is_there(app):
-    with app.test_client() as client:
-        assert client.get('/conferences').status_code == 200
+def test_conferences_is_there(app_client):
+    assert app_client.get('/conferences').status_code == 200
 
 
-def test_jobs_redirects_to_search(app):
-    with app.test_client() as client:
-        response = client.get('/jobs')
+def test_jobs_redirects_to_search(app_client):
+    response = app_client.get('/jobs')
 
-        assert response.status_code == 302
-        assert response.location == 'http://localhost:5000/search?cc=jobs'
-
-
-def test_institutions_is_there(app):
-    with app.test_client() as client:
-        assert client.get('/institutions').status_code == 200
+    assert response.status_code == 302
+    assert response.location == 'http://localhost:5000/search?cc=jobs'
 
 
-def test_experiments_is_there(app):
-    with app.test_client() as client:
-        assert client.get('/experiments').status_code == 200
+def test_institutions_is_there(app_client):
+    assert app_client.get('/institutions').status_code == 200
 
 
-def test_journals_is_there(app):
-    with app.test_client() as client:
-        assert client.get('/journals').status_code == 200
+def test_experiments_is_there(app_client):
+    assert app_client.get('/experiments').status_code == 200
 
 
-def test_data_is_there(app):
-    with app.test_client() as client:
-        assert client.get('/data').status_code == 200
+def test_journals_is_there(app_client):
+    assert app_client.get('/journals').status_code == 200
 
 
-def test_ping_responds_ok(app):
-    with app.test_client() as client:
-        assert client.get('/ping').data == 'OK'
+def test_data_is_there(app_client):
+    assert app_client.get('/data').status_code == 200
 
 
-def test_record_url_redirects_to_literature(app):
-    with app.test_client() as client:
-        response = client.get('/record/4328')
-
-        assert response.status_code == 301
-        assert response.location == 'http://localhost:5000/literature/4328'
+def test_ping_responds_ok(app_client):
+    assert app_client.get('/ping').data == 'OK'
 
 
-def test_record_url_redirects_to_authors(app):
-    with app.test_client() as client:
-        response = client.get('/record/993224')
+def test_record_url_redirects_to_literature(app_client):
+    response = app_client.get('/record/4328')
 
-        assert response.status_code == 301
-        assert response.location == 'http://localhost:5000/authors/993224'
-
-
-def test_record_url_returns_404_when_there_is_no_corresponding_record(app):
-    with app.test_client() as client:
-        assert client.get('/record/0').status_code == 404
+    assert response.status_code == 301
+    assert response.location == 'http://localhost:5000/literature/4328'
 
 
-def test_author_new_form_redirects_without_bai(app):
-    with app.test_client() as client:
-        response = client.get('/author/new')
+def test_record_url_redirects_to_authors(app_client):
+    response = app_client.get('/record/993224')
 
-        assert response.status_code == 301
-        assert response.location == 'http://localhost:5000/authors/new'
-
-
-def test_author_new_form_redirects_with_bai(app):
-    with app.test_client() as client:
-        response = client.get('/author/new?bai=foo')
-
-        assert response.status_code == 301
-        assert response.location == 'http://localhost:5000/authors/new?bai=foo'
+    assert response.status_code == 301
+    assert response.location == 'http://localhost:5000/authors/993224'
 
 
-def test_author_update_form_redirects_to_new_without_recid(app):
-    with app.test_client() as client:
-        response = client.get('/author/update')
-
-        assert response.status_code == 301
-        assert response.location == 'http://localhost:5000/authors/new'
+def test_record_url_returns_404_when_there_is_no_corresponding_record(app_client):
+    assert app_client.get('/record/0').status_code == 404
 
 
-def test_author_update_form_redirects_with_recid(app):
-    with app.test_client() as client:
-        response = client.get('/author/update?recid=123')
+def test_author_new_form_redirects_without_bai(app_client):
+    response = app_client.get('/author/new')
 
-        assert response.status_code == 301
-        assert response.location == 'http://localhost:5000/authors/123/update'
+    assert response.status_code == 301
+    assert response.location == 'http://localhost:5000/authors/new'
 
 
-def test_literature_new_form_redirects(app):
-    with app.test_client() as client:
-        response = client.get('/submit/literature/create')
+def test_author_new_form_redirects_with_bai(app_client):
+    response = app_client.get('/author/new?bai=foo')
 
-        assert response.status_code == 301
-        assert response.location == 'http://localhost:5000/literature/new'
+    assert response.status_code == 301
+    assert response.location == 'http://localhost:5000/authors/new?bai=foo'
+
+
+def test_author_update_form_redirects_to_new_without_recid(app_client):
+    response = app_client.get('/author/update')
+
+    assert response.status_code == 301
+    assert response.location == 'http://localhost:5000/authors/new'
+
+
+def test_author_update_form_redirects_with_recid(app_client):
+    response = app_client.get('/author/update?recid=123')
+
+    assert response.status_code == 301
+    assert response.location == 'http://localhost:5000/authors/123/update'
+
+
+def test_literature_new_form_redirects(app_client):
+    response = app_client.get('/submit/literature/create')
+
+    assert response.status_code == 301
+    assert response.location == 'http://localhost:5000/literature/new'


### PR DESCRIPTION
## Description:
The `app`, `app_client`, and `api_client` fixtures already provide the
right contexts, so there's no need to explicitly instantiate one.

This is done everywhere except in `orcid`, where the app fixtures are
defined in an obsolete fashion, and `workflows`, where it's possible
they might conflict too much with in-flight PRs.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.