### PR TITLE
travis: pull Docker images in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,7 @@ before_install:
   - sudo mv docker-compose /usr/local/bin
 
 install:
-  - travis_retry docker-compose pull
-  - travis_retry docker-compose build
+  - travis_retry docker-compose pull --parallel
   - travis_retry docker-compose -f docker-compose.deps.yml run --rm pip
   - travis_retry docker-compose -f docker-compose.deps.yml run --rm assets
 


### PR DESCRIPTION
## Description
Pulls the Docker images in parallel as local testing has shown that it
speeds up the process by 40%. Also deletes the build step as it's not
needed, since we only pull pre-built images.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.