### PR TITLE
workflows: also run refextract on the textbox refs

### DIFF
--- a/inspirehep/modules/workflows/tasks/refextract.py
+++ b/inspirehep/modules/workflows/tasks/refextract.py
@@ -26,7 +26,11 @@ from __future__ import absolute_import, division, print_function
 
 from timeout_decorator import timeout
 
-from refextract import extract_journal_reference, extract_references_from_file
+from refextract import (
+    extract_journal_reference,
+    extract_references_from_file,
+    extract_references_from_string,
+)
 
 from inspire_schemas.utils import split_page_artid
 from inspire_utils.helpers import maybe_int
@@ -87,12 +91,24 @@ def extract_journal_info(obj, eng):
 
 
 @timeout(5 * 60)
-def extract_references(filepath, source=None, custom_kbs_file=None):
+def extract_references_from_pdf(filepath, source=None, custom_kbs_file=None):
     """Extract references from PDF and return in INSPIRE format."""
     extracted_references = extract_references_from_file(
         filepath,
         override_kbs_files=get_refextract_kbs_path(),
-        reference_format=u'{title},{volume},{page}'
+        reference_format=u'{title},{volume},{page}',
+    )
+
+    return map_refextract_to_schema(extracted_references, source=source)
+
+
+@timeout(5 * 60)
+def extract_references_from_text(text, source=None, custom_kbs_file=None):
+    """Extract references from text and return in INSPIRE format."""
+    extracted_references = extract_references_from_string(
+        text,
+        override_kbs_files=get_refextract_kbs_path(),
+        reference_format=u'{title},{volume},{page}',
     )
 
     return map_refextract_to_schema(extracted_references, source=source)

--- a/tests/unit/workflows/test_workflows_tasks_refextract.py
+++ b/tests/unit/workflows/test_workflows_tasks_refextract.py
@@ -28,7 +28,8 @@ import pkg_resources
 from inspire_schemas.api import load_schema, validate
 from inspirehep.modules.workflows.tasks.refextract import (
     extract_journal_info,
-    extract_references,
+    extract_references_from_pdf,
+    extract_references_from_text,
 )
 
 from mocks import MockEng, MockObj
@@ -92,22 +93,43 @@ def test_extract_journal_info_handles_year_an_empty_string():
     ]
 
 
-def test_extract_references_handles_unicode():
+def test_extract_references_from_pdf_handles_unicode():
     schema = load_schema('hep')
     subschema = schema['properties']['references']
 
     filename = pkg_resources.resource_filename(
         __name__, os.path.join('fixtures', '1704.00452.pdf'))
 
-    result = extract_references(filename)
+    result = extract_references_from_pdf(filename)
 
     assert validate(result, subschema) is None
+    assert len(result) > 0
 
 
-def test_extract_references_populates_raw_refs_source():
+def test_extract_references_from_pdf_populates_raw_refs_source():
     filename = pkg_resources.resource_filename(
         __name__, os.path.join('fixtures', '1704.00452.pdf'))
 
-    result = extract_references(filename, source='arXiv')
+    result = extract_references_from_pdf(filename, source='arXiv')
 
     assert result[0]['raw_refs'][0]['source'] == 'arXiv'
+
+
+def test_extract_references_from_text_handles_unicode():
+    schema = load_schema('hep')
+    subschema = schema['properties']['references']
+
+    text = u'Iskra Ł W et al 2017 Acta Phys. Pol. B 48 581'
+
+    result = extract_references_from_text(text)
+
+    assert validate(result, subschema) is None
+    assert len(result) > 0
+
+
+def test_extract_references_from_text_populates_raw_refs_source():
+    text = u'Iskra Ł W et al 2017 Acta Phys. Pol. B 48 581'
+
+    result = extract_references_from_text(text, source='submitter')
+
+    assert result[0]['raw_refs'][0]['source'] == 'submitter'


### PR DESCRIPTION
## Description
Runs ``refextract`` on both the PDF in the workflow and the references
provided by the submitter, if any, then chooses the one that generated
the most and attaches them to the workflow object.

## Related Issue
https://github.com/inspirehep/inspire-next/issues/2587

## Motivation and Context
Previously references in the textbox were ignored and the curator had to copy/paste the references again in bibedit on legacy which is not efficient in terms of time.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.