### PR TITLE
orcid: sync OAUTH tokens from legacy

### DIFF
--- a/inspirehep/modules/orcid/__init__.py
+++ b/inspirehep/modules/orcid/__init__.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""ORCID integration module."""
+
+from __future__ import absolute_import, division, print_function
+
+from .ext import InspireOrcid  # noqa: F401

--- a/inspirehep/modules/orcid/ext.py
+++ b/inspirehep/modules/orcid/ext.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""ORCID extension."""
+
+from __future__ import absolute_import, division, print_function
+
+
+class InspireOrcid(object):
+    def __init__(self, app=None):
+        if app:
+            self.init_app(app)
+
+    def init_app(self, app):
+        app.extensions['inspire-orcid'] = self

--- a/inspirehep/modules/orcid/tasks.py
+++ b/inspirehep/modules/orcid/tasks.py
@@ -90,7 +90,8 @@ def _link_user_and_token(user, name, orcid, token):
             secret=None,
             extra_data={
                 'orcid': orcid,
-                'full_name': name
+                'full_name': name,
+                'allow_push': True,
             }
         ))
 

--- a/inspirehep/modules/orcid/tasks.py
+++ b/inspirehep/modules/orcid/tasks.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Manage ORCID OAUTH token migration from INSPIRE legacy instance."""
+
+from __future__ import absolute_import, division, print_function
+
+from flask import current_app
+from celery import shared_task
+from celery.utils.log import get_task_logger
+from redis import StrictRedis
+from redis_lock import Lock
+from ast import literal_eval
+from invenio_oauthclient.utils import oauth_get_user, oauth_link_external_id
+from invenio_oauthclient.models import RemoteToken, User, RemoteAccount, UserIdentity
+from invenio_db import db
+from inspire_utils.record import get_value
+from invenio_oauthclient.errors import AlreadyLinkedError
+
+logger = get_task_logger(__name__)
+
+
+def legacy_orcid_tuples():
+    """Generator to fetch token data from redis.
+
+    Yields:
+        tuple: user data in the form of (orcid, token, email, name)
+    """
+    redis_url = current_app.config.get('CACHE_REDIS_URL')
+    r = StrictRedis.from_url(redis_url)
+    lock = Lock(r, 'import_legacy_orcid_tokens', expire=120, auto_renewal=True)
+    if lock.acquire(blocking=False):
+        try:
+            while r.llen('legacy_orcid_tokens'):
+                yield literal_eval(r.lrange('legacy_orcid_tokens', 0, 1)[0])
+                r.lpop('legacy_orcid_tokens')
+        finally:
+            lock.release()
+    else:
+        logger.info("Import_legacy_orcid_tokens already executed. Skipping.")
+
+
+def _link_user_and_token(user, name, orcid, token):
+    """Create a link between a user and token, if possible.
+
+    Args:
+        user (invenio_oauthclient.models.User): an existing user object to connect the token to
+        orcid (string): user's ORCID identifier
+        token (string): OAUTH token for the user
+    """
+    try:
+        # Link user and ORCID
+        oauth_link_external_id(user, {
+            'id': orcid,
+            'method': 'orcid'
+        })
+    except AlreadyLinkedError:
+        # User already has their ORCID linked
+        pass
+
+    # Is there already a token associated with this ORCID identifier?
+    if RemoteToken.query.join(RemoteAccount).join(User).join(UserIdentity).filter(UserIdentity.id == orcid).count():
+        return
+
+    # If not, create and put the token entry
+    with db.session.begin_nested():
+        db.session.add(RemoteToken.create(
+            user_id=user.id,
+            client_id=get_value(current_app.config, 'ORCID_APP_CREDENTIALS.consumer_key'),
+            token=token,
+            secret=None,
+            extra_data={
+                'orcid': orcid,
+                'full_name': name
+            }
+        ))
+
+
+def _register_user(name, email, orcid, token):
+    """Add a token to the user, creating the user if doesn't exist.
+
+    There are multiple possible scenarios:
+    - user exists, has ORCID and token already linked
+    - user exists and has their ORCID linked, but no token is associated
+    - user exists, but doesn't have the ORCID identifier linked
+    - user doesn't exist at all
+
+    In all the above scenarios this will create the missing parts.
+
+    Args:
+        name (string): user's name
+        email (string): user's email address
+        orcid (string): user's ORCID identifier
+        token (string): OAUTH authorization token
+    """
+
+    # Try to find an existing user entry
+    user_by_orcid = oauth_get_user(orcid)
+    user_by_email = oauth_get_user(None, {
+        'user': {
+            'email': email
+        }
+    })
+
+    # Make the user if didn't find existing one
+    if not user_by_email and not user_by_orcid:
+        user = User()
+        user.email = email
+        with db.session.begin_nested():
+            db.session.add(user)
+    else:
+        user = user_by_orcid or user_by_email
+
+    _link_user_and_token(user, name, orcid, token)
+
+
+@shared_task(ignore_result=True)
+def import_legacy_orcid_tokens():
+    """Task to import OAUTH ORCID tokens from legacy."""
+    if get_value(current_app.config, 'ORCID_APP_CREDENTIALS.consumer_key') is None:
+        return
+
+    for user_data in legacy_orcid_tuples():
+        orcid, token, email, name = user_data
+        _register_user(name, email, orcid, token)

--- a/setup.py
+++ b/setup.py
@@ -228,6 +228,7 @@ setup(
         ],
         'invenio_celery.tasks': [
             'inspire_migrator = inspirehep.modules.migrator.tasks',
+            'inspire_orcid = inspirehep.modules.orcid.tasks',
             'inspire_records = inspirehep.modules.records.tasks',
             'inspire_refextract = inspirehep.modules.refextract.tasks',
         ],

--- a/tests/integration/test_orcid_import_legacy_tokens.py
+++ b/tests/integration/test_orcid_import_legacy_tokens.py
@@ -1,0 +1,250 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+from flask import current_app
+from redis import StrictRedis
+from pytest import fixture
+from mock import patch
+
+from inspirehep.modules.orcid.tasks import legacy_orcid_tuples, import_legacy_orcid_tokens, _register_user
+from invenio_oauthclient.models import User, RemoteToken, RemoteAccount, UserIdentity
+from invenio_db import db
+
+
+SAMPLE_USER = {
+    'orcid': '0000-0002-1825-0097',
+    'token': '3d25a708-dae9-48eb-b676-80a2bfb9d35c',
+    'email': 'j.carberry@orcid.org',
+    'name': 'Josiah Carberry',
+}
+SAMPLE_USER_2 = {
+    'orcid': '0000-0001-1234-1234',
+    'token': '12345678-9abc-def1-2345-6789abcdef12',
+    'email': 'j.doe@orcid.org',
+    'name': 'John Doe',
+}
+SAMPLE_USER_EDITED = {
+    'orcid': '0000-0002-1825-0097',
+    'token': '00000000-0000-0000-0000-000000000000',
+    'email': 'j.carberry@orcid.org',
+    'name': 'Josiah Carberry',
+}
+
+
+def record_dict_to_tuple(user_record):
+    """Convert user record to a tuple, like ones received through redis."""
+    key_ordering = ['orcid', 'token', 'email', 'name']
+    return tuple(user_record[key] for key in key_ordering)
+
+
+def push_to_redis(user_record):
+    """Push a user record to redis."""
+    user_record_tuple = record_dict_to_tuple(user_record)
+    redis_url = current_app.config.get('CACHE_REDIS_URL')
+    r = StrictRedis.from_url(redis_url)
+    r.lpush('legacy_orcid_tokens', user_record_tuple)
+
+
+def assert_db_has_n_legacy_records(n, record):
+    assert n == User.query.filter_by(email=record['email']).count()
+    assert n == RemoteAccount.query.filter_by(client_id=record['orcid']).count()  # FIXME: Not client ID
+    assert n == RemoteToken.query.filter_by(access_token=record['token']).count()
+    assert n == UserIdentity.query.filter_by(id=record['orcid']).count()
+
+
+def cleanup_record(record):
+    RemoteToken.query.filter_by(access_token=record['token']).delete()
+    RemoteAccount.query.filter_by(client_id=record['orcid']).delete()  # FIXME: Not client ID
+    UserIdentity.query.filter_by(id=record['orcid']).delete()
+    User.query.filter_by(email=record['email']).delete()
+
+
+@fixture(scope='function')
+def teardown_sample_user(app):
+    yield
+
+    cleanup_record(SAMPLE_USER)
+    assert_db_has_n_legacy_records(0, SAMPLE_USER)
+
+
+@fixture(scope='function')
+def teardown_sample_user_2(app):
+    yield
+
+    cleanup_record(SAMPLE_USER_2)
+    assert_db_has_n_legacy_records(0, SAMPLE_USER_2)
+
+
+@fixture(scope='function')
+def teardown_sample_user_edited(app):
+    yield
+
+    cleanup_record(SAMPLE_USER_EDITED)
+    assert_db_has_n_legacy_records(0, SAMPLE_USER_EDITED)
+
+
+@fixture(scope='function')
+def redis_setup(app):
+    redis_url = current_app.config.get('CACHE_REDIS_URL')
+    r = StrictRedis.from_url(redis_url)
+
+    yield r
+
+    r.delete('legacy_orcid_tokens')
+
+
+@fixture(scope='function')
+def app_with_config(app):
+    config = {
+        'ORCID_APP_CREDENTIALS': {
+            'consumer_key': '0000-0000-0000-0000'
+        }
+    }
+
+    with patch.dict(current_app.config, config):
+        yield app
+
+
+@fixture(scope='function')
+def app_without_config(app):
+    config = {
+        'ORCID_APP_CREDENTIALS': {
+            'consumer_key': None
+        }
+    }
+
+    with patch.dict(current_app.config, config):
+        yield app
+
+
+def test_multiple_tuple_generator(app, redis_setup):
+    """Test the generator functionality."""
+    push_to_redis(SAMPLE_USER_2)
+    push_to_redis(SAMPLE_USER)
+
+    # Check initial state of queue
+    assert redis_setup.llen('legacy_orcid_tokens') == 2
+
+    # Take all the records from the queue
+    tuple_list = list(legacy_orcid_tuples())
+
+    # Check if results are expected, and that redis is empty
+    assert tuple_list == [record_dict_to_tuple(x) for x in [SAMPLE_USER, SAMPLE_USER_2]]
+    assert redis_setup.llen('legacy_orcid_tokens') == 0
+
+
+def test_import_multiple_orcid_tokens_no_user_exists(
+        app_with_config, redis_setup, teardown_sample_user, teardown_sample_user_2):
+    """Create two users and all the associate entries."""
+    push_to_redis(SAMPLE_USER_2)
+    push_to_redis(SAMPLE_USER)
+
+    # Check initial state
+    assert redis_setup.llen('legacy_orcid_tokens') == 2
+    assert_db_has_n_legacy_records(0, SAMPLE_USER)
+    assert_db_has_n_legacy_records(0, SAMPLE_USER_2)
+
+    # Migrate
+    import_legacy_orcid_tokens()
+
+    # Check state after migration
+    assert not redis_setup.llen('legacy_orcid_tokens')
+    assert_db_has_n_legacy_records(1, SAMPLE_USER)
+    assert_db_has_n_legacy_records(1, SAMPLE_USER_2)
+
+
+def test_import_multiple_orcid_tokens_no_configuration(
+        app_without_config, redis_setup, teardown_sample_user, teardown_sample_user_2):
+    """Attempt and fail to create new users when configuration missing."""
+    push_to_redis(SAMPLE_USER_2)
+    push_to_redis(SAMPLE_USER)
+
+    # Check initial state
+    assert redis_setup.llen('legacy_orcid_tokens') == 2
+    assert_db_has_n_legacy_records(0, SAMPLE_USER)
+    assert_db_has_n_legacy_records(0, SAMPLE_USER_2)
+
+    # Migrate
+    import_legacy_orcid_tokens()
+
+    # Assert state unchanged after migration
+    assert redis_setup.llen('legacy_orcid_tokens') == 2
+    assert_db_has_n_legacy_records(0, SAMPLE_USER)
+    assert_db_has_n_legacy_records(0, SAMPLE_USER_2)
+
+
+def test_linked_user_with_token_exists(app_with_config, teardown_sample_user):
+    """Ignore token, if already has one."""
+    assert_db_has_n_legacy_records(0, SAMPLE_USER)
+
+    # Register sample user
+    _register_user(**SAMPLE_USER)
+
+    # Check state after migration
+    assert_db_has_n_legacy_records(1, SAMPLE_USER)
+
+    # Register the same user with another token
+    _register_user(**SAMPLE_USER_EDITED)
+
+    # Assert token unchanged
+    assert_db_has_n_legacy_records(1, SAMPLE_USER)
+    assert 0 == RemoteToken.query.filter_by(token=SAMPLE_USER_EDITED).count()
+
+
+def test_linked_user_without_token_exists(app_with_config, teardown_sample_user_edited):
+    """Add a token to an existing user with an ORCID paired."""
+    assert_db_has_n_legacy_records(0, SAMPLE_USER)
+
+    # Register sample user
+    _register_user(**SAMPLE_USER)
+
+    # Check state after migration
+    assert_db_has_n_legacy_records(1, SAMPLE_USER)
+
+    # Remove token and remote account
+    RemoteToken.query.filter_by(access_token=SAMPLE_USER['token']).delete()
+    RemoteAccount.query.filter_by(client_id=SAMPLE_USER['orcid']).delete()  # FIXME: Not client ID
+
+    # Register the same user with another token
+    _register_user(**SAMPLE_USER_EDITED)
+
+    # Assert new token
+    assert_db_has_n_legacy_records(1, SAMPLE_USER_EDITED)
+
+
+def test_unlinked_user_exists(app_with_config, teardown_sample_user):
+    """Add a token to an existing user without a paired ORCID."""
+    assert_db_has_n_legacy_records(0, SAMPLE_USER)
+
+    # Register sample user
+    user = User()
+    user.email = SAMPLE_USER['email']
+    with db.session.begin_nested():
+        db.session.add(user)
+
+    # Register the token
+    _register_user(**SAMPLE_USER)
+
+    # Assert new token
+    assert_db_has_n_legacy_records(1, SAMPLE_USER)


### PR DESCRIPTION
Celery task pulls ORCID token data from legacy through redis, as described in issue #2894, and adds the data to inspire-next.

## Description

Will try to match an existing user to add the token to, upon failing will silently create a new user for that token. If the user already has a token assigned, this will leave it untouched.

## Related Issue

implements #2894

## Motivation and Context

ORCID API ver. 1.2 used in legacy will be switched off. In the meantime, until inspire-next is fully functional we could use inspire-next to push records from legacy using API ver. 2.0. To do this we need to copy over users' OAUTH tokens. See: #2894.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
