### PR TITLE
jinja2filters: back_to_search_link handle unicode

### DIFF
--- a/inspirehep/modules/theme/jinja2filters.py
+++ b/inspirehep/modules/theme/jinja2filters.py
@@ -620,8 +620,8 @@ def back_to_search_link(referer, collection):
         url = url_for(
             'inspirehep_search.search', cc=collection, q=url_map['q']
         )
-        text = "Back to search results for \"{}\"".format(url_map['q'])
-    url_html = '<a href="{}">{}</a>'.format(url, text)
+        text = u"Back to search results for \"{}\"".format(url_map['q'])
+    url_html = u'<a href="{}">{}</a>'.format(url, text)
     return url_html
 
 

--- a/tests/unit/theme/test_theme_jinja2filters.py
+++ b/tests/unit/theme/test_theme_jinja2filters.py
@@ -26,7 +26,7 @@ import jinja2
 import pytest
 from elasticsearch_dsl import result
 from flask import current_app
-from mock import patch
+from mock import Mock, patch
 
 from inspirehep.modules.records.api import InspireRecord
 from inspirehep.modules.records.wrappers import LiteratureRecord
@@ -35,6 +35,7 @@ from inspirehep.modules.theme.jinja2filters import (
     apply_template_on_array,
     author_profile,
     author_urls,
+    back_to_search_link,
     citation_phrase,
     collection_select_current,
     conference_date,
@@ -1258,3 +1259,15 @@ def test_is_cataloger_returns_true_when_user_is_a_superuser():
 def test_is_cataloger_returns_false_when_user_has_no_roles():
     user = MockUser('user@example.com')
     assert not is_cataloger(user)
+
+
+@patch('inspirehep.modules.theme.jinja2filters.url_decode')
+def test_back_to_search_link_handles_unicode_title(mocked_url_decode):
+    collection = 'HEP'
+    unicode_query = u'Göbel, Carla'
+    url_map = {'q': unicode_query}
+
+    mocked_referrer = Mock()
+    mocked_url_decode.return_value = url_map
+
+    assert back_to_search_link(mocked_referrer, collection)


### PR DESCRIPTION
Ensure jinja2filters:back_to_search_link handles unicode titles
(addresses #2133).

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
