### PR TITLE
global: remove internal imports

### DIFF
--- a/inspirehep/modules/authors/views.py
+++ b/inspirehep/modules/authors/views.py
@@ -43,8 +43,8 @@ from flask_breadcrumbs import register_breadcrumb
 from flask_login import login_required, current_user
 from werkzeug.datastructures import MultiDict
 
+from dojson.contrib.marc21.utils import create_record
 from invenio_db import db
-
 from invenio_workflows import workflow_object_class, start, resume
 from invenio_workflows_ui.api import WorkflowUIRecord
 
@@ -232,8 +232,6 @@ def new():
 @login_required
 def update(recid):
     """View for INSPIRE author update form."""
-    from dojson.contrib.marc21.utils import create_record
-
     data = {}
     if recid:
         try:

--- a/inspirehep/modules/forms/fields/language.py
+++ b/inspirehep/modules/forms/fields/language.py
@@ -22,6 +22,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+import warnings
+
 from wtforms import SelectField
 from wtforms.validators import optional
 
@@ -32,7 +34,6 @@ __all__ = ['LanguageField']
 
 class LanguageField(INSPIREField, SelectField):
     def __init__(self, **kwargs):
-        import warnings
         warnings.warn("Field has been deprecated", PendingDeprecationWarning)
         defaults = dict(icon='flag',
                         export_key='language',

--- a/inspirehep/modules/forms/fields/title.py
+++ b/inspirehep/modules/forms/fields/title.py
@@ -24,24 +24,11 @@
 
 from __future__ import absolute_import, division, print_function
 
-from wtforms import StringField, ValidationError
+from wtforms import StringField
 
 from ..field_base import INSPIREField
 
 __all__ = ['TitleField']
-
-
-def validate_title(form, field):
-    """Deprecated."""
-    import warnings
-    warnings.warn("Validator has been deprecated", PendingDeprecationWarning)
-
-    value = field.data or ''
-    if value == "" or value.isspace():
-        return
-
-    if len(value) <= 4:
-        raise ValidationError("This field must have at least 4 characters")
 
 
 class TitleField(INSPIREField, StringField):
@@ -56,7 +43,6 @@ class TitleField(INSPIREField, StringField):
             icon='book',
             export_key='title.title',
             widget_classes="form-control"
-            # FIXMEvalidators=[validate_title]
         )
         defaults.update(kwargs)
         super(TitleField, self).__init__(**defaults)

--- a/inspirehep/modules/forms/fields/title.py
+++ b/inspirehep/modules/forms/fields/title.py
@@ -24,6 +24,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+import warnings
+
 from wtforms import StringField
 
 from ..field_base import INSPIREField
@@ -37,7 +39,6 @@ class TitleField(INSPIREField, StringField):
 
     def __init__(self, **kwargs):
         """Deprecated."""
-        import warnings
         warnings.warn("Field has been deprecated", PendingDeprecationWarning)
         defaults = dict(
             icon='book',

--- a/inspirehep/modules/workflows/tasks/classifier.py
+++ b/inspirehep/modules/workflows/tasks/classifier.py
@@ -26,6 +26,13 @@ from __future__ import absolute_import, division, print_function
 
 from functools import wraps
 
+from invenio_classifier import (
+    get_keywords_from_local_file,
+    get_keywords_from_text,
+)
+from invenio_classifier.errors import ClassifierException
+from invenio_classifier.reader import KeywordToken
+
 from ..proxies import antihep_keywords
 from ..utils import with_debug_logging, get_pdf_in_workflow
 
@@ -54,12 +61,6 @@ def classify_paper(taxonomy, rebuild_cache=False, no_cache=False,
     @with_debug_logging
     @wraps(classify_paper)
     def _classify_paper(obj, eng):
-        from invenio_classifier.errors import ClassifierException
-        from invenio_classifier import (
-            get_keywords_from_text,
-            get_keywords_from_local_file,
-        )
-
         params = dict(
             taxonomy_name=taxonomy,
             output_mode='dict',
@@ -110,7 +111,6 @@ def classify_paper(taxonomy, rebuild_cache=False, no_cache=False,
 @with_debug_logging
 def clean_instances_from_data(output):
     """Check if specific keys are of InstanceType and replace them with their id."""
-    from invenio_classifier.reader import KeywordToken
     new_output = {}
     for output_key in output.keys():
         keywords = output[output_key]

--- a/inspirehep/wsgi.py
+++ b/inspirehep/wsgi.py
@@ -26,12 +26,13 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 
-from inspirehep.factory import create_app
+from werkzeug.debug import DebuggedApplication
+
+from .factory import create_app
 
 
 application = create_app()
 if application.debug:
-    from werkzeug.debug import DebuggedApplication
     application = DebuggedApplication(application, evalex=True)
 
 # We don't want to log to Sentry backoff errors


### PR DESCRIPTION
## Description:
Imports inside of functions make static code analysis impossible, as you must be running the code to know which names are defined when a certain line is running.

This PR doesn't remove all of them, as some are still happening in the `workflows` module, but I avoided touching those to not cause merge conflicts with @ammirate's PR.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.