### PR TITLE
forms: normalize DOIs at ingestion time

### DIFF
--- a/inspirehep/modules/crossref/config.py
+++ b/inspirehep/modules/crossref/config.py
@@ -32,4 +32,5 @@ CROSSREF_RESPONSE_CODES = {
     'notfound': 404,
     'malformed': 422,
     'multiplefound': 300,
+    'badrequest': 400,
 }

--- a/inspirehep/modules/crossref/core.py
+++ b/inspirehep/modules/crossref/core.py
@@ -33,7 +33,7 @@ def get_response(crossref_doi):
     response = requests.get(
         urljoin(
             current_app.config['CROSSREF_API_URL'],
-            '{term}'.format(term=crossref_doi.strip()),
+            '{term}'.format(term=crossref_doi),
         ),
     )
     return response

--- a/inspirehep/modules/forms/validation_utils.py
+++ b/inspirehep/modules/forms/validation_utils.py
@@ -35,19 +35,18 @@ from requests import RequestException
 
 from wtforms.validators import StopValidation
 
+from idutils import doi_regexp
+
 
 class DOISyntaxValidator(object):
 
     """DOI syntax validator."""
-
-    pattern = "(^$|(doi:)?10\.\d+(.\d+)*/.*)"
 
     def __init__(self, message=None):
         """Constructor.
 
         :param message: message to override the default one.
         """
-        self.regexp = re.compile(self.pattern, re.I)
         self.message = message if message else (
             "The provided DOI is invalid - it should look similar to "
             "'10.1234/foo.bar'.")
@@ -59,7 +58,7 @@ class DOISyntaxValidator(object):
         :param form: validated form.
         """
         doi = field.data
-        if doi and not self.regexp.match(doi):
+        if doi and not doi_regexp.match(doi):
             # no point to further validate DOI which is invalid
             raise StopValidation(self.message)
 

--- a/inspirehep/modules/literaturesuggest/normalizers.py
+++ b/inspirehep/modules/literaturesuggest/normalizers.py
@@ -27,6 +27,7 @@ import json
 from sqlalchemy import text
 from sqlalchemy.orm.exc import NoResultFound
 
+from idutils import normalize_doi
 from invenio_accounts.models import User
 from invenio_db import db
 from invenio_oauthclient.models import UserIdentity
@@ -74,12 +75,23 @@ def check_journal_existence(title):
 
 
 def normalize_formdata(obj, formdata):
+    formdata = normalize_provided_doi(obj, formdata)
     formdata = get_user_orcid(obj, formdata)
     formdata = get_user_email(obj, formdata)
     formdata = split_page_range_article_id(obj, formdata)
     formdata = normalize_journal_title(obj, formdata)
     formdata = remove_english_language(obj, formdata)
     formdata = find_book_id(obj, formdata)
+
+    return formdata
+
+
+def normalize_provided_doi(obj, formdata):
+    try:
+        doi = formdata.get('doi')
+        formdata['doi'] = normalize_doi(doi)
+    except AttributeError:
+        formdata['doi'] = None
 
     return formdata
 

--- a/tests/integration/crossref/test_crossref_views.py
+++ b/tests/integration/crossref/test_crossref_views.py
@@ -82,21 +82,14 @@ def test_crossref_search_handles_the_response_when_the_request_is_valid(log_in_a
         assert result['status'] == 'success'
 
 
-def test_crossref_search_handles_the_response_when_the_request_asks_for_a_non_existing_doi(log_in_as_scientist, app_client):
-    with requests_mock.Mocker() as requests_mocker:
-        requests_mocker.register_uri(
-            'GET', 'http://api.crossref.org/works/does-not-exist',
-            status_code=404,
-            text=pkg_resources.resource_string(
-                __name__, os.path.join('fixtures', 'does-not-exist')),
-        )
+def test_crossref_search_returns_an_error_when_the_doi_cant_be_normalized(log_in_as_scientist, app_client):
+    with requests_mock.Mocker():
+        response = app_client.get('/doi/search?doi=cant-be-normalized')
 
-        response = app_client.get('/doi/search?doi=does-not-exist')
-
-        assert response.status_code == 404
+        assert response.status_code == 400
 
         result = json.loads(response.data)
 
         assert result['query'] == {}
-        assert result['source'] == 'crossref'
-        assert result['status'] == 'notfound'
+        assert result['source'] == 'inspire'
+        assert result['status'] == 'badrequest'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- I relaxed the form validator on DOI input in order to allow for ` (https?://)?(dx\.)?doi.org/ `.
- I added a new normalizer that cleans up the DOI value to make it conform with the schema.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/inspirehep/inspire-next/issues/2712.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The DOI input box should be less strict and attempt to normalize the DOI.
It should:
    - strip whitespace
    - strip leading doi:
    - strip leading ` (https?://)?(dx\.)?doi.org/ `


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
