### PR TITLE
docker: also upgrade dependencies in pip command

### DIFF
--- a/docker-compose.deps.yml
+++ b/docker-compose.deps.yml
@@ -27,7 +27,7 @@ services:
     extends:
       file: services.yml
       service: base
-    command: pip install --editable .[all] --find-links /pip-cache --pre --requirement requirements.txt
+    command: pip install --editable .[all] --find-links /pip-cache --pre --requirement requirements.txt --upgrade
     volumes_from:
       - static
 


### PR DESCRIPTION
## Description:
Commit 0ffd8c0 forgot to add the ``--upgrade`` flag, which is essential
to use ``docker-compose -f docker-compose.deps.yml run --rm pip``as the
only command to deal with dependencies during development.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.