### PR TITLE
Workflows: set `refereed` and conference paper in `document_type`

### DIFF
--- a/inspirehep/modules/workflows/tasks/actions.py
+++ b/inspirehep/modules/workflows/tasks/actions.py
@@ -233,6 +233,20 @@ def is_submission(obj, eng):
 
 
 @with_debug_logging
+def get_journal_coverage(obj, eng):
+    """Return the journal coverage that this article belongs to."""
+    journals = replace_refs(get_value(obj.data, 'publication_info.journal_record'), 'db')
+
+    if not journals:
+        return
+
+    if any(journal['_harvesting_info'].get('coverage') == 'full' for journal in journals):
+        obj.extra_data['journal_coverage'] = 'full'
+    else:
+        obj.extra_data['journal_coverage'] = 'partial'
+
+
+@with_debug_logging
 def submission_fulltext_download(obj, eng):
     submission_pdf = obj.extra_data.get('submission_pdf')
     if submission_pdf and is_pdf_link(submission_pdf):

--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -54,6 +54,7 @@ from inspirehep.modules.workflows.tasks.actions import (
     normalize_journal_titles,
     prepare_update_payload,
     refextract,
+    set_document_type_and_refereed,
     submission_fulltext_download,
     save_workflow,
 )
@@ -205,6 +206,7 @@ POSTENHANCE_RECORD = [
     filter_keywords,
     prepare_keywords,
     remove_references,
+    set_document_type_and_refereed,
 ]
 
 

--- a/tests/integration/workflows/fixtures/jou_record_not_refereed_and_no_proceedings.json
+++ b/tests/integration/workflows/fixtures/jou_record_not_refereed_and_no_proceedings.json
@@ -1,0 +1,16 @@
+{
+    "$schema":"http://localhost:5000/schemas/records/journals.json",
+    "_collections":[
+        "Journals"
+    ],
+    "control_number":1936477,
+    "journal_title":{
+        "title":"No Proceedings and Not Refereed J."
+    },
+    "self":{
+        "$ref":"http://localhost:5000/api/journals/1936477"
+    },
+    "proceedings":false,
+    "refereed":false,
+    "short_title":"No.Pro.No.Ref.J."
+}

--- a/tests/integration/workflows/fixtures/jou_record_not_refereed_and_proceedings.json
+++ b/tests/integration/workflows/fixtures/jou_record_not_refereed_and_proceedings.json
@@ -1,0 +1,16 @@
+{
+    "$schema":"http://localhost:5000/schemas/records/journals.json",
+    "_collections":[
+        "Journals"
+    ],
+    "control_number":1936478,
+    "journal_title":{
+        "title":"Proceedings and Not Refereed J. A"
+    },
+    "self":{
+        "$ref":"http://localhost:5000/api/journals/1936478"
+    },
+    "proceedings":true,
+    "refereed":false,
+    "short_title":"Pro.No.Ref.J.A."
+}

--- a/tests/integration/workflows/fixtures/jou_record_not_refereed_and_proceedings_2.json
+++ b/tests/integration/workflows/fixtures/jou_record_not_refereed_and_proceedings_2.json
@@ -1,0 +1,16 @@
+{
+    "$schema":"http://localhost:5000/schemas/records/journals.json",
+    "_collections":[
+        "Journals"
+    ],
+    "control_number":1936479,
+    "journal_title":{
+        "title":"Proceedings and Not Refereed J. B"
+    },
+    "self":{
+        "$ref":"http://localhost:5000/api/journals/1936479"
+    },
+    "proceedings":true,
+    "refereed":false,
+    "short_title":"Pro.No.Ref.J.B."
+}

--- a/tests/integration/workflows/fixtures/jou_record_refereed.json
+++ b/tests/integration/workflows/fixtures/jou_record_refereed.json
@@ -5,17 +5,17 @@
     ],
     "control_number":1936475,
     "journal_title":{
-        "title":"A Test Journal1"
+        "title":"No Proceedings and Refereed J."
     },
     "title_variants":[
-        "A Test Journal1 Variant 1",
-        "A Test Journal1 Variant 2",
-        "A Test Journal1 Variant 3"
+        "No Proceedings and Refereed J. Variant 1",
+        "No Proceedings and Refereed J. Variant 2",
+        "No Proceedings and Refereed J. Variant 3"
     ],
     "self":{
         "$ref":"http://localhost:5000/api/journals/1936475"
     },
     "proceedings":false,
     "refereed":true,
-    "short_title":"Test.Jou.1"
+    "short_title":"No.Pro.Ref.J."
 }

--- a/tests/integration/workflows/fixtures/jou_record_refereed_and_proceedings.json
+++ b/tests/integration/workflows/fixtures/jou_record_refereed_and_proceedings.json
@@ -5,17 +5,17 @@
     ],
     "control_number":1936476,
     "journal_title":{
-        "title":"A Test Journal2"
+        "title":"Proceedings and Refereed J."
     },
     "title_variants":[
-        "A Test Journal2 Variant 1",
-        "A Test Journal2 Variant 2",
-        "A Test Journal2 Variant 3"
+        "Proceedings and Refereed J. Variant 1",
+        "Proceedings and Refereed J. Variant 2",
+        "Proceedings and Refereed J. Variant 3"
     ],
     "self":{
         "$ref":"http://localhost:5000/api/journals/1936476"
     },
     "proceedings":true,
     "refereed":true,
-    "short_title":"Test.Jou.2"
+    "short_title":"Pro.Ref.J."
 }

--- a/tests/integration/workflows/helpers/utils.py
+++ b/tests/integration/workflows/helpers/utils.py
@@ -51,6 +51,26 @@ def _delete_record(pid_type, pid_value):
 
     db.session.commit()
 
+from inspirehep.utils.record_getter import get_db_record
+
+
+# TODO: duplicate function from `tests/workflows/helpers/utils.py` - technical debt
+def _delete_record(pid_type, pid_value):
+    get_db_record(pid_type, pid_value)._delete(force=True)
+
+    pid = PersistentIdentifier.get(pid_type, pid_value)
+    PersistentIdentifier.delete(pid)
+
+    recpid = RecordIdentifier.query.filter_by(recid=pid_value).one_or_none()
+    if recpid:
+        db.session.delete(recpid)
+
+    object_uuid = pid.object_uuid
+    PersistentIdentifier.query.filter(
+        object_uuid == PersistentIdentifier.object_uuid).delete()
+
+    db.session.commit()
+
 
 @mock.patch(
     'inspirehep.modules.workflows.tasks.arxiv.is_pdf_link'

--- a/tests/integration/workflows/helpers/utils.py
+++ b/tests/integration/workflows/helpers/utils.py
@@ -31,25 +31,6 @@ from invenio_workflows import (
     WorkflowEngine,
     start,
 )
-from inspirehep.utils.record_getter import get_db_record
-
-
-# TODO: duplicate function from `tests/workflows/helpers/utils.py` - technical debt
-def _delete_record(pid_type, pid_value):
-    get_db_record(pid_type, pid_value)._delete(force=True)
-
-    pid = PersistentIdentifier.get(pid_type, pid_value)
-    PersistentIdentifier.delete(pid)
-
-    recpid = RecordIdentifier.query.filter_by(recid=pid_value).one_or_none()
-    if recpid:
-        db.session.delete(recpid)
-
-    object_uuid = pid.object_uuid
-    PersistentIdentifier.query.filter(
-        object_uuid == PersistentIdentifier.object_uuid).delete()
-
-    db.session.commit()
 
 from inspirehep.utils.record_getter import get_db_record
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
After the workflow [step](https://github.com/inspirehep/inspire-next/issues/2862) that normalizes the journal title, set refereed/document_type fields according to the journals information accessed in `publication_info` and a set of rules.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/inspirehep/inspire-next/issues/2863

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
 This is needed to properly handle hepcrawl harvests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
