### PR TITLE
workflows: stop the workflow after closing tickets

### DIFF
--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -239,7 +239,6 @@ NOTIFY_NOT_ACCEPTED = [
 
 NOTIFY_ALREADY_EXISTING = [
     reject_record('Article was already found on INSPIRE'),
-    stop_processing,
     reply_ticket(
         template=(
             "literaturesuggest/tickets/"
@@ -248,6 +247,7 @@ NOTIFY_ALREADY_EXISTING = [
         context_factory=reply_ticket_context
     ),
     close_ticket(ticket_id_key="ticket_id"),
+    stop_processing,
 ]
 
 


### PR DESCRIPTION
Some workflows are getting discarded without actually closing the
tickets or notifying anyone, this solves that case.
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Signed-off-by: David Caro <david@dcaro.es>