### PR TITLE
mappings: don't analyze _collections

### DIFF
--- a/inspirehep/modules/records/mappings/records/authors.json
+++ b/inspirehep/modules/records/mappings/records/authors.json
@@ -11,6 +11,7 @@
                     "type": "string"
                 },
                 "_collections": {
+                    "index": "not_analyzed",
                     "type": "string"
                 },
                 "_private_notes": {

--- a/inspirehep/modules/records/mappings/records/conferences.json
+++ b/inspirehep/modules/records/mappings/records/conferences.json
@@ -11,6 +11,7 @@
                     "type": "string"
                 },
                 "_collections": {
+                    "index": "not_analyzed",
                     "type": "string"
                 },
                 "_private_notes": {

--- a/inspirehep/modules/records/mappings/records/experiments.json
+++ b/inspirehep/modules/records/mappings/records/experiments.json
@@ -11,6 +11,7 @@
                     "type": "string"
                 },
                 "_collections": {
+                    "index": "not_analyzed",
                     "type": "string"
                 },
                 "_full_ingestion": {

--- a/inspirehep/modules/records/mappings/records/hep.json
+++ b/inspirehep/modules/records/mappings/records/hep.json
@@ -295,6 +295,10 @@
                     },
                     "type": "object"
                 },
+                "bookautocomplete": {
+                    "payloads": true,
+                    "type": "completion"
+                },
                 "citation_count": {
                     "type": "integer"
                 },
@@ -532,10 +536,6 @@
                         }
                     },
                     "type": "object"
-                },
-                "bookautocomplete": {
-                    "payloads": true,
-                    "type": "completion"
                 },
                 "keywords": {
                     "properties": {

--- a/inspirehep/modules/records/mappings/records/hep.json
+++ b/inspirehep/modules/records/mappings/records/hep.json
@@ -11,6 +11,7 @@
                     "type": "string"
                 },
                 "_collections": {
+                    "index": "not_analyzed",
                     "type": "string"
                 },
                 "_desy_bookkeeping": {

--- a/inspirehep/modules/records/mappings/records/institutions.json
+++ b/inspirehep/modules/records/mappings/records/institutions.json
@@ -15,6 +15,7 @@
                     "type": "string"
                 },
                 "_collections": {
+                    "index": "not_analyzed",
                     "type": "string"
                 },
                 "_private_notes": {

--- a/inspirehep/modules/records/mappings/records/jobs.json
+++ b/inspirehep/modules/records/mappings/records/jobs.json
@@ -11,6 +11,7 @@
                     "type": "string"
                 },
                 "_collections": {
+                    "index": "not_analyzed",
                     "type": "string"
                 },
                 "_private_notes": {

--- a/inspirehep/modules/records/mappings/records/journals.json
+++ b/inspirehep/modules/records/mappings/records/journals.json
@@ -11,6 +11,7 @@
                     "type": "string"
                 },
                 "_collections": {
+                    "index": "not_analyzed",
                     "type": "string"
                 },
                 "_harvesting_info": {


### PR DESCRIPTION
## Description
As discovered by @jmartinm, we shouldn't be analyzing this field, as we use it for exact searches when determining which records can a user see.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.