### PR TITLE
utils: remove is_submitted_but_not_published

### DIFF
--- a/inspirehep/utils/bibtex.py
+++ b/inspirehep/utils/bibtex.py
@@ -27,7 +27,6 @@ import re
 from inspire_utils.helpers import force_list
 from inspire_utils.record import get_value
 from inspirehep.utils import bibtex_booktitle
-from inspirehep.utils.record import is_submitted_but_not_published
 from inspirehep.utils.record_getter import get_es_record
 
 from .export import MissingRequiredFieldError, Export
@@ -510,23 +509,18 @@ class Bibtex(Export):
                              'artid' in val or
                              'year' in val):
                             if 'journal_title' in val:
-                                if is_submitted_but_not_published(self.record):
-                                    note += 'Submitted to: ' +\
-                                            re.sub(r'\.([A-Z])', r'. \1',
-                                                   val['journal_title'])
-                                else:
-                                    note += re.sub(r'\.([A-Z])', r'. \1',
-                                                   val['journal_title'])
-                                    if 'journal_volume' in val:
-                                        if note.find("JHEP") > -1:
-                                            note += re.sub(r'\d\d(\d\d)', r'\1',
-                                                           val['journal_volume'])
-                                        else:
-                                            note += val['journal_volume']
-                                    if 'journal_issue' in val:
-                                        note += ',no.' + val['journal_issue']
-                                    if 'page_start' in val or 'artid' in val:
-                                        note += ',' + (val.get('page_start') or val['artid'])
+                                note += re.sub(r'\.([A-Z])', r'. \1',
+                                               val['journal_title'])
+                                if 'journal_volume' in val:
+                                    if note.find("JHEP") > -1:
+                                        note += re.sub(r'\d\d(\d\d)', r'\1',
+                                                       val['journal_volume'])
+                                    else:
+                                        note += val['journal_volume']
+                                if 'journal_issue' in val:
+                                    note += ',no.' + val['journal_issue']
+                                if 'page_start' in val or 'artid' in val:
+                                    note += ',' + (val.get('page_start') or val['artid'])
                             if 'year' in val:
                                 note += "(" + str(val['year']) + ")"
                             elif 'preprint_date' in self.record:

--- a/inspirehep/utils/cv_latex_html_text.py
+++ b/inspirehep/utils/cv_latex_html_text.py
@@ -27,8 +27,6 @@ import re
 from .export import MissingRequiredFieldError, Export
 from inspirehep import config
 
-from inspirehep.utils.record import is_submitted_but_not_published
-
 
 class Cv_latex_html_text(Export):
 
@@ -205,27 +203,21 @@ class Cv_latex_html_text(Export):
             for field in self.record['publication_info']:
                 out = ''
                 if 'journal_title' in field:
-                    if is_submitted_but_not_published(self.record):
-                        journal_title = 'Submitted to: ' +\
-                            field['journal_title']
-                        if 'year' in field:
-                            year = ' (' + str(field['year']) + ')'
-                    else:
-                        journal_title = field['journal_title']
-                        if 'journal_volume' in field:
-                            journal_volume = ' ' + field['journal_volume']
-                        if 'year' in field:
-                            year = ' (' + str(field['year']) + ')'
-                        if 'journal_issue' in field:
-                            if field['journal_issue']:
-                                journal_issue = ' ' + \
-                                                field['journal_issue'] + ','
-                        if 'page_start' in field and 'page_end' in field:
-                            pages = ' {page_start}-{page_end}'.format(**field)
-                        elif 'page_start' in field:
-                            pages = ' {page_start}'.format(**field)
-                        elif 'artid' in field:
-                            pages = ' {artid}'.format(**field)
+                    journal_title = field['journal_title']
+                    if 'journal_volume' in field:
+                        journal_volume = ' ' + field['journal_volume']
+                    if 'year' in field:
+                        year = ' (' + str(field['year']) + ')'
+                    if 'journal_issue' in field:
+                        if field['journal_issue']:
+                            journal_issue = ' ' + \
+                                            field['journal_issue'] + ','
+                    if 'page_start' in field and 'page_end' in field:
+                        pages = ' {page_start}-{page_end}'.format(**field)
+                    elif 'page_start' in field:
+                        pages = ' {page_start}'.format(**field)
+                    elif 'artid' in field:
+                        pages = ' {artid}'.format(**field)
                     out += journal_title + journal_volume + year + \
                         journal_issue + pages
                     result.append(out)

--- a/inspirehep/utils/record.py
+++ b/inspirehep/utils/record.py
@@ -79,32 +79,3 @@ def get_subtitle(record):
 def get_title(record):
     """Get preferred title from record."""
     return get_value(record, 'titles.title[0]', default='')
-
-
-def is_submitted_but_not_published(record):
-    """Return True if article is submitted to journal.
-
-    Returns True if and only an article is submitted to a journal but has not
-    yet been published (as far as we know).
-    """
-    def is_complete(publication_info):
-        return (('journal_issue' in publication_info or
-                 'journal_volume' in publication_info or
-                 'year' in publication_info) and
-                ('page_start' in publication_info or
-                 'artid' in publication_info))
-    if 'dois' in record:
-        # DOIs exist, hence it's already published
-        return False
-    had_at_least_one_journal_title = False
-    if 'publication_info' in record:
-        for publication_info in record['publication_info']:
-            if 'journal_title' in publication_info:
-                had_at_least_one_journal_title = True
-                if (publication_info['journal_title'].lower() in ('econf', ) and
-                        'journal_volume' in publication_info):
-                    # eConf are special
-                    return False
-                if is_complete(publication_info):
-                    return False
-    return had_at_least_one_journal_title

--- a/tests/unit/utils/test_utils_bibtex.py
+++ b/tests/unit/utils/test_utils_bibtex.py
@@ -1224,20 +1224,6 @@ def test_get_note_publication_info_a_list_two_els():
     assert expected == result
 
 
-def test_get_note_publication_info_a_list_not_a_note_with_title():
-    publication_info_a_list_not_a_note_with_title = {
-        'publication_info': [
-            {'journal_title': 'Phys.Rev.'},
-            {'journal_title': 'Phys.Rev.'}
-        ]
-    }
-
-    expected = '[Submitted to: Phys. Rev.]'
-    result = Bibtex(publication_info_a_list_not_a_note_with_title)._get_note()
-
-    assert expected == result
-
-
 def test_get_note_publication_info_a_list_not_a_note_with_volume():
     publication_info_a_list_not_a_note_with_volume = {
         'publication_info': [
@@ -1248,26 +1234,6 @@ def test_get_note_publication_info_a_list_not_a_note_with_volume():
 
     expected = '[]'
     result = Bibtex(publication_info_a_list_not_a_note_with_volume)._get_note()
-
-    assert expected == result
-
-
-def test_get_note_publication_info_a_list_not_a_note_with_volume_JHEP():
-    publication_info_a_list_not_a_note_with_volume_JHEP = {
-        'publication_info': [
-            {
-                'journal_title': 'JHEP',
-                'journal_volume': '9712'
-            },
-            {
-                'journal_title': 'JHEP',
-                'journal_volume': '9712'
-            }
-        ]
-    }
-
-    expected = '[Submitted to: JHEP]'
-    result = Bibtex(publication_info_a_list_not_a_note_with_volume_JHEP)._get_note()
 
     assert expected == result
 
@@ -1312,21 +1278,6 @@ def test_get_note_publication_info_a_list_not_a_note_with_year():
 
     expected = '[(2015)]'
     result = Bibtex(publication_info_a_list_not_a_note_with_year)._get_note()
-
-    assert expected == result
-
-
-def test_get_note_publication_info_a_list_not_a_note_with_preprint():
-    publication_info_a_list_not_a_note_with_preprint = {
-        'preprint_date': '2015-12-04',
-        'publication_info': [
-            {'journal_title': 'Acta Phys.Polon.'},
-            {'journal_title': 'Acta Phys.Polon.'}
-        ]
-    }
-
-    expected = '[Submitted to: Acta Phys. Polon.(2015)]'
-    result = Bibtex(publication_info_a_list_not_a_note_with_preprint)._get_note()
 
     assert expected == result
 

--- a/tests/unit/utils/test_utils_cv_latex_html_text.py
+++ b/tests/unit/utils/test_utils_cv_latex_html_text.py
@@ -323,21 +323,6 @@ def test_get_publi_info_from_publication_info_an_empty_list():
     assert expected == result
 
 
-def test_get_publi_info_from_publication_info_with_journal_title():
-    journal_title = {
-        'publication_info': [
-            {'journal_title': 'Nucl.Phys.'}
-        ]
-    }
-    cv_latex_html_text = Cv_latex_html_text(
-        journal_title, 'cv_latex_html_text', ',')
-
-    expected = ['Submitted to: Nucl.Phys.']
-    result = cv_latex_html_text._get_publi_info()
-
-    assert expected == result
-
-
 def test_get_publi_info_from_publication_info_with_journal_volume():
     journal_volume = {
         'publication_info': [
@@ -351,78 +336,6 @@ def test_get_publi_info_from_publication_info_with_journal_volume():
         journal_volume, 'cv_latex_html_text', ',')
 
     expected = ['eConf C050318']
-    result = cv_latex_html_text._get_publi_info()
-
-    assert expected == result
-
-
-def test_get_publi_info_from_publication_info_with_journal_volume_with_letter():
-    journal_volume_with_letter = {
-        'publication_info': [
-            {
-                'journal_title': 'Eur.Phys.J.',
-                'journal_volume': 'C73'
-            }
-        ]
-    }
-    cv_latex_html_text = Cv_latex_html_text(
-        journal_volume_with_letter, 'cv_latex_html_text', ',')
-
-    expected = ['Submitted to: Eur.Phys.J.']
-    result = cv_latex_html_text._get_publi_info()
-
-    assert expected == result
-
-
-def test_get_publi_info_from_publication_info_with_year():
-    year_not_a_list = {
-        'publication_info': [
-            {
-                'journal_title': 'Phys.Lett.',
-                'year': '1999'
-            }
-        ]
-    }
-    cv_latex_html_text = Cv_latex_html_text(
-        year_not_a_list, 'cv_latex_html_text', ',')
-
-    expected = ['Submitted to: Phys.Lett. (1999)']
-    result = cv_latex_html_text._get_publi_info()
-
-    assert expected == result
-
-
-def test_get_publi_info_from_publication_info_with_journal_issue():
-    journal_issue = {
-        'publication_info': [
-            {
-                'journal_title': 'Class.Quant.Grav.',
-                'journal_issue': '10'
-            }
-        ]
-    }
-    cv_latex_html_text = Cv_latex_html_text(
-        journal_issue, 'cv_latex_html_text', ',')
-
-    expected = ['Submitted to: Class.Quant.Grav.']
-    result = cv_latex_html_text._get_publi_info()
-
-    assert expected == result
-
-
-def test_get_publi_info_from_publication_info_with_page_start():
-    page_start = {
-        'publication_info': [
-            {
-                'journal_title': 'JHEP',
-                'page_start': '190'
-            }
-        ]
-    }
-    cv_latex_html_text = Cv_latex_html_text(
-        page_start, 'cv_latex_html_text', ',')
-
-    expected = ['Submitted to: JHEP']
     result = cv_latex_html_text._get_publi_info()
 
     assert expected == result

--- a/tests/unit/utils/test_utils_record.py
+++ b/tests/unit/utils/test_utils_record.py
@@ -29,7 +29,6 @@ from inspirehep.utils.record import (
     get_arxiv_id,
     get_subtitle,
     get_title,
-    is_submitted_but_not_published,
 )
 
 
@@ -173,50 +172,3 @@ def test_get_title_returns_first_title():
     result = get_title(record)
 
     assert expected == result
-
-
-def test_is_submitted_but_not_published_returns_false_if_record_has_dois():
-    record = {
-        'dois': [
-            {'value': 'doi'},
-        ],
-    }
-
-    assert not is_submitted_but_not_published(record)
-
-
-def test_is_submitted_but_not_published_returns_true_if_record_has_at_least_one_journal_title():
-    record = {
-        'publication_info': [
-            {'journal_title': 'journal title'},
-        ],
-    }
-
-    assert is_submitted_but_not_published(record)
-
-
-def test_is_submitted_but_not_published_returns_false_if_record_is_from_econf_and_has_journal_volume():
-    record = {
-        'publication_info': [
-            {
-                'journal_title': 'eConf',
-                'journal_volume': 'journal volume',
-            },
-        ],
-    }
-
-    assert not is_submitted_but_not_published(record)
-
-
-def test_is_submitted_but_not_published_returns_false_if_record_has_a_complete_publication_info():
-    record = {
-        'publication_info': [
-            {
-                'journal_title': 'journal title',
-                'journal_volume': 'journal volume',
-                'page_start': 'page start',
-            },
-        ],
-    }
-
-    assert not is_submitted_but_not_published(record)


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
Since inspirehep/inspire-dojson#127 and inspirehep/inspire-schemas#272,
incomplete `publication_info`s having only a `journal_title`, which
represent articles submitted to a journal but not published, have been
moved to `public_notes`, so this function is no longer needed.

The failing tests for the cv_latex and bibtex serializers have been
removed, as they will be rewritten completely by #2839 anyway.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
