### PR TITLE
celery: enable LOGGING_SENTRY_CELERY

### DIFF
--- a/inspirehep/celery.py
+++ b/inspirehep/celery.py
@@ -31,7 +31,9 @@ from flask_celeryext import create_celery_app
 from .factory import create_app
 
 
-celery = create_celery_app(create_app())
+celery = create_celery_app(
+    create_app(LOGGING_SENTRY_CELERY=True)
+)
 
 # We don't want to log to Sentry backoff errors
 logging.getLogger('backoff').propagate = 0

--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -99,9 +99,6 @@ REST_ENABLE_CORS = True
 # To enable file logging set it to e.g. "{sys_prefix}/var/log/inspirehep.log"
 LOGGING_FS_LOGFILE = None
 
-# Overwrite default Sentry extension class to support Sentry 6.
-LOGGING_SENTRY_CLASS = 'invenio_logging.sentry6:Sentry6'
-
 # Accounts
 # ========
 RECAPTCHA_PUBLIC_KEY = "CHANGE_ME"


### PR DESCRIPTION
While testing on QA, for actually getting the log entries in Sentry, we have to enable this flag. 
Additionally, we don't need the `LOGGING_SENTRY_CLASS` anymore.

## Related Issue
https://github.com/inspirehep/inspire-next/issues/1371

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
