### PR TITLE
global: don't use refersto in queries

### DIFF
--- a/inspirehep/modules/records/serializers/impactgraph_serializer.py
+++ b/inspirehep/modules/records/serializers/impactgraph_serializer.py
@@ -54,8 +54,8 @@ class ImpactGraphSerializer(object):
         # Get citations
         citations = []
 
-        record_citations = LiteratureSearch().query_from_iq(
-            'refersto:' + str(record['control_number'])
+        record_citations = LiteratureSearch().query(
+            'match', references__recid=record['control_number'],
         ).params(
             size=9999,
             _source=[

--- a/inspirehep/utils/citations.py
+++ b/inspirehep/utils/citations.py
@@ -29,8 +29,8 @@ from inspirehep.utils.jinja2 import render_template_to_string
 def get_and_format_citations(record):
     result = []
 
-    citations = LiteratureSearch().query_from_iq(
-        'refersto:' + str(record['control_number'])
+    citations = LiteratureSearch().query(
+        'match', references__recid=record['control_number'],
     ).params(
         _source=[
             'citation_count',


### PR DESCRIPTION
## Description
inspirehep/inspire-query-parser#30 removed support for ``refersto:``,
so we will have to rewrite these queries using ``references__recid``.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.