### PR TITLE
permissions: move DynamicPermission to Permission

### DIFF
--- a/inspirehep/modules/authors/permissions.py
+++ b/inspirehep/modules/authors/permissions.py
@@ -23,7 +23,7 @@
 from __future__ import absolute_import, division, print_function
 
 from invenio_access.permissions import (
-    DynamicPermission,
+    Permission,
     ParameterizedActionNeed
 )
 
@@ -32,6 +32,6 @@ action_admin_holdingpen_authors = ParameterizedActionNeed(
     'admin-holdingpen-authors', argument=None
 )
 
-holdingpen_author_permission = DynamicPermission(
+holdingpen_author_permission = Permission(
     action_admin_holdingpen_authors
 )

--- a/inspirehep/modules/editor/permissions.py
+++ b/inspirehep/modules/editor/permissions.py
@@ -23,7 +23,7 @@
 from __future__ import absolute_import, division, print_function
 
 from invenio_access.permissions import (
-    DynamicPermission,
+    Permission,
     ParameterizedActionNeed
 )
 
@@ -32,6 +32,6 @@ action_editor_manage_tickets = ParameterizedActionNeed(
     'editor_manage_tickets', argument=None
 )
 
-editor_manage_tickets_permission = DynamicPermission(
+editor_manage_tickets_permission = Permission(
     action_editor_manage_tickets
 )

--- a/inspirehep/modules/records/permissions.py
+++ b/inspirehep/modules/records/permissions.py
@@ -29,7 +29,7 @@ from werkzeug.local import LocalProxy
 
 from invenio_access.models import ActionUsers, ActionRoles
 from invenio_access.permissions import (
-    DynamicPermission,
+    Permission,
     ParameterizedActionNeed,
 )
 from invenio_cache import current_cache
@@ -141,7 +141,7 @@ class RecordPermission(object):
 def has_read_permission(user, record):
     """Check if user has read access to the record."""
     def _cant_view(collection):
-        return not DynamicPermission(
+        return not Permission(
             ParameterizedActionNeed(
                 'view-restricted-collection',
                 collection)).can()
@@ -174,7 +174,7 @@ def has_update_permission(user, record):
 def has_admin_permission(user, record):
     """Check if user has admin access to record."""
     # Allow administrators
-    if DynamicPermission(ActionNeed('admin-access')):
+    if Permission(ActionNeed('admin-access')):
         return True
 
 


### PR DESCRIPTION
* Since DynamicPermission is deprecated in invenio-access, moves
  usages to the recommended Permission class.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
