### PR TITLE
Add new arxiv/doi validators to the literature form.

### DIFF
--- a/inspirehep/modules/literaturesuggest/forms.py
+++ b/inspirehep/modules/literaturesuggest/forms.py
@@ -45,7 +45,9 @@ from inspirehep.modules.forms.validators.dynamic_fields import (
 )
 from inspirehep.modules.forms.validators.simple_fields import (
     arxiv_syntax_validation,
+    arxiv_id_already_pending_in_holdingpen_validator,
     date_validator,
+    doi_already_pending_in_holdingpen_validator,
     duplicated_arxiv_id_validator,
     duplicated_doi_validator,
     no_pdf_validator,
@@ -229,14 +231,24 @@ class LiteratureForm(INSPIREForm):
         export_key='doi',
         description='e.g. 10.1086/305772 or doi:10.1086/305772',
         placeholder='',
-        validators=[DOISyntaxValidator("The provided DOI is invalid - it should look similar to '10.1086/305772'."),
-                    duplicated_doi_validator],
+        validators=[
+            DOISyntaxValidator(
+                "The provided DOI is invalid - it should look similar to "
+                "'10.1086/305772'."
+            ),
+            duplicated_doi_validator,
+            doi_already_pending_in_holdingpen_validator,
+        ],
     )
 
     arxiv_id = fields.ArXivField(
         label='arXiv ID',
         export_key="arxiv_id",
-        validators=[arxiv_syntax_validation, duplicated_arxiv_id_validator],
+        validators=[
+            arxiv_syntax_validation,
+            duplicated_arxiv_id_validator,
+            arxiv_id_already_pending_in_holdingpen_validator,
+        ],
     )
 
     categories_arXiv = fields.TextField(

--- a/tests/unit/forms/test_forms_validators_simple_fields.py
+++ b/tests/unit/forms/test_forms_validators_simple_fields.py
@@ -28,6 +28,7 @@ from mock import patch
 from wtforms.validators import StopValidation, ValidationError
 
 from inspirehep.modules.forms.validators.simple_fields import (
+    already_pending_in_holdingpen_validator,
     arxiv_syntax_validation,
     date_validator,
     duplicated_validator,
@@ -314,3 +315,57 @@ def test_duplicated_arxiv_id_validator_not_exsting_anywhere_valid(
     field = MockField(u'1207.7235')
 
     duplicated_arxiv_id_validator(None, field)
+
+
+@patch('inspirehep.modules.forms.validators.simple_fields.es')
+def test_already_pending_in_holdingpen_validator_arxiv_id_non_existing_valid(
+    es_mock,
+):
+    es_mock.search.return_value = {
+        'hits': {
+            'hits': [],
+        }
+    }
+
+    already_pending_in_holdingpen_validator('arXiv ID', 'dummy_id')
+
+
+@patch('inspirehep.modules.forms.validators.simple_fields.es')
+def test_already_pending_in_holdingpen_validator_arxiv_id_existing_invalid(
+    es_mock,
+):
+    es_mock.search.return_value = {
+        'hits': {
+            'hits': [{'_id': '123'}],
+        }
+    }
+
+    with pytest.raises(ValidationError):
+        already_pending_in_holdingpen_validator('arXiv ID', 'dummy_id')
+
+
+@patch('inspirehep.modules.forms.validators.simple_fields.es')
+def test_already_pending_in_holdingpen_validator_doi_non_existing_valid(
+    es_mock,
+):
+    es_mock.search.return_value = {
+        'hits': {
+            'hits': [],
+        }
+    }
+
+    already_pending_in_holdingpen_validator('DOI', 'dummy_id')
+
+
+@patch('inspirehep.modules.forms.validators.simple_fields.es')
+def test_already_pending_in_holdingpen_validator_doi_existing_invalid(
+    es_mock,
+):
+    es_mock.search.return_value = {
+        'hits': {
+            'hits': [{'_id': '123'}],
+        }
+    }
+
+    with pytest.raises(ValidationError):
+        already_pending_in_holdingpen_validator('DOI', 'dummy_id')


### PR DESCRIPTION
Adds some extra checks to the form when passing an arxiv id or doi:
    * Check if is already ni the holdingpen with the same source.
    * Check locally (in the DB) if there's a record that matches.

In those cases, it will not allow to pass it.

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->