### PR TITLE
mappings: rename facet_inspire_subjects

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -879,7 +879,7 @@ RECORDS_REST_FACETS = {
     "records-hep": {
         "filters": {
             "author": terms_filter('facet_author_name'),
-            "subject": terms_filter('facet_inspire_subjects'),
+            "subject": terms_filter('facet_inspire_categories'),
             "arxiv_categories": terms_filter('facet_arxiv_categories'),
             "doc_type": terms_filter('facet_inspire_doc_type'),
             "experiment": terms_filter('facet_experiment'),
@@ -891,7 +891,7 @@ RECORDS_REST_FACETS = {
         "aggs": {
             "subject": {
                 "terms": {
-                    "field": "facet_inspire_subjects",
+                    "field": "facet_inspire_categories",
                     "size": 20
                 }
             },

--- a/inspirehep/modules/authors/rest/stats.py
+++ b/inspirehep/modules/authors/rest/stats.py
@@ -68,7 +68,7 @@ class AuthorAPIStats(object):
                 "citation_count",
                 "control_number",
                 "facet_inspire_doc_type",
-                "facet_inspire_subjects",
+                "facet_inspire_categories",
                 "keywords",
             ]
         )
@@ -100,7 +100,7 @@ class AuthorAPIStats(object):
                     statistics['types'][publication_type] = 1
 
             # Get fields.
-            for field in result_source.get('facet_inspire_subjects', []):
+            for field in result_source.get('facet_inspire_categories', []):
                 fields.add(field)
 
             # Get keywords.

--- a/inspirehep/modules/records/mappings/records/hep.json
+++ b/inspirehep/modules/records/mappings/records/hep.json
@@ -422,7 +422,7 @@
                     "index": "not_analyzed",
                     "type": "string"
                 },
-                "facet_inspire_subjects": {
+                "facet_inspire_categories": {
                     "index": "not_analyzed",
                     "type": "string"
                 },
@@ -486,7 +486,7 @@
                             "type": "string"
                         },
                         "term": {
-                            "copy_to": "facet_inspire_subjects",
+                            "copy_to": "facet_inspire_categories",
                             "type": "string"
                         }
                     },


### PR DESCRIPTION
Rename facet_inspire_subjects so it follows the field it takes its
value from, i.e. facet_inspire_categories.

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>

## Motivation and Context
The goal is to ensure uniformity in naming several mappings fields.
As we discussed with @jacquerie IRL, mappings naming can be improved (e.g. has inconsistencies). 
The goal is to gather (in time) some naming schemes/guidelines for anyone editing the mappings to follow.

For example, this PR is fixing the inconsistency of `facet_inspire_subjects` which got its values from `inspire_categories`.  

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
