### PR TITLE
hal: fix issues during second push

### DIFF
--- a/inspirehep/modules/hal/core/tei.py
+++ b/inspirehep/modules/hal/core/tei.py
@@ -99,7 +99,7 @@ def _get_comm_context(record):
     conference_city = get_conference_city(conference_record)
     conference_country = get_conference_country(conference_record)
     conference_end_date = get_conference_end_date(conference_record)
-    conference_start_date = get_conference_start_date(conference_record),
+    conference_start_date = get_conference_start_date(conference_record)
     conference_title = get_conference_title(conference_record)
 
     return {

--- a/inspirehep/modules/hal/templates/hal/art.xml
+++ b/inspirehep/modules/hal/templates/hal/art.xml
@@ -57,8 +57,12 @@
   {% if abstract and abstract_language %}
   <abstract xml:lang="{{ abstract_language }}">{{ abstract }}</abstract>
   {% endif %}
-  {% for collaboration in collaborations %}
-  <org type="consortium">{{ collaboration }}</org>
-  {% endfor %}
+  {% if collaborations %}
+  <particDesc>
+    {% for collaboration in collaborations %}
+    <org type="consortium">{{ collaboration }}</org>
+    {% endfor %}
+  </particDesc>
+  {% endif %}
 </profileDesc>
 {% endblock profileDesc %}

--- a/inspirehep/modules/hal/templates/hal/comm.xml
+++ b/inspirehep/modules/hal/templates/hal/comm.xml
@@ -70,8 +70,12 @@
   {% if abstract and abstract_language %}
   <abstract xml:lang="{{ abstract_language }}">{{ abstract }}</abstract>
   {% endif %}
-  {% for collaboration in collaborations %}
-  <org type="consortium">{{ collaboration }}</org>
-  {% endfor %}
+  {% if collaborations %}
+  <particDesc>
+    {% for collaboration in collaborations %}
+    <org type="consortium">{{ collaboration }}</org>
+    {% endfor %}
+  </particDesc>
+  {% endif %}
 </profileDesc>
 {% endblock profileDesc %}


### PR DESCRIPTION
## Description
The `org` tags must appear, according the the XML schema, inside
of a `particDesc` tag.

Because of a runaway comma `conference_start_date` resulted in a tuple,
whose string serialization in the template resulted in an invalid date
for all comm records.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.