### PR TITLE
travis: wrap docker pull with something that echoes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ before_install:
   - sudo mv docker-compose /usr/local/bin
 
 install:
-  - travis_retry docker-compose pull
+  - travis_retry scripts/docker_compose_pull_wrapper.sh
   - travis_retry docker-compose build
   - travis_retry docker-compose -f docker-compose.deps.yml run --rm pip
   - travis_retry docker-compose -f docker-compose.deps.yml run --rm assets

--- a/scripts/docker_compose_pull_wrapper.sh
+++ b/scripts/docker_compose_pull_wrapper.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+
+logger() {
+    while true; do
+        echo 'Still pulling...'
+        sleep 60
+    done
+}
+
+
+main() {
+    local logger_pid \
+        docker_compose_rc
+
+    logger &
+    logger_pid=$!
+    docker-compose pull --parallel
+    docker_compose_rc=$?
+    kill "$logger_pid"
+    return "$docker_compose_rc"
+}
+
+
+main

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,8 @@ install_requires = [
     'amqp~=1.0,>=1.4.9',
     'backoff~=1.0,>=1.4.3',
     'backports.tempfile>=1.0rc1',
+    # Required by beard, but we pin to a working version
+    'scipy==1.0.0rc2',
     'beard~=0.0,>=0.2.0',
     'celery~=3.0,>=3.1.25',
     'elasticsearch-dsl~=2.0,>=2.2.0',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

<!--- Why is this change required? What problem does it solve? -->

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

* This allows us to still download images on travis even if they
  take more than 10min. This should not be considered the standard,
  it's just a work-around for unexpected travis slowness.

Signed-off-by: David Caro <david@dcaro.es>