### PR TITLE
setup: fix celery entrypoint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -260,10 +260,10 @@ setup(
             'inspire_disambiguation = inspirehep.modules.disambiguation.models',
         ],
         'invenio_celery.tasks': [
-            'inspire_refextract = inspirehep.modules.refextract.tasks',
-            'inspire_authors = inspirehep.modules.authors.tasks',
             'inspire_disambiguation = inspirehep.modules.disambiguation.tasks',
+            'inspire_migrator = inspirehep.modules.migrator.tasks',
             'inspire_records = inspirehep.modules.records.tasks',
+            'inspire_refextract = inspirehep.modules.refextract.tasks',
         ],
     },
     tests_require=tests_require,


### PR DESCRIPTION
## Description
There are no longer tasks in `inspirehep.modules.authors`, but there
were undeclared tasks in `inspirehep.modules.migrator`.

## Related Issue:
Sentry: https://sentry.cern.ch/inspire-sentry/inspire-labs/group/822729/

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.