### PR TITLE
refextract: pass correct options everywhere

### DIFF
--- a/inspirehep/modules/editor/views.py
+++ b/inspirehep/modules/editor/views.py
@@ -27,7 +27,10 @@ from __future__ import absolute_import, division, print_function
 from flask import Blueprint, jsonify, request
 from flask_login import current_user
 
-from inspirehep.utils.references import map_refextract_to_schema
+from inspirehep.utils.references import (
+    get_refextract_kbs_path,
+    map_refextract_to_schema,
+)
 from refextract import (
     extract_references_from_string,
     extract_references_from_url,
@@ -45,7 +48,11 @@ blueprint = Blueprint('inspirehep_editor',
 @blueprint.route('/refextract/text', methods=['POST'])
 def refextract_text():
     """Run refextract on a piece of text."""
-    extracted_references = extract_references_from_string(request.json['text'])
+    extracted_references = extract_references_from_string(
+        request.json['text'],
+        override_kbs_files=get_refextract_kbs_path(),
+        reference_format=u'{title},{volume},{page}'
+    )
     references = map_refextract_to_schema(extracted_references)
 
     return jsonify(references)
@@ -54,7 +61,11 @@ def refextract_text():
 @blueprint.route('/refextract/url', methods=['POST'])
 def refextract_url():
     """Run refextract on a URL."""
-    extracted_references = extract_references_from_url(request.json['url'])
+    extracted_references = extract_references_from_url(
+        request.json['url'],
+        override_kbs_files=get_refextract_kbs_path(),
+        reference_format=u'{title},{volume},{page}'
+    )
     references = map_refextract_to_schema(extracted_references)
 
     return jsonify(references)

--- a/inspirehep/modules/workflows/tasks/actions.py
+++ b/inspirehep/modules/workflows/tasks/actions.py
@@ -248,11 +248,7 @@ def refextract(obj, eng):
     source = get_value(obj.data, 'acquisition_source.source')
     if uri:
         try:
-            journal_kb_path = current_app.config.get('REFEXTRACT_JOURNAL_KB_PATH', None)
-            if journal_kb_path:
-                references = extract_references(uri, source, {'journals': journal_kb_path})
-            else:
-                references = extract_references(uri, source)
+            references = extract_references(uri, source)
 
             if references:
                 obj.data['references'] = references

--- a/inspirehep/modules/workflows/tasks/refextract.py
+++ b/inspirehep/modules/workflows/tasks/refextract.py
@@ -31,7 +31,10 @@ from refextract import extract_journal_reference, extract_references_from_file
 from inspire_schemas.utils import split_page_artid
 from inspire_utils.helpers import maybe_int
 from inspire_utils.record import get_value
-from inspirehep.utils.references import map_refextract_to_schema
+from inspirehep.utils.references import (
+    get_refextract_kbs_path,
+    map_refextract_to_schema,
+)
 
 from ..utils import with_debug_logging
 
@@ -53,9 +56,7 @@ def extract_journal_info(obj, eng):
                 freetext = ". ".join(freetext)
             extracted_publication_info = extract_journal_reference(
                 freetext,
-                # override_kbs_files={
-                #    'journals': get_mappings_from_kbname(['REFEXTRACT_KB_NAME'])
-                # }
+                override_kbs_files=get_refextract_kbs_path()
             )
             if extracted_publication_info:
                 if "volume" in extracted_publication_info:
@@ -90,7 +91,7 @@ def extract_references(filepath, source=None, custom_kbs_file=None):
     """Extract references from PDF and return in INSPIRE format."""
     extracted_references = extract_references_from_file(
         filepath,
-        override_kbs_files=custom_kbs_file,
+        override_kbs_files=get_refextract_kbs_path(),
         reference_format=u'{title},{volume},{page}'
     )
 

--- a/inspirehep/utils/references.py
+++ b/inspirehep/utils/references.py
@@ -22,6 +22,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+from flask import current_app
+
 from inspire_schemas.api import ReferenceBuilder
 from inspire_utils.helpers import force_list
 from inspirehep.utils.jinja2 import render_template_to_string
@@ -123,3 +125,9 @@ def map_refextract_to_schema(extracted_references, source=None):
         result.append(rb.obj)
 
     return result
+
+
+def get_refextract_kbs_path():
+    """Get the path to the refextract kbs from the application config."""
+    journal_kb_path = current_app.config.get('REFEXTRACT_JOURNAL_KB_PATH')
+    return {'journals': journal_kb_path} if journal_kb_path else None

--- a/tests/unit/editor/test_editor_views.py
+++ b/tests/unit/editor/test_editor_views.py
@@ -29,6 +29,7 @@ import pkg_resources
 import requests_mock
 
 from inspire_schemas.api import load_schema, validate
+from inspire_utils.record import get_value
 
 
 def test_refextract_text(api_client):
@@ -46,9 +47,11 @@ def test_refextract_text(api_client):
             ),
         }),
     )
+    references = json.loads(response.data)
 
     assert response.status_code == 200
-    assert validate(json.loads(response.data), subschema) is None
+    assert validate(references, subschema) is None
+    assert get_value({'references': references}, 'references.reference.publication_info.journal_title')
 
 
 def test_refextract_url(api_client):
@@ -69,6 +72,8 @@ def test_refextract_url(api_client):
                 'url': 'https://arxiv.org/pdf/1612.06414.pdf',
             }),
         )
+        references = json.loads(response.data)
 
     assert response.status_code == 200
-    assert validate(json.loads(response.data), subschema) is None
+    assert validate(references, subschema) is None
+    assert get_value({'references': references}, 'references.reference.publication_info.journal_title')


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`refextract` was sometimes being called without the right arguments (by
the editor and `extract_journal_info` in the workflows) resulting in the
static journal KB shipped with refextract being used instead of the
dynamic one and/or the publication info being produced in an incorrect
format.
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
