### PR TITLE
api: add v1 recids serializer

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -361,6 +361,7 @@ RECORDS_REST_ENDPOINTS = dict(
             'application/x-cvformattext': (
                 'inspirehep.modules.records.serializers'
                 ':cvformattext_v1_search'),
+            'application/vnd+inspire.ids+json': 'inspirehep.modules.api.v1.common_serializers:json_recids_response',
         },
         suggesters=dict(
             abstract_source=dict(completion=dict(
@@ -417,6 +418,7 @@ RECORDS_REST_ENDPOINTS = dict(
                 'inspirehep.modules.records.serializers'
                 ':json_literature_brief_v1_search'
             ),
+            'application/vnd+inspire.ids+json': 'inspirehep.modules.api.v1.common_serializers:json_recids_response',
         },
         list_route='/authors/',
         item_route='/authors/<pid(aut,record_class="inspirehep.modules.records.api:InspireRecord"):pid_value>',
@@ -599,6 +601,7 @@ RECORDS_REST_ENDPOINTS = dict(
                 'inspirehep.modules.records.serializers'
                 ':json_literature_brief_v1_search'
             ),
+            'application/vnd+inspire.ids+json': 'inspirehep.modules.api.v1.common_serializers:json_recids_response',
         },
         list_route='/conferences/',
         item_route='/conferences/<pid(con,record_class="inspirehep.modules.records.api:InspireRecord"):pid_value>',
@@ -642,6 +645,7 @@ RECORDS_REST_ENDPOINTS = dict(
                 'inspirehep.modules.records.serializers'
                 ':json_literature_brief_v1_search'
             ),
+            'application/vnd+inspire.ids+json': 'inspirehep.modules.api.v1.common_serializers:json_recids_response',
         },
         list_route='/jobs/',
         item_route='/jobs/<pid(job,record_class="inspirehep.modules.records.api:InspireRecord"):pid_value>',
@@ -685,6 +689,7 @@ RECORDS_REST_ENDPOINTS = dict(
                 'inspirehep.modules.records.serializers'
                 ':json_literature_brief_v1_search'
             ),
+            'application/vnd+inspire.ids+json': 'inspirehep.modules.api.v1.common_serializers:json_recids_response',
         },
         suggesters=dict(
             affiliation=dict(completion=dict(
@@ -733,6 +738,7 @@ RECORDS_REST_ENDPOINTS = dict(
                 'inspirehep.modules.records.serializers'
                 ':json_literature_brief_v1_search'
             ),
+            'application/vnd+inspire.ids+json': 'inspirehep.modules.api.v1.common_serializers:json_recids_response',
         },
         suggesters=dict(
             experiment=dict(completion=dict(
@@ -781,6 +787,7 @@ RECORDS_REST_ENDPOINTS = dict(
                 'inspirehep.modules.records.serializers'
                 ':json_literature_brief_v1_search'
             ),
+            'application/vnd+inspire.ids+json': 'inspirehep.modules.api.v1.common_serializers:json_recids_response',
         },
         suggesters=dict(
             journal_title=dict(completion=dict(

--- a/inspirehep/modules/api/__init__.py
+++ b/inspirehep/modules/api/__init__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""API of INSPIRE."""
+
+from __future__ import absolute_import, division, print_function

--- a/inspirehep/modules/api/v1/__init__.py
+++ b/inspirehep/modules/api/v1/__init__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Version 1 of the API of INSPIRE."""
+
+from __future__ import absolute_import, division, print_function

--- a/inspirehep/modules/api/v1/common_serializers.py
+++ b/inspirehep/modules/api/v1/common_serializers.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Common (to all collections) API of INSPIRE."""
+
+from __future__ import absolute_import, division, print_function
+
+import json
+
+from invenio_records_rest.serializers.response import search_responsify
+
+
+class APIRecidsSerializer(object):
+    """Recids serializer."""
+
+    def serialize_search(self, pid_fetcher, search_result, item_links_factory=None, links=None):
+        return json.dumps(dict(
+            hits=dict(
+                recids=[record['_source']['control_number'] for record in search_result['hits']['hits']],
+                total=search_result['hits']['total'],
+            ),
+            links=links or {},
+        ))
+
+
+json_recids = APIRecidsSerializer()
+json_recids_response = search_responsify(
+    json_recids,
+    'application/vnd+inspire.ids+json'
+)

--- a/inspirehep/modules/records/mappings/records/jobs.json
+++ b/inspirehep/modules/records/mappings/records/jobs.json
@@ -87,6 +87,10 @@
                 "description": {
                     "type": "string"
                 },
+                "earliest_date": {
+                    "format": "yyyy||yyyy-MM||yyyy-MM-dd",
+                    "type": "date"
+                },
                 "experiments": {
                     "properties": {
                         "curated_relation": {

--- a/tests/integration/api/v1/test_common_serializers.py
+++ b/tests/integration/api/v1/test_common_serializers.py
@@ -1,0 +1,131 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import json
+
+
+def test_literature_recids_serializer(api_client):
+    response = api_client.get(
+        '/literature/?q=title collider',
+        headers={'Accept': 'application/vnd+inspire.ids+json'}
+    )
+
+    assert response.status_code == 200
+
+    response_json = json.loads(response.data)
+
+    assert response_json['hits']['total'] == 2
+
+    expected_recids = {1373790, 701585}
+    response_recids = set([recid for recid in response_json['hits']['recids']])
+
+    assert response_recids == expected_recids
+
+
+def test_authors_recids_serializer(api_client):
+    response = api_client.get(
+        '/authors/?q=arxiv_categories:"hep-ph"',
+        headers={'Accept': 'application/vnd+inspire.ids+json'}
+    )
+
+    assert response.status_code == 200
+
+    response_json = json.loads(response.data)
+
+    assert response_json['hits']['total'] == 4
+
+    expected_recids = {1057204, 984519, 1073117, 1060891}
+    response_recids = set([recid for recid in response_json['hits']['recids']])
+
+    assert response_recids == expected_recids
+
+
+def test_conferences_recids_serializer(api_client):
+    response = api_client.get(
+        '/conferences/',
+        headers={'Accept': 'application/vnd+inspire.ids+json'}
+    )
+
+    assert response.status_code == 200
+
+    response_json = json.loads(response.data)
+
+    assert response_json['hits']['total'] == 1
+
+    assert response_json['hits']['recids'][0] == 972464
+
+
+def test_institutions_recids_serializer(api_client):
+    response = api_client.get(
+        '/institutions/',
+        headers={'Accept': 'application/vnd+inspire.ids+json'}
+    )
+
+    assert response.status_code == 200
+
+    response_json = json.loads(response.data)
+
+    assert response_json['hits']['total'] == 1
+
+    assert response_json['hits']['recids'][0] == 902725
+
+
+def test_experiments_recids_serializer(api_client):
+    response = api_client.get(
+        '/experiments/',
+        headers={'Accept': 'application/vnd+inspire.ids+json'}
+    )
+
+    assert response.status_code == 200
+
+    response_json = json.loads(response.data)
+
+    assert response_json['hits']['total'] == 1
+
+    assert response_json['hits']['recids'][0] == 1108642
+
+
+def test_journals_recids_serializer(api_client):
+    response = api_client.get(
+        '/journals/',
+        headers={'Accept': 'application/vnd+inspire.ids+json'}
+    )
+
+    assert response.status_code == 200
+
+    response_json = json.loads(response.data)
+
+    expected_recids = {1214516, 1213103}
+    response_recids = set([recid for recid in response_json['hits']['recids']])
+
+    assert response_recids == expected_recids
+
+
+def test_jobs_recids_serializer(api_client):
+    response = api_client.get(
+        '/jobs/',
+        headers={'Accept': 'application/vnd+inspire.ids+json'}
+    )
+
+    assert response.status_code == 200


### PR DESCRIPTION
* Add api and v1 packages.
* Add recids serializer for all main collection endpoints (addresses
  #2840).

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>

## Motivation and Context
Provides a way to request record ids by using the search for main collections. 
Currently required by the editor.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

