### PR TITLE
mappings: add earliest_date in jobs collection

### DIFF
--- a/inspirehep/modules/records/mappings/records/jobs.json
+++ b/inspirehep/modules/records/mappings/records/jobs.json
@@ -87,6 +87,10 @@
                 "description": {
                     "type": "string"
                 },
+                "earliest_date": {
+                    "format": "yyyy||yyyy-MM||yyyy-MM-dd",
+                    "type": "date"
+                },
                 "experiments": {
                     "properties": {
                         "curated_relation": {


### PR DESCRIPTION
* Add earliest_date field in jobs mapping since it is used as a default
  sorting option in `RECORDS_REST_SORT_OPTIONS` configuration.

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>

## Motivation and Context
Jobs page can now be viewed normally.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
