### PR TITLE
setup: unpin simplekv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ install_requires = [
     'librabbitmq>=1.6.1',
     'idutils>=0.2.1',
     'invenio-access>=1.0.0a7',
-    'invenio-accounts>=1.0.0b7',
+    'invenio-accounts>=1.0.0b10',
     'invenio-admin>=1.0.0a3',
     'invenio-assets>=1.0.0b2',
     'invenio-base>=1.0.0a11',
@@ -95,7 +95,6 @@ install_requires = [
     'Babel~=2.0,>=2.4.0',
     'setproctitle~=1.0,>=1.1.10',
     'backports.tempfile>=1.0rc1',
-    'simplekv~=0.0,<0.11',
     'node-semver~=0.0,<0.2',
 ]
 


### PR DESCRIPTION
## Description
We can remove this pin as `simplekv` is already pinned by the latest
version of `invenio-accounts`

## Related Issue
Closes #2749.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.