### PR TITLE
tests: fix flake8 error in acceptance/conftest.py

### DIFF
--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -107,9 +107,9 @@ def cleanup_workflows_tables(app):
     """
     with app.app_context():
         obj_types = (
-                WorkflowsAudit.query.all(),
-                WorkflowsPendingRecord.query.all(),
-                workflow_object_class.query(),
+            WorkflowsAudit.query.all(),
+            WorkflowsPendingRecord.query.all(),
+            workflow_object_class.query(),
         )
         for obj_type in obj_types:
             for obj in obj_type:


### PR DESCRIPTION
## Description:
Commit a863384 introduced Flake8 checks on indentation, but missed the
one fixed in this commit because `acceptance/conftest.py` is no longer
part of either ``acceptance-authors`` or ``acceptance-literature``.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.