### PR TITLE
refextract: fix create_journal_kb_file

### DIFF
--- a/inspirehep/modules/refextract/tasks.py
+++ b/inspirehep/modules/refextract/tasks.py
@@ -75,12 +75,27 @@ def create_journal_kb_file():
 
     with codecs.open(refextract_journal_kb_path, encoding='utf-8', mode='w') as fd:
         for row in titles_query:
-            fd.write(u'{}---{}\n'.format(_normalize(row['short_title']), row['short_title']))
-            fd.write(u'{}---{}\n'.format(_normalize(row['journal_title']), row['short_title']))
+            normalized_short_title = _normalize(row['short_title'])
+            if normalized_short_title:
+                fd.write(u'{}---{}\n'.format(normalized_short_title, row['short_title']))
+            normalized_journal_title = _normalize(row['journal_title'])
+            if normalized_journal_title:
+                fd.write(u'{}---{}\n'.format(normalized_journal_title, row['short_title']))
 
         for row in title_variants_query:
-            fd.write(u'{}---{}\n'.format(_normalize(row['title_variant']), row['short_title']))
+            normalized_title_variant = _normalize(row['title_variant'])
+            if normalized_title_variant:
+                fd.write(u'{}---{}\n'.format(normalized_title_variant, row['short_title']))
 
 
 def _normalize(s):
-    return ' '.join((RE_ALPHANUMERIC.sub(' ', s)).split()).upper()
+    if not s:
+        return
+
+    result = RE_ALPHANUMERIC.sub(' ', s)
+    result = ' '.join(result.split())
+    result = result.upper()
+
+    if not result:
+        return
+    return result


### PR DESCRIPTION
## Description
Avoids generating lines like `---DESTINATION`, and makes the code a
little bit more robust.

## Related Issue
Closes #2732.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.