### PR TITLE
holdingpen: do not index record_matches

### DIFF
--- a/inspirehep/modules/workflows/mappings/holdingpen/hep.json
+++ b/inspirehep/modules/workflows/mappings/holdingpen/hep.json
@@ -23,6 +23,11 @@
                                 }
                             },
                             "type": "object"
+                        },
+                        "record_matches": {
+                            "include_in_all": false,
+                            "enabled": false,
+                            "type": "object"
                         }
                     },
                     "type": "object"


### PR DESCRIPTION
Fixes: https://sentry.cern.ch/inspire-sentry/inspire-labs/group/931989/
<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

<!--- Why is this change required? What problem does it solve? -->

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

* Disables indexing of record_matches, which is not needed and has
  changed type in a 6e8432a thus making impossible to index
  both entries before the commit and after it.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>