### PR TITLE
submission: Handle correctly the files in hep approval

### DIFF
--- a/inspirehep/modules/workflows/actions/hep_approval.py
+++ b/inspirehep/modules/workflows/actions/hep_approval.py
@@ -53,6 +53,11 @@ class HEPApproval(object):
         if not upload_pdf:
             if 'fulltext.pdf' in obj.files:
                 del obj.files['fulltext.pdf']
+            documents = obj.data.get('documents', [])
+            for doc in documents:
+                if doc['key'] == 'fulltext.pdf':
+                    documents.remove(doc)
+                    break
 
         approved = value in ('accept', 'accept_core')
 
@@ -60,6 +65,7 @@ class HEPApproval(object):
         obj.remove_action()
 
         obj.extra_data["user_action"] = value
+        obj.extra_data["upload_pdf"] = upload_pdf
         obj.extra_data["core"] = value == "accept_core"
         obj.extra_data["reason"] = reason
         obj.status = ObjectStatus.WAITING

--- a/tests/integration/workflows/test_hep_approval.py
+++ b/tests/integration/workflows/test_hep_approval.py
@@ -61,6 +61,7 @@ def test_resolve_accept(small_app, workflow):
     expected = {
         'core': False,
         'user_action': 'accept',
+        'upload_pdf': False,
         '_action': None,
         '_message': '',
         'reason': '',
@@ -79,6 +80,7 @@ def test_resolve_accept_core(small_app, workflow):
     expected = {
         'core': True,
         'user_action': 'accept_core',
+        'upload_pdf': False,
         '_action': None,
         '_message': '',
         'reason': '',
@@ -98,6 +100,7 @@ def test_resolve_rejected(small_app, workflow):
     expected = {
         'core': False,
         'user_action': 'rejected',
+        'upload_pdf': False,
         '_action': None,
         '_message': '',
         'reason': 'Duplicated article',
@@ -113,11 +116,17 @@ def test_resolve_attach_pdf(small_app, workflow):
             'pdf_upload': True
         }
     }
+    workflow.data = {
+        'documents': [{
+            'key': 'fulltext.pdf'
+        }]
+    }
     workflow.files['fulltext.pdf'] = StringIO.StringIO()
     HEPApproval.resolve(workflow, **args)
     expected = {
         'core': False,
         'user_action': 'accept',
+        'upload_pdf': True,
         '_action': None,
         '_message': '',
         'reason': '',
@@ -126,6 +135,7 @@ def test_resolve_attach_pdf(small_app, workflow):
 
     assert workflow.extra_data == expected
     assert 'fulltext.pdf' in workflow.files
+    assert 'fulltext.pdf' in [doc['key'] for doc in workflow.data['documents']]
 
 
 def test_resolve_remove_pdf(small_app, workflow):
@@ -135,11 +145,17 @@ def test_resolve_remove_pdf(small_app, workflow):
             'pdf_upload': False
         }
     }
+    workflow.data = {
+        'documents': [{
+            'key': 'fulltext.pdf'
+        }]
+    }
     workflow.files['fulltext.pdf'] = StringIO.StringIO()
     HEPApproval.resolve(workflow, **args)
     expected = {
         'core': False,
         'user_action': 'accept',
+        'upload_pdf': False,
         '_action': None,
         '_message': '',
         'reason': '',
@@ -148,3 +164,4 @@ def test_resolve_remove_pdf(small_app, workflow):
 
     assert workflow.extra_data == expected
     assert 'fulltext.pdf' not in workflow.files
+    assert 'fulltext.pdf' not in [doc['key'] for doc in workflow.data['documents']]


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Deletes from workflow data the corresponding document
that was marked as not attached. Currently the file was
deleted from `obj.files` but the `documents` metadata were
not cleaned. This was leading to creating `FFT` for a file
that was already deleted.
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/inspirehep/inspire-next/issues/2873

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
