### PR TITLE
refextract: also use journal_title and short_title

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,6 +85,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.todo',
     'sphinx.ext.napoleon',
+    'celery.contrib.sphinx',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ tests_require = [
 
 extras_require = {
     'docs': [
-        'Sphinx~=1.0,>=1.6.2',
+        'Sphinx~=1.0,<1.6',
     ],
     'postgresql': [
         'invenio-db[postgresql,versioning]>=1.0.0b2',

--- a/tests/integration/refextract/test_refextract_tasks.py
+++ b/tests/integration/refextract/test_refextract_tasks.py
@@ -39,7 +39,16 @@ def test_create_journal_kb_file(app):
         create_journal_kb_file()
 
     with open(path, 'r') as fd:
-        assert 'JOURNAL OF HIGH ENERGY PHYSICS---JHEP' in fd.read()
+        journal_kb = fd.read().splitlines()
+
+        assert 'JHEP---JHEP' in journal_kb
+        '''short_title -> short_title'''
+
+        assert 'THE JOURNAL OF HIGH ENERGY PHYSICS JHEP---JHEP' in journal_kb
+        '''journal_title.title -> short_title, normalization is applied'''
+
+        assert 'JOURNAL OF HIGH ENERGY PHYSICS---JHEP' in journal_kb
+        '''title_variants -> short_title'''
 
     os.close(temporary_fd)
     os.remove(path)


### PR DESCRIPTION
## Description
Expands the task that populates the Knowledge Base used by refextract
to also use the `short_title` and the `journal_title`.

Adds the `celery.contrib.sphinx` extension to Sphinx in order to also
generate docs for Celery tasks.

This requires to pin the version of Sphinx to a lower version as there
is currently an API incompatibility with this extension and the latest
version of Sphinx.

## Related Issue
Closes #2612 and closes #2613 

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.