### PR TITLE
forms: filter out deleted records when checking dupes

### DIFF
--- a/inspirehep/modules/forms/validators/simple_fields.py
+++ b/inspirehep/modules/forms/validators/simple_fields.py
@@ -88,6 +88,9 @@ def does_exist_in_inspirehep(query, collections=None):
 
 
 def duplicated_validator(property_name, property_value):
+    def _is_not_deleted(base_record, match_result):
+        return not get_value(match_result, '_source.deleted', default=False)
+
     config = {
         'algorithm': [
             {
@@ -103,6 +106,7 @@ def duplicated_validator(property_name, property_value):
                         'type': 'exact',
                     },
                 ],
+                'validator': _is_not_deleted,
             },
         ],
         'doc_type': 'hep',
@@ -119,11 +123,11 @@ def duplicated_validator(property_name, property_value):
         }
 
     matches = dedupe_list(match(data, config))
-    mached_ids = [int(el['_source']['control_number']) for el in matches]
-    if mached_ids:
+    matched_ids = [int(el['_source']['control_number']) for el in matches]
+    if matched_ids:
         url = url_for(
             'invenio_records_ui.literature',
-            pid_value=mached_ids[0],
+            pid_value=matched_ids[0],
         )
         raise ValidationError(
             'There exists already an item with the same %s. '

--- a/tests/integration/forms/test_forms_validators_simple_fields.py
+++ b/tests/integration/forms/test_forms_validators_simple_fields.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import pytest
+from wtforms.validators import ValidationError
+
+from inspirehep.modules.forms.validators.simple_fields import (
+    duplicated_arxiv_id_validator,
+    duplicated_doi_validator,
+)
+
+from utils import _create_record, _delete_record
+
+
+class MockField(object):
+    def __init__(self, data):
+        self.data = data
+
+
+@pytest.fixture(scope='function')
+def deleted_record(app):
+    record = {
+        '$schema': 'http://localhost:5000/schemas/records/hep.json',
+        'arxiv_eprints': [
+            {
+                'categories': [
+                    'hep-th'
+                ],
+                'value': '1607.12345'
+            }
+        ],
+        'control_number': 111,
+        'deleted': True,
+        'document_type': [
+            'article',
+        ],
+        'dois': [
+            {
+                'value': '10.1234/PhysRevD.94.054021'
+            }
+        ],
+        'titles': [
+            {'title': 'deleted'},
+        ],
+        'self': {
+            '$ref': 'http://localhost:5000/schemas/records/hep.json',
+        },
+        '_collections': ['Literature']
+    }
+
+    _create_record(record)
+
+    yield record
+
+    _delete_record('lit', 111)
+
+
+@pytest.fixture(scope='function')
+def normal_record(app):
+    record = {
+        '$schema': 'http://localhost:5000/schemas/records/hep.json',
+        'arxiv_eprints': [
+            {
+                'categories': [
+                    'hep-th'
+                ],
+                'value': '1607.12345'
+            }
+        ],
+        'control_number': 111,
+        'document_type': [
+            'article',
+        ],
+        'dois': [
+            {
+                'value': '10.1234/PhysRevD.94.054021'
+            }
+        ],
+        'titles': [
+            {'title': 'deleted'},
+        ],
+        'self': {
+            '$ref': 'http://localhost:5000/schemas/records/hep.json',
+        },
+        '_collections': ['Literature']
+    }
+
+    _create_record(record)
+
+    yield record
+
+    _delete_record('lit', 111)
+
+
+def test_existing_arxiv_id_deleted_record_does_not_fail(deleted_record):
+    duplicated_arxiv_id_validator(
+        None,
+        MockField(deleted_record['arxiv_eprints'][0]['value']),
+    )
+
+
+def test_existing_doi_deleted_record_does_not_fail(deleted_record):
+    duplicated_doi_validator(
+        None,
+        MockField(deleted_record['dois'][0]['value']),
+    )
+
+
+def test_existing_arxiv_id_record_does_fail(normal_record):
+    with pytest.raises(ValidationError):
+        duplicated_arxiv_id_validator(
+            None,
+            MockField(normal_record['arxiv_eprints'][0]['value']),
+        )
+
+
+def test_existing_doi_record_does_fail(normal_record):
+    with pytest.raises(ValidationError):
+        duplicated_doi_validator(
+            None,
+            MockField(normal_record['dois'][0]['value']),
+        )


### PR DESCRIPTION
We are currently blocking submissions of records that were deleted,
we should let them go to the holding pen.

This depends on https://github.com/inspirehep/inspire-matcher/pull/31


<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Signed-off-by: David Caro <david@dcaro.es>