### PR TITLE
utils: always get first abstract in get_abstract

### DIFF
--- a/inspirehep/modules/hal/core/tei.py
+++ b/inspirehep/modules/hal/core/tei.py
@@ -28,10 +28,9 @@ from flask import render_template
 from langdetect import detect
 from langdetect.lang_detect_exception import LangDetectException
 
-from inspirehep.utils.record import get_arxiv_id, get_title
+from inspirehep.utils.record import get_abstract, get_arxiv_id, get_title
 
 from ..utils import (
-    get_abstract,
     get_authors,
     get_collaborations,
     get_conference_city,

--- a/inspirehep/modules/hal/utils.py
+++ b/inspirehep/modules/hal/utils.py
@@ -38,24 +38,6 @@ from inspirehep.modules.records.json_ref_loader import replace_refs
 from inspirehep.utils.record_getter import get_es_records
 
 
-def get_abstract(record):
-    """Return the first abstract of a record.
-
-    Args:
-        record(InspireRecord): a record.
-
-    Returns:
-        string: the first abstract of the record.
-
-    Examples:
-        >>> record = {'abstracts': [{'value': 'Probably not.'}]}
-        >>> get_abstract(record)
-        'Probably not.'
-
-    """
-    return get_value(record, 'abstracts.value[0]', default='')
-
-
 def get_authors(record):
     """Return the authors of a record.
 

--- a/inspirehep/utils/record.py
+++ b/inspirehep/utils/record.py
@@ -30,21 +30,21 @@ from inspire_utils.record import get_value
 
 
 def get_abstract(record):
-    """Get preferred abstract from record."""
-    chosen_abstract = ""
+    """Return the first abstract of a record.
 
-    for abstract in record.get('abstracts', []):
-        if 'source' in abstract and abstract.get('source') != 'arXiv':
-            return abstract.get('value')
-        elif 'source' in abstract and abstract.get('source') == 'arXiv':
-            pass
-        else:
-            chosen_abstract = abstract.get('value')
+    Args:
+        record(InspireRecord): a record.
 
-    if not chosen_abstract and len(record.get('abstracts', [])) > 0:
-        chosen_abstract = record['abstracts'][0]['value']
+    Returns:
+        string: the first abstract of the record.
 
-    return chosen_abstract
+    Examples:
+        >>> record = {'abstracts': [{'value': 'Probably not.'}]}
+        >>> get_abstract(record)
+        'Probably not.'
+
+    """
+    return get_value(record, 'abstracts.value[0]', default='')
 
 
 def get_arxiv_categories(record):

--- a/tests/unit/hal/test_hal_utils.py
+++ b/tests/unit/hal/test_hal_utils.py
@@ -26,7 +26,6 @@ from mock import patch
 
 from inspire_schemas.api import load_schema, validate
 from inspirehep.modules.hal.utils import (
-    get_abstract,
     get_collaborations,
     get_conference_city,
     get_conference_country,
@@ -47,23 +46,6 @@ from inspirehep.modules.hal.utils import (
     get_publication_date,
     is_published,
 )
-
-
-def test_get_abstract():
-    schema = load_schema('hep')
-    subschema = schema['properties']['abstracts']
-
-    record = {
-        'abstracts': [
-            {'value': 'Probably not.'},
-        ],
-    }
-    assert validate(record['abstracts'], subschema) is None
-
-    expected = 'Probably not.'
-    result = get_abstract(record)
-
-    assert expected == result
 
 
 def test_get_collaborations():

--- a/tests/unit/utils/test_utils_record.py
+++ b/tests/unit/utils/test_utils_record.py
@@ -33,71 +33,27 @@ from inspirehep.utils.record import (
 )
 
 
-def test_get_abstract_returns_empty_string_when_no_abstracts():
-    record = {}
+def test_get_abstract_returns_first_abstract():
+    schema = load_schema('hep')
+    subschema = schema['properties']['abstracts']
 
-    expected = ''
-    result = get_abstract(record)
-
-    assert expected == result
-
-
-def test_get_abstract_returns_empty_string_when_abstracts_is_empty():
-    record = {'abstracts': []}
-
-    expected = ''
-    result = get_abstract(record)
-
-    assert expected == result
-
-
-def test_get_abstract_returns_first_abstract_with_source_not_arxiv():
     record = {
         'abstracts': [
             {
                 'source': 'arXiv',
-                'value': 'abstract with source arXiv',
+                'value': 'first abstract',
             },
             {
-                'source': 'not arXiv',
-                'value': 'abstract with source not arXiv',
+                'source': 'publisher',
+                'value': 'second abstract',
             },
         ],
     }
 
-    expected = 'abstract with source not arXiv'
+    expected = 'first abstract'
     result = get_abstract(record)
 
-    assert expected == result
-
-
-def test_get_abstract_returns_last_abstract_without_a_source():
-    record = {
-        'abstracts': [
-            {'value': 'first abstract without a source'},
-            {'value': 'last abstract without a source'},
-        ],
-    }
-
-    expected = 'last abstract without a source'
-    result = get_abstract(record)
-
-    assert expected == result
-
-
-def test_get_abstract_falls_back_to_first_abstract_even_if_from_arxiv():
-    record = {
-        'abstracts': [
-            {
-                'source': 'arXiv',
-                'value': 'abstract with source arXiv',
-            },
-        ],
-    }
-
-    expected = 'abstract with source arXiv'
-    result = get_abstract(record)
-
+    assert validate(record['abstracts'], subschema) is None
     assert expected == result
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The convoluted logic is not needed anymore, as the data now reflect what
the preferred abstract is and it doesn't have to be computed at display
time.
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
inspirehep/inspire-dojson/pull/148

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
