### PR TITLE
InspireRecord: allow skipping the files downloading

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -1139,6 +1139,11 @@ RECORDS_VALIDATION_TYPES = {
     'array': (list, tuple),
 }
 
+# If set, will disable downloading records files by default (can be overriden
+# by the `skip_files` parameter of `InspireRecord.create` and
+# `InspireRecord.update`)
+RECORDS_SKIP_FILES = False
+
 JSONSCHEMAS_HOST = "localhost:5000"
 JSONSCHEMAS_REPLACE_REFS = True
 JSONSCHEMAS_LOADER_CLS = 'inspirehep.modules.records.json_ref_loader.SCHEMA_LOADER_CLS'

--- a/inspirehep/modules/records/api.py
+++ b/inspirehep/modules/records/api.py
@@ -72,9 +72,19 @@ class InspireRecord(Record):
                 records.
         """
         files_src_record = kwargs.pop('files_src_record', None)
+        skip_files = kwargs.pop(
+            'skip_files',
+            current_app.config.get('RECORDS_SKIP_FILES', False),
+        )
+
         new_record = super(InspireRecord, cls).create(*args, **kwargs)
-        new_record.download_documents_and_figures(src_record=files_src_record)
-        new_record.commit()
+
+        if not skip_files:
+            new_record.download_documents_and_figures(
+                src_record=files_src_record,
+            )
+            new_record.commit()
+
         return new_record
 
     def update(self, *args, **kwargs):
@@ -90,11 +100,20 @@ class InspireRecord(Record):
                 records.
         """
         files_src_record = kwargs.pop('files_src_record', None)
-        super(InspireRecord, self).update(*args, **kwargs)
-        self.download_documents_and_figures(
-            only_new=True,
-            src_record=files_src_record,
+        skip_files = kwargs.pop(
+            'skip_files',
+            current_app.config.get('RECORDS_SKIP_FILES', False),
         )
+
+        res = super(InspireRecord, self).update(*args, **kwargs)
+
+        if not skip_files:
+            self.download_documents_and_figures(
+                only_new=True,
+                src_record=files_src_record,
+            )
+
+        return res
 
     def merge(self, other):
         """Redirect pidstore of current record to the other InspireRecord.

--- a/tests/integration/test_records.py
+++ b/tests/integration/test_records.py
@@ -25,7 +25,6 @@ from __future__ import absolute_import, division, print_function
 import copy
 import pytest
 import StringIO
-import requests_mock
 from mock import patch, mock_open
 
 from dojson.contrib.marc21.utils import create_record
@@ -44,7 +43,7 @@ from inspirehep.modules.records.tasks import merge_merged_records, update_refs
 from inspirehep.modules.migrator.tasks import record_insert_or_replace
 from inspirehep.utils.record_getter import get_db_record, get_es_records
 
-from utils import _delete_record
+from utils import _delete_record, mock_addresses
 
 
 def _delete_merged_records(pid_type, merged_pid_value, deleted_pid_value, merged_uuid, deleted_uuid):
@@ -433,28 +432,31 @@ def test_update_handles_documents(app):
         }],
     }
 
+    expected_file_content = 'dummy body'
+    expected_key = '1_Fulltext.pdf'
+
     record = InspireRecord.create(record_json)
     assert not len(record.files)
 
-    with requests_mock.Mocker() as requests_mocker:
-        expected_file_content = 'dummy body'
-        requests_mocker.register_uri(
-            'GET', 'http://www.mdpi.com/2218-1997/3/1/24/pdf',
-            body=StringIO.StringIO(expected_file_content),
-        )
+    record.clear()
+    updated_json = record_json
+    updated_json.update(copy.deepcopy(update_to_record))
 
-        record.clear()
-        updated_json = record_json
-        updated_json.update(copy.deepcopy(update_to_record))
+    mocked_addresses = [
+        {
+            'method': 'GET',
+            'url': 'http://www.mdpi.com/2218-1997/3/1/24/pdf',
+            'body': StringIO.StringIO(expected_file_content),
+        }
+    ]
+    with mock_addresses(mocked_addresses):
         record.update(updated_json)
 
-        expected_key = '1_Fulltext.pdf'
-
-        assert expected_key in record.files.keys
-        assert len(record.files) == len(update_to_record['documents'])
-        assert len(record['documents']) == len(update_to_record['documents'])
-        file_content = open(record.files[expected_key].obj.file.uri).read()
-        assert file_content == expected_file_content
+    assert expected_key in record.files.keys
+    assert len(record.files) == len(update_to_record['documents'])
+    assert len(record['documents']) == len(update_to_record['documents'])
+    file_content = open(record.files[expected_key].obj.file.uri).read()
+    assert file_content == expected_file_content
 
 
 @patch(
@@ -513,22 +515,25 @@ def test_update_handles_figures(app):
         }],
     }
 
+    expected_file_content = 'dummy body'
+    expected_key = '1_graph.png'
+
     record = InspireRecord.create(record_json)
     assert not len(record.files)
 
-    with requests_mock.Mocker() as requests_mocker:
-        expected_file_content = 'dummy body'
-        requests_mocker.register_uri(
-            'GET', 'http://www.mdpi.com/2218-1997/3/1/24/png',
-            body=StringIO.StringIO(expected_file_content),
-        )
+    record.clear()
+    updated_json = record_json
+    updated_json.update(copy.deepcopy(update_to_record))
 
-        record.clear()
-        updated_json = record_json
-        updated_json.update(copy.deepcopy(update_to_record))
+    mocked_addresses = [
+        {
+            'method': 'GET',
+            'url': 'http://www.mdpi.com/2218-1997/3/1/24/png',
+            'body': StringIO.StringIO(expected_file_content),
+        }
+    ]
+    with mock_addresses(mocked_addresses):
         record.update(updated_json)
-
-        expected_key = '1_graph.png'
 
     assert expected_key in record.files.keys
     assert len(record.files) == len(update_to_record['figures'])
@@ -587,15 +592,17 @@ def test_update_with_only_new(app):
     assert file_content == doc1_expected_file_content
 
     doc1_old_api_url = record['documents'][0]['url']
+    record.clear()
+    record_json.update(copy.deepcopy(update_to_record))
 
-    with requests_mock.Mocker() as requests_mocker:
-        requests_mocker.register_uri(
-            'GET', 'http://www.mdpi.com/2218-1997/3/1/24/pdf',
-            body=StringIO.StringIO(doc2_expected_file_content),
-        )
-
-        record.clear()
-        record_json.update(copy.deepcopy(update_to_record))
+    mocked_addresses = [
+        {
+            'method': 'GET',
+            'url': 'http://www.mdpi.com/2218-1997/3/1/24/pdf',
+            'body': StringIO.StringIO(doc2_expected_file_content),
+        }
+    ]
+    with mock_addresses(mocked_addresses):
         record.update(record_json, only_new=True)
 
     assert len(record['documents']) == len(update_to_record['documents'])
@@ -728,3 +735,155 @@ def test_create_with_source_record_with_different_control_number(app):
         record2.files[rec2_expected_key].obj.file.uri
     ).read()
     assert rec2_file_content == expected_file_content
+
+
+def test_create_with_skip_files_param_does_not_add_documents_or_figures(app):
+    record_json = {
+        '$schema': 'http://localhost:5000/schemas/records/hep.json',
+        'control_number': 1,
+        'document_type': [
+            'article',
+        ],
+        'titles': [
+            {'title': 'foo'},
+        ],
+        '_collections': [
+            'Literature'
+        ],
+        'figures': [{
+            'key': 'graph.png',
+            'url': 'http://www.mdpi.com/2218-1997/3/1/24/png',
+        }],
+        'documents': [{
+            'key': 'arXiv:1710.01187.pdf',
+            'url': '/afs/cern.ch/project/inspire/PROD/var/data/files/g151/3037619/content.pdf;1',
+        }]  # record/1628455/export/xme -- with some modification
+    }
+
+    record = InspireRecord.create(record_json, skip_files=True)
+
+    assert len(record.files) == 0
+    assert record['documents'] == record_json['documents']
+    assert record['figures'] == record_json['figures']
+
+
+def test_create_with_records_skip_files_conf_does_not_add_documents_or_figures(app):
+    record_json = {
+        '$schema': 'http://localhost:5000/schemas/records/hep.json',
+        'control_number': 1,
+        'document_type': [
+            'article',
+        ],
+        'titles': [
+            {'title': 'foo'},
+        ],
+        '_collections': [
+            'Literature'
+        ],
+        'figures': [{
+            'key': 'graph.png',
+            'url': 'http://www.mdpi.com/2218-1997/3/1/24/png',
+        }],
+        'documents': [{
+            'key': 'arXiv:1710.01187.pdf',
+            'url': '/afs/cern.ch/project/inspire/PROD/var/data/files/g151/3037619/content.pdf;1',
+        }]  # record/1628455/export/xme -- with some modification
+    }
+
+    with patch.dict(app.config, {'RECORDS_SKIP_FILES': True}):
+        record = InspireRecord.create(record_json)
+
+    assert len(record.files) == 0
+    assert record['documents'] == record_json['documents']
+    assert record['figures'] == record_json['figures']
+
+
+@patch(
+    'inspirehep.modules.records.utils.open',
+    mock_open(read_data='dummy body'),
+)
+def test_create_with_skip_files_param_overrides_records_skip_files_conf_and_does_add_documents_or_figures(app):
+    record_json = {
+        '$schema': 'http://localhost:5000/schemas/records/hep.json',
+        'control_number': 1,
+        'document_type': [
+            'article',
+        ],
+        'titles': [
+            {'title': 'foo'},
+        ],
+        '_collections': [
+            'Literature'
+        ],
+        'figures': [{
+            'key': 'graph.png',
+            'url': 'http://www.mdpi.com/2218-1997/3/1/24/png',
+        }],
+        'documents': [{
+            'key': 'arXiv:1710.01187.pdf',
+            'url': '/afs/cern.ch/project/inspire/PROD/var/data/files/g151/3037619/content.pdf;1',
+        }]  # record/1628455/export/xme -- with some modification
+    }
+    expected_document_file_content = 'dummy body'
+    expected_document_key = '1_graph.png'
+
+    expected_figure_file_content = 'dummy body'
+    expected_figure_key = '1_graph.png'
+
+    mocked_addresses = [
+        {
+            'method': 'GET',
+            'url': 'http://www.mdpi.com/2218-1997/3/1/24/png',
+            'body': StringIO.StringIO(expected_figure_file_content),
+        }
+    ]
+    with patch.dict(app.config, {'RECORDS_SKIP_FILES': True}):
+        with mock_addresses(mocked_addresses):
+            record = InspireRecord.create(record_json, skip_files=False)
+
+    assert len(record.files) == 2
+
+    assert expected_document_key in record.files.keys
+    assert len(record['documents']) == len(record_json['documents'])
+    document_file_content = open(
+        record.files[expected_document_key].obj.file.uri
+    ).read()
+    assert document_file_content == expected_document_file_content
+
+    assert expected_figure_key in record.files.keys
+    assert len(record['figures']) == len(record_json['figures'])
+    figure_file_content = open(
+        record.files[expected_figure_key].obj.file.uri
+    ).read()
+    assert figure_file_content == expected_figure_file_content
+
+
+def test_create_with_skip_files_param_overrides_records_skip_files_conf_and_does_not_add_documents_or_figures(app):
+    record_json = {
+        '$schema': 'http://localhost:5000/schemas/records/hep.json',
+        'control_number': 1,
+        'document_type': [
+            'article',
+        ],
+        'titles': [
+            {'title': 'foo'},
+        ],
+        '_collections': [
+            'Literature'
+        ],
+        'figures': [{
+            'key': 'graph.png',
+            'url': 'http://www.mdpi.com/2218-1997/3/1/24/png',
+        }],
+        'documents': [{
+            'key': 'arXiv:1710.01187.pdf',
+            'url': '/afs/cern.ch/project/inspire/PROD/var/data/files/g151/3037619/content.pdf;1',
+        }]  # record/1628455/export/xme -- with some modification
+    }
+
+    with patch.dict(app.config, {'RECORDS_SKIP_FILES': False}):
+        record = InspireRecord.create(record_json, skip_files=True)
+
+    assert len(record.files) == 0
+    assert record['documents'] == record_json['documents']
+    assert record['figures'] == record_json['figures']


### PR DESCRIPTION
We need a way to skip downloading the records files to speed up the
migrations and not use any space, as those migrations will be used
only for it's metadata until labs becomes master.


<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Added two methods to skip the files downloading:
* Using a global setting RECORDS_SKIP_FILES
* Using a parameter to `InspireRecord.create` and
  `InspireRecord.update` called `skip_files`.

The latter has precedence. By default the previous behavior
(downloading the files) is preserved.

Signed-off-by: David Caro <david@dcaro.es>