### PR TITLE
editor: permission decorator cache fix

### DIFF
--- a/inspirehep/modules/editor/permissions.py
+++ b/inspirehep/modules/editor/permissions.py
@@ -56,7 +56,10 @@ def editor_permission(fn):
         )
         is_allowed = session.get(cache_key)
         if is_allowed is not None:
-            return is_allowed
+            if is_allowed:
+                return fn(endpoint, pid_value, **kwargs)
+            else:
+                abort(403)
 
         pid_type = get_pid_type_from_endpoint(endpoint)
         record = get_db_record(pid_type, pid_value)
@@ -64,7 +67,7 @@ def editor_permission(fn):
         is_allowed = has_update_permission(current_user, record)
         session[cache_key] = is_allowed
         if is_allowed:
-            return fn(endpoint, pid_type, **kwargs)
+            return fn(endpoint, pid_value, **kwargs)
         else:
             abort(403)
 


### PR DESCRIPTION
* When a permission is cached, return a response object instead of
  a boolean.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
