### PR TITLE
workflows: decrease log level for invalid tarball

### DIFF
--- a/inspirehep/modules/workflows/tasks/arxiv.py
+++ b/inspirehep/modules/workflows/tasks/arxiv.py
@@ -138,7 +138,7 @@ def arxiv_plot_extract(obj, eng):
             try:
                 plots = process_tarball(tarball.file.uri, output_directory=scratch_space)
             except (InvalidTarball, NoTexFilesFound):
-                obj.log.error(
+                obj.log.info(
                     'Invalid tarball %s for arxiv_id %s', tarball.file.uri, arxiv_id)
                 return
             except DelegateError as err:
@@ -216,7 +216,7 @@ def arxiv_author_list(stylesheet="authorlist2marcxml.xsl"):
                 try:
                     file_list = untar(tarball.file.uri, scratch_space)
                 except InvalidTarball:
-                    obj.log.error('Invalid tarball %s for arxiv_id %s', tarball.file.uri, arxiv_id)
+                    obj.log.info('Invalid tarball %s for arxiv_id %s', tarball.file.uri, arxiv_id)
                     return
                 obj.log.info('Extracted tarball to: {0}'.format(scratch_space))
 

--- a/tests/unit/workflows/test_workflows_tasks_arxiv.py
+++ b/tests/unit/workflows/test_workflows_tasks_arxiv.py
@@ -367,7 +367,7 @@ def test_arxiv_plot_extract_logs_when_tarball_is_invalid(mock_process_tarball):
     assert arxiv_plot_extract(obj, eng) is None
 
     expected = 'Invalid tarball http://export.arxiv.org/e-print/1612.00626 for arxiv_id 1612.00626'
-    result = obj.log._error.getvalue()
+    result = obj.log._info.getvalue()
 
     assert expected == result
 
@@ -603,6 +603,6 @@ def test_arxiv_author_list_logs_on_error(mock_untar):
     assert default_arxiv_author_list(obj, eng) is None
 
     expected = 'Invalid tarball http://export.arxiv.org/e-print/1605.07707 for arxiv_id 1605.07707'
-    result = obj.log._error.getvalue()
+    result = obj.log._info.getvalue()
 
     assert expected == result


### PR DESCRIPTION
## Description:
Some arXiv records just don't have a tarball, as they are allowed to
have anything there, so we shouldn't log an error whenever we don't
see one.

Note also that logging an error eats rapidly into our ``sentry.io``
quota, as we see roughly a thousand such events per day per instance.

## Related Issues:
https://sentry.io/inspirehep/inspire-prod/issues/388912388/
https://sentry.io/inspirehep/inspire-qa/issues/388908905/

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.