### PR TITLE
config: don't register invenio-collection signals 

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -164,6 +164,14 @@ NOTE that ES percolator uses high memory and there might be some problems
 when creating records.
 """
 
+COLLECTIONS_REGISTER_RECORD_SIGNALS = False
+"""Don't register the signals when instantiating the extension.
+
+Since we are instantiating the `invenio-collections` extension two times
+we don't want to register the signals twice, but we want to explicitly
+call `register_signals()` on our own.
+"""
+
 RECORD_EDITOR_INDEX_TEMPLATE = 'inspirehep_theme/invenio_record_editor/index.html'
 RECORD_EDITOR_PREVIEW_TEMPLATE_FUNCTION = get_detailed_template_from_record
 

--- a/inspirehep/modules/migrator/tasks.py
+++ b/inspirehep/modules/migrator/tasks.py
@@ -43,7 +43,6 @@ from redis_lock import Lock
 from six import text_type
 
 from dojson.contrib.marc21.utils import create_record as marc_create_record
-from invenio_collections import current_collections
 from invenio_db import db
 from invenio_indexer.api import RecordIndexer, current_record_to_index
 from invenio_pidstore.errors import PIDDoesNotExistError
@@ -185,7 +184,6 @@ def create_index_op(record):
 @shared_task(ignore_result=False, compress='zlib', acks_late=True)
 def migrate_chunk(chunk):
     models_committed.disconnect(index_after_commit)
-    current_collections.unregister_signals()
 
     index_queue = []
 
@@ -208,7 +206,6 @@ def migrate_chunk(chunk):
     )
 
     models_committed.connect(index_after_commit)
-    current_collections.register_signals()
 
 
 @shared_task()

--- a/inspirehep/modules/theme/ext.py
+++ b/inspirehep/modules/theme/ext.py
@@ -25,15 +25,21 @@
 from __future__ import absolute_import, division, print_function
 
 from flask_breadcrumbs import Breadcrumbs
+from flask_gravatar import Gravatar
 from flask_login import user_logged_in
 from flask_menu import Menu
-
-from .views import blueprint, unauthorized, insufficient_permissions, \
-    page_not_found, internal_error
-
 from pkg_resources import resource_filename
 
 from inspirehep.modules.records.permissions import load_user_collections
+
+from .bundles import js
+from .views import (
+    blueprint,
+    insufficient_permissions,
+    internal_error,
+    page_not_found,
+    unauthorized,
+)
 
 
 class INSPIRETheme(object):
@@ -79,7 +85,6 @@ class INSPIRETheme(object):
 
     def init_config(self, config):
         """Initialize configuration."""
-        from .bundles import js
         # Set JS bundles to exclude for purpose of avoiding double jQuery etc.
         # when other modules are building their JS bundles.
         config.setdefault("THEME_BASE_BUNDLES_EXCLUDE_JS", [js])
@@ -87,7 +92,6 @@ class INSPIRETheme(object):
 
     def setup_app(self, app):
         """Initialize Gravatar extension."""
-        from flask_gravatar import Gravatar
         gravatar = Gravatar(app,
                             size=app.config.get('GRAVATAR_SIZE', 100),
                             rating=app.config.get('GRAVATAR_RATING', 'g'),


### PR DESCRIPTION
## Description:
Because we are instantiating `invenio-collection` two times, we can't
have it register its signals on instantiation, as we end up with the
same signal registered twice and no way of unregistering one of them.

Therefore, we don't need to unregister them during migration, as they
were never registered in the first place.

## Related Issue:
Closes https://github.com/inspirehep/inspire-next/issues/2770

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.