### PR TITLE
migrator: use raise_for_status in one command

### DIFF
--- a/inspirehep/modules/migrator/cli.py
+++ b/inspirehep/modules/migrator/cli.py
@@ -102,11 +102,10 @@ def populate(file_input=None,
 @migrator.command()
 @click.option('--recid', '-r', type=int, help="recid on INSPIRE")
 def one(recid):
-    click.echo(
-        "Migrating record {recid} from INSPIRE legacy".format(recid=recid))
-    raw_record = requests.get(
-        "http://inspirehep.net/record/{recid}/export/xme".format(recid=recid)).content
-    migrate_chunk(split_blob(raw_record))
+    click.echo('Migrating record {recid} from INSPIRE legacy'.format(recid=recid))
+    response = requests.get('http://inspirehep.net/record/{recid}/export/xme'.format(recid=recid))
+    response.raise_for_status()
+    migrate_chunk(split_blob(response.content))
 
 
 @migrator.command()


### PR DESCRIPTION
Ensure response status code is checked before proceeding with a
migration. The problem was that if a request fails, the error was
undetected as the `response.content` contained an HTML page describing
the error.

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>

## Description
When requesting a migration for one record, if the request failed for some reason you couldn't see the failure. 
For example, when requesting for a record from legacy, response.content was
```
'<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">\n<html>  
<head>\n<title>502 Proxy Error</title>\n</head>  
<body>\n<h1>Proxy Error</h1>\n  
<p>The proxy server received an invalid\r\nresponse from an upstream server.<br />  
\r\nThe proxy server could not handle the request <em>  
<a href="/record/1631985/export/xme">GET&nbsp;/record/1631985/export/xme</a></em>.  
<p>\nReason: <strong>Error reading from remote server</strong></p>  
</p>\n<hr>\n<address>Apache Server at inspirehep.net Port 80</address>\n  
</body>  
</html>\n'
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
