### PR TITLE
workflows: use local scratch space

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,7 @@ install_requires = [
     'timeout-decorator~=0.0,>=0.3.3',
     'Babel~=2.0,>=2.4.0',
     'setproctitle~=1.0,>=1.1.10',
+    'backports.tempfile>=1.0rc1',
 ]
 
 tests_require = [

--- a/tests/unit/workflows/test_workflows_tasks_arxiv.py
+++ b/tests/unit/workflows/test_workflows_tasks_arxiv.py
@@ -481,8 +481,7 @@ def test_arxiv_derive_inspire_categories_does_nothing_with_existing_categories()
     assert expected == result
 
 
-@patch('inspirehep.modules.workflows.tasks.arxiv.os')
-def test_arxiv_author_list_handles_auto_ignore_comment(mock_os):
+def test_arxiv_author_list_handles_auto_ignore_comment():
     schema = load_schema('hep')
     subschema = schema['properties']['arxiv_eprints']
 
@@ -514,18 +513,11 @@ def test_arxiv_author_list_handles_auto_ignore_comment(mock_os):
 
     default_arxiv_author_list = arxiv_author_list()
 
-    try:
-        temporary_dir = mkdtemp()
-        mock_os.path.abspath.return_value = temporary_dir
-
-        assert default_arxiv_author_list(obj, eng) is None
-    finally:
-        rmtree(temporary_dir)
+    assert default_arxiv_author_list(obj, eng) is None
 
 
 @patch('inspirehep.modules.workflows.tasks.arxiv.untar')
-@patch('inspirehep.modules.workflows.tasks.arxiv.os')
-def test_arxiv_author_list_logs_on_error(mock_os, mock_untar):
+def test_arxiv_author_list_logs_on_error(mock_untar):
     mock_untar.side_effect = InvalidTarball
 
     schema = load_schema('hep')
@@ -556,15 +548,9 @@ def test_arxiv_author_list_logs_on_error(mock_os, mock_untar):
 
     default_arxiv_author_list = arxiv_author_list()
 
-    try:
-        temporary_dir = mkdtemp()
-        mock_os.path.abspath.return_value = temporary_dir
+    assert default_arxiv_author_list(obj, eng) is None
 
-        assert default_arxiv_author_list(obj, eng) is None
+    expected = 'Invalid tarball http://export.arxiv.org/e-print/1605.07707 for arxiv_id 1605.07707'
+    result = obj.log._error.getvalue()
 
-        expected = 'Invalid tarball http://export.arxiv.org/e-print/1605.07707 for arxiv_id 1605.07707'
-        result = obj.log._error.getvalue()
-
-        assert expected == result
-    finally:
-        rmtree(temporary_dir)
+    assert expected == result


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

<!--- Why is this change required? What problem does it solve? -->

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Rather than using local .tar directory (currently on a networked
filesystem) as a scratch space for extracting plots and author.xml
file, uses a temporary local directory that is cleaned up at the end.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>