### PR TITLE
setup: add theme extension to the API application

### DIFF
--- a/inspirehep/factory.py
+++ b/inspirehep/factory.py
@@ -29,14 +29,19 @@ import sys
 
 from invenio_base.app import create_app_factory
 from invenio_base.wsgi import create_wsgi_factory
-from invenio_config import create_conf_loader
+from invenio_config import create_config_loader
 
 from . import config
 
 
 env_prefix = 'APP'
 
-config_loader = create_conf_loader(config=config, env_prefix=env_prefix)
+config_loader = create_config_loader(config=config, env_prefix=env_prefix)
+
+
+def api_config_loader(app, **kwargs_config):
+    return config_loader(app, RESTFUL_API=True, **kwargs_config)
+
 
 instance_path = os.getenv(env_prefix + '_INSTANCE_PATH') or \
     os.path.join(sys.prefix, 'var', 'inspirehep-instance')
@@ -56,7 +61,7 @@ set ``<sys.prefix>/var/<app_name>-instance/static``.
 
 create_api = create_app_factory(
     'inspirehep',
-    config_loader=config_loader,
+    config_loader=api_config_loader,
     blueprint_entry_points=['invenio_base.api_blueprints'],
     extension_entry_points=['invenio_base.api_apps'],
     converter_entry_points=['invenio_base.api_converters'],

--- a/inspirehep/modules/theme/views.py
+++ b/inspirehep/modules/theme/views.py
@@ -192,24 +192,31 @@ def data():
 # Error handlers
 #
 
+def error_render_response(config_template_name, error):
+    if current_app.config.get('RESTFUL_API', False):
+        return jsonify(message=error.name, code=error.code), error.code
+
+    return render_template(current_app.config[config_template_name]), error.code
+
+
 def unauthorized(e):
     """Error handler to show a 401.html page in case of a 401 error."""
-    return render_template(current_app.config['THEME_401_TEMPLATE']), 401
+    return error_render_response('THEME_401_TEMPLATE', e)
 
 
 def insufficient_permissions(e):
     """Error handler to show a 403.html page in case of a 403 error."""
-    return render_template(current_app.config['THEME_403_TEMPLATE']), 403
+    return error_render_response('THEME_403_TEMPLATE', e)
 
 
 def page_not_found(e):
     """Error handler to show a 404.html page in case of a 404 error."""
-    return render_template(current_app.config['THEME_404_TEMPLATE']), 404
+    return error_render_response('THEME_404_TEMPLATE', e)
 
 
 def internal_error(e):
     """Error handler to show a 500.html page in case of a 500 error."""
-    return render_template(current_app.config['THEME_500_TEMPLATE']), 500
+    return error_render_response('THEME_500_TEMPLATE', e)
 
 
 #

--- a/setup.py
+++ b/setup.py
@@ -195,6 +195,7 @@ setup(
         ],
         'invenio_base.api_apps': [
             'inspire_search = inspirehep.modules.search:InspireSearch',
+            'inspire_theme = inspirehep.modules.theme:INSPIRETheme',
             'inspire_utils = inspirehep.utils.ext:INSPIREUtils',
             'inspire_workflows = inspirehep.modules.workflows:INSPIREWorkflows',
             'invenio_collections = invenio_collections:InvenioCollections',

--- a/tests/unit/theme/test_theme_views.py
+++ b/tests/unit/theme/test_theme_views.py
@@ -90,3 +90,25 @@ def test_postfeedback_send_email_failure(delay, app_client):
 
     assert response.status_code == 500
     assert json.loads(response.data) == {'success': False}
+
+
+def test_page_not_found_renders_template_when_in_app(app_client):
+    response = app_client.get('/does-not-exist')
+
+    assert response.status_code == 404
+    assert response.mimetype == 'text/html'
+
+
+def test_page_not_Found_returns_json_when_in_api(api_client):
+    response = api_client.get('/does-not-exist')
+
+    assert response.status_code == 404
+    assert response.mimetype == 'application/json'
+
+    expected = {
+        'code': 404,
+        'message': 'Not Found',
+    }
+    result = json.loads(response.data)
+
+    assert expected == result


### PR DESCRIPTION
Inspire-theme added to API entry point

## Description
In setup.py inspire-theme added to api_apps.
Changes made to not render HTML error pages when
in the API application.

## Related Issue
N/A

## Motivation and Context
Enables to use jinja2 templates in the API.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
