### PR TITLE
mappings-hep: populate two diff. name variations

### DIFF
--- a/inspirehep/modules/records/mappings/records/hep.json
+++ b/inspirehep/modules/records/mappings/records/hep.json
@@ -230,8 +230,17 @@
                             "type": "completion"
                         },
                         "name_variations": {
-                            "index": "not_analyzed",
-                            "type": "string"
+                            "properties": {
+                                "all": {
+                                    "index": "not_analyzed",
+                                    "type": "string"
+                                },
+                                "specific": {
+                                    "index": "not_analyzed",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
                         },
                         "raw_affiliations": {
                             "properties": {

--- a/inspirehep/modules/records/receivers.py
+++ b/inspirehep/modules/records/receivers.py
@@ -382,9 +382,20 @@ def populate_name_variations(sender, json, *args, **kwargs):
                 el['value'] for el in author.get('ids', [])
                 if el['schema'] == 'INSPIRE BAI'
             ]
-            name_variations = generate_name_variations(full_name)
 
-            author.update({'name_variations': name_variations})
+            name_variations = generate_name_variations(full_name)
+            no_lastnames_variations = [
+                name_variation
+                for name_variation
+                in name_variations
+                if len(name_variation.split()) > 1
+            ]
+
+            author.update({'name_variations': {
+                'all': name_variations,
+                'specific': no_lastnames_variations
+            }})
+
             author.update({'name_suggest': {
                 'input': name_variations,
                 'output': full_name,


### PR DESCRIPTION
Populate two distinct name variations field, one containing all
variations and one ignoring single name variations (i.e. lastnames).
That way depending on the user's query we can select which field to
filter with. E.g. `a Ellis` will filter using the "all variations"
field, while `a Ellis, John` will query the more specific one.

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>

## Motivation and Context
Attempts to imitate better the behaviour of legacy to get more exact results. 

### Note 
The way the no lastnames list (_i.e. more specific one_) is generated (ignoring variations which after being `.split()` have length more than one) will result in adding also name variations for authors with many lastnames.  

For example, `Caro-Estevez` lastname, becomes  a lastname variation: `['Caro', 'Caro Estevez']`.
The way it's implemented now, it will add `'Caro Estevez'` in the no lastnames list, but will not add `Caro`.  


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
