### PR TITLE
workflows: fix submission number for harvests

### DIFF
--- a/inspirehep/modules/workflows/tasks/actions.py
+++ b/inspirehep/modules/workflows/tasks/actions.py
@@ -257,6 +257,29 @@ def populate_journal_coverage(obj, eng):
 
 
 @with_debug_logging
+def fix_submission_number(obj, eng):
+    """Ensure that the submission number contains the workflow object id.
+
+    Unlike form submissions, records coming from HEPCrawl can't know yet which
+    workflow object they will create, so they use the crawler job id as their
+    submission number. We would like to have there instead the id of the workflow
+    object from which they came from, so that, given a record, we can link to their
+    original Holding Pen entry.
+
+    Args:
+        obj: a workflow object.
+        eng: a workflow engine.
+
+    Returns:
+        None
+
+    """
+    method = get_value(obj.data, 'acquisition_source.method', default='')
+    if method == 'hepcrawl':
+        obj.data['acquisition_source']['submission_number'] = obj.id
+
+
+@with_debug_logging
 def submission_fulltext_download(obj, eng):
     submission_pdf = obj.extra_data.get('submission_pdf')
     if submission_pdf and is_pdf_link(submission_pdf):

--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -41,21 +41,22 @@ from inspirehep.modules.workflows.tasks.arxiv import (
 from inspirehep.modules.workflows.tasks.actions import (
     add_core,
     error_workflow,
+    fix_submission_number,
     halt_record,
-    is_record_relevant,
-    populate_journal_coverage,
-    is_record_accepted,
-    reject_record,
+    is_arxiv_paper,
     is_experimental_paper,
     is_marked,
+    is_record_accepted,
+    is_record_relevant,
     is_submission,
-    is_arxiv_paper,
     mark,
     normalize_journal_titles,
+    populate_journal_coverage,
     refextract,
+    reject_record,
+    save_workflow,
     set_refereed_and_fix_document_type,
     submission_fulltext_download,
-    save_workflow,
 )
 
 from inspirehep.modules.workflows.tasks.classifier import (
@@ -219,6 +220,7 @@ POSTENHANCE_RECORD = [
     prepare_keywords,
     remove_references,
     set_refereed_and_fix_document_type,
+    fix_submission_number,
 ]
 
 


### PR DESCRIPTION
## Description
The ``submission_number`` key in ``acquisition_source`` is currently
being populated differently between HEPCrawl and form submissions.
In fact, HEPCrawl puts there the Scrapy job id as it can't possibly
know the workflow object id since it will be generated later. This
workflow step makes sure that they will both contain the workflow id
as we'd might want to link from the record to the Holding Pen entry
from which it came from.

## Related Issue
Closes https://github.com/inspirehep/inspire-next/issues/2687.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.