### PR TITLE
editor: add general API permission

### DIFF
--- a/inspirehep/modules/editor/permissions.py
+++ b/inspirehep/modules/editor/permissions.py
@@ -27,9 +27,23 @@ from functools import wraps
 from flask import abort, session
 from flask_login import current_user
 
+from invenio_access.permissions import (
+    ParameterizedActionNeed,
+    Permission,
+)
+
 from inspirehep.modules.pidstore.utils import get_pid_type_from_endpoint
 from inspirehep.modules.records.permissions import has_update_permission
 from inspirehep.utils.record_getter import get_db_record
+
+
+action_editor_use_api = ParameterizedActionNeed(
+    'editor-use-api', argument=None
+)
+
+editor_use_api_permission = Permission(
+    action_editor_use_api
+)
 
 
 def editor_permission(fn):

--- a/inspirehep/modules/editor/views.py
+++ b/inspirehep/modules/editor/views.py
@@ -37,7 +37,7 @@ from refextract import (
     extract_references_from_url,
 )
 
-from .permissions import editor_permission
+from .permissions import editor_permission, editor_use_api_permission
 from ...utils import tickets
 
 
@@ -58,9 +58,9 @@ def check_permission(endpoint, pid_value):
     return jsonify(success=True)
 
 
-@blueprint.route('/<endpoint>/<pid_value>/authorlist/text', methods=['POST'])
-@editor_permission
-def authorlist_text(endpoint, pid_value):
+@blueprint.route('/authorlist/text', methods=['POST'])
+@editor_use_api_permission.require(http_exception=403)
+def authorlist_text():
     """Run authorlist on a piece of text."""
     try:
         parsed_authors = authorlist(request.json['text'])
@@ -69,9 +69,9 @@ def authorlist_text(endpoint, pid_value):
         return jsonify(status=500, message=u' / '.join(err.args)), 500
 
 
-@blueprint.route('/<endpoint>/<pid_value>/refextract/text', methods=['POST'])
-@editor_permission
-def refextract_text(endpoint, pid_value):
+@blueprint.route('/refextract/text', methods=['POST'])
+@editor_use_api_permission.require(http_exception=403)
+def refextract_text():
     """Run refextract on a piece of text."""
     extracted_references = extract_references_from_string(
         request.json['text'],
@@ -83,9 +83,9 @@ def refextract_text(endpoint, pid_value):
     return jsonify(references)
 
 
-@blueprint.route('/<endpoint>/<pid_value>/refextract/url', methods=['POST'])
-@editor_permission
-def refextract_url(endpoint, pid_value):
+@blueprint.route('/refextract/url', methods=['POST'])
+@editor_use_api_permission.require(http_exception=403)
+def refextract_url():
     """Run refextract on a URL."""
     extracted_references = extract_references_from_url(
         request.json['url'],
@@ -137,17 +137,17 @@ def get_tickets_for_record(endpoint, pid_value):
     return jsonify(simplified_tickets)
 
 
-@blueprint.route('/<endpoint>/<pid_value>/rt/users', methods=['GET'])
-@editor_permission
-def get_rt_users(endpoint, pid_value):
+@blueprint.route('/rt/users', methods=['GET'])
+@editor_use_api_permission.require(http_exception=403)
+def get_rt_users():
     """View to get all rt users"""
 
     return jsonify(tickets.get_users())
 
 
-@blueprint.route('/<endpoint>/<pid_value>/rt/queues', methods=['GET'])
-@editor_permission
-def get_rt_queues(endpoint, pid_value):
+@blueprint.route('/rt/queues', methods=['GET'])
+@editor_use_api_permission.require(http_exception=403)
+def get_rt_queues():
     """View to get all rt queues"""
 
     return jsonify(tickets.get_queues())

--- a/inspirehep/modules/fixtures/users.py
+++ b/inspirehep/modules/fixtures/users.py
@@ -120,6 +120,10 @@ def init_permissions():
         role=cataloger)
     )
     db.session.add(ActionRoles(
+        action='editor-use-api',
+        role=cataloger)
+    )
+    db.session.add(ActionRoles(
         action='update-collection',
         argument='HERMES Internal Notes',
         role=hermes_curator)

--- a/setup.py
+++ b/setup.py
@@ -170,6 +170,7 @@ setup(
         ],
         'invenio_access.actions': [
             'admin_holdingpen_authors = inspirehep.modules.authors.permissions:action_admin_holdingpen_authors',
+            'editor_use_api = inspirehep.modules.editor.permissions:action_editor_use_api',
             'update_collection = inspirehep.modules.records.permissions:action_update_collection',
             'view_restricted_collection = inspirehep.modules.records.permissions:action_view_restricted_collection',
         ],

--- a/tests/integration/editor/test_editor_views.py
+++ b/tests/integration/editor/test_editor_views.py
@@ -159,26 +159,26 @@ def test_get_tickets_for_record_returns_403_on_authentication_error(api_client):
 
 @patch('inspirehep.modules.editor.views.tickets')
 def test_get_rt_users(mock_tickets, log_in_as_cataloger, api_client):
-    response = api_client.get('/editor/literature/1497201/rt/users')
+    response = api_client.get('/editor/rt/users')
 
     assert response.status_code == 200
 
 
 def test_get_rt_users_returns_403_on_authentication_error(api_client):
-    response = api_client.get('/editor/literature/1497201/rt/users')
+    response = api_client.get('/editor/rt/users')
 
     assert response.status_code == 403
 
 
 @patch('inspirehep.modules.editor.views.tickets')
 def test_get_rt_queues(mock_tickets, log_in_as_cataloger, api_client):
-    response = api_client.get('/editor/literature/1497201/rt/queues')
+    response = api_client.get('/editor/rt/queues')
 
     assert response.status_code == 200
 
 
 def test_get_rt_queues_returns_403_on_authentication_error(log_in_as_scientist, api_client):
-    response = api_client.get('/editor/literature/1497201/rt/queues')
+    response = api_client.get('/editor/rt/queues')
 
     assert response.status_code == 403
 
@@ -211,7 +211,7 @@ def test_authorlist_text(log_in_as_cataloger, api_client):
     subschema = schema['properties']['authors']
 
     response = api_client.post(
-        '/editor/literature/1497201/authorlist/text',
+        '/editor/authorlist/text',
         content_type='application/json',
         data=json.dumps({
             'text': (
@@ -250,7 +250,7 @@ def test_authorlist_text(log_in_as_cataloger, api_client):
 
 def test_authorlist_text_exception(log_in_as_cataloger, api_client):
     response = api_client.post(
-        '/editor/literature/1497201/authorlist/text',
+        '/editor/authorlist/text',
         content_type='application/json',
         data=json.dumps({
             'text': 'A. Einstein, N. Bohr2'
@@ -273,7 +273,7 @@ def test_refextract_text(log_in_as_cataloger, api_client):
     subschema = schema['properties']['references']
 
     response = api_client.post(
-        '/editor/literature/1497201/refextract/text',
+        '/editor/refextract/text',
         content_type='application/json',
         data=json.dumps({
             'text': (
@@ -302,7 +302,7 @@ def test_refextract_url(log_in_as_cataloger, api_client):
         )
 
         response = api_client.post(
-            '/editor/literature/1497201/refextract/url',
+            '/editor/refextract/url',
             content_type='application/json',
             data=json.dumps({
                 'url': 'https://arxiv.org/pdf/1612.06414.pdf',


### PR DESCRIPTION
## Description
Adds permission to access editor API endpoints that do not require checking the record collections.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.