### PR TITLE
workflows: don't add curation status notes

### DIFF
--- a/inspirehep/modules/workflows/tasks/actions.py
+++ b/inspirehep/modules/workflows/tasks/actions.py
@@ -107,19 +107,6 @@ def halt_record(action=None, message=None):
     return _halt_record
 
 
-@with_debug_logging
-def update_note(metadata):
-    """Check if the record was approved as CORE."""
-    new_notes = []
-    for note in metadata.get("public_notes", []):
-        if note.get("value", "") == "*Brief entry*":
-            note = {"value": "*Temporary entry*"}
-        new_notes.append(note)
-    if new_notes:
-        metadata["public_notes"] = new_notes
-    return metadata
-
-
 def reject_record(message):
     """Reject record with message."""
     @with_debug_logging

--- a/inspirehep/modules/workflows/tasks/submission.py
+++ b/inspirehep/modules/workflows/tasks/submission.py
@@ -277,22 +277,6 @@ def wait_webcoll(obj, eng):
 
 
 @with_debug_logging
-def add_note_entry(obj, eng):
-    """Add note entry to metadata on approval."""
-    def _has_note(reference_note, notes):
-        return any(reference_note == note for note in notes)
-
-    entry = {'value': '*Temporary entry*'} if obj.extra_data.get("core") \
-        else {'value': '*Brief entry*'}
-    if obj.data.get('public_notes') is None or \
-            not isinstance(obj.data.get("public_notes"), list):
-        obj.data['public_notes'] = [entry]
-    else:
-        if not _has_note(entry, obj.data['public_notes']):
-            obj.data['public_notes'].append(entry)
-
-
-@with_debug_logging
 def filter_keywords(obj, eng):
     """Removes non-accepted keywords from the metadata"""
     prediction = obj.extra_data.get('keywords_prediction', {})

--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -77,7 +77,6 @@ from inspirehep.modules.workflows.tasks.matching import (
 )
 from inspirehep.modules.workflows.tasks.upload import store_record, set_schema
 from inspirehep.modules.workflows.tasks.submission import (
-    add_note_entry,
     close_ticket,
     create_ticket,
     filter_keywords,
@@ -279,7 +278,6 @@ NOTIFY_USER_OR_CURATOR = [
 
 POSTENHANCE_RECORD = [
     add_core,
-    add_note_entry,
     filter_keywords,
     prepare_keywords,
     remove_references,

--- a/tests/unit/workflows/test_workflows_tasks_actions.py
+++ b/tests/unit/workflows/test_workflows_tasks_actions.py
@@ -46,7 +46,6 @@ from inspirehep.modules.workflows.tasks.actions import (
     reject_record,
     refextract,
     shall_halt_workflow,
-    update_note,
 )
 
 from mocks import MockEng, MockObj
@@ -233,42 +232,6 @@ def test_halt_record_accepts_custom_msg():
 
     assert bar_message_halt_record(obj, eng) is None
     assert eng.msg == 'bar'
-
-
-def test_update_note():
-    metadata = {
-        'public_notes': [
-            {'value': '*Brief entry*'},
-        ],
-    }
-
-    expected = {
-        'public_notes': [
-            {'value': '*Temporary entry*'},
-        ]
-    }
-    result = update_note(metadata)
-
-    assert expected == result
-
-
-def test_update_note_preserves_other_notes():
-    metadata = {
-        'public_notes': [
-            {'value': '*Brief entry*'},
-            {'value': 'Other note'},
-        ],
-    }
-
-    expected = {
-        'public_notes': [
-            {'value': '*Temporary entry*'},
-            {'value': 'Other note'},
-        ]
-    }
-    result = update_note(metadata)
-
-    assert expected == result
 
 
 @patch('inspirehep.modules.workflows.tasks.actions.log_workflows_action')

--- a/tests/unit/workflows/test_workflows_tasks_submission.py
+++ b/tests/unit/workflows/test_workflows_tasks_submission.py
@@ -31,7 +31,6 @@ from inspire_dojson.hep import hep2marc
 from inspire_dojson.hepnames import hepnames2marc
 from inspire_schemas.api import load_schema, validate
 from inspirehep.modules.workflows.tasks.submission import (
-    add_note_entry,
     close_ticket,
     create_ticket,
     filter_keywords,
@@ -460,80 +459,6 @@ def test_wait_webcoll_does_nothing_otherwise():
         eng = MockEng()
 
         assert wait_webcoll(obj, eng) is None
-
-
-def test_add_note_entry():
-    schema = load_schema('hep')
-    subschema = schema['properties']['public_notes']
-
-    data = {
-        'public_notes': [
-            {'value': 'Reprinted in *Duff, M.J. (ed.): The world in eleven dimensions* 492-513'},
-        ],
-    }
-    extra_data = {}
-    assert validate(data['public_notes'], subschema) is None
-
-    obj = MockObj(data, extra_data)
-    eng = MockEng()
-
-    assert add_note_entry(obj, eng) is None
-
-    expected = [
-        {'value': 'Reprinted in *Duff, M.J. (ed.): The world in eleven dimensions* 492-513'},
-        {'value': '*Brief entry*'},
-    ]
-    result = obj.data
-
-    assert validate(result['public_notes'], subschema) is None
-    assert expected == result['public_notes']
-
-
-def test_add_note_entry_creates_public_notes_if_not_present():
-    schema = load_schema('hep')
-    subschema = schema['properties']['public_notes']
-
-    data = {}
-    extra_data = {}
-
-    obj = MockObj(data, extra_data)
-    eng = MockEng()
-
-    assert add_note_entry(obj, eng) is None
-
-    expected = [
-        {'value': '*Brief entry*'},
-    ]
-    result = obj.data
-
-    assert validate(result['public_notes'], subschema) is None
-    assert expected == result['public_notes']
-
-
-def test_add_note_entry_does_not_add_value_that_is_already_present():
-    schema = load_schema('hep')
-    subschema = schema['properties']['public_notes']
-
-    data = {
-        'public_notes': [
-            {'value': '*Temporary entry*'},
-        ],
-    }
-    extra_data = {'core': 'something'}
-    assert validate(data['public_notes'], subschema) is None
-
-    obj = MockObj(data, extra_data)
-    eng = MockEng()
-
-    assert add_note_entry(obj, eng) is None
-
-    expected = [
-        {'value': '*Temporary entry*'},
-    ]
-    result = obj.data
-
-    assert validate(result['public_notes'], subschema) is None
-    assert expected == result['public_notes']
 
 
 def test_filter_keywords():


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
* After inspirehep/inspire-schemas#231 and inspirehep/inspire-dojson#94, the information about whether the record has been curated can be completely handled by means of the `curated` flag.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
