### PR TITLE
migrator: detach receivers during migration

### DIFF
--- a/inspirehep/modules/migrator/cli.py
+++ b/inspirehep/modules/migrator/cli.py
@@ -24,14 +24,10 @@
 
 from __future__ import absolute_import, division, print_function
 
-import logging
 import os
 
 import click
 import requests
-from flask_sqlalchemy import models_committed
-
-from inspirehep.modules.records.receivers import receive_after_model_commit
 
 from .tasks import (
     add_citation_counts,
@@ -45,15 +41,6 @@ from .tasks import (
 @click.group()
 def migrator():
     """Command related to migrating INSPIRE data."""
-    logging.basicConfig()
-    # Disable auto-indexing receiver in migration tasks
-    models_committed.disconnect(receive_after_model_commit)
-
-
-@migrator.resultcallback()
-def process_result(result, **kwargs):
-    """Callback run after migrator commands."""
-    models_committed.connect(receive_after_model_commit)
 
 
 @migrator.command()

--- a/inspirehep/modules/migrator/tasks.py
+++ b/inspirehep/modules/migrator/tasks.py
@@ -43,6 +43,7 @@ from redis_lock import Lock
 from six import text_type
 
 from dojson.contrib.marc21.utils import create_record as marc_create_record
+from invenio_collections import current_collections
 from invenio_db import db
 from invenio_indexer.api import RecordIndexer, current_record_to_index
 from invenio_pidstore.errors import PIDDoesNotExistError
@@ -184,6 +185,7 @@ def create_index_op(record):
 @shared_task(ignore_result=False, compress='zlib', acks_late=True)
 def migrate_chunk(chunk):
     models_committed.disconnect(receive_after_model_commit)
+    current_collections.unregister_signals()
 
     index_queue = []
 
@@ -206,6 +208,7 @@ def migrate_chunk(chunk):
     )
 
     models_committed.connect(receive_after_model_commit)
+    current_collections.register_signals()
 
 
 @shared_task()


### PR DESCRIPTION
## Description
The solution attempted in 16e9cb9 didn't work as that receiver was
detached by the Python interpreter executing the CLI command, not
the one executing the task code in the worker.

Fixes the performance issue caused by invenio-collections by detaching
its receiver during migration. Its work, in fact, is already handled
by inspire-dojson since inspirehep/inspire-dojson#62.

## Related Issue
Closes https://github.com/inspirehep/inspire-next/issues/1640

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.