### PR TITLE
Setting 'marionette' capability in selenium to False

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -82,7 +82,7 @@ services:
   acceptance:
     extends:
       service: test-service_base
-    command: py.test --driver Remote --host selenium --port 4444 --capability browserName firefox --html=selenium-report.html tests/acceptance
+    command: py.test --driver Remote --host selenium --port 4444 --capability browserName firefox --capability marionette '' --html=selenium-report.html tests/acceptance
     volumes_from:
       - test-static
     depends_on:


### PR DESCRIPTION
Disabling 'marionette' capability in selenium

## Motivation and Context
After update of the `pytest-selenium` library from `1.11.1` to `1.11.2` acceptance tests started to fail due to absence of `geckodriver` (`WebDriverException: Message: 'geckodriver' executable needs to be in PATH.`).
New version of this library now uses defined `DesiredCapabilities` from the Selenium, among which there is `"marionette": True` flag (which was not set up in the previous version). Thus, it needs to be set up as False to make it work again.

## Description
It's possible to set capability via pytest arguments, but it accepts everything as a string, thus by providing `False` it will assume only that it's `'False'`. The workaround is to put there an empty string, so python considers it as a False value.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
