### PR TITLE
workflows.matching: fix legacy existance check

### DIFF
--- a/inspirehep/modules/workflows/tasks/matching.py
+++ b/inspirehep/modules/workflows/tasks/matching.py
@@ -77,7 +77,7 @@ def match_by_arxiv_id(record):
     arxiv_id = get_arxiv_id(record)
 
     if arxiv_id:
-        query = '035:"{0}"'.format(arxiv_id)
+        query = '035__a:oai:arXiv.org:{0}'.format(arxiv_id)
         return search(query)
 
     return list()


### PR DESCRIPTION
* We were doing a query that never returned any results, so we thought
  the records were new when checking for their existance in the legacy
  system.


We were seeing duplicated records being submitted to legacy, this is
the first guess towards answering why.

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->


Signed-off-by: David Caro <david@dcaro.es>