### PR TITLE
setup: pin simplekv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,7 @@ install_requires = [
     'Babel~=2.0,>=2.4.0',
     'setproctitle~=1.0,>=1.1.10',
     'backports.tempfile>=1.0rc1',
+    'simplekv~=0.0,<0.11',
 ]
 
 tests_require = [


### PR DESCRIPTION
## Description
Fixes the build by pinning `simplekv` since a new version of it
appears to be incompatible with Python 2.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.