### PR TITLE
mappings: add raw and search fields to authors.ids

### DIFF
--- a/inspirehep/modules/records/mappings/records/hep.json
+++ b/inspirehep/modules/records/mappings/records/hep.json
@@ -217,6 +217,16 @@
                                     "type": "string"
                                 },
                                 "value": {
+                                    "fields": {
+                                        "raw": {
+                                            "index": "not_analyzed",
+                                            "type": "string"
+                                        },
+                                        "search": {
+                                            "analyzer": "lowercase_analyzer",
+                                            "type": "string"
+                                        }
+                                    },
                                     "type": "string"
                                 }
                             },


### PR DESCRIPTION
Add raw, search fields for providing exact and match support for BAIs.
The search field uses the `lowercase_analyzer` which does only
lowercasing in identifiers, which is usefull for searches like
`a a.einstein.1` to be equivalent with `a A.Einstein.1`.

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>

## Motivation and Context
For supporting BAI search in `inspire-query-parser`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
