### PR TITLE
tests: httpretty -> requests_mock

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,6 @@ tests_require = [
     'pytest-cache>=1.0',
     'pytest-cov>=1.8.0',
     'pytest-flake8>=0.8.1',
-    'pytest-httpretty>=0.2.0',
     'pytest-selenium>=1.3.1',
     'pytest>=2.8.0',
     'mock>=1.3.0',

--- a/tests/unit/forms/test_forms_validators_simple_fields.py
+++ b/tests/unit/forms/test_forms_validators_simple_fields.py
@@ -22,8 +22,8 @@
 
 from __future__ import absolute_import, division, print_function
 
-import httpretty
 import pytest
+import requests_mock
 from wtforms.validators import StopValidation
 
 from inspirehep.modules.forms.validators.simple_fields import (
@@ -104,62 +104,58 @@ def test_date_validator_raises_on_invalid_dates():
         assert date_validator(None, field) is None
 
 
-@pytest.mark.httpretty
 def test_pdf_validator_raises_on_link_to_not_a_pdf():
-    httpretty.register_uri(
-        httpretty.GET,
-        'http://example.com/not-a-pdf',
-        body='<!doctype html>',
-        content_type='text/html; charset=utf-8',
-    )
+    with requests_mock.Mocker() as requests_mocker:
+        requests_mocker.register_uri(
+            'GET', 'http://example.com/not-a-pdf',
+            text='<!doctype html>',
+            headers={'content-type': 'text/html; charset=utf-8'},
+        )
 
-    field = MockField('http://example.com/not-a-pdf')
+        field = MockField('http://example.com/not-a-pdf')
 
-    with pytest.raises(StopValidation):
-        pdf_validator(None, field)
+        with pytest.raises(StopValidation):
+            pdf_validator(None, field)
 
 
-@pytest.mark.httpretty
 def test_pdf_validator_accepts_a_link_to_a_pdf():
-    httpretty.register_uri(
-        httpretty.GET,
-        'http://example.com/a-pdf',
-        body='%PDF1.3',
-        content_type='application/pdf',
-    )
+    with requests_mock.Mocker() as requests_mocker:
+        requests_mocker.register_uri(
+            'GET', 'http://example.com/a-pdf',
+            text='%PDF1.3',
+            headers={'content-type': 'application/pdf'},
+        )
 
-    field = MockField('http://example.com/a-pdf')
+        field = MockField('http://example.com/a-pdf')
 
-    assert pdf_validator(None, field) is None
+        assert pdf_validator(None, field) is None
 
 
-@pytest.mark.httpretty
 def test_pdf_validator_accepts_a_link_to_a_pdf_on_a_misconfigured_server():
-    httpretty.register_uri(
-        httpretty.GET,
-        'http://example.com/a-pdf',
-        body='%PDF1.3',
-        content_type='image/pdf;charset=ISO-8859-1',
-    )
+    with requests_mock.Mocker() as requests_mocker:
+        requests_mocker.register_uri(
+            'GET', 'http://example.com/a-pdf',
+            text='%PDF1.3',
+            headers={'content-type': 'image/pdf;charset=ISO-8859-1'},
+        )
 
-    field = MockField('http://example.com/a-pdf')
+        field = MockField('http://example.com/a-pdf')
 
-    assert pdf_validator(None, field) is None
+        assert pdf_validator(None, field) is None
 
 
-@pytest.mark.httpretty
 def test_no_pdf_validator_raises_on_link_to_a_pdf():
-    httpretty.register_uri(
-        httpretty.GET,
-        'http://example.com/a-pdf',
-        body='%PDF1.3',
-        content_type='application/pdf',
-    )
+    with requests_mock.Mocker() as requests_mocker:
+        requests_mocker.register_uri(
+            'GET', 'http://example.com/a-pdf',
+            text='%PDF1.3',
+            headers={'content-type': 'application/pdf'},
+        )
 
-    field = MockField('http://example.com/a-pdf')
+        field = MockField('http://example.com/a-pdf')
 
-    with pytest.raises(StopValidation):
-        no_pdf_validator(None, field)
+        with pytest.raises(StopValidation):
+            no_pdf_validator(None, field)
 
 
 def test_year_validator_accepts_a_valid_year():

--- a/tests/unit/utils/test_utils_robotupload.py
+++ b/tests/unit/utils/test_utils_robotupload.py
@@ -22,67 +22,59 @@
 
 from __future__ import absolute_import, division, print_function
 
-import httpretty
 import pytest
+import requests_mock
 from flask import current_app
 from mock import patch
 
 from inspirehep.utils.robotupload import make_robotupload_marcxml
 
 
-@pytest.mark.httpretty
 def test_make_robotupload_marcxml():
-    httpretty.HTTPretty.allow_net_connect = False
-    httpretty.register_uri(
-        httpretty.POST, 'http://localhost:5000/batchuploader/robotupload/insert')
+    with requests_mock.Mocker() as requests_mocker:
+        requests_mocker.register_uri(
+            'POST', 'http://localhost:5000/batchuploader/robotupload/insert'
+        )
 
-    make_robotupload_marcxml(
-        'http://localhost:5000', '<record></record>', 'insert')
-
-    httpretty.HTTPretty.allow_net_connect = True
+        make_robotupload_marcxml(
+            'http://localhost:5000', '<record></record>', 'insert')
 
 
-@pytest.mark.httpretty
 def test_make_robotupload_marcxml_falls_back_to_config_when_url_is_none():
-    httpretty.HTTPretty.allow_net_connect = False
-    httpretty.register_uri(
-        httpretty.POST, 'http://inspirehep.net/batchuploader/robotupload/insert')
+    with requests_mock.Mocker() as requests_mocker:
+        requests_mocker.register_uri(
+            'POST', 'http://inspirehep.net/batchuploader/robotupload/insert'
+        )
 
-    config = {'LEGACY_ROBOTUPLOAD_URL': 'http://inspirehep.net'}
+        config = {'LEGACY_ROBOTUPLOAD_URL': 'http://inspirehep.net'}
 
-    with patch.dict(current_app.config, config):
-        make_robotupload_marcxml(None, '<record></record>', 'insert')
-
-    httpretty.HTTPretty.allow_net_connect = True
+        with patch.dict(current_app.config, config):
+            make_robotupload_marcxml(None, '<record></record>', 'insert')
 
 
-@pytest.mark.httpretty
 def test_make_robotupload_marcxml_raises_when_url_is_none_and_config_is_empty():
-    httpretty.HTTPretty.allow_net_connect = False
-    httpretty.register_uri(
-        httpretty.POST, 'http://localhost:5000/batchuploader/robotupload/insert')
+    with requests_mock.Mocker() as requests_mocker:
+        requests_mocker.register_uri(
+            'POST', 'http://localhost:5000/batchuploader/robotupload/insert'
+        )
 
-    with pytest.raises(ValueError) as excinfo:
-        make_robotupload_marcxml(None, '<record></record>', 'insert')
-    assert 'LEGACY_ROBOTUPLOAD_URL' in str(excinfo.value)
-
-    httpretty.HTTPretty.allow_net_connect = True
+        with pytest.raises(ValueError) as excinfo:
+            make_robotupload_marcxml(None, '<record></record>', 'insert')
+        assert 'LEGACY_ROBOTUPLOAD_URL' in str(excinfo.value)
 
 
-@pytest.mark.httpretty
 def test_make_robotupload_marcxml_handles_unicode():
-    httpretty.HTTPretty.allow_net_connect = False
-    httpretty.register_uri(
-        httpretty.POST, 'http://localhost:5000/batchuploader/robotupload/insert')
+    with requests_mock.Mocker() as requests_mocker:
+        requests_mocker.register_uri(
+            'POST', 'http://localhost:5000/batchuploader/robotupload/insert'
+        )
 
-    snippet = (
-        u'<record>'
-        u'  <datafield tag="700" ind1=" " ind2=" ">'
-        u'    <subfield code="a">André, M.</subfield>'
-        u'  </datafield>'
-        u'</record>'
-    )  # record/1503367
+        snippet = (
+            u'<record>'
+            u'  <datafield tag="700" ind1=" " ind2=" ">'
+            u'    <subfield code="a">André, M.</subfield>'
+            u'  </datafield>'
+            u'</record>'
+        )  # record/1503367
 
-    make_robotupload_marcxml('http://localhost:5000', snippet, 'insert')
-
-    httpretty.HTTPretty.allow_net_connect = True
+        make_robotupload_marcxml('http://localhost:5000', snippet, 'insert')


### PR DESCRIPTION
## Description:
Replaces all uses of `httpretty` with `requests_mock`, since the
former has bugs that the author has declared he's not going to
fix and it probably won't ever support Python 3 (closes #2354).

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.