### PR TITLE
setup: unpin flake8

### DIFF
--- a/inspirehep/modules/authors/utils.py
+++ b/inspirehep/modules/authors/utils.py
@@ -138,7 +138,7 @@ def scan_author_string_for_phrases(s):
         'nonlastnames': [],
         'titles': [],
         'raw': s}
-    l = s.split(',')
+    l = s.split(',')  # noqa: E741
     if len(l) < 2:
         # No commas means a simple name
         new = s.strip()
@@ -271,7 +271,7 @@ def expand_nonlastnames(namelist):
         """Lists every combination of head with each and all of tail"""
         if len(tail) == 0:
             return [head]
-        l = []
+        l = []  # noqa: E741
         l.extend([head + ' ' + tail[0]])
         l.extend(_pair_items(head, tail[1:]))
         return l
@@ -286,7 +286,7 @@ def expand_nonlastnames(namelist):
 
         if len(tail) == 0:
             return [head]
-        l = []
+        l = []  # noqa: E741
         l.extend(_pair_items(head, _expand_name(tail[0])))
         l.extend([' '.join(_cons(head, tail)).strip()])
         l.extend(_collect(head, tail[1:]))

--- a/inspirehep/modules/theme/views.py
+++ b/inspirehep/modules/theme/views.py
@@ -371,7 +371,7 @@ def get_institution_people_datatables_rows(recid):
                     name=recid_map[author['key']].preferred_name
                 )
             )
-        except:
+        except Exception:
             # No preferred name, use value
             row.append(
                 author_html_link.format(

--- a/inspirehep/utils/bibtex.py
+++ b/inspirehep/utils/bibtex.py
@@ -652,7 +652,7 @@ class Bibtex(Export):
                         coden = ','.join(
                             [record['coden'][0], volume, pages])
                         return coden
-                except:
+                except Exception:
                     return ''
         else:
             return ''

--- a/inspirehep/utils/latex.py
+++ b/inspirehep/utils/latex.py
@@ -290,7 +290,7 @@ class Latex(Export):
                         coden = ','.join(
                             [record['coden'][0], volume, pages])
                         return coden
-                except:
+                except Exception:
                     return ''
         else:
             return ''

--- a/setup.py
+++ b/setup.py
@@ -109,11 +109,10 @@ docs_require = [
 ]
 
 tests_require = [
-    'flake8~=3.0,>=3.4.1,<3.5.0',
     'flake8-future-import~=0.0,>=0.4.3',
     'mock~=2.0,>=2.0.0',
     'pytest-cov~=2.0,>=2.5.1',
-    'pytest-flake8~=0.0,>=0.8.1',
+    'pytest-flake8~=0.0,>=0.9',
     'pytest-selenium~=1.0,>=1.11.1',
     'pytest~=3.0,>=3.2.2',
     'requests_mock~=1.0,>=1.3.0',


### PR DESCRIPTION
## Description:
Removes the pin introduced in 71c01de as the latest version of
``pytest-flake8`` is again compatible with the latest version
of ``flake8``.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
