### PR TITLE
workflow: change logic of matches in holdingpen

### DIFF
--- a/inspirehep/modules/workflows/tasks/matching.py
+++ b/inspirehep/modules/workflows/tasks/matching.py
@@ -30,12 +30,13 @@ from functools import wraps
 from flask import current_app
 
 from invenio_db import db
-from invenio_workflows import workflow_object_class
+from invenio_workflows import workflow_object_class, WorkflowEngine
 
 from inspire_matcher.api import match
 from inspire_utils.dedupers import dedupe_list
 from inspirehep.utils.datefilter import date_older_than
-from inspirehep.utils.record import get_arxiv_categories, get_arxiv_id
+from inspirehep.utils.record import get_arxiv_categories, get_arxiv_id, get_value
+from inspirehep.modules.workflows.tasks.actions import mark
 
 from ..utils import with_debug_logging
 
@@ -151,12 +152,12 @@ def previously_rejected(days_ago=None):
     return _previously_rejected
 
 
-@with_debug_logging
-def pending_in_holding_pen(obj, eng):
-    """Return ``True`` if the record is already present in the Holding Pen.
+def match_non_completed_wf_in_holdingpen(obj, eng):
+    """Return ``True`` if a matching wf is processing in the HoldingPen.
 
     Uses a custom configuration of the ``inspire-matcher`` to find duplicates
-    of the current workflow object in the Holding Pen.
+    of the current workflow object in the Holding Pen not in the
+    COMPLETED state.
 
     Also sets ``holdingpen_matches`` in ``extra_data`` to the list of ids that
     matched.
@@ -167,7 +168,59 @@ def pending_in_holding_pen(obj, eng):
 
     Returns:
         bool: ``True`` if the workflow object has a duplicate in the Holding
-        Pen, ``False`` otherwise.
+        Pen that is not COMPLETED, ``False`` otherwise.
+
+    """
+    def _non_completed(base_record, match_result):
+        return not get_value(match_result, '_source._workflow.status') == 'COMPLETED'
+
+    matched_ids = _pending_in_holding_pen(obj, _non_completed)
+    obj.extra_data['holdingpen_matches'] = matched_ids
+    return bool(matched_ids)
+
+
+def match_previously_rejected_wf_in_holdingpen(obj, eng):
+    """Return ``True`` if matches a COMPLETED and rejected wf in the HoldingPen.
+
+    Uses a custom configuration of the ``inspire-matcher`` to find duplicates
+    of the current workflow object in the Holding Pen in the
+    COMPLETED state, marked as ``approved = False``.
+
+    Also sets ``holdingpen_matches`` in ``extra_data`` to the list of ids that
+    matched.
+
+    Arguments:
+        obj: a workflow object.
+        eng: a workflow engine.
+
+    Returns:
+        bool: ``True`` if the workflow object has a duplicate in the Holding
+        Pen that is not COMPLETED, ``False`` otherwise.
+
+    """
+    def _rejected_and_completed(base_record, match_result):
+        return get_value(match_result, '_source._workflow.status') == 'COMPLETED' and \
+            get_value(match_result, '_source._extra_data.approved') is False
+
+    matched_ids = _pending_in_holding_pen(obj, _rejected_and_completed)
+    obj.extra_data['previously_rejected_matches'] = matched_ids
+    return bool(matched_ids)
+
+
+@with_debug_logging
+def _pending_in_holding_pen(obj, validation_func):
+    """Return the list of matching workflows in the holdingpen.
+
+    Matches the holdingpen records by their ``arxiv_eprint``, their ``doi``,
+    and by a custom validator function.
+
+    Args:
+        obj: a workflow object.
+        validation_func: a function used to filter the matched records.
+
+    Returns:
+        (list): the ids matching the current ``obj`` that satisfy
+        ``validation_func``.
 
     """
     config = {
@@ -185,20 +238,14 @@ def pending_in_holding_pen(obj, eng):
                         'type': 'exact',
                     },
                 ],
+                'validator': validation_func,
             },
         ],
         'doc_type': 'hep',
         'index': 'holdingpen-hep',
     }
-
     matches = dedupe_list(match(obj.data, config))
-    holdingpen_ids = [int(el['_id']) for el in matches if int(el['_id']) != obj.id]
-    if holdingpen_ids:
-        obj.extra_data['holdingpen_matches'] = holdingpen_ids
-        return True
-
-    obj.extra_data['holdingpen_matches'] = []
-    return False
+    return [int(el['_id']) for el in matches if int(el['_id']) != obj.id]
 
 
 @with_debug_logging
@@ -210,33 +257,82 @@ def delete_self_and_stop_processing(obj, eng):
 
 @with_debug_logging
 def stop_processing(obj, eng):
-    """Stop processing for object and return as completed."""
-    eng.stopProcessing()
+    """Stop processing the given workflow.
+
+    Stops the given workflow engine. This causes the stop of all the workflows
+    related to it.
+
+    Args:
+        obj: a workflow object.
+        eng: a workflow engine.
+
+    Returns:
+        None
+    """
+    eng.stop()
 
 
-@with_debug_logging
-def update_existing_workflow_object(obj, eng):
-    """Update the data of the old object with the new data."""
-    holdingpen_ids = obj.extra_data.get('holdingpen_matches', [])
+def has_same_source(extra_data_key):
+    """Match a workflow in obj.extra_data[`extra_data_key`] by the source.
 
-    if not holdingpen_ids:
-        return
+    Takes a list of workflows from extra_data using as key `extra_data_key`
+    and goes through them checking if at least one workflow has the same source
+    of the current workflow object.
 
-    for matched_id in holdingpen_ids:
-        existing_obj = workflow_object_class.get(matched_id)
-        if (
-                obj.data.get('acquisition_source') and
-                existing_obj.data.get('acquisition_source')
-        ):
-            if (
-                    obj.data['acquisition_source'].get('method') ==
-                    existing_obj.data['acquisition_source'].get('method')
-            ):
-                # Method is the same, update obj
-                existing_obj.data.update(obj.data)
-                existing_obj.save()
-                break
-    else:
-        msg = "Cannot update old object, non valid ids: %s"
-        obj.log.error(msg, holdingpen_ids)
-        raise Exception(msg % holdingpen_ids)
+    Args:
+        extra_data_key: the key to retrieve a workflow list from the current
+        workflow object.
+
+    Returns:
+        bool: True if a workflow, whose id is in obj.extra_data[
+        `extra_data_key`], matches the current workflow by the source.
+    """
+
+    def _get_wfs_same_source(obj, eng):
+        current_source = get_value(obj.data, 'acquisition_source.source').lower()
+
+        try:
+            workflows = obj.extra_data[extra_data_key]
+        except KeyError:
+            workflows = []
+
+        for wf_id in workflows:
+            wf = workflow_object_class.get(wf_id)
+            wf_source = get_value(wf.data, 'acquisition_source.source').lower()
+            if wf_source == current_source:
+                return True
+        return False
+
+    return _get_wfs_same_source
+
+
+def stop_matched_holdingpen_wfs(obj, eng):
+    """Stop the matched workflow objects in the holdingpen.
+
+    Stops the matched workflows in the holdingpen by replacing their steps with
+    a new one defined on the fly, containing a ``stop`` step, and executing it.
+    For traceability reason, these workflows are also marked as
+    ``'stopped-by-wf'``, whose value is the current workflow's id.
+
+    In the use case of harvesting twice an article, this function is involved
+    to stop the first workflow and let the current one being processed,
+    since it the latest metadata.
+
+    Args:
+        obj: a workflow object.
+        eng: a workflow engine.
+
+    Returns:
+        None
+    """
+    stopping_steps = [mark('stopped-by-wf', int(obj.id)), stop_processing]
+
+    obj.save()
+
+    for holdingpen_wf_id in obj.extra_data['holdingpen_matches']:
+        holdingpen_wf = workflow_object_class.get(holdingpen_wf_id)
+        holdingpen_wf_eng = WorkflowEngine.from_uuid(holdingpen_wf.id_workflow)
+
+        # stop this holdingpen workflow by replacing its steps with a stop step
+        holdingpen_wf_eng.callbacks.replace(stopping_steps)
+        holdingpen_wf_eng.process([holdingpen_wf])

--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -27,7 +27,6 @@ from __future__ import absolute_import, division, print_function
 from workflow.patterns.controlflow import (
     IF,
     IF_ELSE,
-    IF_NOT,
 )
 
 from inspirehep.modules.workflows.tasks.refextract import extract_journal_info
@@ -40,9 +39,9 @@ from inspirehep.modules.workflows.tasks.arxiv import (
 )
 from inspirehep.modules.workflows.tasks.actions import (
     add_core,
+    error_workflow,
     halt_record,
     is_record_relevant,
-    in_production_mode,
     is_record_accepted,
     reject_record,
     is_experimental_paper,
@@ -53,6 +52,7 @@ from inspirehep.modules.workflows.tasks.actions import (
     prepare_update_payload,
     refextract,
     submission_fulltext_download,
+    save_workflow,
 )
 
 from inspirehep.modules.workflows.tasks.classifier import (
@@ -66,13 +66,14 @@ from inspirehep.modules.workflows.tasks.magpie import (
     guess_experiments,
 )
 from inspirehep.modules.workflows.tasks.matching import (
-    delete_self_and_stop_processing,
     stop_processing,
-    pending_in_holding_pen,
+    match_non_completed_wf_in_holdingpen,
+    match_previously_rejected_wf_in_holdingpen,
     article_exists,
     already_harvested,
     previously_rejected,
-    update_existing_workflow_object,
+    has_same_source,
+    stop_matched_holdingpen_wfs,
 )
 from inspirehep.modules.workflows.tasks.upload import store_record, set_schema
 from inspirehep.modules.workflows.tasks.submission import (
@@ -95,8 +96,6 @@ from inspirehep.modules.literaturesuggest.tasks import (
 
 
 NOTIFY_SUBMISSION = [
-    # Special RT integration for submissions
-    # ======================================
     create_ticket(
         template="literaturesuggest/tickets/curator_submitted.html",
         queue="HEP_add_user",
@@ -111,68 +110,7 @@ NOTIFY_SUBMISSION = [
 ]
 
 
-ADD_INGESTION_MARKS = [
-    # Article matching for non-submissions
-    # ====================================
-    # Query holding pen to see if we already have this article ingested
-    #
-    # NOTE on updates:
-    #     If the same article has been harvested before and the
-    #     ingestion has been completed, process is continued
-    #     to allow for updates.
-    IF(
-        is_marked('already-in-holding-pen'),
-        [mark('delete', True)]
-    ),
-    IF(
-        is_arxiv_paper,
-        [
-            # FIXME: This filtering step should be removed when this
-            #        workflow includes arXiv CORE harvesting
-            IF(
-                already_harvested,
-                [
-                    mark('already-ingested', True),
-                    mark('stop', True),
-                ]
-            ),
-            # FIXME: This filtering step should be removed when:
-            #        old previously rejected records are treated
-            #        differently e.g. good auto-reject heuristics or better
-            #        time based filtering (5 days is quite random now).
-            IF(
-                previously_rejected(),
-                [
-                    mark('already-ingested', True),
-                    mark('stop', True),
-                ]
-            ),
-        ]
-    ),
-]
-
-
-DELETE_AND_STOP_IF_NEEDED = [
-    IF(
-        is_marked('delete'),
-        [
-            update_existing_workflow_object,
-            # TODO: Wen we get to fix refextract, we can remove the
-            # following step as the references will be good enough to
-            # trust
-            delete_self_and_stop_processing
-        ]
-    ),
-    IF(
-        is_marked('stop'),
-        [stop_processing]
-    ),
-]
-
-
 ENHANCE_RECORD = [
-    # Article Processing
-    # ==================
     IF(
         is_arxiv_paper,
         [
@@ -202,42 +140,24 @@ ENHANCE_RECORD = [
     guess_categories,
     IF(
         is_experimental_paper,
-        [guess_experiments]
+        guess_experiments,
     ),
     guess_keywords,
-    # Predict action for a generic HEP paper based only on title
-    # and abstract.
-    guess_coreness,  # ("arxiv_skip_astro_title_abstract.pickle)
-    # Check if we shall halt or auto-reject
-    # =====================================
-]
-
-
-CHECK_IF_SUBMISSION_AND_ASK_FOR_APPROVAL = [
-    IF_ELSE(
-        is_record_relevant,
-        [halt_record(
-            action="hep_approval",
-            message="Submission halted for curator approval.",
-        )],
-        [
-            reject_record("Article automatically rejected"),
-            stop_processing
-        ]
-    ),
+    guess_coreness,
 ]
 
 
 NOTIFY_NOT_ACCEPTED = [
     IF(
         is_submission,
-        [reply_ticket(context_factory=reply_ticket_context)]
+        reply_ticket(context_factory=reply_ticket_context),
     )
 ]
 
 
 NOTIFY_ALREADY_EXISTING = [
     reject_record('Article was already found on INSPIRE'),
+    mark('approved', False),
     reply_ticket(
         template=(
             "literaturesuggest/tickets/"
@@ -246,30 +166,31 @@ NOTIFY_ALREADY_EXISTING = [
         context_factory=reply_ticket_context
     ),
     close_ticket(ticket_id_key="ticket_id"),
+    save_workflow,
     stop_processing,
 ]
 
 
-NOTIFY_USER_OR_CURATOR = [
+NOTIFY_ACCEPTED = [
     IF(
         is_submission,
-        [
-            reply_ticket(
-                template='literaturesuggest/tickets/user_accepted.html',
-                context_factory=reply_ticket_context,
-            ),
-        ],
+        reply_ticket(
+            template='literaturesuggest/tickets/user_accepted.html',
+            context_factory=reply_ticket_context,
+        ),
     ),
+]
+
+
+NOTIFY_CURATOR_IF_CORE = [
     IF(
         curation_ticket_needed,
-        [
-            create_ticket(
-                template='literaturesuggest/tickets/curation_core.html',
-                queue='HEP_curation',
-                context_factory=curation_ticket_context,
-                ticket_id_key='curation_ticket_id',
-            ),
-        ],
+        create_ticket(
+            template='literaturesuggest/tickets/curation_core.html',
+            queue='HEP_curation',
+            context_factory=curation_ticket_context,
+            ticket_id_key='curation_ticket_id',
+        ),
     ),
 ]
 
@@ -287,56 +208,212 @@ SEND_TO_LEGACY_AND_WAIT = [
         is_marked('is-update'),
         [
             prepare_update_payload(extra_data_key="update_payload"),
-            send_robotupload(
-                mode="correct",
-                extra_data_key="update_payload"
-            ),
-        ], [
-            send_robotupload(
-                mode="insert"
-            ),
+            send_robotupload(mode="correct", extra_data_key="update_payload"),
+        ],
+        [
+            send_robotupload(mode="insert"),
             wait_webcoll,
         ]
     ),
 ]
 
-CHECK_IF_MERGE_AND_STOP_IF_SO = [
+
+STOP_IF_EXISTING_SUBMISSION = [
     IF(
-        is_marked('is-update'),
+        is_submission,
+        IF(
+            is_marked('is-update'),
+            NOTIFY_ALREADY_EXISTING
+        )
+    )
+]
+
+
+HALT_FOR_APPROVAL = [
+    IF_ELSE(
+        is_record_relevant,
+        halt_record(
+            action="hep_approval",
+            message="Submission halted for curator approval.",
+        ),
         [
-            IF_ELSE(
-                is_submission,
-                NOTIFY_ALREADY_EXISTING,
-                [
-                    # halt_record(action="merge_approval"),
-                    delete_self_and_stop_processing,
-                ]
-            ),
+            reject_record("Article automatically rejected"),
+            mark('approved', False),  # auto reject
+            save_workflow,
+            stop_processing,
         ]
     )
 ]
 
 
-ADD_MARKS = [
-    IF(
-        article_exists,
-        [
-            mark('is-update', True),
-        ],
-    ),
-    IF(
-        pending_in_holding_pen,
+STORE_RECORD = [
+    store_record
+]
+
+
+MARK_IF_MATCH_IN_HOLDINGPEN = [
+    IF_ELSE(
+        match_non_completed_wf_in_holdingpen,
         [
             mark('already-in-holding-pen', True),
+            save_workflow,
         ],
+        mark('already-in-holding-pen', False),
     ),
+
     IF_ELSE(
-        is_submission,
-        NOTIFY_SUBMISSION,
-        (
-            ADD_INGESTION_MARKS
+        match_previously_rejected_wf_in_holdingpen,
+        [
+            mark('previously_rejected', True),
+            save_workflow,
+        ],
+        mark('previously_rejected', False),
+    )
+]
+
+
+ERROR_WITH_UNEXPECTED_WORKFLOW_PATH = [
+    mark('unexpected-workflow-path', True),
+    error_workflow('Unexpected workflow path.'),
+    save_workflow,
+]
+
+
+# Currently we handle harvests as if all were arxiv, that will have to change.
+PROCESS_HOLDINGPEN_MATCH_HARVEST = [
+    IF(
+        is_marked('previously_rejected'),
+        IF(
+            has_same_source('previously_rejected_matches'),
+            [
+                mark('approved', False),  # auto-reject
+                save_workflow,
+                stop_processing,
+            ],
         )
     ),
+
+    IF_ELSE(
+        is_marked('already-in-holding-pen'),
+        IF_ELSE(
+            has_same_source('holdingpen_matches'),
+            # stop the matched wf and continue this one
+            [
+                stop_matched_holdingpen_wfs,
+                mark('stopped-matched-holdingpen-wf', True),
+            ],
+            [
+                # else, it's an update from another source
+                # keep the old one
+                mark('stopped-matched-holdingpen-wf', False),
+                save_workflow,
+                stop_processing
+            ],
+        ),
+        mark('stopped-matched-holdingpen-wf', False),
+    ),
+    save_workflow,
+]
+
+
+PROCESS_HOLDINGPEN_MATCH_SUBMISSION = [
+    IF(
+        is_marked('already-in-holding-pen'),
+        IF_ELSE(
+            has_same_source('holdingpen_matches'),
+            # form should detect this double submission
+            ERROR_WITH_UNEXPECTED_WORKFLOW_PATH,
+
+            # stop the matched wf and continue this one
+            [
+                stop_matched_holdingpen_wfs,
+                mark('stopped-matched-holdingpen-wf', True),
+                save_workflow
+            ],
+
+        )
+    )
+]
+
+
+PROCESS_HOLDINGPEN_MATCHES = [
+    IF_ELSE(
+        is_submission,
+        PROCESS_HOLDINGPEN_MATCH_SUBMISSION,
+        PROCESS_HOLDINGPEN_MATCH_HARVEST,
+    )
+]
+
+
+MARK_IF_UPDATE = [
+    IF_ELSE(
+        article_exists,
+        mark('is-update', True),
+        mark('is-update', False),
+    ),
+    save_workflow,
+]
+
+
+STOP_IF_ALREADY_HARVESTED_ON_LEGACY_OR_TOO_OLD = [
+    # checks to perform only for harvested records
+    IF_ELSE(
+        is_submission,
+        [
+            mark('already-ingested', False),
+            mark('too-many-days', False),
+        ],
+        [
+            IF_ELSE(
+                already_harvested,
+                [
+                    mark('already-ingested', True),
+                    save_workflow,
+                    stop_processing
+                ],
+                mark('already-ingested', False),
+            ),
+
+            IF_ELSE(
+                previously_rejected(),
+                [
+                    mark('too-many-days', True),
+                    save_workflow,
+                    stop_processing,
+                ],
+                mark('too-many-days', False),
+            ),
+        ]
+    ),
+    save_workflow,
+]
+
+
+NOTIFY_IF_SUBMISSION = [
+    IF(
+        is_submission,
+        NOTIFY_SUBMISSION,
+    )
+]
+
+
+INIT_MARKS = [
+    mark('already-ingested', None),
+    mark('too-many-days', None),
+    mark('already-in-holding-pen', None),
+    mark('previously_rejected', None),
+    mark('is-update', None),
+    mark('stopped-matched-holdingpen-wf', None),
+    mark('approved', None),
+    mark('unexpected-workflow-path', None),
+    save_workflow
+]
+
+
+PRE_PROCESSING = [
+    # Make sure schema is set for proper indexing in Holding Pen
+    set_schema,
+    INIT_MARKS,
 ]
 
 
@@ -346,36 +423,30 @@ class Article(object):
     data_type = "hep"
 
     workflow = (
-        [
-            # Make sure schema is set for proper indexing in Holding Pen
-            set_schema,
-        ] +
-        ADD_MARKS +
-        DELETE_AND_STOP_IF_NEEDED +
+        PRE_PROCESSING +
+        STOP_IF_ALREADY_HARVESTED_ON_LEGACY_OR_TOO_OLD +
+        NOTIFY_IF_SUBMISSION +
+        MARK_IF_MATCH_IN_HOLDINGPEN +
+        PROCESS_HOLDINGPEN_MATCHES +
+        MARK_IF_UPDATE +
         ENHANCE_RECORD +
-        # TODO: Once we have a way to resolve merges, we should
-        # use that instead of stopping
-        CHECK_IF_MERGE_AND_STOP_IF_SO +
-        CHECK_IF_SUBMISSION_AND_ASK_FOR_APPROVAL +
+        STOP_IF_EXISTING_SUBMISSION +
+        HALT_FOR_APPROVAL +
         [
             IF_ELSE(
                 is_record_accepted,
                 (
                     POSTENHANCE_RECORD +
+                    STORE_RECORD +
                     SEND_TO_LEGACY_AND_WAIT +
-                    NOTIFY_USER_OR_CURATOR +
-                    [
-                        # TODO: once legacy is out, this should become
-                        # unconditional, and remove the SEND_TO_LEGACY_AND_WAIT
-                        # steps
-                        IF_NOT(in_production_mode, [store_record]),
-                    ]
+                    NOTIFY_ACCEPTED +
+                    NOTIFY_CURATOR_IF_CORE
                 ),
                 NOTIFY_NOT_ACCEPTED,
             ),
             IF(
                 is_submission,
-                [close_ticket(ticket_id_key="ticket_id")],
+                close_ticket(ticket_id_key="ticket_id"),
             )
         ]
     )

--- a/tests/integration/tasks/test_matching.py
+++ b/tests/integration/tasks/test_matching.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+from invenio_search import current_search_client as es
+from invenio_workflows import (
+    ObjectStatus,
+    start,
+    WorkflowEngine,
+    WorkflowObject,
+    workflow_object_class,
+)
+
+from inspirehep.modules.workflows.tasks.matching import (
+    has_same_source,
+    match_non_completed_wf_in_holdingpen,
+    match_previously_rejected_wf_in_holdingpen,
+    stop_matched_holdingpen_wfs,
+)
+
+
+@pytest.fixture
+def simple_record(app):
+    yield {
+        '$schema': 'http://localhost:5000/schemas/records/hep.json',
+        '_collections': ['Literature'],
+        'document_type': ['article'],
+        'titles': [{'title': 'Superconductivity'}],
+        'acquisition_source': {'source': 'arXiv'},
+        'dois': [{'value': '10.3847/2041-8213/aa9110'}]
+    }
+
+    _es = app.extensions['invenio-search']
+    list(_es.client.indices.delete(index='holdingpen-hep'))
+    list(_es.create(ignore=[400]))
+
+
+def test_pending_holdingpen_matches_wf_if_not_completed(app, simple_record):
+    obj = workflow_object_class.create(
+        data=simple_record,
+        status=ObjectStatus.HALTED,
+        data_type='hep',
+    )
+    obj_id = obj.id
+    obj.save()
+    es.indices.refresh('holdingpen-hep')
+
+    obj2 = WorkflowObject.create(data=simple_record, data_type='hep')
+    assert match_non_completed_wf_in_holdingpen(obj2, None)
+    assert obj2.extra_data['holdingpen_matches'] == [obj_id]
+
+    obj = workflow_object_class.get(obj_id)
+    obj.status = ObjectStatus.COMPLETED
+    obj.save()
+    es.indices.refresh('holdingpen-hep')
+
+    # doesn't match anymore because obj is COMPLETED
+    assert not match_non_completed_wf_in_holdingpen(obj2, None)
+
+
+def test_match_previously_rejected_wf_in_holdingpen(app, simple_record):
+    obj = workflow_object_class.create(
+        data=simple_record,
+        status=ObjectStatus.COMPLETED,
+        data_type='hep',
+    )
+    obj_id = obj.id
+    obj.extra_data['approved'] = False  # reject it
+    obj.save()
+    es.indices.refresh('holdingpen-hep')
+
+    obj2 = WorkflowObject.create(data=simple_record, data_type='hep')
+    assert match_previously_rejected_wf_in_holdingpen(obj2, None)
+    assert obj2.extra_data['previously_rejected_matches'] == [obj_id]
+
+    obj = workflow_object_class.get(obj_id)
+    obj.status = ObjectStatus.HALTED
+    obj.save()
+    es.indices.refresh('holdingpen-hep')
+
+    # doesn't match anymore because obj is COMPLETED
+    assert not match_previously_rejected_wf_in_holdingpen(obj2, None)
+
+
+def test_has_same_source(app, simple_record):
+    obj = workflow_object_class.create(
+        data=simple_record,
+        status=ObjectStatus.HALTED,
+        data_type='hep',
+    )
+    obj_id = obj.id
+    obj.save()
+    es.indices.refresh('holdingpen-hep')
+
+    obj2 = WorkflowObject.create(data=simple_record, data_type='hep')
+    match_non_completed_wf_in_holdingpen(obj2, None)
+
+    same_source_func = has_same_source('holdingpen_matches')
+
+    assert same_source_func(obj2, None)
+    assert obj2.extra_data['holdingpen_matches'] == [obj_id]
+
+    # change source and match the wf in the holdingpen
+    different_source_rec = dict(simple_record)
+    different_source_rec['acquisition_source'] = {'source': 'different'}
+    obj3 = WorkflowObject.create(data=different_source_rec, data_type='hep')
+
+    assert match_non_completed_wf_in_holdingpen(obj3, None)
+    assert not same_source_func(obj3, None)
+
+
+def test_stop_matched_holdingpen_wfs(app, simple_record):
+    # need to run a wf in order to assign to it the wf definition and a uuid
+    # for it
+    workflow_uuid = start('article', [simple_record])
+    eng = WorkflowEngine.from_uuid(workflow_uuid)
+    obj = eng.processed_objects[0]
+    obj.status = ObjectStatus.HALTED
+    obj.save()
+    obj_id = obj.id
+
+    es.indices.refresh('holdingpen-hep')
+
+    obj2 = WorkflowObject.create(data=simple_record, data_type='hep')
+    obj2_id = obj2.id
+
+    match_non_completed_wf_in_holdingpen(obj2, None)
+    assert obj2.extra_data['holdingpen_matches'] == [obj_id]
+
+    stop_matched_holdingpen_wfs(obj2, None)
+
+    stopped_wf = workflow_object_class.get(obj_id)
+    assert stopped_wf.status == ObjectStatus.COMPLETED
+    assert stopped_wf.extra_data['stopped-by-wf'] == obj2_id

--- a/tests/integration/workflows/conftest.py
+++ b/tests/integration/workflows/conftest.py
@@ -23,47 +23,21 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+import re
+import pytest
+import requests_mock
 import sys
 
-import pytest
-
 from invenio_db import db
-from invenio_workflows import workflow_object_class
 
 from inspirehep.factory import create_app
-from inspirehep.modules.workflows.models import (
-    WorkflowsAudit,
-    WorkflowsPendingRecord,
-)
-
+from inspirehep.modules.fixtures.collections import init_collections
+from inspirehep.modules.fixtures.files import init_all_storage_paths
+from inspirehep.modules.fixtures.users import init_users_and_permissions
 
 # Use the helpers folder to store test helpers.
 # See: http://stackoverflow.com/a/33515264/374865
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'helpers'))
-
-
-@pytest.fixture(autouse=True)
-def cleanup_workflows_tables(small_app):
-    """Delete the contents of the workflow tables after each test.
-
-    .. deprecated:: 2017-09-18
-       Tests that need to clean up should do so explicitly.
-    """
-    with small_app.app_context():
-        obj_types = (
-            WorkflowsAudit.query.all(),
-            WorkflowsPendingRecord.query.all(),
-            workflow_object_class.query(),
-        )
-        for obj_type in obj_types:
-            for obj in obj_type:
-                obj.delete()
-
-        db.session.commit()
-
-        _es = small_app.extensions['invenio-search']
-        list(_es.delete(ignore=[404]))
-        list(_es.create(ignore=[404]))
 
 
 @pytest.fixture
@@ -85,8 +59,73 @@ def workflow_app():
             'http://localhost:1234'
         ),
         MAGPIE_API_URL="http://example.com/magpie",
+        WORKFLOWS_MATCH_REMOTE_SERVER_URL="http://legacy_search.endpoint/",
+        WORKFLOWS_FILE_LOCATION="/",
         WTF_CSRF_ENABLED=False,
     )
 
     with app.app_context():
         yield app
+
+
+def drop_all(app):
+    db.drop_all()
+    _es = app.extensions['invenio-search']
+    list(_es.delete(ignore=[404]))
+
+
+def create_all(app):
+    db.create_all()
+    _es = app.extensions['invenio-search']
+    list(_es.create(ignore=[400]))
+
+    init_all_storage_paths()
+    init_users_and_permissions()
+    init_collections()
+
+
+@pytest.fixture(autouse=True)
+def cleanup_workflows(workflow_app):
+    db.session.close_all()
+    drop_all(app=workflow_app)
+    create_all(app=workflow_app)
+
+
+@pytest.fixture
+def mocked_external_services(workflow_app):
+    with requests_mock.Mocker() as requests_mocker:
+        requests_mocker.register_uri(
+            requests_mock.ANY,
+            re.compile('.*(indexer|localhost).*'),
+            real_http=True,
+        )
+        requests_mocker.register_uri(
+            'POST',
+            re.compile(
+                'https?://localhost:1234.*',
+            ),
+            text=u'[INFO]',
+            status_code=200,
+        )
+        requests_mocker.register_uri(
+            requests_mock.ANY,
+            re.compile(
+                '.*' +
+                workflow_app.config['WORKFLOWS_MATCH_REMOTE_SERVER_URL'] +
+                '.*'
+            ),
+            status_code=200,
+            json=[],
+        )
+        requests_mocker.register_uri(
+            requests_mock.ANY,
+            re.compile(
+                '.*' +
+                workflow_app.config['BEARD_API_URL'] +
+                '/text/phonetic_blocks.*'
+            ),
+            status_code=200,
+            json={'phonetic_blocks': {}},
+        )
+
+        yield

--- a/tests/integration/workflows/helpers/utils.py
+++ b/tests/integration/workflows/helpers/utils.py
@@ -83,6 +83,6 @@ def get_halted_workflow(mocked_is_pdf_link, app, record, extra_config=None):
     } in keywords_prediction['keywords']
 
     # This record should not have been touched yet
-    assert "approved" not in obj.extra_data
+    assert obj.extra_data['approved'] is None
 
     return workflow_uuid, eng, obj

--- a/tests/integration/workflows/test_arxiv_workflow.py
+++ b/tests/integration/workflows/test_arxiv_workflow.py
@@ -25,9 +25,8 @@
 from __future__ import absolute_import, division, print_function
 
 import mock
-import re
-import requests_mock
 
+from invenio_search import current_search_client as es
 from invenio_db import db
 from invenio_workflows import (
     ObjectStatus,
@@ -41,7 +40,7 @@ from calls import (
     do_accept_core,
     do_webcoll_callback,
     do_robotupload_callback,
-    generate_record
+    generate_record,
 )
 from mocks import (
     fake_download_file,
@@ -52,7 +51,10 @@ from utils import get_halted_workflow
 
 
 @mock.patch(
-    'inspirehep.modules.workflows.utils.download_file_to_workflow',
+    'inspirehep.modules.workflows.tasks.arxiv.is_pdf_link'
+)
+@mock.patch(
+    'inspirehep.modules.workflows.tasks.arxiv.download_file_to_workflow',
     side_effect=fake_download_file,
 )
 @mock.patch(
@@ -68,11 +70,12 @@ from utils import get_halted_workflow
     return_value=[],
 )
 def test_harvesting_arxiv_workflow_manual_rejected(
+    mocked_arxiv_download,
     mocked_refextract_extract_refs,
     mocked_api_request_magpie,
     mocked_api_request_beard,
-    mocked_download,
-    small_app,
+    workflow_app,
+    mocked_external_services,
 ):
     """Test a full harvesting workflow."""
     record = generate_record()
@@ -81,36 +84,33 @@ def test_harvesting_arxiv_workflow_manual_rejected(
         "MAGPIE_API_URL": "http://example.com/magpie",
     }
 
-    workflow_uuid = None
-    with small_app.app_context():
-        workflow_uuid, eng, obj = get_halted_workflow(
-            app=small_app,
-            extra_config=extra_config,
-            record=record,
-        )
+    workflow_uuid, eng, obj = get_halted_workflow(
+        app=workflow_app,
+        extra_config=extra_config,
+        record=record,
+    )
 
-        # Now let's resolve it as accepted and continue
-        # FIXME Should be accept, but record validation prevents us.
-        obj.remove_action()
-        obj.extra_data["approved"] = False
-        # obj.extra_data["core"] = True
-        obj.save()
+    obj.extra_data["approved"] = False
+    obj.save()
+    db.session.commit()
 
-        db.session.commit()
+    eng = WorkflowEngine.from_uuid(workflow_uuid)
+    obj = eng.processed_objects[0]
+    obj_id = obj.id
+    obj.continue_workflow()
 
-        eng = WorkflowEngine.from_uuid(workflow_uuid)
-        obj = eng.processed_objects[0]
-        obj_id = obj.id
-        obj.continue_workflow()
-
-        obj = workflow_object_class.get(obj_id)
-        # It was rejected
-        assert obj.status == ObjectStatus.COMPLETED
+    obj = workflow_object_class.get(obj_id)
+    # It was rejected
+    assert obj.status == ObjectStatus.COMPLETED
 
 
 @mock.patch(
-    'inspirehep.modules.workflows.utils.download_file_to_workflow',
+    'inspirehep.modules.workflows.tasks.arxiv.download_file_to_workflow',
     side_effect=fake_download_file,
+)
+@mock.patch(
+    'inspirehep.modules.workflows.tasks.arxiv.is_pdf_link',
+    return_value=True
 )
 @mock.patch(
     'inspirehep.modules.workflows.tasks.beard.json_api_request',
@@ -125,11 +125,13 @@ def test_harvesting_arxiv_workflow_manual_rejected(
     return_value=[],
 )
 def test_harvesting_arxiv_workflow_already_on_legacy(
+    mocked_download,
+    mocked_is_pdf,
     mocked_refextract_extract_refs,
     mocked_api_request_magpie,
     mocked_api_request_beard,
-    mocked_download,
-    small_app
+    workflow_app,
+    mocked_external_services
 ):
     """Test a full harvesting workflow."""
     record, categories = already_harvested_on_legacy_record()
@@ -139,8 +141,8 @@ def test_harvesting_arxiv_workflow_already_on_legacy(
         "MAGPIE_API_URL": "http://example.com/magpie",
         'ARXIV_CATEGORIES_ALREADY_HARVESTED_ON_LEGACY': categories,
     }
-    with small_app.app_context():
-        with mock.patch.dict(small_app.config, extra_config):
+    with workflow_app.app_context():
+        with mock.patch.dict(workflow_app.config, extra_config):
             workflow_uuid = start('article', [record])
 
         eng = WorkflowEngine.from_uuid(workflow_uuid)
@@ -183,53 +185,193 @@ def test_harvesting_arxiv_workflow_manual_accepted(
     mocked_download_utils,
     mocked_download_arxiv,
     workflow_app,
+    mocked_external_services,
 ):
     record = generate_record()
     """Test a full harvesting workflow."""
-    with requests_mock.Mocker() as requests_mocker:
-        requests_mocker.register_uri(
-            requests_mock.ANY,
-            re.compile('.*(indexer|localhost).*'),
-            real_http=True,
-        )
-        requests_mocker.register_uri(
-            'POST',
-            re.compile(
-                'https?://localhost:1234.*',
-            ),
-            text=u'[INFO]',
-            status_code=200,
-        )
 
-        workflow_uuid, eng, obj = get_halted_workflow(
-            app=workflow_app,
-            extra_config={'PRODUCTION_MODE': False},
-            record=record,
-        )
+    workflow_uuid, eng, obj = get_halted_workflow(
+        app=workflow_app,
+        record=record,
+    )
 
-        do_accept_core(
-            app=workflow_app,
-            workflow_id=obj.id,
-        )
+    do_accept_core(
+        app=workflow_app,
+        workflow_id=obj.id,
+    )
 
-        eng = WorkflowEngine.from_uuid(workflow_uuid)
-        obj = eng.processed_objects[0]
-        assert obj.status == ObjectStatus.WAITING
+    eng = WorkflowEngine.from_uuid(workflow_uuid)
+    obj = eng.processed_objects[0]
+    assert obj.status == ObjectStatus.WAITING
 
-        response = do_robotupload_callback(
-            app=workflow_app,
-            workflow_id=obj.id,
-            recids=[12345],
-        )
-        assert response.status_code == 200
+    response = do_robotupload_callback(
+        app=workflow_app,
+        workflow_id=obj.id,
+        recids=[12345],
+    )
+    assert response.status_code == 200
 
-        obj = workflow_object_class.get(obj.id)
-        assert obj.status == ObjectStatus.WAITING
+    obj = workflow_object_class.get(obj.id)
+    assert obj.status == ObjectStatus.WAITING
 
-        response = do_webcoll_callback(app=workflow_app, recids=[12345])
-        assert response.status_code == 200
+    response = do_webcoll_callback(app=workflow_app, recids=[12345])
+    assert response.status_code == 200
 
-        eng = WorkflowEngine.from_uuid(workflow_uuid)
-        obj = eng.processed_objects[0]
-        # It was accepted
-        assert obj.status == ObjectStatus.COMPLETED
+    eng = WorkflowEngine.from_uuid(workflow_uuid)
+    obj = eng.processed_objects[0]
+    # It was accepted
+    assert obj.status == ObjectStatus.COMPLETED
+
+
+@mock.patch(
+    'inspirehep.modules.workflows.tasks.arxiv.is_pdf_link',
+    return_value=True
+)
+@mock.patch(
+    'inspirehep.modules.workflows.tasks.arxiv.download_file_to_workflow',
+    side_effect=fake_download_file,
+)
+@mock.patch(
+    'inspirehep.modules.workflows.tasks.beard.json_api_request',
+    side_effect=fake_beard_api_request,
+)
+@mock.patch(
+    'inspirehep.modules.workflows.tasks.magpie.json_api_request',
+    side_effect=fake_magpie_api_request,
+)
+def test_match_in_holdingpen_stops_pending_wf(
+    mocked_download_arxiv,
+    mocked_api_request_beard,
+    mocked_api_request_magpie,
+    workflow_app,
+    mocked_external_services,
+):
+    record = generate_record()
+
+    eng_uuid = start('article', [record])
+    es.indices.refresh('holdingpen-hep')
+    eng = WorkflowEngine.from_uuid(eng_uuid)
+    old_wf = eng.objects[0]
+    obj_id = old_wf.id
+
+    assert old_wf.status == ObjectStatus.HALTED
+    assert old_wf.extra_data['previously_rejected'] is False
+
+    record2 = record
+    record['titles'][0]['title'] = 'This is an update that will match the wf in the holdingpen'
+    eng_uuid2 = start('article', [record2])
+    es.indices.refresh('holdingpen-hep')
+    eng2 = WorkflowEngine.from_uuid(eng_uuid2)
+    update_wf = eng2.objects[0]
+
+    assert update_wf.status == ObjectStatus.HALTED
+    assert update_wf.extra_data['already-ingested'] is False
+    assert update_wf.extra_data['already-in-holding-pen'] is True
+    assert update_wf.extra_data['previously_rejected'] is False
+    assert update_wf.extra_data['stopped-matched-holdingpen-wf'] is True
+    assert update_wf.extra_data['is-update'] is False
+
+    old_wf = workflow_object_class.get(obj_id)
+    assert old_wf.extra_data['already-ingested'] is False
+    assert old_wf.extra_data['already-in-holding-pen'] is False
+    assert old_wf.extra_data['previously_rejected'] is False
+    assert old_wf.extra_data['stopped-by-wf'] == update_wf.id
+    assert old_wf.extra_data.get('approved') is None
+    assert old_wf.extra_data['is-update'] is False
+    assert old_wf.status == ObjectStatus.COMPLETED
+
+
+@mock.patch(
+    'inspirehep.modules.workflows.tasks.arxiv.is_pdf_link',
+    return_value=True
+)
+@mock.patch(
+    'inspirehep.modules.workflows.tasks.arxiv.download_file_to_workflow',
+    side_effect=fake_download_file,
+)
+@mock.patch(
+    'inspirehep.modules.workflows.tasks.beard.json_api_request',
+    side_effect=fake_beard_api_request,
+)
+@mock.patch(
+    'inspirehep.modules.workflows.tasks.magpie.json_api_request',
+    side_effect=fake_magpie_api_request,
+)
+def test_match_in_holdingpen_previously_rejected_wf_stop(
+    mocked_download_arxiv,
+    mocked_api_request_beard,
+    mocked_api_request_magpie,
+    workflow_app,
+    mocked_external_services,
+):
+    record = generate_record()
+
+    eng_uuid = start('article', [record])
+    eng = WorkflowEngine.from_uuid(eng_uuid)
+    obj_id = eng.objects[0].id
+    obj = workflow_object_class.get(obj_id)
+    obj.extra_data["approved"] = False  # reject record
+    obj.continue_workflow()
+    obj = workflow_object_class.get(obj_id)
+    assert obj.status == ObjectStatus.COMPLETED
+    assert obj.extra_data.get('approved') is False
+
+    es.indices.refresh('holdingpen-hep')
+
+    record['titles'][0]['title'] = 'This is an update that will match the wf in the holdingpen'
+    # this workflow matches in the holdingpen and stops because the
+    # matched one was rejected
+    eng_uuid = start('article', [record])
+    eng = WorkflowEngine.from_uuid(eng_uuid)
+    obj2 = eng.objects[0]
+
+    assert obj2.extra_data['already-in-holding-pen'] is False
+    assert obj2.extra_data['previously_rejected'] is True
+    assert obj2.extra_data['previously_rejected_matches'] == [obj_id]
+
+
+@mock.patch(
+    'inspirehep.modules.workflows.tasks.arxiv.is_pdf_link',
+    return_value=True
+)
+@mock.patch(
+    'inspirehep.modules.workflows.tasks.arxiv.download_file_to_workflow',
+    side_effect=fake_download_file,
+)
+@mock.patch(
+    'inspirehep.modules.workflows.tasks.beard.json_api_request',
+    side_effect=fake_beard_api_request,
+)
+@mock.patch(
+    'inspirehep.modules.workflows.tasks.magpie.json_api_request',
+    side_effect=fake_magpie_api_request,
+)
+def test_match_in_holdingpen_different_sources_continues(
+    mocked_download_arxiv,
+    mocked_api_request_beard,
+    mocked_api_request_magpie,
+    workflow_app,
+    mocked_external_services,
+):
+    record = generate_record()
+
+    eng_uuid = start('article', [record])
+    es.indices.refresh('holdingpen-hep')
+    eng = WorkflowEngine.from_uuid(eng_uuid)
+    wf_to_match = eng.objects[0].id
+    obj = workflow_object_class.get(wf_to_match)
+    assert obj.status == ObjectStatus.HALTED
+    # generated wf pending in holdingpen
+
+    record['titles'][0]['title'] = 'This is an update that will match the wf in the holdingpen'
+    record['acquisition_source']['source'] = 'but not the source'
+    # this workflow matches in the holdingpen but continues because has a
+    # different source
+    eng_uuid = start('article', [record])
+    eng = WorkflowEngine.from_uuid(eng_uuid)
+    obj = eng.objects[0]
+
+    assert obj.extra_data['already-in-holding-pen'] is True
+    assert obj.extra_data['holdingpen_matches'] == [wf_to_match]
+    assert obj.extra_data['previously_rejected'] is False
+    assert not obj.extra_data.get('stopped-matched-holdingpen-wf')

--- a/tests/integration/workflows/test_audit.py
+++ b/tests/integration/workflows/test_audit.py
@@ -33,10 +33,10 @@ from inspirehep.modules.workflows.models import WorkflowsAudit
 from inspirehep.modules.workflows.utils import log_workflows_action
 
 
-def test_audit(small_app):
+def test_audit(workflow_app):
     user_id = None
     workflow_id = None
-    with small_app.app_context():
+    with workflow_app.app_context():
         user = User(email="test@example.com", active=True)
         user.password = "test"
         db.session.add(user)
@@ -47,7 +47,7 @@ def test_audit(small_app):
         user_id = user.id
         workflow_id = workflows_object.id
 
-    with small_app.app_context():
+    with workflow_app.app_context():
         logging_info = {
             'object_id': workflow_id,
             'user_id': user_id,
@@ -73,7 +73,7 @@ def test_audit(small_app):
     relevance_prediction = dict(
         max_score=0.222113, decision="Rejected"
     )
-    with small_app.app_context():
+    with workflow_app.app_context():
         log_workflows_action(
             action="accept_core",
             relevance_prediction=relevance_prediction,

--- a/tests/integration/workflows/test_hep_approval.py
+++ b/tests/integration/workflows/test_hep_approval.py
@@ -51,7 +51,7 @@ def workflow():
     db.session.commit()
 
 
-def test_resolve_accept(small_app, workflow):
+def test_resolve_accept(workflow_app, workflow):
     args = {
         'request_data': {
             'value': 'accept',
@@ -70,7 +70,7 @@ def test_resolve_accept(small_app, workflow):
     assert workflow.extra_data == expected
 
 
-def test_resolve_accept_core(small_app, workflow):
+def test_resolve_accept_core(workflow_app, workflow):
     args = {
         'request_data': {
             'value': 'accept_core'
@@ -89,7 +89,7 @@ def test_resolve_accept_core(small_app, workflow):
     assert workflow.extra_data == expected
 
 
-def test_resolve_rejected(small_app, workflow):
+def test_resolve_rejected(workflow_app, workflow):
     args = {
         'request_data': {
             'value': 'rejected',
@@ -109,7 +109,7 @@ def test_resolve_rejected(small_app, workflow):
     assert workflow.extra_data == expected
 
 
-def test_resolve_attach_pdf(small_app, workflow):
+def test_resolve_attach_pdf(workflow_app, workflow):
     args = {
         'request_data': {
             'value': 'accept',
@@ -138,7 +138,7 @@ def test_resolve_attach_pdf(small_app, workflow):
     assert 'fulltext.pdf' in [doc['key'] for doc in workflow.data['documents']]
 
 
-def test_resolve_remove_pdf(small_app, workflow):
+def test_resolve_remove_pdf(workflow_app, workflow):
     args = {
         'request_data': {
             'value': 'accept',

--- a/tests/unit/workflows/test_workflows_tasks_matching.py
+++ b/tests/unit/workflows/test_workflows_tasks_matching.py
@@ -29,7 +29,7 @@ from inspirehep.modules.workflows.tasks.matching import (
     already_harvested,
     article_exists,
     is_being_harvested_on_legacy,
-    pending_in_holding_pen,
+    _pending_in_holding_pen,
 )
 
 from mocks import MockEng, MockObj
@@ -238,13 +238,7 @@ def test_pending_in_holding_pen_returns_true_if_something_matched(mock_match):
     obj = MockObj(data, extra_data, id=2)
     eng = MockEng()
 
-    assert pending_in_holding_pen(obj, eng)
-    assert 'holdingpen_matches' in obj.extra_data
-
-    expected = [1]
-    result = obj.extra_data['holdingpen_matches']
-
-    assert expected == result
+    assert _pending_in_holding_pen(obj, eng)
 
 
 @patch('inspirehep.modules.workflows.tasks.matching.match')
@@ -257,9 +251,4 @@ def test_pending_in_holding_pen_returns_false_if_nothing_matched(mock_match):
     obj = MockObj(data, extra_data)
     eng = MockEng()
 
-    assert not pending_in_holding_pen(obj, eng)
-    assert 'holdingpen_matches' in obj.extra_data
-    expected = []
-    result = obj.extra_data['holdingpen_matches']
-
-    assert expected == result
+    assert not _pending_in_holding_pen(obj, eng)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Change the workflow's logic for handling matches in the holdingpen

## Description
This pull request changes the workflow's logic for rejecting, stopping or continuing workflows when the payload matches an existing workflow in the holdingpen.
The new business logic is:
* if matches in holdingpen but have different sources then continue.
* if matches in holdingpen but different sources, reject if the matched was previously rejected.
* if matches in holdingpen but different sources, stop the matched workflow if it wasn't rejected and continue. 

This PR also refactors some workflow's parts, adding marks in the main decisional points. Such marks are used in integration tests to check that the right control flow has been executed. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Closes #1800, closes #1799, closes #1724.

Signed-off-by: Antonio Cesarano <cesarano2607@gmail.com>
Co-Authored-By: David Caro <david@dcaro.es>