### PR TITLE
minter: increase record's pid properly when migrating records from legacy

### DIFF
--- a/inspirehep/modules/pidstore/providers.py
+++ b/inspirehep/modules/pidstore/providers.py
@@ -69,8 +69,12 @@ class InspireRecordIdProvider(BaseProvider):
         if 'pid_value' not in kwargs:
             if current_app.config.get('LEGACY_PID_PROVIDER'):
                 kwargs['pid_value'] = _get_next_pid_from_legacy()
+                RecordIdentifier.insert(kwargs['pid_value'])
             else:
                 kwargs['pid_value'] = RecordIdentifier.next()
+        else:
+            RecordIdentifier.insert(kwargs['pid_value'])
+
         kwargs.setdefault('status', cls.default_status)
         if object_type and object_uuid:
             kwargs['status'] = PIDStatus.REGISTERED

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -22,6 +22,9 @@
 
 from __future__ import absolute_import, division, print_function
 
+import sys
+import os
+
 import pytest
 
 from invenio_db import db
@@ -31,6 +34,11 @@ from inspirehep.factory import create_app
 from inspirehep.modules.fixtures.collections import init_collections
 from inspirehep.modules.fixtures.files import init_all_storage_paths
 from inspirehep.modules.fixtures.users import init_users_and_permissions
+
+
+# Use the helpers folder to store test helpers.
+# See: http://stackoverflow.com/a/33515264/374865
+sys.path.append(os.path.join(os.path.dirname(__file__), 'helpers'))
 
 
 @pytest.fixture(scope='session')

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -38,7 +38,7 @@ from inspirehep.modules.fixtures.users import init_users_and_permissions
 
 # Use the helpers folder to store test helpers.
 # See: http://stackoverflow.com/a/33515264/374865
-sys.path.append(os.path.join(os.path.dirname(__file__), 'helpers'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'helpers'))
 
 
 @pytest.fixture(scope='session')

--- a/tests/integration/editor/test_editor_views.py
+++ b/tests/integration/editor/test_editor_views.py
@@ -35,25 +35,13 @@ from invenio_accounts.models import SessionActivity
 from invenio_accounts.testutils import login_user_via_session
 from invenio_cache import current_cache
 from invenio_db import db
-from invenio_pidstore.models import PersistentIdentifier
 
 from inspire_schemas.api import load_schema, validate
 from inspire_utils.record import get_value
 from inspirehep.modules.migrator.tasks import record_insert_or_replace
 from inspirehep.utils.record_getter import get_db_record
 
-
-def _delete_record(pid_type, pid_value):
-    get_db_record(pid_type, pid_value)._delete(force=True)
-
-    pid = PersistentIdentifier.get(pid_type, pid_value)
-    PersistentIdentifier.delete(pid)
-
-    object_uuid = pid.object_uuid
-    PersistentIdentifier.query.filter(
-        object_uuid == PersistentIdentifier.object_uuid).delete()
-
-    db.session.commit()
+from utils import _delete_record
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/helpers/utils.py
+++ b/tests/integration/helpers/utils.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+from invenio_db import db
+from invenio_pidstore.models import PersistentIdentifier, RecordIdentifier
+
+from inspirehep.utils.record_getter import get_db_record
+
+
+def _delete_record(pid_type, pid_value):
+    get_db_record(pid_type, pid_value)._delete(force=True)
+
+    pid = PersistentIdentifier.get(pid_type, pid_value)
+    PersistentIdentifier.delete(pid)
+
+    recpid = RecordIdentifier.query.filter_by(recid=pid_value).one_or_none()
+    if recpid:
+        db.session.delete(recpid)
+
+    object_uuid = pid.object_uuid
+    PersistentIdentifier.query.filter(
+        object_uuid == PersistentIdentifier.object_uuid).delete()
+
+    db.session.commit()

--- a/tests/integration/test_migrator.py
+++ b/tests/integration/test_migrator.py
@@ -30,25 +30,11 @@ import pytest
 from flask import current_app
 from redis import StrictRedis
 
-from invenio_db import db
-from invenio_pidstore.models import PersistentIdentifier
-
 from inspirehep.modules.migrator.models import InspireProdRecords
 from inspirehep.modules.migrator.tasks import continuous_migration
 from inspirehep.utils.record_getter import get_db_record
 
-
-def _delete_record(pid_type, pid_value):
-    get_db_record(pid_type, pid_value)._delete(force=True)
-
-    pid = PersistentIdentifier.get(pid_type, pid_value)
-    PersistentIdentifier.delete(pid)
-
-    object_uuid = pid.object_uuid
-    PersistentIdentifier.query.filter(
-        object_uuid == PersistentIdentifier.object_uuid).delete()
-
-    db.session.commit()
+from utils import _delete_record
 
 
 def push_to_redis(record_file):

--- a/tests/integration/workflows/conftest.py
+++ b/tests/integration/workflows/conftest.py
@@ -39,7 +39,7 @@ from inspirehep.modules.workflows.models import (
 
 # Use the helpers folder to store test helpers.
 # See: http://stackoverflow.com/a/33515264/374865
-sys.path.append(os.path.join(os.path.dirname(__file__), 'helpers'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'helpers'))
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -32,7 +32,7 @@ from inspirehep.factory import create_app
 
 # Use the helpers folder to store test helpers.
 # See: http://stackoverflow.com/a/33515264/374865
-sys.path.append(os.path.join(os.path.dirname(__file__), 'helpers'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'helpers'))
 
 
 @pytest.fixture(autouse=True, scope='session')


### PR DESCRIPTION
Signed-off-by: Antonio Cesarano <cesarano2607@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
When inserting a new record having already a ``pid``, this is not added to the table ``pidstore_recid``, making the identifiers out of synch.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
