### PR TITLE
receivers: populate author_count

### DIFF
--- a/inspirehep/modules/records/mappings/records/hep.json
+++ b/inspirehep/modules/records/mappings/records/hep.json
@@ -161,6 +161,9 @@
                     },
                     "type": "object"
                 },
+                "author_count": {
+                    "type": "integer"
+                },
                 "authors": {
                     "properties": {
                         "affiliations": {

--- a/inspirehep/modules/records/receivers.py
+++ b/inspirehep/modules/records/receivers.py
@@ -140,6 +140,7 @@ def enhance_after_index(sender, json, *args, **kwargs):
     generate_name_variations(sender, json, *args, **kwargs)
     populate_abstract_source_suggest(sender, json, *args, **kwargs)
     populate_affiliation_suggest(sender, json, *args, **kwargs)
+    populate_author_count(sender, json, *args, **kwargs)
     populate_earliest_date(sender, json, *args, **kwargs)
     populate_inspire_document_type(sender, json, *args, **kwargs)
     populate_title_suggest(sender, json, *args, **kwargs)
@@ -388,3 +389,21 @@ def generate_name_variations(sender, json, *args, **kwargs):
                 'output': full_name,
                 'payload': {'bai': bais[0] if bais else None}
             }})
+
+
+def populate_author_count(sender, json, *args, **kwargs):
+    """Populate the ```author_count``` field of Literature records.
+
+    Filtering must be enforced so that we only count authors with 'inspire_roles' not equal to 'supervisor', i.e. roles
+    that only contain either 'author' or 'editor'.
+    """
+    if 'hep.json' not in json.get('$schema'):
+        return
+
+    authors = json.get('authors', [])
+
+    authors_excluding_supervisors = [
+        author for author in authors
+        if 'supervisor' not in author.get('inspire_roles', [])
+    ]
+    json['author_count'] = len(authors_excluding_supervisors)

--- a/inspirehep/modules/workflows/mappings/holdingpen/hep.json
+++ b/inspirehep/modules/workflows/mappings/holdingpen/hep.json
@@ -12,6 +12,11 @@
                         "is-update": {
                             "type": "boolean"
                         },
+                        "record_matches": {
+                            "enabled": false,
+                            "include_in_all": false,
+                            "type": "object"
+                        },
                         "relevance_prediction": {
                             "properties": {
                                 "decision": {
@@ -22,11 +27,6 @@
                                     "type": "float"
                                 }
                             },
-                            "type": "object"
-                        },
-                        "record_matches": {
-                            "include_in_all": false,
-                            "enabled": false,
                             "type": "object"
                         }
                     },

--- a/tests/unit/records/test_records_receivers.py
+++ b/tests/unit/records/test_records_receivers.py
@@ -468,7 +468,7 @@ def test_populate_earliest_date_from_imprints_date():
 
 
 def test_populate_earliest_date_does_nothing_if_record_is_not_literature():
-    record = {'$schema': 'http://localhost:5000/schemas/records/hep.json'}
+    record = {'$schema': 'http://localhost:5000/schemas/records/other.json'}
 
     populate_earliest_date(None, record)
 

--- a/tests/unit/records/test_records_receivers.py
+++ b/tests/unit/records/test_records_receivers.py
@@ -38,6 +38,7 @@ from inspirehep.modules.records.receivers import (
     populate_inspire_document_type,
     populate_recid_from_ref,
     populate_title_suggest,
+    populate_author_count,
 )
 
 
@@ -1145,3 +1146,35 @@ def test_populate_affiliation_suggest_does_nothing_if_record_is_not_institution(
     populate_affiliation_suggest(None, record)
 
     assert 'affiliation_suggest' not in record
+
+
+def test_populate_author_count():
+    record = {
+        '$schema': 'http://localhost:5000/records/schemas/hep.json',
+        'authors': [
+            {
+                'full_name': 'Smith, John',
+                'inspire_roles': ['author'],
+            },
+            {
+                'full_name': 'Rafelski, Johann',
+                'inspire_roles': ['author', 'editor'],
+            },
+            {
+                'full_name': 'Rohan, George',
+                'inspire_roles': ['supervisor', 'author'],
+            },
+        ],
+    }
+
+    populate_author_count(None, record)
+
+    assert record['author_count'] == 2
+
+
+def test_populate_author_count_does_nothing_if_record_is_not_literature():
+    record = {'$schema': 'http://localhost:5000/schemas/records/other.json'}
+
+    populate_author_count(None, record)
+
+    assert 'author_count' not in record


### PR DESCRIPTION
* Add author_count field in hep mapping.
* Populate author_count when `inspire_roles` doesn't contain
  `supervisor`.

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>

## Motivation and Context
For adding support for `author-count` related queries.

I've also run the `prettify_json` script for the `holdingpen/hep` mapping. If we don't want it on this PR then I can create another one.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
