### PR TITLE
workflows: handle client request to remove PDF

### DIFF
--- a/inspirehep/modules/workflows/actions/hep_approval.py
+++ b/inspirehep/modules/workflows/actions/hep_approval.py
@@ -50,6 +50,10 @@ class HEPApproval(object):
             user_action=value,
         )
 
+        if not upload_pdf:
+            if 'fulltext.pdf' in obj.files:
+                del obj.files['fulltext.pdf']
+
         approved = value in ('accept', 'accept_core')
 
         obj.extra_data["approved"] = approved
@@ -58,7 +62,6 @@ class HEPApproval(object):
         obj.extra_data["user_action"] = value
         obj.extra_data["core"] = value == "accept_core"
         obj.extra_data["reason"] = reason
-        obj.extra_data["pdf_upload"] = upload_pdf
         obj.status = ObjectStatus.WAITING
         obj.save()
 

--- a/tests/integration/workflows/test_hep_approval.py
+++ b/tests/integration/workflows/test_hep_approval.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Tests for hep_approval action."""
+
+from __future__ import absolute_import, division, print_function
+
+import StringIO
+import pytest
+
+from invenio_db import db
+from invenio_workflows import workflow_object_class
+from invenio_workflows.models import WorkflowObjectModel
+
+from inspirehep.modules.workflows.actions.hep_approval import HEPApproval
+
+
+@pytest.fixture(scope='function')
+def workflow():
+    workflow_object = workflow_object_class.create(
+        data={},
+        id_user=1,
+        data_type="hep"
+    )
+    workflow_object.save()
+    db.session.commit()
+    workflow_object.continue_workflow = lambda **args: True
+
+    yield workflow_object
+
+    WorkflowObjectModel.query.filter_by(id=workflow_object.id).delete()
+    db.session.commit()
+
+
+def test_resolve_accept(small_app, workflow):
+    args = {
+        'request_data': {
+            'value': 'accept',
+        }
+    }
+    HEPApproval.resolve(workflow, **args)
+    expected = {
+        'core': False,
+        'user_action': 'accept',
+        '_action': None,
+        '_message': '',
+        'reason': '',
+        'approved': True
+    }
+    assert workflow.extra_data == expected
+
+
+def test_resolve_accept_core(small_app, workflow):
+    args = {
+        'request_data': {
+            'value': 'accept_core'
+        }
+    }
+    HEPApproval.resolve(workflow, **args)
+    expected = {
+        'core': True,
+        'user_action': 'accept_core',
+        '_action': None,
+        '_message': '',
+        'reason': '',
+        'approved': True
+    }
+    assert workflow.extra_data == expected
+
+
+def test_resolve_rejected(small_app, workflow):
+    args = {
+        'request_data': {
+            'value': 'rejected',
+            'reason': 'Duplicated article'
+        }
+    }
+    HEPApproval.resolve(workflow, **args)
+    expected = {
+        'core': False,
+        'user_action': 'rejected',
+        '_action': None,
+        '_message': '',
+        'reason': 'Duplicated article',
+        'approved': False
+    }
+    assert workflow.extra_data == expected
+
+
+def test_resolve_attach_pdf(small_app, workflow):
+    args = {
+        'request_data': {
+            'value': 'accept',
+            'pdf_upload': True
+        }
+    }
+    workflow.files['fulltext.pdf'] = StringIO.StringIO()
+    HEPApproval.resolve(workflow, **args)
+    expected = {
+        'core': False,
+        'user_action': 'accept',
+        '_action': None,
+        '_message': '',
+        'reason': '',
+        'approved': True
+    }
+
+    assert workflow.extra_data == expected
+    assert 'fulltext.pdf' in workflow.files
+
+
+def test_resolve_remove_pdf(small_app, workflow):
+    args = {
+        'request_data': {
+            'value': 'accept',
+            'pdf_upload': False
+        }
+    }
+    workflow.files['fulltext.pdf'] = StringIO.StringIO()
+    HEPApproval.resolve(workflow, **args)
+    expected = {
+        'core': False,
+        'user_action': 'accept',
+        '_action': None,
+        '_message': '',
+        'reason': '',
+        'approved': True
+    }
+
+    assert workflow.extra_data == expected
+    assert 'fulltext.pdf' not in workflow.files


### PR DESCRIPTION
* When handling the user action from the Holding Pen page, the
  checkbox to remove the user PDF was not being handled. (closes #2725)

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
