### PR TITLE
records: use validate from inspire_schemas

### DIFF
--- a/inspirehep/modules/records/api.py
+++ b/inspirehep/modules/records/api.py
@@ -30,6 +30,7 @@ import arrow
 from elasticsearch.exceptions import NotFoundError
 from flask import current_app
 
+from inspire_schemas.api import validate
 from invenio_files_rest.models import Bucket
 from invenio_pidstore.errors import PIDDoesNotExistError
 from invenio_pidstore.models import PersistentIdentifier
@@ -89,6 +90,10 @@ class InspireRecord(Record):
             storage_class=storage_class
         )
         return bucket
+
+    def validate(self):
+        """Validate the record, also ensuring format compliance."""
+        validate(self)
 
 
 class ESRecord(InspireRecord):

--- a/tests/integration/records/test_records_api.py
+++ b/tests/integration/records/test_records_api.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+from inspirehep.utils.record_getter import get_db_record
+from jsonschema import ValidationError
+
+
+def test_validate_validates_format(app):
+    article = get_db_record('lit', 4328)
+    article.setdefault('acquisition_source', {})['email'] = 'not an email'
+    with pytest.raises(ValidationError):
+        article.commit()


### PR DESCRIPTION
## Description:
This ensures that we have a single implementation of schema
validation (for constraints that do not require a DB) and
that we validate ``format``s.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.