### PR TITLE
mappings: exclude references from _all in hep

### DIFF
--- a/inspirehep/modules/records/mappings/records/hep.json
+++ b/inspirehep/modules/records/mappings/records/hep.json
@@ -728,6 +728,7 @@
                     "type": "boolean"
                 },
                 "references": {
+                    "include_in_all": false,
                     "properties": {
                         "curated_relation": {
                             "type": "boolean"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I set 'include_in_all' for the 'references' field of Literature collection records to false. I concluded that this was the right thing to do as follows:
1. I ran the search and noticed the high number of results
2. I copied the query which was available in the console in DEBUG mode
3. I opened Sentry and accessed the _explain endpoint in ES with the query
4. I investigated and noticed that most hits/matches occured in the '_all' which also contains the values from the  'references' field, specifically from 'full_name' in our case
5. I concluded that this is not what we need to happen as these matches are rather spurious, thus I configurated ES so that it shall not add the 'references' to '_all' by setting the 'include_in_all' field to false (by default it is true) int the Literature records mapping (hep.json).

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/inspirehep/inspire-next/issues/2857

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When searching for an author's name in the Literature collection, only records whose authors match should be returned and the referenced authors matches should be ignored.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
