### PR TITLE
tests: remove InspireRecord from unit tests

### DIFF
--- a/tests/unit/authors/test_authors_views.py
+++ b/tests/unit/authors/test_authors_views.py
@@ -23,14 +23,13 @@
 from __future__ import absolute_import, division, print_function
 
 from inspirehep.modules.authors.views import convert_for_form, get_inspire_url
-from inspirehep.modules.records.api import InspireRecord
 
 
 def test_convert_for_form_without_name_urls_fc_positions_advisors_and_ids():
-    without_name_urls_fc_positions_advisors_and_ids = InspireRecord({})
+    without_name_urls_fc_positions_advisors_and_ids = {}
     convert_for_form(without_name_urls_fc_positions_advisors_and_ids)
 
-    assert InspireRecord({}) == without_name_urls_fc_positions_advisors_and_ids
+    assert {} == without_name_urls_fc_positions_advisors_and_ids
 
 
 def test_convert_for_form_public_emails():
@@ -92,7 +91,7 @@ def test_convert_for_form_advisors():
 
 
 def test_get_inspire_url_with_bai():
-    with_bai = InspireRecord({'bai': 'J.R.Ellis.1'})
+    with_bai = {'bai': 'J.R.Ellis.1'}
 
     expected = 'http://inspirehep.net/author/profile/J.R.Ellis.1'
     result = get_inspire_url(with_bai)
@@ -101,7 +100,7 @@ def test_get_inspire_url_with_bai():
 
 
 def test_get_inspire_url_with_control_number():
-    with_recid = InspireRecord({'control_number': 1010819})
+    with_recid = {'control_number': 1010819}
 
     expected = 'http://inspirehep.net/record/1010819'
     result = get_inspire_url(with_recid)
@@ -110,7 +109,7 @@ def test_get_inspire_url_with_control_number():
 
 
 def test_get_inspire_url_without_recid_or_bai():
-    without_recid_or_bai = InspireRecord({})
+    without_recid_or_bai = {}
 
     expected = 'http://inspirehep.net/hepnames'
     result = get_inspire_url(without_recid_or_bai)

--- a/tests/unit/theme/test_theme_jinja2filters.py
+++ b/tests/unit/theme/test_theme_jinja2filters.py
@@ -28,7 +28,6 @@ from elasticsearch_dsl import result
 from flask import current_app
 from mock import Mock, patch
 
-from inspirehep.modules.records.api import InspireRecord
 from inspirehep.modules.records.wrappers import LiteratureRecord
 from inspirehep.modules.theme.jinja2filters import (
     ads_links,
@@ -327,7 +326,7 @@ def test_email_link_returns_email_link_on_element(request_context):
 
 
 def test_url_links_returns_url_link_on_list_of_one_element():
-    record_with_urls = InspireRecord({'urls': [{'value': 'http://www.example.com'}]})
+    record_with_urls = {'urls': [{'value': 'http://www.example.com'}]}
 
     expected = ['\n<a href="http://www.example.com">http://www.example.com</a>']
     result = url_links(record_with_urls)
@@ -336,7 +335,7 @@ def test_url_links_returns_url_link_on_list_of_one_element():
 
 
 def test_institutes_links():
-    record_with_institute = InspireRecord({'institute': ['foo']})
+    record_with_institute = {'institute': ['foo']}
 
     expected = ['\n<a href="search/?cc=Institutions&p=110_u%3Afoo&of=hd">foo</a>']
     result = institutes_links(record_with_institute)
@@ -345,7 +344,7 @@ def test_institutes_links():
 
 
 def test_author_profile():
-    record_with_profile = InspireRecord({'profile': ['foo']})
+    record_with_profile = {'profile': ['foo']}
 
     expected = ['\n<a href="/author/search?q=foo">foo</a>']
     result = author_profile(record_with_profile)
@@ -390,7 +389,7 @@ def test_remove_duplicates__from_list_removes_duplicates_from_non_empty_list():
 
 
 def test_conference_date_returns_date_when_record_has_a_date():
-    with_a_date = InspireRecord({'date': '26-30 Mar 2012'})
+    with_a_date = {'date': '26-30 Mar 2012'}
 
     expected = '26-30 Mar 2012'
     result = conference_date(with_a_date)
@@ -399,7 +398,7 @@ def test_conference_date_returns_date_when_record_has_a_date():
 
 
 def test_conference_date_returns_empty_string_when_no_opening_date():
-    no_opening_date = InspireRecord({'closing_date': '2015-03-21'})
+    no_opening_date = {'closing_date': '2015-03-21'}
 
     expected = ''
     result = conference_date(no_opening_date)
@@ -408,7 +407,7 @@ def test_conference_date_returns_empty_string_when_no_opening_date():
 
 
 def test_conference_date_returns_empty_string_when_no_closing_date():
-    no_closing_date = InspireRecord({'opening_date': '2015-03-14'})
+    no_closing_date = {'opening_date': '2015-03-14'}
 
     expected = ''
     result = conference_date(no_closing_date)
@@ -417,10 +416,10 @@ def test_conference_date_returns_empty_string_when_no_closing_date():
 
 
 def test_conference_date_formats_date_when_same_year_same_month():
-    same_year_same_month = InspireRecord({
+    same_year_same_month = {
         'opening_date': '2015-03-14',
         'closing_date': '2015-03-21'
-    })
+    }
 
     expected = '14-21 Mar 2015'
     result = conference_date(same_year_same_month)
@@ -429,10 +428,10 @@ def test_conference_date_formats_date_when_same_year_same_month():
 
 
 def test_conference_date_formats_date_when_same_year_different_month():
-    same_year_different_month = InspireRecord({
+    same_year_different_month = {
         'opening_date': '2012-05-28',
         'closing_date': '2012-06-01'
-    })
+    }
 
     expected = '28 May - 01 Jun 2012'
     result = conference_date(same_year_different_month)
@@ -441,10 +440,10 @@ def test_conference_date_formats_date_when_same_year_different_month():
 
 
 def test_conference_date_formats_date_when_different_year():
-    different_year = InspireRecord({
+    different_year = {
         'opening_date': '2012-12-31',
         'closing_date': '2013-01-01'
-    })
+    }
 
     expected = '31 Dec 2012 - 01 Jan 2013'
     result = conference_date(different_year)
@@ -477,13 +476,13 @@ def test_search_for_experiments_joins_with_a_comma_and_a_space():
 
 
 def test_experiment_date_returns_none_with_no_dates():
-    with_no_dates = InspireRecord({})
+    with_no_dates = {}
 
     assert experiment_date(with_no_dates) is None
 
 
 def test_experiment_date_returns_started_with_date_started():
-    with_date_started = InspireRecord({'date_started': '1993'})
+    with_date_started = {'date_started': '1993'}
 
     expected = 'Started: 1993'
     result = experiment_date(with_date_started)
@@ -492,7 +491,7 @@ def test_experiment_date_returns_started_with_date_started():
 
 
 def test_experiment_date_returns_proposed_with_date_started():
-    with_date_started = InspireRecord({'date_proposed': '1993'})
+    with_date_started = {'date_proposed': '1993'}
 
     expected = 'Proposed: 1993'
     result = experiment_date(with_date_started)
@@ -501,7 +500,7 @@ def test_experiment_date_returns_proposed_with_date_started():
 
 
 def test_experiment_date_returns_approved_with_date_started():
-    with_date_started = InspireRecord({'date_approved': '1993'})
+    with_date_started = {'date_approved': '1993'}
 
     expected = 'Approved: 1993'
     result = experiment_date(with_date_started)
@@ -510,7 +509,7 @@ def test_experiment_date_returns_approved_with_date_started():
 
 
 def test_experiment_date_returns_still_running_with_date_completed_9999():
-    with_date_completed_9999 = InspireRecord({'date_completed': '9999'})
+    with_date_completed_9999 = {'date_completed': '9999'}
 
     expected = 'Still Running'
     result = experiment_date(with_date_completed_9999)
@@ -519,7 +518,7 @@ def test_experiment_date_returns_still_running_with_date_completed_9999():
 
 
 def test_experiment_date_returns_completed_with_date_completed():
-    with_date_completed = InspireRecord({'date_completed': '1993'})
+    with_date_completed = {'date_completed': '1993'}
 
     expected = 'Completed: 1993'
     result = experiment_date(with_date_completed)
@@ -528,7 +527,7 @@ def test_experiment_date_returns_completed_with_date_completed():
 
 
 def test_proceedings_link_returns_empty_string_without_cnum():
-    without_cnum = InspireRecord({})
+    without_cnum = {}
 
     expected = ''
     result = proceedings_link(without_cnum)
@@ -540,7 +539,7 @@ def test_proceedings_link_returns_empty_string_without_cnum():
 def test_proceedings_link_returns_empty_string_with_zero_search_results(c, mock_perform_es_search_empty):
     c.return_value = mock_perform_es_search_empty
 
-    with_cnum = InspireRecord({'cnum': 'banana'})
+    with_cnum = {'cnum': 'banana'}
 
     expected = ''
     result = proceedings_link(with_cnum)
@@ -552,7 +551,7 @@ def test_proceedings_link_returns_empty_string_with_zero_search_results(c, mock_
 def test_proceedings_link_returns_a_link_with_one_search_result(c, mock_perform_es_search_onerecord):
     c.return_value = mock_perform_es_search_onerecord
 
-    with_cnum = InspireRecord({'cnum': 'banana'})
+    with_cnum = {'cnum': 'banana'}
 
     expected = '<a href="/record/1410174">Proceedings</a>'
     result = proceedings_link(with_cnum)
@@ -564,7 +563,7 @@ def test_proceedings_link_returns_a_link_with_one_search_result(c, mock_perform_
 def test_proceedings_link_joins_with_a_comma_and_a_space(s, mock_perform_es_search_tworecord):
     s.return_value = mock_perform_es_search_tworecord
 
-    with_cnum = InspireRecord({'cnum': 'banana'})
+    with_cnum = {'cnum': 'banana'}
 
     expected = ('Proceedings: <a href="/record/1407068">#1</a> (DOI: <a '
                 'href="http://dx.doi.org/10.1016/j.ppnp.2015.10.002">'
@@ -576,7 +575,7 @@ def test_proceedings_link_joins_with_a_comma_and_a_space(s, mock_perform_es_sear
 
 
 def test_experiment_link_returns_empty_list_without_related_experiments():
-    without_related_experiment = InspireRecord({})
+    without_related_experiment = {}
 
     expected = []
     result = experiment_link(without_related_experiment)
@@ -585,11 +584,11 @@ def test_experiment_link_returns_empty_list_without_related_experiments():
 
 
 def test_experiment_link_returns_link_for_a_list_of_one_element():
-    related_experiments_a_list_of_one_element = InspireRecord({
+    related_experiments_a_list_of_one_element = {
         'related_experiments': [
             {'name': 'foo'}
         ]
-    })
+    }
 
     expected = ['<a href=/search?cc=Experiments&p=experiment_name:foo>foo</a>']
     result = experiment_link(related_experiments_a_list_of_one_element)
@@ -612,7 +611,7 @@ def test_format_cnum_with_hyphons():
 
 
 def test_link_to_hep_affiliation_returns_empty_string_when_record_has_no_ICN():
-    without_ICN = InspireRecord({})
+    without_ICN = {}
 
     expected = ''
     result = link_to_hep_affiliation(without_ICN)
@@ -624,7 +623,7 @@ def test_link_to_hep_affiliation_returns_empty_string_when_record_has_no_ICN():
 def test_link_to_hep_affiliation_returns_empty_string_when_empty_results(s, mock_perform_es_search_empty):
     s.return_value = mock_perform_es_search_empty
 
-    with_ICN = InspireRecord({'ICN': 'CERN'})
+    with_ICN = {'ICN': 'CERN'}
 
     expected = ''
     result = link_to_hep_affiliation(with_ICN)
@@ -636,7 +635,7 @@ def test_link_to_hep_affiliation_returns_empty_string_when_empty_results(s, mock
 def test_link_to_hep_affiliation_singular_when_one_result(s, mock_perform_es_search_onerecord):
     s.return_value = mock_perform_es_search_onerecord
 
-    with_ICN = InspireRecord({'ICN': 'DESY'})
+    with_ICN = {'ICN': 'DESY'}
 
     expected = '1 Paper from DESY'
     result = link_to_hep_affiliation(with_ICN)
@@ -648,7 +647,7 @@ def test_link_to_hep_affiliation_singular_when_one_result(s, mock_perform_es_sea
 def test_link_to_hep_affiliation_plural_when_more_results(s, mock_perform_es_search_tworecord):
     s.return_value = mock_perform_es_search_tworecord
 
-    with_ICN = InspireRecord({'ICN': 'Fermilab'})
+    with_ICN = {'ICN': 'Fermilab'}
 
     expected = '2 Papers from Fermilab'
     result = link_to_hep_affiliation(with_ICN)
@@ -763,7 +762,7 @@ def test_author_urls_joins_with_the_separator():
 
 
 def test_ads_links_returns_empty_string_when_record_has_no_name():
-    without_name = InspireRecord({})
+    without_name = {}
 
     expected = ''
     result = ads_links(without_name)
@@ -772,9 +771,9 @@ def test_ads_links_returns_empty_string_when_record_has_no_name():
 
 
 def test_ads_links_builds_link_from_full_name():
-    with_full_name = InspireRecord({
+    with_full_name = {
         'name': {'value': 'Ellis, John R.'}
-    })
+    }
 
     expected = 'http://adsabs.harvard.edu/cgi-bin/author_form?author=Ellis,+J&fullauthor=Ellis,+John+R.'
     result = ads_links(with_full_name)
@@ -783,12 +782,12 @@ def test_ads_links_builds_link_from_full_name():
 
 
 def test_ads_links_uses_preferred_name_when_name_has_no_lastname():
-    without_last_name = InspireRecord({
+    without_last_name = {
         'name': {
             'value': ', John R.',
             'preferred_name': 'Ellis, John R.'
         }
-    })
+    }
 
     expected = 'http://adsabs.harvard.edu/cgi-bin/author_form?author=Ellis, John R.'
     result = ads_links(without_last_name)
@@ -847,7 +846,7 @@ def test_json_dumps():
 
 
 def test_publication_info_returns_empty_dict_when_no_publication_info():
-    without_publication_info = InspireRecord({})
+    without_publication_info = {}
 
     expected = {}
     result = publication_info(without_publication_info)

--- a/tests/unit/utils/test_utils_bibtex.py
+++ b/tests/unit/utils/test_utils_bibtex.py
@@ -29,11 +29,9 @@ import pytest
 
 from inspirehep.utils.bibtex import Bibtex
 
-from inspirehep.modules.records.api import InspireRecord
-
 
 def test_get_entry_type_no_collections_no_pubinfo():
-    no_collections_no_pubinfo = InspireRecord({})
+    no_collections_no_pubinfo = {}
 
     expected = ('article', 'article')
     result = Bibtex(no_collections_no_pubinfo)._get_entry_type()
@@ -42,11 +40,11 @@ def test_get_entry_type_no_collections_no_pubinfo():
 
 
 def test_get_entry_type_no_primary_collections_no_pubinfo():
-    no_primary_collections_no_pubinfo = InspireRecord({
+    no_primary_collections_no_pubinfo = {
         'collections': [
             {'not-primary': 'foo'}
         ]
-    })
+    }
 
     expected = ('article', 'article')
     result = Bibtex(no_primary_collections_no_pubinfo)._get_entry_type()
@@ -55,11 +53,11 @@ def test_get_entry_type_no_primary_collections_no_pubinfo():
 
 
 def test_get_entry_type_conferencepaper_no_pubinfo():
-    conferencepaper_no_pubinfo = InspireRecord({
+    conferencepaper_no_pubinfo = {
         'collections': [
             {'primary': 'conferencepaper'}
         ]
-    })
+    }
 
     expected = ('inproceedings', 'inproceedings')
     result = Bibtex(conferencepaper_no_pubinfo)._get_entry_type()
@@ -68,11 +66,11 @@ def test_get_entry_type_conferencepaper_no_pubinfo():
 
 
 def test_get_entry_type_thesis_no_pubinfo():
-    thesis_no_pubinfo = InspireRecord({
+    thesis_no_pubinfo = {
         'collections': [
             {'primary': 'thesis'}
         ]
-    })
+    }
 
     expected = ('thesis', 'thesis')
     result = Bibtex(thesis_no_pubinfo)._get_entry_type()
@@ -81,11 +79,11 @@ def test_get_entry_type_thesis_no_pubinfo():
 
 
 def test_get_entry_type_proceedings_no_pubinfo():
-    proceedings_no_pubinfo = InspireRecord({
+    proceedings_no_pubinfo = {
         'collections': [
             {'primary': 'proceedings'}
         ]
-    })
+    }
 
     expected = ('proceedings', 'proceedings')
     result = Bibtex(proceedings_no_pubinfo)._get_entry_type()
@@ -94,11 +92,11 @@ def test_get_entry_type_proceedings_no_pubinfo():
 
 
 def test_get_entry_type_book_no_pubinfo():
-    book_no_pubinfo = InspireRecord({
+    book_no_pubinfo = {
         'collections': [
             {'primary': 'book'}
         ]
-    })
+    }
 
     expected = ('book', 'book')
     result = Bibtex(book_no_pubinfo)._get_entry_type()
@@ -107,11 +105,11 @@ def test_get_entry_type_book_no_pubinfo():
 
 
 def test_get_entry_type_bookchapter_no_pubinfo():
-    bookchapter_no_pubinfo = InspireRecord({
+    bookchapter_no_pubinfo = {
         'collections': [
             {'primary': 'bookchapter'}
         ]
-    })
+    }
 
     expected = ('inbook', 'inbook')
     result = Bibtex(bookchapter_no_pubinfo)._get_entry_type()
@@ -120,11 +118,11 @@ def test_get_entry_type_bookchapter_no_pubinfo():
 
 
 def test_get_entry_type_arxiv_no_pubinfo():
-    arxiv_no_pubinfo = InspireRecord({
+    arxiv_no_pubinfo = {
         'collections': [
             {'primary': 'arxiv'}
         ]
-    })
+    }
 
     expected = ('article', 'article')
     result = Bibtex(arxiv_no_pubinfo)._get_entry_type()
@@ -133,11 +131,11 @@ def test_get_entry_type_arxiv_no_pubinfo():
 
 
 def test_get_entry_type_published_no_pubinfo():
-    published_no_pubinfo = InspireRecord({
+    published_no_pubinfo = {
         'collections': [
             {'primary': 'published'}
         ]
-    })
+    }
 
     expected = ('article', 'article')
     result = Bibtex(published_no_pubinfo)._get_entry_type()
@@ -146,14 +144,14 @@ def test_get_entry_type_published_no_pubinfo():
 
 
 def test_get_entry_type_no_collections_one_valid_pubinfo():
-    no_collections_one_valid_pubinfo = InspireRecord({
+    no_collections_one_valid_pubinfo = {
         'publication_info': {
             'journal_title': 'foo',
             'journal_volume': 'bar',
             'page_start': 'baz',
             'year': 'quux'
         }
-    })
+    }
 
     expected = ('article', 'article')
     result = Bibtex(no_collections_one_valid_pubinfo)._get_entry_type()
@@ -162,9 +160,9 @@ def test_get_entry_type_no_collections_one_valid_pubinfo():
 
 
 def test_get_entry_type_no_collections_one_invalid_pubinfo():
-    no_collections_one_invalid_pubinfo = InspireRecord({
+    no_collections_one_invalid_pubinfo = {
         'publication_info': {}
-    })
+    }
 
     expected = ('article', 'article')
     result = Bibtex(no_collections_one_invalid_pubinfo)._get_entry_type()
@@ -173,7 +171,7 @@ def test_get_entry_type_no_collections_one_invalid_pubinfo():
 
 
 def test_get_entry_type_no_collections_second_pubinfo_valid():
-    no_collections_second_pubinfo_valid = InspireRecord({
+    no_collections_second_pubinfo_valid = {
         'publication_info': [
             {},
             {
@@ -183,7 +181,7 @@ def test_get_entry_type_no_collections_second_pubinfo_valid():
                 'year': 'quux'
             }
         ]
-    })
+    }
 
     expected = ('article', 'article')
     result = Bibtex(no_collections_second_pubinfo_valid)._get_entry_type()
@@ -192,7 +190,7 @@ def test_get_entry_type_no_collections_second_pubinfo_valid():
 
 
 def test_get_entry_type_one_collection_one_pubinfo():
-    one_collection_one_pubinfo = InspireRecord({
+    one_collection_one_pubinfo = {
         'collections': [{'primary': 'conferencepaper'}],
         'publication_info': [
             {
@@ -202,7 +200,7 @@ def test_get_entry_type_one_collection_one_pubinfo():
                 'year': 'quux'
             }
         ]
-    })
+    }
 
     expected = ('article', 'inproceedings')
     result = Bibtex(one_collection_one_pubinfo)._get_entry_type()
@@ -217,7 +215,7 @@ def test_fetch_fields_missing_required_key(self, _get_key):
 
     from inspirehep.utils.export import MissingRequiredFieldError
 
-    dummy = InspireRecord({})
+    dummy = {}
 
     with pytest.raises(MissingRequiredFieldError) as excinfo:
         Bibtex(dummy)._fetch_fields(['key'], [])
@@ -225,7 +223,7 @@ def test_fetch_fields_missing_required_key(self, _get_key):
 
 
 def test_format_output_row_single_author():
-    dummy = InspireRecord({})
+    dummy = {}
 
     expected = u'      author         = "0",\n'
     result = Bibtex(dummy)._format_output_row('author', [0])
@@ -234,7 +232,7 @@ def test_format_output_row_single_author():
 
 
 def test_format_output_row_between_one_and_ten_authors():
-    dummy = InspireRecord({})
+    dummy = {}
 
     expected = u'      author         = "0 and 1 and 2",\n'
     result = Bibtex(dummy)._format_output_row('author', list(range(3)))
@@ -243,7 +241,7 @@ def test_format_output_row_between_one_and_ten_authors():
 
 
 def test_format_output_row_more_than_ten_authors():
-    dummy = InspireRecord({})
+    dummy = {}
 
     expected = u'      author         = "0 and others",\n'
     result = Bibtex(dummy)._format_output_row('author', list(range(11)))
@@ -252,7 +250,7 @@ def test_format_output_row_more_than_ten_authors():
 
 
 def test_format_output_row_title():
-    dummy = InspireRecord({})
+    dummy = {}
 
     expected = u'      title          = "{bar}",\n'
     result = Bibtex(dummy)._format_output_row('title', 'bar')
@@ -261,7 +259,7 @@ def test_format_output_row_title():
 
 
 def test_format_output_row_doi():
-    dummy = InspireRecord({})
+    dummy = {}
 
     expected = u'      doi            = "bar",\n'
     result = Bibtex(dummy)._format_output_row('doi', 'bar')
@@ -270,7 +268,7 @@ def test_format_output_row_doi():
 
 
 def test_format_output_row_slaccitation():
-    dummy = InspireRecord({})
+    dummy = {}
 
     expected = u'      SLACcitation   = "bar"'
     result = Bibtex(dummy)._format_output_row('SLACcitation', 'bar')
@@ -279,7 +277,7 @@ def test_format_output_row_slaccitation():
 
 
 def test_format_output_row_number_value():
-    dummy = InspireRecord({})
+    dummy = {}
 
     expected = u'      foo            = "0",\n'
     result = Bibtex(dummy)._format_output_row('foo', 0)
@@ -288,7 +286,7 @@ def test_format_output_row_number_value():
 
 
 def test_format_output_row_not_number_value():
-    dummy = InspireRecord({})
+    dummy = {}
 
     expected = u'      foo            = "bar",\n'
     result = Bibtex(dummy)._format_output_row('foo', 'bar')
@@ -297,7 +295,7 @@ def test_format_output_row_not_number_value():
 
 
 def test_is_number():
-    dummy = InspireRecord({})
+    dummy = {}
 
     assert Bibtex(dummy)._is_number(0)
     assert not Bibtex(dummy)._is_number('foo')
@@ -307,7 +305,7 @@ def test_is_number():
 def test_get_key_empty(_g_c_k):
     _g_c_k.return_value = True
 
-    dummy = InspireRecord({})
+    dummy = {}
 
     expected = ''
     result = Bibtex(dummy)._get_key()
@@ -319,7 +317,7 @@ def test_get_key_empty(_g_c_k):
 def test_get_key_from_control_number(_g_c_k):
     _g_c_k.return_value = False
 
-    with_control_number = InspireRecord({'control_number': 1})
+    with_control_number = {'control_number': 1}
 
     expected = 1
     result = Bibtex(with_control_number)._get_key()
@@ -328,7 +326,7 @@ def test_get_key_from_control_number(_g_c_k):
 
 
 def test_get_author_no_authors_no_corporate_author():
-    no_authors_no_corporate_author = InspireRecord({})
+    no_authors_no_corporate_author = {}
 
     expected = []
     result = Bibtex(no_authors_no_corporate_author)._get_author()
@@ -337,9 +335,9 @@ def test_get_author_no_authors_no_corporate_author():
 
 
 def test_get_author_one_author_without_full_name():
-    one_author_without_full_name = InspireRecord({
+    one_author_without_full_name = {
         'authors': [{}]
-    })
+    }
 
     expected = []
     result = Bibtex(one_author_without_full_name)._get_author()
@@ -348,11 +346,11 @@ def test_get_author_one_author_without_full_name():
 
 
 def test_get_author_one_author_with_one_fullname():
-    one_author_with_one_fullname = InspireRecord({
+    one_author_with_one_fullname = {
         'authors': [
             {'full_name': 'Higgs, Peter W.'}
         ]
-    })
+    }
 
     expected = ['Higgs, Peter W.']
     result = Bibtex(one_author_with_one_fullname)._get_author()
@@ -361,12 +359,12 @@ def test_get_author_one_author_with_one_fullname():
 
 
 def test_get_author_two_authors_with_fullnames():
-    two_authors_with_fullnames = InspireRecord({
+    two_authors_with_fullnames = {
         'authors': [
             {'full_name': 'Englert, F.'},
             {'full_name': 'Brout, R.'}
         ]
-    })
+    }
 
     expected = ['Englert, F.', 'Brout, R.']
     result = Bibtex(two_authors_with_fullnames)._get_author()
@@ -375,7 +373,7 @@ def test_get_author_two_authors_with_fullnames():
 
 
 def test_get_author_two_authors_one_a_supervisor():
-    two_authors_one_a_supervisor = InspireRecord({
+    two_authors_one_a_supervisor = {
         'authors': [
             {'full_name': 'Mankuzhiyil, Nijil'},
             {
@@ -388,7 +386,7 @@ def test_get_author_two_authors_one_a_supervisor():
                 'full_name': 'de Angelis, Alessandro',
             },
         ],
-    })
+    }
 
     expected = ['Mankuzhiyil, Nijil']
     result = Bibtex(two_authors_one_a_supervisor)._get_author()
@@ -397,11 +395,11 @@ def test_get_author_two_authors_one_a_supervisor():
 
 
 def test_get_author_corporate_author():
-    corporate_author = InspireRecord({
+    corporate_author = {
         'corporate_author': [
             'CMS Collaboration'
         ]
-    })
+    }
 
     expected = ['CMS Collaboration']
     result = Bibtex(corporate_author)._get_author()
@@ -410,24 +408,24 @@ def test_get_author_corporate_author():
 
 
 def test_get_editor_no_authors():
-    no_authors = InspireRecord({})
+    no_authors = {}
 
     assert Bibtex(no_authors)._get_editor() is None
 
 
 def test_get_editor_no_author_has_editor_role():
-    no_author_has_editor_role = InspireRecord({
+    no_author_has_editor_role = {
         'authors': [
             {'full_name': 'Englert, F.'},
             {'full_name': 'Brout, R.'}
         ]
-    })
+    }
 
     assert Bibtex(no_author_has_editor_role)._get_editor() is None
 
 
 def test_get_editor_first_author_has_editor_role():
-    first_author_has_editor_role = InspireRecord({
+    first_author_has_editor_role = {
         'authors': [
             {
                 'full_name': 'Englert, F.',
@@ -435,7 +433,7 @@ def test_get_editor_first_author_has_editor_role():
             },
             {'full_name': 'Brout, R.'}
         ]
-    })
+    }
 
     expected = 'Englert, F.'
     result = Bibtex(first_author_has_editor_role)._get_editor()
@@ -444,7 +442,7 @@ def test_get_editor_first_author_has_editor_role():
 
 
 def test_get_editor_non_first_author_has_editor_role():
-    non_first_author_has_editor_role = InspireRecord({
+    non_first_author_has_editor_role = {
         'authors': [
             {'full_name': 'Englert, F.'},
             {
@@ -452,13 +450,13 @@ def test_get_editor_non_first_author_has_editor_role():
                 'role': 'ed.'
             }
         ]
-    })
+    }
 
     assert Bibtex(non_first_author_has_editor_role)._get_editor() is None
 
 
 def test_get_title_no_titles():
-    no_titles = InspireRecord({})
+    no_titles = {}
 
     expected = ''
     result = Bibtex(no_titles)._get_title()
@@ -467,11 +465,11 @@ def test_get_title_no_titles():
 
 
 def test_get_title_one_title():
-    one_title = InspireRecord({
+    one_title = {
         'titles': {
             'title': 'Partial Symmetries of Weak Interactions'
         }
-    })
+    }
 
     expected = 'Partial Symmetries of Weak Interactions'
     result = Bibtex(one_title)._get_title()
@@ -480,12 +478,12 @@ def test_get_title_one_title():
 
 
 def test_get_title_with_a_list_of_titles_selectes_first():
-    a_list_of_titles = InspireRecord({
+    a_list_of_titles = {
         'titles': [
             {'title': 'Broken Symmetries and the Masses of Gauge Bosons'},
             {'title': 'BROKEN SYMMETRIES AND THE MASSES OF GAUGE BOSONS.'}
         ]
-    })
+    }
 
     expected = 'Broken Symmetries and the Masses of Gauge Bosons'
     result = Bibtex(a_list_of_titles)._get_title()
@@ -494,7 +492,7 @@ def test_get_title_with_a_list_of_titles_selectes_first():
 
 
 def test_get_collaboration_no_collaboration():
-    no_collaboration = InspireRecord({})
+    no_collaboration = {}
 
     expected = ''
     result = Bibtex(no_collaboration)._get_collaboration()
@@ -503,12 +501,12 @@ def test_get_collaboration_no_collaboration():
 
 
 def test_get_collaboration_with_a_list_of_collaboration_selects_first():
-    a_list_of_collaboration = InspireRecord({
+    a_list_of_collaboration = {
         'collaboration': [
             {'value': 'ATLAS'},
             {'value': 'CMS'}
         ]
-    })
+    }
 
     expected = 'ATLAS'
     result = Bibtex(a_list_of_collaboration)._get_collaboration()
@@ -517,11 +515,11 @@ def test_get_collaboration_with_a_list_of_collaboration_selects_first():
 
 
 def test_get_collaboration_malformed_collaboration():
-    malformed_collaboration = InspireRecord({
+    malformed_collaboration = {
         'collaboration': [
             {'notvalue': 'ATLAS'}
         ]
-    })
+    }
 
     expected = ''
     result = Bibtex(malformed_collaboration)._get_collaboration()
@@ -530,7 +528,7 @@ def test_get_collaboration_malformed_collaboration():
 
 
 def test_get_organization_no_imprints():
-    no_imprints = InspireRecord({})
+    no_imprints = {}
 
     expected = ''
     result = Bibtex(no_imprints)._get_organization()
@@ -539,12 +537,12 @@ def test_get_organization_no_imprints():
 
 
 def test_get_organization_with_a_list_of_imprints_selects_first_with_a_publisher():
-    a_list_of_imprints_with_a_publisher = InspireRecord({
+    a_list_of_imprints_with_a_publisher = {
         'imprints': [
             {},
             {'publisher': 'Cambridge University Press'}
         ]
-    })
+    }
 
     expected = 'Cambridge University Press'
     result = Bibtex(a_list_of_imprints_with_a_publisher)._get_organization()
@@ -553,7 +551,7 @@ def test_get_organization_with_a_list_of_imprints_selects_first_with_a_publisher
 
 
 def test_get_address_no_imprints():
-    no_imprints = InspireRecord({})
+    no_imprints = {}
 
     expected = []
     result = Bibtex(no_imprints)._get_address()
@@ -562,21 +560,21 @@ def test_get_address_no_imprints():
 
 
 def test_get_address_a_list_of_imprints_with_no_places():
-    a_list_of_imprints_with_no_places = InspireRecord({
+    a_list_of_imprints_with_no_places = {
         'imprints': [
             {'notplace': 'Piscataway, USA'}
         ]
-    })
+    }
 
     assert Bibtex(a_list_of_imprints_with_no_places)._get_address() is None
 
 
 def test_get_address_a_list_of_imprints_with_one_place_not_a_list():
-    a_list_of_imprints_with_one_place_not_a_list = InspireRecord({
+    a_list_of_imprints_with_one_place_not_a_list = {
         'imprints': [
             {'place': 'Piscataway, USA'}
         ]
-    })
+    }
 
     expected = 'Piscataway, USA'
     result = Bibtex(a_list_of_imprints_with_one_place_not_a_list)._get_address()
@@ -585,7 +583,7 @@ def test_get_address_a_list_of_imprints_with_one_place_not_a_list():
 
 
 def test_get_address_a_list_of_imprints_with_one_place_a_list():
-    a_list_of_imprints_with_one_place_a_list = InspireRecord({
+    a_list_of_imprints_with_one_place_a_list = {
         'imprints': [
             {
                 'place': [
@@ -594,7 +592,7 @@ def test_get_address_a_list_of_imprints_with_one_place_a_list():
                 ]
             }
         ]
-    })
+    }
 
     expected = 'Moscow'
     result = Bibtex(a_list_of_imprints_with_one_place_a_list)._get_address()
@@ -603,12 +601,12 @@ def test_get_address_a_list_of_imprints_with_one_place_a_list():
 
 
 def test_get_address_a_list_of_imprints_with_two_places():
-    a_list_of_imprints_with_two_places = InspireRecord({
+    a_list_of_imprints_with_two_places = {
         'imprints': [
             {'place': 'Moscow'},
             {'place': 'Russia'}
         ]
-    })
+    }
 
     expected = 'Moscow'
     result = Bibtex(a_list_of_imprints_with_two_places)._get_address()
@@ -617,7 +615,7 @@ def test_get_address_a_list_of_imprints_with_two_places():
 
 
 def test_get_school_no_authors():
-    no_authors = InspireRecord({})
+    no_authors = {}
 
     expected = ''
     result = Bibtex(no_authors)._get_school()
@@ -626,7 +624,7 @@ def test_get_school_no_authors():
 
 
 def test_get_school_a_list_of_authors_with_no_affiliations():
-    a_list_of_authors_with_no_affiliations = InspireRecord({'authors': []})
+    a_list_of_authors_with_no_affiliations = {'authors': []}
 
     expected = ''
     result = Bibtex(a_list_of_authors_with_no_affiliations)._get_school()
@@ -635,7 +633,7 @@ def test_get_school_a_list_of_authors_with_no_affiliations():
 
 
 def test_get_school_a_list_of_authors_with_one_affiliation_each():
-    a_list_of_authors_with_one_affiliation_each = InspireRecord({
+    a_list_of_authors_with_one_affiliation_each = {
         'authors': [
             {
                 'affiliations': [
@@ -648,7 +646,7 @@ def test_get_school_a_list_of_authors_with_one_affiliation_each():
                 ]
             }
         ]
-    })
+    }
 
     expected = 'Edinburgh U.'
     result = Bibtex(a_list_of_authors_with_one_affiliation_each)._get_school()
@@ -657,7 +655,7 @@ def test_get_school_a_list_of_authors_with_one_affiliation_each():
 
 
 def test_get_school_a_list_of_authors_with_more_than_one_affiliation_each():
-    a_list_of_authors_with_more_than_one_affiliation_each = InspireRecord({
+    a_list_of_authors_with_more_than_one_affiliation_each = {
         'authors': [
             {
                 'affiliations': [
@@ -672,7 +670,7 @@ def test_get_school_a_list_of_authors_with_more_than_one_affiliation_each():
                 ]
             }
         ]
-    })
+    }
 
     expected = 'Potsdam, Max Planck Inst.'
     result = Bibtex(a_list_of_authors_with_more_than_one_affiliation_each)._get_school()
@@ -681,7 +679,7 @@ def test_get_school_a_list_of_authors_with_more_than_one_affiliation_each():
 
 
 def test_get_booktitle_not_in_proceedings():
-    record = InspireRecord({})
+    record = {}
 
     not_in_proceedings = Bibtex(record)
     not_in_proceedings.entry_type = 'not-inproceedings'
@@ -695,7 +693,7 @@ def test_get_booktitle_from_generate_booktitle(g_b):
     # TODO: mock the actual generate_booktitle output.
     g_b.return_value = 'foo bar baz'
 
-    record = InspireRecord({})
+    record = {}
 
     in_proceedings = Bibtex(record)
     in_proceedings.entry_type = 'inproceedings'
@@ -707,7 +705,7 @@ def test_get_booktitle_from_generate_booktitle(g_b):
 
 
 def test_get_year_no_publication_info_no_thesis_no_imprints_no_preprint_date():
-    no_publication_info_no_thesis_no_imprints_no_preprint_date = InspireRecord({})
+    no_publication_info_no_thesis_no_imprints_no_preprint_date = {}
 
     expected = ''
     result = Bibtex(no_publication_info_no_thesis_no_imprints_no_preprint_date)._get_year()
@@ -716,9 +714,9 @@ def test_get_year_no_publication_info_no_thesis_no_imprints_no_preprint_date():
 
 
 def test_get_year_from_publication_info_an_empty_list():
-    publication_info_an_empty_list = InspireRecord({
+    publication_info_an_empty_list = {
         'publication_info': []
-    })
+    }
 
     expected = ''
     result = Bibtex(publication_info_an_empty_list)._get_year()
@@ -727,11 +725,11 @@ def test_get_year_from_publication_info_an_empty_list():
 
 
 def test_get_year_from_publication_info_a_list_one_year():
-    publication_info_a_list_one_year = InspireRecord({
+    publication_info_a_list_one_year = {
         'publication_info': [
             {'year': '2015'}
         ]
-    })
+    }
 
     expected = '2015'
     result = Bibtex(publication_info_a_list_one_year)._get_year()
@@ -740,12 +738,12 @@ def test_get_year_from_publication_info_a_list_one_year():
 
 
 def test_get_year_from_publication_info_a_list_from_imprints():
-    publication_info_a_list_from_imprints = InspireRecord({
+    publication_info_a_list_from_imprints = {
         'publication_info': [],
         'imprints': [
             {'date': '2015-12-04'}
         ]
-    })
+    }
 
     expected = '2015'
     result = Bibtex(publication_info_a_list_from_imprints)._get_year()
@@ -754,12 +752,12 @@ def test_get_year_from_publication_info_a_list_from_imprints():
 
 
 def test_get_year_from_publication_info_a_list_from_preprint_date():
-    publication_info_a_list_from_preprint_date = InspireRecord({
+    publication_info_a_list_from_preprint_date = {
         'publication_info': [],
         'preprint_date': [
             '2015-12-04'
         ]
-    })
+    }
 
     expected = '2015'
     result = Bibtex(publication_info_a_list_from_preprint_date)._get_year()
@@ -768,9 +766,9 @@ def test_get_year_from_publication_info_a_list_from_preprint_date():
 
 
 def test_get_year_from_thesis_an_empty_obj():
-    record = InspireRecord({
+    record = {
         'thesis': {}
-    })
+    }
 
     thesis_an_empty_list = Bibtex(record)
     thesis_an_empty_list.original_entry = 'thesis'
@@ -782,10 +780,10 @@ def test_get_year_from_thesis_an_empty_obj():
 
 
 def test_get_year_from_thesis_an_empty_obj_but_preprint_date():
-    record = InspireRecord({
+    record = {
         'preprint_date': '1998-04-30',
         'thesis': {}
-    })
+    }
 
     thesis_an_empty_list_but_preprint_date = Bibtex(record)
     thesis_an_empty_list_but_preprint_date.original_entry = 'thesis'
@@ -797,10 +795,10 @@ def test_get_year_from_thesis_an_empty_obj_but_preprint_date():
 
 
 def test_get_year_from_thesis_an_empty_obj_but_imprints():
-    record = InspireRecord({
+    record = {
         'imprints': [{'date': '2015-12-04'}],
         'thesis': {}
-    })
+    }
 
     thesis_an_empty_list_but_imprints = Bibtex(record)
     thesis_an_empty_list_but_imprints.original_entry = 'thesis'
@@ -812,9 +810,9 @@ def test_get_year_from_thesis_an_empty_obj_but_imprints():
 
 
 def test_get_year_from_thesis_one_date():
-    record = InspireRecord({
+    record = {
         'thesis': {'date': '2008'}
-    })
+    }
 
     thesis_one_date = Bibtex(record)
     thesis_one_date.original_entry = 'thesis'
@@ -826,9 +824,9 @@ def test_get_year_from_thesis_one_date():
 
 
 def test_get_year_from_imprints_an_empty_list():
-    imprints_an_empty_list = InspireRecord({
+    imprints_an_empty_list = {
         'imprints': []
-    })
+    }
 
     expected = ''
     result = Bibtex(imprints_an_empty_list)._get_year()
@@ -837,11 +835,11 @@ def test_get_year_from_imprints_an_empty_list():
 
 
 def test_get_year_from_imprints_one_date():
-    imprints_one_date = InspireRecord({
+    imprints_one_date = {
         'imprints': [
             {'date': '1998-04-30'}
         ]
-    })
+    }
 
     expected = '1998'
     result = Bibtex(imprints_one_date)._get_year()
@@ -850,12 +848,12 @@ def test_get_year_from_imprints_one_date():
 
 
 def test_get_year_from_imprints_two_dates():
-    imprints_two_dates = InspireRecord({
+    imprints_two_dates = {
         'imprints': [
             {'date': '1998-04-30'},
             {'date': '2015-12-04'}
         ]
-    })
+    }
 
     expected = '2015'
     result = Bibtex(imprints_two_dates)._get_year()
@@ -864,9 +862,9 @@ def test_get_year_from_imprints_two_dates():
 
 
 def test_get_year_from_preprint_date_an_empty_list():
-    preprint_date_an_empty_list = InspireRecord({
+    preprint_date_an_empty_list = {
         'preprint_date': []
-    })
+    }
 
     expected = ''
     result = Bibtex(preprint_date_an_empty_list)._get_year()
@@ -875,11 +873,11 @@ def test_get_year_from_preprint_date_an_empty_list():
 
 
 def test_get_year_from_preprint_date_one_date():
-    preprint_date_one_date = InspireRecord({
+    preprint_date_one_date = {
         'preprint_date': [
             '2015-12-04'
         ]
-    })
+    }
 
     expected = '2015'
     result = Bibtex(preprint_date_one_date)._get_year()
@@ -888,12 +886,12 @@ def test_get_year_from_preprint_date_one_date():
 
 
 def test_get_year_from_preprint_date_two_dates():
-    preprint_date_two_dates = InspireRecord({
+    preprint_date_two_dates = {
         'preprint_date': [
             '1998-04-30',
             '2015-12-04'
         ]
-    })
+    }
 
     expected = '1998'
     result = Bibtex(preprint_date_two_dates)._get_year()
@@ -902,7 +900,7 @@ def test_get_year_from_preprint_date_two_dates():
 
 
 def test_get_journal_no_publication_info():
-    no_publication_info = InspireRecord({})
+    no_publication_info = {}
 
     expected = ''
     result = Bibtex(no_publication_info)._get_journal()
@@ -911,9 +909,9 @@ def test_get_journal_no_publication_info():
 
 
 def test_get_journal_publication_info_a_list_no_journal_title():
-    publication_info_a_list_no_journal_title = InspireRecord({
+    publication_info_a_list_no_journal_title = {
         'publication_info': []
-    })
+    }
 
     expected = ''
     result = Bibtex(publication_info_a_list_no_journal_title)._get_journal()
@@ -922,11 +920,11 @@ def test_get_journal_publication_info_a_list_no_journal_title():
 
 
 def test_get_journal_publication_info_a_list_one_journal_title():
-    publication_info_a_list_one_journal_title = InspireRecord({
+    publication_info_a_list_one_journal_title = {
         'publication_info': [
             {'journal_title': 'Nucl.Phys.'}
         ]
-    })
+    }
 
     expected = 'Nucl. Phys.'
     result = Bibtex(publication_info_a_list_one_journal_title)._get_journal()
@@ -935,7 +933,7 @@ def test_get_journal_publication_info_a_list_one_journal_title():
 
 
 def test_get_journal_publication_info_a_list_one_journal_title_a_list():
-    publication_info_a_list_one_journal_title_a_list = InspireRecord({
+    publication_info_a_list_one_journal_title_a_list = {
         'publication_info': [
             {
                 'journal_title': [
@@ -944,7 +942,7 @@ def test_get_journal_publication_info_a_list_one_journal_title_a_list():
                 ]
             }
         ]
-    })
+    }
 
     expected = 'Nucl.Phys.'
     result = Bibtex(publication_info_a_list_one_journal_title_a_list)._get_journal()
@@ -953,7 +951,7 @@ def test_get_journal_publication_info_a_list_one_journal_title_a_list():
 
 
 def test_get_volume_no_publication_info_no_book_series():
-    no_publication_info_no_book_series = InspireRecord({})
+    no_publication_info_no_book_series = {}
 
     expected = ''
     result = Bibtex(no_publication_info_no_book_series)._get_volume()
@@ -962,9 +960,9 @@ def test_get_volume_no_publication_info_no_book_series():
 
 
 def test_get_volume_from_publication_info_an_empty_list():
-    publication_info_an_empty_list = InspireRecord({
+    publication_info_an_empty_list = {
         'publication_info': []
-    })
+    }
 
     expected = ''
     result = Bibtex(publication_info_an_empty_list)._get_volume()
@@ -973,11 +971,11 @@ def test_get_volume_from_publication_info_an_empty_list():
 
 
 def test_get_volume_from_publication_info_a_list_one_with_volume():
-    publication_info_a_list_one_with_volume = InspireRecord({
+    publication_info_a_list_one_with_volume = {
         'publication_info': [
             {'journal_volume': 'D89'}
         ]
-    })
+    }
 
     expected = 'D89'
     result = Bibtex(publication_info_a_list_one_with_volume)._get_volume()
@@ -986,14 +984,14 @@ def test_get_volume_from_publication_info_a_list_one_with_volume():
 
 
 def test_get_volume_from_publication_info_one_with_volume_JHEP():
-    publication_info_a_list_one_with_volume_JHEP = InspireRecord({
+    publication_info_a_list_one_with_volume_JHEP = {
         'publication_info': [
             {
                 'journal_title': 'JHEP',
                 'journal_volume': '1511'
             }
         ]
-    })
+    }
 
     expected = '11'
     result = Bibtex(publication_info_a_list_one_with_volume_JHEP)._get_volume()
@@ -1002,12 +1000,12 @@ def test_get_volume_from_publication_info_one_with_volume_JHEP():
 
 
 def test_get_volume_from_publication_info_a_list_two_with_volume():
-    publication_info_a_list_two_with_volume = InspireRecord({
+    publication_info_a_list_two_with_volume = {
         'publication_info': [
             {'journal_volume': 'D89'},
             {'journal_volume': 'D91'}
         ]
-    })
+    }
 
     expected = 'D89'
     result = Bibtex(publication_info_a_list_two_with_volume)._get_volume()
@@ -1016,12 +1014,12 @@ def test_get_volume_from_publication_info_a_list_two_with_volume():
 
 
 def test_get_volume_from_publication_info_actually_from_book_series():
-    publication_info_actually_from_book_series = InspireRecord({
+    publication_info_actually_from_book_series = {
         'publication_info': [],
         'book_series': [
             {'volume': '11'}
         ]
-    })
+    }
 
     expected = '11'
     result = Bibtex(publication_info_actually_from_book_series)._get_volume()
@@ -1030,9 +1028,9 @@ def test_get_volume_from_publication_info_actually_from_book_series():
 
 
 def test_get_volume_from_book_series_an_empty_list():
-    book_series_an_empty_list = InspireRecord({
+    book_series_an_empty_list = {
         'book_series': []
-    })
+    }
 
     expected = ''
     result = Bibtex(book_series_an_empty_list)._get_volume()
@@ -1041,11 +1039,11 @@ def test_get_volume_from_book_series_an_empty_list():
 
 
 def test_get_volume_from_book_series_one_volume():
-    book_series_one_volume = InspireRecord({
+    book_series_one_volume = {
         'book_series': [
             {'volume': '11'}
         ]
-    })
+    }
 
     expected = '11'
     result = Bibtex(book_series_one_volume)._get_volume()
@@ -1054,12 +1052,12 @@ def test_get_volume_from_book_series_one_volume():
 
 
 def test_get_volume_from_book_series_two_volumes():
-    book_series_two_volumes = InspireRecord({
+    book_series_two_volumes = {
         'book_series': [
             {'volume': '11'},
             {'volume': '5'}
         ]
-    })
+    }
 
     expected = '5'
     result = Bibtex(book_series_two_volumes)._get_volume()
@@ -1068,7 +1066,7 @@ def test_get_volume_from_book_series_two_volumes():
 
 
 def test_get_number_no_publication_info():
-    no_publication_info = InspireRecord({})
+    no_publication_info = {}
 
     expected = ''
     result = Bibtex(no_publication_info)._get_number()
@@ -1077,9 +1075,9 @@ def test_get_number_no_publication_info():
 
 
 def test_get_number_publication_info_an_empty_list():
-    publication_info_an_empty_list = InspireRecord({
+    publication_info_an_empty_list = {
         'publication_info': []
-    })
+    }
 
     expected = ''
     result = Bibtex(publication_info_an_empty_list)._get_number()
@@ -1088,11 +1086,11 @@ def test_get_number_publication_info_an_empty_list():
 
 
 def test_get_number_publication_info_a_list_one_issue():
-    publication_info_a_list_one_issue = InspireRecord({
+    publication_info_a_list_one_issue = {
         'publication_info': [
             {'journal_issue': '5'}
         ]
-    })
+    }
 
     expected = '5'
     result = Bibtex(publication_info_a_list_one_issue)._get_number()
@@ -1101,12 +1099,12 @@ def test_get_number_publication_info_a_list_one_issue():
 
 
 def test_get_number_publication_info_a_list_two_issues():
-    publication_info_a_list_two_issues = InspireRecord({
+    publication_info_a_list_two_issues = {
         'publication_info': [
             {'journal_issue': '11'},
             {'journal_issue': '5'}
         ]
-    })
+    }
 
     expected = '11'
     result = Bibtex(publication_info_a_list_two_issues)._get_number()
@@ -1115,7 +1113,7 @@ def test_get_number_publication_info_a_list_two_issues():
 
 
 def test_get_pages_no_publication_info():
-    no_publication_info = InspireRecord({})
+    no_publication_info = {}
 
     expected = ''
     result = Bibtex(no_publication_info)._get_pages()
@@ -1124,9 +1122,9 @@ def test_get_pages_no_publication_info():
 
 
 def test_get_pages_publication_info_an_empty_list():
-    publication_info_an_empty_list = InspireRecord({
+    publication_info_an_empty_list = {
         'publication_info': []
-    })
+    }
 
     expected = ''
     result = Bibtex(publication_info_an_empty_list)._get_pages()
@@ -1135,12 +1133,12 @@ def test_get_pages_publication_info_an_empty_list():
 
 
 def test_get_pages_publication_info_one_page():
-    publication_info_one_page = InspireRecord({
+    publication_info_one_page = {
         'publication_info': [
             {'page_start': '585',
              'page_end': '587'}
         ]
-    })
+    }
 
     expected = '585-587'
     result = Bibtex(publication_info_one_page)._get_pages()
@@ -1149,14 +1147,14 @@ def test_get_pages_publication_info_one_page():
 
 
 def test_get_pages_publication_info_two_pages():
-    publication_info_two_pages = InspireRecord({
+    publication_info_two_pages = {
         'publication_info': [
             {'page_start': '585',
              'page_end': '587'},
             {'page_start': '508',
              'page_end': '509'}
         ]
-    })
+    }
 
     expected = '585-587'
     result = Bibtex(publication_info_two_pages)._get_pages()
@@ -1165,7 +1163,7 @@ def test_get_pages_publication_info_two_pages():
 
 
 def test_get_note_not_article_not_in_proceedings():
-    record = InspireRecord({})
+    record = {}
 
     not_article_not_in_proceedings = Bibtex(record)
     not_article_not_in_proceedings.entry_type = 'not-article'
@@ -1174,15 +1172,15 @@ def test_get_note_not_article_not_in_proceedings():
 
 
 def test_get_note_no_publication_info():
-    no_publication_info = InspireRecord({})
+    no_publication_info = {}
 
     assert Bibtex(no_publication_info)._get_note() is None
 
 
 def test_get_note_publication_info_an_empty_list():
-    publication_info_an_empty_list = InspireRecord({
+    publication_info_an_empty_list = {
         'publication_info': []
-    })
+    }
 
     expected = ''
     result = Bibtex(publication_info_an_empty_list)._get_note()
@@ -1191,14 +1189,14 @@ def test_get_note_publication_info_an_empty_list():
 
 
 def test_get_note_publication_info_a_list_one_el():
-    publication_info_a_list_one_el = InspireRecord({
+    publication_info_a_list_one_el = {
         'publication_info': [
             {
                 'note': 'Erratum',
                 'journal_title': 'Phys.Rev.'
             }
         ]
-    })
+    }
 
     expected = ''
     result = Bibtex(publication_info_a_list_one_el)._get_note()
@@ -1207,7 +1205,7 @@ def test_get_note_publication_info_a_list_one_el():
 
 
 def test_get_note_publication_info_a_list_two_els():
-    publication_info_a_list_two_els = InspireRecord({
+    publication_info_a_list_two_els = {
         'publication_info': [
             {
                 'note': 'Erratum',
@@ -1218,7 +1216,7 @@ def test_get_note_publication_info_a_list_two_els():
                 'journal_title': 'Phys.Rev.'
             }
         ]
-    })
+    }
 
     expected = '[Erratum: Phys. Rev.]'
     result = Bibtex(publication_info_a_list_two_els)._get_note()
@@ -1227,12 +1225,12 @@ def test_get_note_publication_info_a_list_two_els():
 
 
 def test_get_note_publication_info_a_list_not_a_note_with_title():
-    publication_info_a_list_not_a_note_with_title = InspireRecord({
+    publication_info_a_list_not_a_note_with_title = {
         'publication_info': [
             {'journal_title': 'Phys.Rev.'},
             {'journal_title': 'Phys.Rev.'}
         ]
-    })
+    }
 
     expected = '[Submitted to: Phys. Rev.]'
     result = Bibtex(publication_info_a_list_not_a_note_with_title)._get_note()
@@ -1241,12 +1239,12 @@ def test_get_note_publication_info_a_list_not_a_note_with_title():
 
 
 def test_get_note_publication_info_a_list_not_a_note_with_volume():
-    publication_info_a_list_not_a_note_with_volume = InspireRecord({
+    publication_info_a_list_not_a_note_with_volume = {
         'publication_info': [
             {'journal_volume': 'D69'},
             {'journal_volume': 'D69'}
         ]
-    })
+    }
 
     expected = '[]'
     result = Bibtex(publication_info_a_list_not_a_note_with_volume)._get_note()
@@ -1255,7 +1253,7 @@ def test_get_note_publication_info_a_list_not_a_note_with_volume():
 
 
 def test_get_note_publication_info_a_list_not_a_note_with_volume_JHEP():
-    publication_info_a_list_not_a_note_with_volume_JHEP = InspireRecord({
+    publication_info_a_list_not_a_note_with_volume_JHEP = {
         'publication_info': [
             {
                 'journal_title': 'JHEP',
@@ -1266,7 +1264,7 @@ def test_get_note_publication_info_a_list_not_a_note_with_volume_JHEP():
                 'journal_volume': '9712'
             }
         ]
-    })
+    }
 
     expected = '[Submitted to: JHEP]'
     result = Bibtex(publication_info_a_list_not_a_note_with_volume_JHEP)._get_note()
@@ -1275,12 +1273,12 @@ def test_get_note_publication_info_a_list_not_a_note_with_volume_JHEP():
 
 
 def test_get_note_publication_info_a_list_not_a_note_with_issue():
-    publication_info_a_list_not_a_note_with_issue = InspireRecord({
+    publication_info_a_list_not_a_note_with_issue = {
         'publication_info': [
             {'journal_issue': '11'},
             {'journal_issue': '11'}
         ]
-    })
+    }
 
     expected = '[]'
     result = Bibtex(publication_info_a_list_not_a_note_with_issue)._get_note()
@@ -1289,14 +1287,14 @@ def test_get_note_publication_info_a_list_not_a_note_with_issue():
 
 
 def test_get_note_publication_info_a_list_not_a_note_with_pages():
-    publication_info_a_list_not_a_note_with_pages = InspireRecord({
+    publication_info_a_list_not_a_note_with_pages = {
         'publication_info': [
             {'page_start': 'pp.2067',
              'page_end': '2414'},
             {'page_start': 'pp.2067',
              'page_end': '2414'}
         ]
-    })
+    }
 
     expected = '[]'
     result = Bibtex(publication_info_a_list_not_a_note_with_pages)._get_note()
@@ -1305,12 +1303,12 @@ def test_get_note_publication_info_a_list_not_a_note_with_pages():
 
 
 def test_get_note_publication_info_a_list_not_a_note_with_year():
-    publication_info_a_list_not_a_note_with_year = InspireRecord({
+    publication_info_a_list_not_a_note_with_year = {
         'publication_info': [
             {'year': '2015'},
             {'year': '2015'}
         ]
-    })
+    }
 
     expected = '[(2015)]'
     result = Bibtex(publication_info_a_list_not_a_note_with_year)._get_note()
@@ -1319,13 +1317,13 @@ def test_get_note_publication_info_a_list_not_a_note_with_year():
 
 
 def test_get_note_publication_info_a_list_not_a_note_with_preprint():
-    publication_info_a_list_not_a_note_with_preprint = InspireRecord({
+    publication_info_a_list_not_a_note_with_preprint = {
         'preprint_date': '2015-12-04',
         'publication_info': [
             {'journal_title': 'Acta Phys.Polon.'},
             {'journal_title': 'Acta Phys.Polon.'}
         ]
-    })
+    }
 
     expected = '[Submitted to: Acta Phys. Polon.(2015)]'
     result = Bibtex(publication_info_a_list_not_a_note_with_preprint)._get_note()
@@ -1334,7 +1332,7 @@ def test_get_note_publication_info_a_list_not_a_note_with_preprint():
 
 
 def test_get_note_publication_info_a_list_not_a_note_with_everything():
-    publication_info_a_list_not_a_note_with_everything = InspireRecord({
+    publication_info_a_list_not_a_note_with_everything = {
         'doi': 'something',
         'publication_info': [
             {
@@ -1352,7 +1350,7 @@ def test_get_note_publication_info_a_list_not_a_note_with_everything():
                 'page_end': '2414'
             },
         ]
-    })
+    }
 
     expected = '[Acta Phys. Polon.B46,no.11,pp.2067]'
     result = Bibtex(publication_info_a_list_not_a_note_with_everything)._get_note()
@@ -1361,7 +1359,7 @@ def test_get_note_publication_info_a_list_not_a_note_with_everything():
 
 
 def test_get_note_publication_info_a_list_a_note_with_title():
-    publication_info_a_list_a_note_with_title = InspireRecord({
+    publication_info_a_list_a_note_with_title = {
         'publication_info': [
             {
                 'note': 'Erratum',
@@ -1372,7 +1370,7 @@ def test_get_note_publication_info_a_list_a_note_with_title():
                 'journal_title': 'Phys.Rev.'
             }
         ]
-    })
+    }
 
     expected = '[Erratum: Phys. Rev.]'
     result = Bibtex(publication_info_a_list_a_note_with_title)._get_note()
@@ -1381,7 +1379,7 @@ def test_get_note_publication_info_a_list_a_note_with_title():
 
 
 def test_get_note_publication_info_a_list_a_note_with_volume():
-    publication_info_a_list_a_note_with_volume = InspireRecord({
+    publication_info_a_list_a_note_with_volume = {
         'publication_info': [
             {
                 'note': 'Addendum',
@@ -1392,7 +1390,7 @@ def test_get_note_publication_info_a_list_a_note_with_volume():
                 'journal_volume': 'D91'
             }
         ]
-    })
+    }
 
     expected = '[Addendum: D91]'
     result = Bibtex(publication_info_a_list_a_note_with_volume)._get_note()
@@ -1401,7 +1399,7 @@ def test_get_note_publication_info_a_list_a_note_with_volume():
 
 
 def test_get_note_publication_info_a_list_a_note_with_volume_JHEP():
-    publication_info_a_list_a_note_with_volume_JHEP = InspireRecord({
+    publication_info_a_list_a_note_with_volume_JHEP = {
         'publication_info': [
             {
                 'note': 'Erratum',
@@ -1414,7 +1412,7 @@ def test_get_note_publication_info_a_list_a_note_with_volume_JHEP():
                 'journal_volume': '1501'
             }
         ]
-    })
+    }
 
     expected = '[Erratum: JHEP01]'
     result = Bibtex(publication_info_a_list_a_note_with_volume_JHEP)._get_note()
@@ -1423,7 +1421,7 @@ def test_get_note_publication_info_a_list_a_note_with_volume_JHEP():
 
 
 def test_get_note_publication_info_a_list_a_note_with_issue():
-    publication_info_a_list_a_note_with_issue = InspireRecord({
+    publication_info_a_list_a_note_with_issue = {
         'publication_info': [
             {
                 'note': 'Corrigendum',
@@ -1434,7 +1432,7 @@ def test_get_note_publication_info_a_list_a_note_with_issue():
                 'journal_issue': '1'
             }
         ]
-    })
+    }
 
     expected = '[Corrigendum: ,no.1]'
     result = Bibtex(publication_info_a_list_a_note_with_issue)._get_note()
@@ -1443,7 +1441,7 @@ def test_get_note_publication_info_a_list_a_note_with_issue():
 
 
 def test_get_note_publication_info_a_list_a_note_with_pages():
-    publication_info_a_list_a_note_with_pages = InspireRecord({
+    publication_info_a_list_a_note_with_pages = {
         'publication_info': [
             {
                 'note': 'Reprint',
@@ -1454,7 +1452,7 @@ def test_get_note_publication_info_a_list_a_note_with_pages():
                 'artid': '019903'
             }
         ]
-    })
+    }
 
     expected = '[Reprint: ,019903]'
     result = Bibtex(publication_info_a_list_a_note_with_pages)._get_note()
@@ -1463,7 +1461,7 @@ def test_get_note_publication_info_a_list_a_note_with_pages():
 
 
 def test_get_note_publication_info_a_list_a_note_with_year():
-    publication_info_a_list_a_note_with_year = InspireRecord({
+    publication_info_a_list_a_note_with_year = {
         'publication_info': [
             {
                 'note': 'Erratum',
@@ -1474,7 +1472,7 @@ def test_get_note_publication_info_a_list_a_note_with_year():
                 'year': '2015'
             }
         ]
-    })
+    }
 
     expected = '[Erratum: (2015)]'
     result = Bibtex(publication_info_a_list_a_note_with_year)._get_note()
@@ -1483,7 +1481,7 @@ def test_get_note_publication_info_a_list_a_note_with_year():
 
 
 def test_get_url_no_urls():
-    no_urls = InspireRecord({})
+    no_urls = {}
 
     expected = ''
     result = Bibtex(no_urls)._get_url()
@@ -1492,9 +1490,9 @@ def test_get_url_no_urls():
 
 
 def test_get_url_empty_urls():
-    empty_urls = InspireRecord({
+    empty_urls = {
         'urls': []
-    })
+    }
 
     expected = ''
     result = Bibtex(empty_urls)._get_url()
@@ -1503,11 +1501,11 @@ def test_get_url_empty_urls():
 
 
 def test_get_url_urls_without_value():
-    urls_without_url = InspireRecord({
+    urls_without_url = {
         'urls': [
             {'not-value': 'foo'}
         ]
-    })
+    }
 
     expected = ''
     result = Bibtex(urls_without_url)._get_url()
@@ -1516,11 +1514,11 @@ def test_get_url_urls_without_value():
 
 
 def test_get_url_one_url_to_an_image():
-    one_url_to_an_image = InspireRecord({
+    one_url_to_an_image = {
         'urls': [
             {'value': 'foo.jpg'}
         ]
-    })
+    }
 
     expected = ''
     result = Bibtex(one_url_to_an_image)._get_url()
@@ -1529,11 +1527,11 @@ def test_get_url_one_url_to_an_image():
 
 
 def test_get_url_one_url_not_to_an_image():
-    one_url_not_to_an_image = InspireRecord({
+    one_url_not_to_an_image = {
         'urls': [
             {'value': 'http://link.aps.org/abstract/PRL/V19/P1264'}
         ]
-    })
+    }
 
     expected = 'http://link.aps.org/abstract/PRL/V19/P1264'
     result = Bibtex(one_url_not_to_an_image)._get_url()
@@ -1542,12 +1540,12 @@ def test_get_url_one_url_not_to_an_image():
 
 
 def test_get_url_more_urls_selects_first():
-    more_urls = InspireRecord({
+    more_urls = {
         'urls': [
             {'value': 'http://link.aps.org/abstract/PRL/V19/P1264'},
             {'value': 'http://example.com'}
         ]
-    })
+    }
 
     expected = 'http://link.aps.org/abstract/PRL/V19/P1264'
     result = Bibtex(more_urls)._get_url()
@@ -1556,7 +1554,7 @@ def test_get_url_more_urls_selects_first():
 
 
 def test_get_eprint_no_arxiv_field():
-    no_arxiv_field = InspireRecord({})
+    no_arxiv_field = {}
 
     expected = []
     result = Bibtex(no_arxiv_field)._get_eprint()
@@ -1565,11 +1563,11 @@ def test_get_eprint_no_arxiv_field():
 
 
 def test_get_eprint_arxiv_field_starts_with_arxiv():
-    starts_with_arxiv = InspireRecord({
+    starts_with_arxiv = {
         'arxiv_eprints': [
             {'value': 'arXiv:1512.01381'}
         ]
-    })
+    }
 
     expected = '1512.01381'
     result = Bibtex(starts_with_arxiv)._get_eprint()
@@ -1578,11 +1576,11 @@ def test_get_eprint_arxiv_field_starts_with_arxiv():
 
 
 def test_get_eprint_arxiv_field_does_not_start_with_arxiv():
-    does_not_start_with_arxiv = InspireRecord({
+    does_not_start_with_arxiv = {
         'arxiv_eprints': [
             {'value': '1512.01381'}
         ]
-    })
+    }
 
     expected = '1512.01381'
     result = Bibtex(does_not_start_with_arxiv)._get_eprint()
@@ -1591,7 +1589,7 @@ def test_get_eprint_arxiv_field_does_not_start_with_arxiv():
 
 
 def test_get_archive_prefix_no_arxiv_eprints():
-    no_arxiv_eprints = InspireRecord({})
+    no_arxiv_eprints = {}
 
     expected = ''
     result = Bibtex(no_arxiv_eprints)._get_archive_prefix()
@@ -1600,9 +1598,9 @@ def test_get_archive_prefix_no_arxiv_eprints():
 
 
 def test_get_archive_prefix_empty_arxiv_eprints():
-    empty_arxiv_eprints = InspireRecord({
+    empty_arxiv_eprints = {
         'arxiv_eprints': []
-    })
+    }
 
     expected = ''
     result = Bibtex(empty_arxiv_eprints)._get_archive_prefix()
@@ -1611,14 +1609,14 @@ def test_get_archive_prefix_empty_arxiv_eprints():
 
 
 def test_get_archive_prefix_some_arxiv_eprints():
-    some_arxiv_eprints = InspireRecord({
+    some_arxiv_eprints = {
         'arxiv_eprints': [
             {
                 u'categories': [u'hep-th'],
                 u'value': u'hep-th/9709220'
             }
         ]
-    })
+    }
 
     expected = 'arXiv'
     result = Bibtex(some_arxiv_eprints)._get_archive_prefix()
@@ -1627,7 +1625,7 @@ def test_get_archive_prefix_some_arxiv_eprints():
 
 
 def test_get_primary_class_no_arxiv_eprints():
-    no_arxiv_eprints = InspireRecord({})
+    no_arxiv_eprints = {}
 
     expected = ''
     result = Bibtex(no_arxiv_eprints)._get_primary_class()
@@ -1636,19 +1634,19 @@ def test_get_primary_class_no_arxiv_eprints():
 
 
 def test_get_primary_class_empty_arxiv_eprints():
-    empty_arxiv_eprints = InspireRecord({
+    empty_arxiv_eprints = {
         'arxiv_eprints': []
-    })
+    }
 
     assert Bibtex(empty_arxiv_eprints)._get_primary_class() is None
 
 
 def test_get_primary_class_one_arxiv_eprint_one_category():
-    one_arxiv_eprint_one_category = InspireRecord({
+    one_arxiv_eprint_one_category = {
         'arxiv_eprints': [
             {'categories': ['hep-th']}
         ]
-    })
+    }
 
     expected = 'hep-th'
     result = Bibtex(one_arxiv_eprint_one_category)._get_primary_class()
@@ -1657,11 +1655,11 @@ def test_get_primary_class_one_arxiv_eprint_one_category():
 
 
 def test_get_primary_class_one_arxiv_eprint_more_categories():
-    one_arxiv_eprint_more_categories = InspireRecord({
+    one_arxiv_eprint_more_categories = {
         'arxiv_eprints': [
             {'categories': ['hep-th', 'hep-ph']}
         ]
-    })
+    }
 
     expected = 'hep-th'
     result = Bibtex(one_arxiv_eprint_more_categories)._get_primary_class()
@@ -1670,12 +1668,12 @@ def test_get_primary_class_one_arxiv_eprint_more_categories():
 
 
 def test_get_primary_class_more_arxiv_eprints_more_categories():
-    more_arxiv_eprints_more_categories = InspireRecord({
+    more_arxiv_eprints_more_categories = {
         'arxiv_eprints': [
             {'categories': ['hep-th', 'hep-ph']},
             {'categories': ['hep-ex']}
         ]
-    })
+    }
 
     expected = 'hep-th'
     result = Bibtex(more_arxiv_eprints_more_categories)._get_primary_class()
@@ -1684,7 +1682,7 @@ def test_get_primary_class_more_arxiv_eprints_more_categories():
 
 
 def test_get_series_no_book_series():
-    no_book_series = InspireRecord({})
+    no_book_series = {}
 
     expected = ''
     result = Bibtex(no_book_series)._get_series()
@@ -1693,9 +1691,9 @@ def test_get_series_no_book_series():
 
 
 def test_get_series_empty_book_series():
-    empty_book_series = InspireRecord({
+    empty_book_series = {
         'book_series': []
-    })
+    }
 
     expected = ''
     result = Bibtex(empty_book_series)._get_series()
@@ -1704,11 +1702,11 @@ def test_get_series_empty_book_series():
 
 
 def test_get_series_one_book_series():
-    one_book_series = InspireRecord({
+    one_book_series = {
         'book_series': [
             {'value': 'Mathematical Physics Studies'}
         ]
-    })
+    }
 
     expected = 'Mathematical Physics Studies'
     result = Bibtex(one_book_series)._get_series()
@@ -1717,12 +1715,12 @@ def test_get_series_one_book_series():
 
 
 def test_get_series_more_book_series():
-    more_book_series = InspireRecord({
+    more_book_series = {
         'book_series': [
             {'value': 'High Energy Physics'},
             {'value': 'Mathematical Physics Studies'}
         ]
-    })
+    }
 
     expected = 'Mathematical Physics Studies'
     result = Bibtex(more_book_series)._get_series()
@@ -1731,7 +1729,7 @@ def test_get_series_more_book_series():
 
 
 def test_get_isbn_no_isbns():
-    no_isbns = InspireRecord({})
+    no_isbns = {}
 
     expected = ''
     result = Bibtex(no_isbns)._get_isbn()
@@ -1741,20 +1739,20 @@ def test_get_isbn_no_isbns():
 
 @pytest.mark.xfail
 def test_get_isbn_empty_isbns():
-    empty_isbns = InspireRecord({
+    empty_isbns = {
         'isbns': []
-    })
+    }
 
     Bibtex(empty_isbns)._get_isbn()
 
 
 @pytest.mark.xfail
 def test_get_isbn_one_isbn_not_a_list():
-    one_isbn_not_a_list = InspireRecord({
+    one_isbn_not_a_list = {
         'isbns': [
             {'value': '978-1-4244-0922-8'}
         ]
-    })
+    }
 
     expected = '978-1-4244-0922-8'
     result = Bibtex(one_isbn_not_a_list)._get_isbn()
@@ -1763,12 +1761,12 @@ def test_get_isbn_one_isbn_not_a_list():
 
 
 def test_get_isbn_two_isbns_not_a_list():
-    two_isbns_not_a_list = InspireRecord({
+    two_isbns_not_a_list = {
         'isbns': [
             {'value': '978-3-319-17544-7'},
             {'value': '978-3-319-17545-4'}
         ]
-    })
+    }
 
     expected = '978-3-319-17544-7, 978-3-319-17545-4'
     result = Bibtex(two_isbns_not_a_list)._get_isbn()
@@ -1777,12 +1775,12 @@ def test_get_isbn_two_isbns_not_a_list():
 
 
 def test_get_isbn_two_isbns_one_a_list():
-    two_isbns_one_a_list = InspireRecord({
+    two_isbns_one_a_list = {
         'isbns': [
             {'value': ['978-3-319-17544-7', '978-3-319-17545-4']},
             {'value': '978-94-010-2276-7'}
         ]
-    })
+    }
 
     expected = '978-3-319-17544-7, 978-94-010-2276-7'
     result = Bibtex(two_isbns_one_a_list)._get_isbn()
@@ -1791,7 +1789,7 @@ def test_get_isbn_two_isbns_one_a_list():
 
 
 def test_get_pubnote_no_publication_info():
-    no_publication_info = InspireRecord({})
+    no_publication_info = {}
 
     expected = ''
     result = Bibtex(no_publication_info)._get_pubnote()
@@ -1800,19 +1798,19 @@ def test_get_pubnote_no_publication_info():
 
 
 def test_get_pubnote_publication_info_an_empty_list():
-    publication_info_an_empty_list = InspireRecord({
+    publication_info_an_empty_list = {
         'publication_info': []
-    })
+    }
 
     assert Bibtex(publication_info_an_empty_list)._get_pubnote() is None
 
 
 def test_get_pubnote_publication_info_a_list_one_with_title():
-    publication_info_a_list_one_with_title = InspireRecord({
+    publication_info_a_list_one_with_title = {
         'publication_info': [
             {'journal_title': 'Nucl.Phys.'}
         ]
-    })
+    }
 
     assert Bibtex(publication_info_a_list_one_with_title)._get_pubnote() is None
 
@@ -1823,14 +1821,14 @@ def test_get_pubnote_publication_info_a_list_one_with_title_and_volume(self, g_k
     # TODO: mock the actual invenio_knowledge API.
     g_k_k.return_value = [['Nucl. Phys.']]
 
-    publication_info_a_list_one_with_title_and_volume = InspireRecord({
+    publication_info_a_list_one_with_title_and_volume = {
         'publication_info': [
             {
                 'journal_title': 'Nucl.Phys.',
                 'journal_volume': '22'
             }
         ]
-    })
+    }
 
     expected = 'Nucl. Phys.,22,'
     result = Bibtex(publication_info_a_list_one_with_title_and_volume)._get_pubnote()
@@ -1844,7 +1842,7 @@ def test_get_pubnote_publication_info_a_list_one_with_title_and_pages_not_a_list
     # TODO: mock the actual invenio_knowledge API.
     g_k_k.return_value = [['Nucl. Phys.']]
 
-    publication_info_a_list_one_with_title_and_pages_not_a_list = InspireRecord({
+    publication_info_a_list_one_with_title_and_pages_not_a_list = {
         'publication_info': [
             {
                 'journal_title': 'Nucl.Phys.',
@@ -1852,7 +1850,7 @@ def test_get_pubnote_publication_info_a_list_one_with_title_and_pages_not_a_list
                 'page_end': '588'
             }
         ]
-    })
+    }
 
     expected = 'Nucl. Phys.,,579'
     result = Bibtex(publication_info_a_list_one_with_title_and_pages_not_a_list)._get_pubnote()
@@ -1866,7 +1864,7 @@ def test_get_pubnote_publication_info_a_list_one_with_everything(self, g_k_k):
     # TODO: mock the actual invenio_knowledge API.
     g_k_k.return_value = [['Nucl. Phys.']]
 
-    publication_info_a_list_one_with_everything = InspireRecord({
+    publication_info_a_list_one_with_everything = {
         'publication_info': [
             {
                 'journal_title': 'Nucl.Phys.',
@@ -1875,7 +1873,7 @@ def test_get_pubnote_publication_info_a_list_one_with_everything(self, g_k_k):
                 'page_end': '588'
             }
         ]
-    })
+    }
 
     expected = 'Nucl. Phys.,22,579'
     result = Bibtex(publication_info_a_list_one_with_everything)._get_pubnote()
@@ -1889,7 +1887,7 @@ def test_get_pubnote_publication_info_a_list_get_kbr_keys_raises(self, g_k_k):
     # TODO: mock the actual invenio_knowledge API.
     g_k_k.side_effect = RuntimeError
 
-    publication_info_a_list_one_with_everything = InspireRecord({
+    publication_info_a_list_one_with_everything = {
         'publication_info': [
             {
                 'journal_title': 'Nucl.Phys.',
@@ -1898,7 +1896,7 @@ def test_get_pubnote_publication_info_a_list_get_kbr_keys_raises(self, g_k_k):
                 'page_end': '588'
             }
         ]
-    })
+    }
 
     expected = ''
     result = Bibtex(publication_info_a_list_one_with_everything)._get_pubnote()

--- a/tests/unit/utils/test_utils_bibtex_booktitle.py
+++ b/tests/unit/utils/test_utils_bibtex_booktitle.py
@@ -26,12 +26,11 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-from inspirehep.modules.records.api import InspireRecord
 from inspirehep.utils.bibtex_booktitle import generate_booktitle, traverse
 
 
 def test_generate_booktitle_no_publication_info():
-    no_publication_info = InspireRecord({})
+    no_publication_info = {}
 
     expected = ''
     result = generate_booktitle(no_publication_info)
@@ -40,9 +39,9 @@ def test_generate_booktitle_no_publication_info():
 
 
 def test_generate_booktitle_publication_info_an_empty_list():
-    publication_info_an_empty_list = InspireRecord({
+    publication_info_an_empty_list = {
         'publication_info': []
-    })
+    }
 
     expected = ''
     result = generate_booktitle(publication_info_an_empty_list)
@@ -51,11 +50,11 @@ def test_generate_booktitle_publication_info_an_empty_list():
 
 
 def test_generate_booktitle_no_reportnumber():
-    no_reportnumber = InspireRecord({
+    no_reportnumber = {
         'publication_info': [
             {}
         ]
-    })
+    }
 
     expected = ''
     result = generate_booktitle(no_reportnumber)
@@ -64,13 +63,13 @@ def test_generate_booktitle_no_reportnumber():
 
 
 def test_generate_booktitle_empty_reportnumber():
-    empty_reportnumber = InspireRecord({
+    empty_reportnumber = {
         'publication_info': [
             {
                 'reportnumber': ''
             }
         ]
-    })
+    }
 
     expected = ''
     result = generate_booktitle(empty_reportnumber)
@@ -80,14 +79,14 @@ def test_generate_booktitle_empty_reportnumber():
 
 @pytest.mark.xfail(reason='KeyError when looking for acronym')
 def test_generate_booktitle_reportnumber_and_conf_acronym():
-    recordnumber_and_conf_acronym = InspireRecord({
+    recordnumber_and_conf_acronym = {
         'publication_info': [
             {
                 'reportnumber': 'CERN-Proceedings-2010-001',
                 'conf_acronym': 'FOO'  # No value in 773__o.
             }
         ]
-    })
+    }
 
     expected = 'CERN-Proceedings-2010-0001: FOO'
     result = generate_booktitle(recordnumber_and_conf_acronym)
@@ -97,13 +96,13 @@ def test_generate_booktitle_reportnumber_and_conf_acronym():
 
 @pytest.mark.xfail(reason='KeyError when looking for acronym')
 def test_generate_booktitle_reportnumber_but_no_conf_acronym():
-    no_conf_acronym = InspireRecord({
+    no_conf_acronym = {
         'publication_info': [
             {
                 'reportnumber': 'CERN-Proceedings-2014-001'
             }
         ]
-    })
+    }
 
     expected = ''
     result = generate_booktitle(no_conf_acronym)
@@ -112,13 +111,13 @@ def test_generate_booktitle_reportnumber_but_no_conf_acronym():
 
 
 def test_generate_booktitle_from_one_pubinfo_freetext():
-    one_pubinfo_freetext = InspireRecord({
+    one_pubinfo_freetext = {
         'publication_info': [
             {
                 'pubinfo_freetext': 'Adv. Theor. Math. Phys. 2 (1998) 51-59'
             }
         ]
-    })
+    }
 
     expected = 'Adv. Theor. Math. Phys. 2 (1998) 51-59'
     result = generate_booktitle(one_pubinfo_freetext)
@@ -127,7 +126,7 @@ def test_generate_booktitle_from_one_pubinfo_freetext():
 
 
 def test_generate_booktitle_from_two_pubinfo_freetext():
-    two_pubinfo_freetext = InspireRecord({
+    two_pubinfo_freetext = {
         'publication_info': [
             {
                 'pubinfo_freetext': 'Prog. Theor. Phys. 49 (1973) 652-657'
@@ -138,7 +137,7 @@ def test_generate_booktitle_from_two_pubinfo_freetext():
                                      ', Vol. 1*, 218-223.')
             }
         ]
-    })
+    }
 
     expected = ('Prog. Theor. Phys. 49 (1973) 652-657, Also in *Lichtenberg, D. B. (Ed.)'
                 ', Rosen, S. P. (Ed.): Developments In The Quark Theory Of Hadrons, Vol.'

--- a/tests/unit/utils/test_utils_cv_latex.py
+++ b/tests/unit/utils/test_utils_cv_latex.py
@@ -25,16 +25,15 @@ from __future__ import absolute_import, division, print_function
 import mock
 import pytest
 
-from inspirehep.modules.records.api import InspireRecord
 from inspirehep.utils.cv_latex import Cv_latex
 
 
 def test_get_author_from_authors_a_list_with_one_element():
-    authors_a_list_with_one_element = InspireRecord({
+    authors_a_list_with_one_element = {
         'authors': [
             {'full_name': 'Glashow, S.L.'}
         ]
-    })
+    }
 
     expected = ['S.~L.~Glashow']
     result = Cv_latex(authors_a_list_with_one_element)._get_author()
@@ -43,12 +42,12 @@ def test_get_author_from_authors_a_list_with_one_element():
 
 
 def test_get_author_from_authors_a_list_with_two_elements():
-    authors_a_list_with_two_elements = InspireRecord({
+    authors_a_list_with_two_elements = {
         'authors': [
             {'full_name': 'Englert, F.'},
             {'full_name': 'Brout, R.'}
         ]
-    })
+    }
 
     expected = ['F.~Englert', 'R.~Brout']
     result = Cv_latex(authors_a_list_with_two_elements)._get_author()
@@ -57,11 +56,11 @@ def test_get_author_from_authors_a_list_with_two_elements():
 
 
 def test_get_author_from_authors_one_author_with_an_empty_list_of_full_names():
-    one_author_with_an_empty_list_of_full_names = InspireRecord({
+    one_author_with_an_empty_list_of_full_names = {
         'authors': [
             {'full_name': []}
         ]
-    })
+    }
 
     expected = []
     result = Cv_latex(one_author_with_an_empty_list_of_full_names)._get_author()
@@ -70,11 +69,11 @@ def test_get_author_from_authors_one_author_with_an_empty_list_of_full_names():
 
 
 def test_get_author_from_authors_one_author_with_a_list_of_one_full_name():
-    one_author_with_a_list_of_one_full_name = InspireRecord({
+    one_author_with_a_list_of_one_full_name = {
         'authors': [
             {'full_name': ['Glashow, S.L.']}
         ]
-    })
+    }
 
     expected = ['S.~L.~Glashow']
     result = Cv_latex(one_author_with_a_list_of_one_full_name)._get_author()
@@ -83,7 +82,7 @@ def test_get_author_from_authors_one_author_with_a_list_of_one_full_name():
 
 
 def test_get_author_from_authors_one_author_with_a_list_of_two_full_names():
-    one_author_with_a_list_of_two_full_names = InspireRecord({
+    one_author_with_a_list_of_two_full_names = {
         'authors': [
             {
                 'full_name': [
@@ -92,7 +91,7 @@ def test_get_author_from_authors_one_author_with_a_list_of_two_full_names():
                 ]
             }
         ]
-    })
+    }
 
     expected = ['F.~B.~Englert, R.']
     result = Cv_latex(one_author_with_a_list_of_two_full_names)._get_author()
@@ -101,7 +100,7 @@ def test_get_author_from_authors_one_author_with_a_list_of_two_full_names():
 
 
 def test_get_author_from_corporate_author_an_empty_list():
-    corporate_author_an_empty_list = InspireRecord({'corporate_author': []})
+    corporate_author_an_empty_list = {'corporate_author': []}
 
     expected = []
     result = Cv_latex(corporate_author_an_empty_list)._get_author()
@@ -111,11 +110,11 @@ def test_get_author_from_corporate_author_an_empty_list():
 
 @pytest.mark.xfail(reason='corporate_author is parsed as a real name')
 def test_get_author_from_corporate_author_a_list_with_one_element():
-    corporate_author_a_list_of_one_element = InspireRecord({
+    corporate_author_a_list_of_one_element = {
         'corporate_author': [
             'CMS Collaboration'
         ]
-    })
+    }
 
     expected = ['CMS Collaboration']
     result = Cv_latex(corporate_author_a_list_of_one_element)._get_author()
@@ -125,12 +124,12 @@ def test_get_author_from_corporate_author_a_list_with_one_element():
 
 @pytest.mark.xfail(reason='corporate_author is parsed as a real name')
 def test_get_author_from_corporate_author_a_list_with_two_elements():
-    corporate_author_a_list_of_two_elements = InspireRecord({
+    corporate_author_a_list_of_two_elements = {
         'corporate_author': [
             'CMS Collaboration',
             'The ATLAS Collaboration'
         ]
-    })
+    }
 
     expected = ['CMS Collaboration', 'The ATLAS Collaboration']
     result = Cv_latex(corporate_author_a_list_of_two_elements)._get_author()
@@ -139,7 +138,7 @@ def test_get_author_from_corporate_author_a_list_with_two_elements():
 
 
 def test_get_title_returns_empty_string_when_no_titles():
-    without_titles = InspireRecord({})
+    without_titles = {}
 
     expected = ''
     result = Cv_latex(without_titles)._get_title()
@@ -148,7 +147,7 @@ def test_get_title_returns_empty_string_when_no_titles():
 
 
 def test_get_title_returns_first_title_found_when_titles_is_a_list():
-    a_list_of_titles = InspireRecord({
+    a_list_of_titles = {
         'titles': [
             {'title': ('Effective relational dynamics of a '
                        'nonintegrable cosmological model')},
@@ -158,7 +157,7 @@ def test_get_title_returns_first_title_found_when_titles_is_a_list():
             {'title': ('Effective relational dynamics of a '
                        'nonintegrable cosmological model')}
         ]
-    })
+    }
 
     expected = ("{\\bf ``Effective relational dynamics of a "
                 "nonintegrable cosmological model''}")
@@ -168,13 +167,13 @@ def test_get_title_returns_first_title_found_when_titles_is_a_list():
 
 
 def test_get_publi_info_no_publication_info():
-    no_publication_info = InspireRecord({})
+    no_publication_info = {}
 
     assert Cv_latex(no_publication_info)._get_publi_info() is None
 
 
 def test_get_publi_info_from_publication_info_an_empty_list():
-    publication_info_an_empty_list = InspireRecord({'publication_info': []})
+    publication_info_an_empty_list = {'publication_info': []}
 
     expected = []
     result = Cv_latex(publication_info_an_empty_list)._get_publi_info()
@@ -183,11 +182,11 @@ def test_get_publi_info_from_publication_info_an_empty_list():
 
 
 def test_get_publi_info_from_publication_info_with_journal_title_not_a_list():
-    journal_title_not_a_list = InspireRecord({
+    journal_title_not_a_list = {
         'publication_info': [
             {'journal_title': 'Nucl.Phys.'}
         ]
-    })
+    }
 
     expected = ['Nucl.\\ Phys.\\ ']
     result = Cv_latex(journal_title_not_a_list)._get_publi_info()
@@ -197,11 +196,11 @@ def test_get_publi_info_from_publication_info_with_journal_title_not_a_list():
 
 @pytest.mark.xfail(reason='IndexError when accessing last element')
 def test_get_publi_info_from_publication_info_with_journal_title_an_empty_list():
-    journal_title_an_empty_list = InspireRecord({
+    journal_title_an_empty_list = {
         'publication_info': [
             {'journal_title': []}
         ]
-    })
+    }
 
     expected = []
     result = Cv_latex(journal_title_an_empty_list)._get_publi_info()
@@ -210,11 +209,11 @@ def test_get_publi_info_from_publication_info_with_journal_title_an_empty_list()
 
 
 def test_get_publi_info_from_publication_info_with_journal_title_a_list_of_one_element():
-    journal_title_a_list_of_one_element = InspireRecord({
+    journal_title_a_list_of_one_element = {
         'publication_info': [
             {'journal_title': ['foo']}
         ]
-    })
+    }
 
     expected = ['foo']
     result = Cv_latex(journal_title_a_list_of_one_element)._get_publi_info()
@@ -223,11 +222,11 @@ def test_get_publi_info_from_publication_info_with_journal_title_a_list_of_one_e
 
 
 def test_get_publi_info_from_publication_info_with_journal_title_a_list_of_two_elements():
-    journal_title_a_list_of_two_elements = InspireRecord({
+    journal_title_a_list_of_two_elements = {
         'publication_info': [
             {'journal_title': ['foo', 'bar']}
         ]
-    })
+    }
 
     expected = ['bar']
     result = Cv_latex(journal_title_a_list_of_two_elements)._get_publi_info()
@@ -236,14 +235,14 @@ def test_get_publi_info_from_publication_info_with_journal_title_a_list_of_two_e
 
 
 def test_get_publi_info_from_publication_info_with_journal_volume():
-    journal_volume = InspireRecord({
+    journal_volume = {
         'publication_info': [
             {
                 'journal_title': 'eConf',
                 'journal_volume': 'C050318'
             }
         ]
-    })
+    }
 
     expected = ['eConf C {\\bf 050318}']
     result = Cv_latex(journal_volume)._get_publi_info()
@@ -252,14 +251,14 @@ def test_get_publi_info_from_publication_info_with_journal_volume():
 
 
 def test_get_publi_info_from_publication_info_with_journal_volume_with_letter():
-    journal_volume_with_letter = InspireRecord({
+    journal_volume_with_letter = {
         'publication_info': [
             {
                 'journal_title': 'Eur.Phys.J.',
                 'journal_volume': 'C73'
             }
         ]
-    })
+    }
 
     expected = ['Eur.\\ Phys.\\ J.\\ C {\\bf 73}']
     result = Cv_latex(journal_volume_with_letter)._get_publi_info()
@@ -268,14 +267,14 @@ def test_get_publi_info_from_publication_info_with_journal_volume_with_letter():
 
 
 def test_get_publi_info_from_publication_info_with_year_not_a_list():
-    year_not_a_list = InspireRecord({
+    year_not_a_list = {
         'publication_info': [
             {
                 'journal_title': 'Phys.Lett.',
                 'year': '1999'
             }
         ]
-    })
+    }
 
     expected = ['Phys.\\ Lett.\\  (1999)']
     result = Cv_latex(year_not_a_list)._get_publi_info()
@@ -285,14 +284,14 @@ def test_get_publi_info_from_publication_info_with_year_not_a_list():
 
 @pytest.mark.xfail(reason='IndexError when accessing last element')
 def test_get_publi_info_from_publication_info_with_year_an_empty_list():
-    year_an_empty_list = InspireRecord({
+    year_an_empty_list = {
         'publication_info': [
             {
                 'journal_title': 'Phys.Rev.',
                 'year': []
             }
         ]
-    })
+    }
 
     expected = ['Phys.\\ Rev.\\ ']
     result = Cv_latex(year_an_empty_list)._get_publi_info()
@@ -301,14 +300,14 @@ def test_get_publi_info_from_publication_info_with_year_an_empty_list():
 
 
 def test_get_publi_info_from_publication_info_with_year_a_list_of_one_element():
-    year_a_list_of_one_element = InspireRecord({
+    year_a_list_of_one_element = {
         'publication_info': [
             {
                 'journal_title': 'JHEP',
                 'year': ['1999']
             }
         ]
-    })
+    }
 
     expected = ['JHEP (1999)']
     result = Cv_latex(year_a_list_of_one_element)._get_publi_info()
@@ -317,14 +316,14 @@ def test_get_publi_info_from_publication_info_with_year_a_list_of_one_element():
 
 
 def test_get_publi_info_from_publication_info_with_year_a_list_of_two_elements():
-    year_a_list_of_two_elements = InspireRecord({
+    year_a_list_of_two_elements = {
         'publication_info': [
             {
                 'journal_title': 'Phys.Rev.Lett.',
                 'year': ['1999', '2000']
             }
         ]
-    })
+    }
 
     expected = ['Phys.\\ Rev.\\ Lett.\\  (2000)']
     result = Cv_latex(year_a_list_of_two_elements)._get_publi_info()
@@ -333,14 +332,14 @@ def test_get_publi_info_from_publication_info_with_year_a_list_of_two_elements()
 
 
 def test_get_publi_info_from_publication_info_with_journal_issue():
-    journal_issue = InspireRecord({
+    journal_issue = {
         'publication_info': [
             {
                 'journal_title': 'Class.Quant.Grav.',
                 'journal_issue': '10'
             }
         ]
-    })
+    }
 
     expected = ['Class.\\ Quant.\\ Grav.\\ , no. 10']
     result = Cv_latex(journal_issue)._get_publi_info()
@@ -349,14 +348,14 @@ def test_get_publi_info_from_publication_info_with_journal_issue():
 
 
 def test_get_publi_info_from_publication_info_with_page_start():
-    page_start = InspireRecord({
+    page_start = {
         'publication_info': [
             {
                 'journal_title': 'JHEP',
                 'page_start': '190'
             }
         ]
-    })
+    }
 
     expected = ['JHEP, 190']
     result = Cv_latex(page_start)._get_publi_info()
@@ -365,11 +364,11 @@ def test_get_publi_info_from_publication_info_with_page_start():
 
 
 def test_get_publi_info_from_pubinfo_freetext():
-    pubinfo_freetext = InspireRecord({
+    pubinfo_freetext = {
         'publication_info': [
             {'pubinfo_freetext': 'Phys. Lett. 12 (1964) 132-133'}
         ]
-    })
+    }
 
     expected = 'Phys. Lett. 12 (1964) 132-133'
     result = Cv_latex(pubinfo_freetext)._get_publi_info()
@@ -378,7 +377,7 @@ def test_get_publi_info_from_pubinfo_freetext():
 
 
 def test_get_publi_info_from_publication_info_a_list_of_two_elements():
-    publication_info_a_list_of_two_elements = InspireRecord({
+    publication_info_a_list_of_two_elements = {
         'publication_info': [
             {
                 'journal_title': 'Int.J.Theor.Phys.',
@@ -395,7 +394,7 @@ def test_get_publi_info_from_publication_info_a_list_of_two_elements():
                 'year': 1998
             }
         ]
-    })
+    }
 
     expected = [
         'Int.\\ J.\\ Theor.\\ Phys.\\  {\\bf 38}, 1113 (1999)',
@@ -410,7 +409,7 @@ def test_get_publi_info_from_publication_info_a_list_of_two_elements():
     'inspirehep.utils.cv_latex.config',
     mock.Mock(SERVER_NAME='http://localhost:5000'))
 def test_get_url():
-    record = InspireRecord({'control_number': 1})
+    record = {'control_number': 1}
 
     expected = 'http://localhost:5000/record/1'
     result = Cv_latex(record)._get_url()
@@ -419,13 +418,13 @@ def test_get_url():
 
 
 def test_get_date_without_any_date_returns_none():
-    without_any_date = InspireRecord({})
+    without_any_date = {}
 
     assert Cv_latex(without_any_date)._get_date() is None
 
 
 def test_get_date_from_preprint_date():
-    preprint_date = InspireRecord({'preprint_date': '2015-11-25'})
+    preprint_date = {'preprint_date': '2015-11-25'}
 
     expected = 'Nov 25, 2015'
     result = Cv_latex(preprint_date)._get_date()
@@ -435,7 +434,7 @@ def test_get_date_from_preprint_date():
 
 @pytest.mark.xfail(reason='zero is not added to the day')
 def test_get_date_from_preprint_date_adds_zero_to_day():
-    preprint_date = InspireRecord({'preprint_date': '2014-10-1'})
+    preprint_date = {'preprint_date': '2014-10-1'}
 
     expected = 'Oct 01, 2014'
     result = Cv_latex(preprint_date)._get_date()
@@ -444,11 +443,11 @@ def test_get_date_from_preprint_date_adds_zero_to_day():
 
 
 def test_get_date_from_publication_info():
-    publication_info = InspireRecord({
+    publication_info = {
         'publication_info': [
             {'year': '2011'}
         ]
-    })
+    }
 
     expected = 2011
     result = Cv_latex(publication_info)._get_date()
@@ -457,20 +456,20 @@ def test_get_date_from_publication_info():
 
 
 def test_get_date_from_publication_info_returns_none_when_no_year():
-    publication_info_without_a_year = InspireRecord({
+    publication_info_without_a_year = {
         'publication_info': []
-    })
+    }
 
     assert Cv_latex(publication_info_without_a_year)._get_date() is None
 
 
 def test_get_date_from_publication_info_uses_first_year_found():
-    publication_info = InspireRecord({
+    publication_info = {
         'publication_info': [
             {},
             {'year': '2012'}
         ]
-    })
+    }
 
     expected = 2012
     result = Cv_latex(publication_info)._get_date()
@@ -479,9 +478,9 @@ def test_get_date_from_publication_info_uses_first_year_found():
 
 
 def test_get_date_from_legacy_creation_date():
-    legacy_creation_date = InspireRecord({
+    legacy_creation_date = {
         'legacy_creation_date': '2012'
-    })
+    }
 
     expected = 2012
     result = Cv_latex(legacy_creation_date)._get_date()
@@ -490,20 +489,20 @@ def test_get_date_from_legacy_creation_date():
 
 
 def test_get_date_from_imprints_returns_none_when_no_date():
-    imprints_without_a_date = InspireRecord({
+    imprints_without_a_date = {
         'imprints': []
-    })
+    }
 
     assert Cv_latex(imprints_without_a_date)._get_date() is None
 
 
 def test_get_date_from_imprints_uses_first_date_found():
-    imprints = InspireRecord({
+    imprints = {
         'imprints': [
             {},
             {'date': '2011-03-29'}
         ]
-    })
+    }
 
     expected = 'Mar 29, 2011'
     result = Cv_latex(imprints)._get_date()
@@ -512,17 +511,17 @@ def test_get_date_from_imprints_uses_first_date_found():
 
 
 def test_get_date_from_thesis_returns_none_when_no_date():
-    thesis_without_a_date = InspireRecord({
+    thesis_without_a_date = {
         'thesis': {}
-    })
+    }
 
     assert Cv_latex(thesis_without_a_date)._get_date() is None
 
 
 def test_get_date_from_thesis_uses_first_date_found():
-    thesis = InspireRecord({
+    thesis = {
         'thesis': {'date': '1966'}
-    })
+    }
 
     expected = 1966
     result = Cv_latex(thesis)._get_date()
@@ -531,7 +530,7 @@ def test_get_date_from_thesis_uses_first_date_found():
 
 
 def test_format_date_when_datestruct_has_one_element():
-    record = InspireRecord({})
+    record = {}
     cv_latex = Cv_latex(record)
 
     expected = 1993
@@ -541,7 +540,7 @@ def test_format_date_when_datestruct_has_one_element():
 
 
 def test_format_date_when_datestruct_has_two_elements():
-    record = InspireRecord({})
+    record = {}
     cv_latex = Cv_latex(record)
 
     expected = 'Feb 1993'
@@ -551,7 +550,7 @@ def test_format_date_when_datestruct_has_two_elements():
 
 
 def test_format_date_when_datestruct_has_three_elements():
-    record = InspireRecord({})
+    record = {}
     cv_latex = Cv_latex(record)
 
     expected = 'Feb 2, 1993'
@@ -561,28 +560,28 @@ def test_format_date_when_datestruct_has_three_elements():
 
 
 def test_format_date_returns_none_when_datestruct_has_four_elements():
-    record = InspireRecord({})
+    record = {}
     cv_latex = Cv_latex(record)
 
     assert cv_latex._format_date((1993, 2, 2, 1)) is None
 
 
 def test_parse_date_returns_none_when_datetext_is_none():
-    record = InspireRecord({})
+    record = {}
     cv_latex = Cv_latex(record)
 
     assert cv_latex.parse_date(None) is None
 
 
 def test_parse_date_returns_none_when_datetext_is_an_empty_string():
-    record = InspireRecord({})
+    record = {}
     cv_latex = Cv_latex(record)
 
     assert cv_latex.parse_date('') is None
 
 
 def test_parse_date_returns_none_when_datetext_is_not_of_type_str():
-    record = InspireRecord({})
+    record = {}
     cv_latex = Cv_latex(record)
 
     assert cv_latex.parse_date(0) is None
@@ -590,7 +589,7 @@ def test_parse_date_returns_none_when_datetext_is_not_of_type_str():
 
 @pytest.mark.xfail(reason='too strict check against str type')
 def test_parse_date_supports_unicode_strings():
-    record = InspireRecord({})
+    record = {}
     cv_latex = Cv_latex(record)
 
     expected = (1993, 2, 2)
@@ -600,7 +599,7 @@ def test_parse_date_supports_unicode_strings():
 
 
 def test_parse_date_partial_spires_format_year_only():
-    record = InspireRecord({})
+    record = {}
     cv_latex = Cv_latex(record)
 
     expected = (1993,)
@@ -610,7 +609,7 @@ def test_parse_date_partial_spires_format_year_only():
 
 
 def test_parse_date_partial_spires_format_year_and_month():
-    record = InspireRecord({})
+    record = {}
     cv_latex = Cv_latex(record)
 
     expected = (1993, 2)
@@ -620,7 +619,7 @@ def test_parse_date_partial_spires_format_year_and_month():
 
 
 def test_parse_date_full_spires_format():
-    record = InspireRecord({})
+    record = {}
     cv_latex = Cv_latex(record)
 
     expected = (1993, 2, 2)
@@ -630,7 +629,7 @@ def test_parse_date_full_spires_format():
 
 
 def test_parse_date_invalid_spires_format():
-    record = InspireRecord({})
+    record = {}
     cv_latex = Cv_latex(record)
 
     expected = (1993, 2)
@@ -640,7 +639,7 @@ def test_parse_date_invalid_spires_format():
 
 
 def test_parse_date_full_invenio_format():
-    record = InspireRecord({})
+    record = {}
     cv_latex = Cv_latex(record)
 
     expected = (1993, 2, 2)
@@ -650,7 +649,7 @@ def test_parse_date_full_invenio_format():
 
 
 def test_parse_date_invalid_invenio_format():
-    record = InspireRecord({})
+    record = {}
     cv_latex = Cv_latex(record)
 
     expected = (1993, 2)

--- a/tests/unit/utils/test_utils_cv_latex_html_text.py
+++ b/tests/unit/utils/test_utils_cv_latex_html_text.py
@@ -22,16 +22,15 @@
 
 from __future__ import absolute_import, division, print_function
 
-from inspirehep.modules.records.api import InspireRecord
 from inspirehep.utils.cv_latex_html_text import Cv_latex_html_text
 
 
 def test_get_author_from_authors_a_list_with_one_element():
-    authors_a_list_with_one_element = InspireRecord({
+    authors_a_list_with_one_element = {
         'authors': [
             {'full_name': 'Glashow, S.L.'}
         ]
-    })
+    }
     cv_latex_html_text = Cv_latex_html_text(
         authors_a_list_with_one_element, 'cv_latex_html', ',')
 
@@ -42,12 +41,12 @@ def test_get_author_from_authors_a_list_with_one_element():
 
 
 def test_get_author_from_authors_a_list_with_two_elements():
-    authors_a_list_with_two_elements = InspireRecord({
+    authors_a_list_with_two_elements = {
         'authors': [
             {'full_name': 'Englert, F.'},
             {'full_name': 'Brout, R.'}
         ]
-    })
+    }
     cv_latex_html_text = Cv_latex_html_text(
         authors_a_list_with_two_elements, 'cv_latex_html', ',')
 
@@ -58,11 +57,11 @@ def test_get_author_from_authors_a_list_with_two_elements():
 
 
 def test_get_author_from_authors_one_author_with_an_empty_list_of_full_names():
-    one_author_with_an_empty_list_of_full_names = InspireRecord({
+    one_author_with_an_empty_list_of_full_names = {
         'authors': [
             {'full_name': []}
         ]
-    })
+    }
     cv_latex_html_text = Cv_latex_html_text(
         one_author_with_an_empty_list_of_full_names, 'cv_latex_html', ',')
 
@@ -73,11 +72,11 @@ def test_get_author_from_authors_one_author_with_an_empty_list_of_full_names():
 
 
 def test_get_author_from_authors_one_author_with_a_list_of_one_full_name():
-    one_author_with_a_list_of_one_full_name = InspireRecord({
+    one_author_with_a_list_of_one_full_name = {
         'authors': [
             {'full_name': ['Glashow, S.L.']}
         ]
-    })
+    }
     cv_latex_html_text = Cv_latex_html_text(
         one_author_with_a_list_of_one_full_name, 'cv_latex_html', ',')
 
@@ -88,7 +87,7 @@ def test_get_author_from_authors_one_author_with_a_list_of_one_full_name():
 
 
 def test_get_author_from_authors_one_author_with_a_list_of_two_full_names():
-    one_author_with_a_list_of_two_full_names = InspireRecord({
+    one_author_with_a_list_of_two_full_names = {
         'authors': [
             {
                 'full_name': [
@@ -97,7 +96,7 @@ def test_get_author_from_authors_one_author_with_a_list_of_two_full_names():
                 ]
             }
         ]
-    })
+    }
     cv_latex_html_text = Cv_latex_html_text(
         one_author_with_a_list_of_two_full_names, 'cv_latex_html', ',')
 
@@ -108,7 +107,7 @@ def test_get_author_from_authors_one_author_with_a_list_of_two_full_names():
 
 
 def test_get_author_from_corporate_author_an_empty_list():
-    corporate_author_an_empty_list = InspireRecord({'corporate_author': []})
+    corporate_author_an_empty_list = {'corporate_author': []}
     cv_latex_html_text = Cv_latex_html_text(
         corporate_author_an_empty_list, 'cv_latex_html_text', ',')
 
@@ -119,11 +118,11 @@ def test_get_author_from_corporate_author_an_empty_list():
 
 
 def test_get_author_from_corporate_author_a_list_with_one_element():
-    corporate_author_a_list_of_one_element = InspireRecord({
+    corporate_author_a_list_of_one_element = {
         'corporate_author': [
             'CMS Collaboration'
         ]
-    })
+    }
     cv_latex_html_text = Cv_latex_html_text(
         corporate_author_a_list_of_one_element, 'cv_latex_html_text', ',')
 
@@ -134,12 +133,12 @@ def test_get_author_from_corporate_author_a_list_with_one_element():
 
 
 def test_get_author_from_corporate_author_a_list_with_two_elements():
-    corporate_author_a_list_of_two_elements = InspireRecord({
+    corporate_author_a_list_of_two_elements = {
         'corporate_author': [
             'CMS Collaboration',
             'The ATLAS Collaboration'
         ]
-    })
+    }
     cv_latex_html_text = Cv_latex_html_text(
         corporate_author_a_list_of_two_elements, 'cv_latex_html_text', ',')
 
@@ -150,7 +149,7 @@ def test_get_author_from_corporate_author_a_list_with_two_elements():
 
 
 def test_get_title_returns_empty_string_when_no_titles():
-    no_titles = InspireRecord({})
+    no_titles = {}
     cv_latex_html_text = Cv_latex_html_text(
         no_titles, 'cv_latex_html_text', ',')
 
@@ -161,9 +160,9 @@ def test_get_title_returns_empty_string_when_no_titles():
 
 
 def test_get_title_returns_empty_string_when_titles_is_an_empty_list():
-    titles_an_empty_list = InspireRecord({
+    titles_an_empty_list = {
         'titles': []
-    })
+    }
     cv_latex_html_text = Cv_latex_html_text(
         titles_an_empty_list, 'cv_latex_html_text', ',')
 
@@ -174,11 +173,11 @@ def test_get_title_returns_empty_string_when_titles_is_an_empty_list():
 
 
 def test_get_title_when_titles_is_a_list_of_one_element_without_subtitles():
-    titles_a_list_of_one_element_without_subtitles = InspireRecord({
+    titles_a_list_of_one_element_without_subtitles = {
         'titles': [
             {'title': 'foo'}
         ]
-    })
+    }
     cv_latex_html_text = Cv_latex_html_text(
         titles_a_list_of_one_element_without_subtitles, 'cv_latex_html_text', ',')
 
@@ -189,12 +188,12 @@ def test_get_title_when_titles_is_a_list_of_one_element_without_subtitles():
 
 
 def test_get_titles_when_titles_is_a_list_of_two_elements_without_subtitles():
-    titles_a_list_of_two_elements_without_subtitles = InspireRecord({
+    titles_a_list_of_two_elements_without_subtitles = {
         'titles': [
             {'title': 'foo'},
             {'title': 'bar'}
         ]
-    })
+    }
     cv_latex_html_text = Cv_latex_html_text(
         titles_a_list_of_two_elements_without_subtitles, 'cv_latex_html_text', ',')
 
@@ -205,14 +204,14 @@ def test_get_titles_when_titles_is_a_list_of_two_elements_without_subtitles():
 
 
 def test_get_title_when_titles_is_a_list_of_one_element_with_subtitle():
-    titles_a_list_of_one_element_with_subtitle = InspireRecord({
+    titles_a_list_of_one_element_with_subtitle = {
         'titles': [
             {
                 'title': 'foo',
                 'subtitle': 'bar'
             }
         ]
-    })
+    }
     cv_latex_html_text = Cv_latex_html_text(
         titles_a_list_of_one_element_with_subtitle, 'cv_latex_html_text', ',')
 
@@ -223,7 +222,7 @@ def test_get_title_when_titles_is_a_list_of_one_element_with_subtitle():
 
 
 def test_get_title_when_titles_is_a_list_of_two_elements_with_subtitles():
-    titles_a_list_of_two_elements_with_subtitles = InspireRecord({
+    titles_a_list_of_two_elements_with_subtitles = {
         'titles': [
             {
                 'title': 'foo',
@@ -234,7 +233,7 @@ def test_get_title_when_titles_is_a_list_of_two_elements_with_subtitles():
                 'subtitle': 'quux'
             }
         ]
-    })
+    }
     cv_latex_html_text = Cv_latex_html_text(
         titles_a_list_of_two_elements_with_subtitles, 'cv_latex_html_text', ',')
 
@@ -245,11 +244,11 @@ def test_get_title_when_titles_is_a_list_of_two_elements_with_subtitles():
 
 
 def test_get_title_when_titles_is_not_a_list_without_subtitles():
-    titles_not_a_list_without_subtitles = InspireRecord({
+    titles_not_a_list_without_subtitles = {
         'titles': {
             'title': 'foo'
         }
-    })
+    }
     cv_latex_html_text = Cv_latex_html_text(
         titles_not_a_list_without_subtitles, 'cv_latex_html_text', ',')
 
@@ -260,12 +259,12 @@ def test_get_title_when_titles_is_not_a_list_without_subtitles():
 
 
 def test_get_title_when_titles_is_not_a_list_with_subtitle():
-    titles_not_a_list_with_subtitle = InspireRecord({
+    titles_not_a_list_with_subtitle = {
         'titles': {
             'title': 'foo',
             'subtitle': 'bar'
         }
-    })
+    }
     cv_latex_html_text = Cv_latex_html_text(
         titles_not_a_list_with_subtitle, 'cv_latex_html_text', ',')
 
@@ -276,11 +275,11 @@ def test_get_title_when_titles_is_not_a_list_with_subtitle():
 
 
 def test_get_title_capitalizes_when_title_is_uppercase():
-    title_is_uppercase = InspireRecord({
+    title_is_uppercase = {
         'titles': [
             {'title': 'FOO'}
         ]
-    })
+    }
     cv_latex_html_text = Cv_latex_html_text(
         title_is_uppercase, 'cv_latex_html_text', ',')
 
@@ -291,11 +290,11 @@ def test_get_title_capitalizes_when_title_is_uppercase():
 
 
 def test_get_title_capitalizes_when_title_contains_uppercase_the():
-    title_contains_uppercase_the = InspireRecord({
+    title_contains_uppercase_the = {
         'titles': [
             {'title': 'foo THE bar'}
         ]
-    })
+    }
     cv_latex_html_text = Cv_latex_html_text(
         title_contains_uppercase_the, 'cv_latex_html_text', ',')
 
@@ -306,7 +305,7 @@ def test_get_title_capitalizes_when_title_contains_uppercase_the():
 
 
 def test_get_publi_info_no_publication_info():
-    no_publication_info = InspireRecord({})
+    no_publication_info = {}
     cv_latex_html_text = Cv_latex_html_text(
         no_publication_info, 'cv_latex_html_text', ',')
 
@@ -314,7 +313,7 @@ def test_get_publi_info_no_publication_info():
 
 
 def test_get_publi_info_from_publication_info_an_empty_list():
-    publication_info_an_empty_list = InspireRecord({'publication_info': []})
+    publication_info_an_empty_list = {'publication_info': []}
     cv_latex_html_text = Cv_latex_html_text(
         publication_info_an_empty_list, 'cv_latex_html_text', ',')
 
@@ -325,11 +324,11 @@ def test_get_publi_info_from_publication_info_an_empty_list():
 
 
 def test_get_publi_info_from_publication_info_with_journal_title():
-    journal_title = InspireRecord({
+    journal_title = {
         'publication_info': [
             {'journal_title': 'Nucl.Phys.'}
         ]
-    })
+    }
     cv_latex_html_text = Cv_latex_html_text(
         journal_title, 'cv_latex_html_text', ',')
 
@@ -340,14 +339,14 @@ def test_get_publi_info_from_publication_info_with_journal_title():
 
 
 def test_get_publi_info_from_publication_info_with_journal_volume():
-    journal_volume = InspireRecord({
+    journal_volume = {
         'publication_info': [
             {
                 'journal_title': 'eConf',
                 'journal_volume': 'C050318'
             }
         ]
-    })
+    }
     cv_latex_html_text = Cv_latex_html_text(
         journal_volume, 'cv_latex_html_text', ',')
 
@@ -358,14 +357,14 @@ def test_get_publi_info_from_publication_info_with_journal_volume():
 
 
 def test_get_publi_info_from_publication_info_with_journal_volume_with_letter():
-    journal_volume_with_letter = InspireRecord({
+    journal_volume_with_letter = {
         'publication_info': [
             {
                 'journal_title': 'Eur.Phys.J.',
                 'journal_volume': 'C73'
             }
         ]
-    })
+    }
     cv_latex_html_text = Cv_latex_html_text(
         journal_volume_with_letter, 'cv_latex_html_text', ',')
 
@@ -376,14 +375,14 @@ def test_get_publi_info_from_publication_info_with_journal_volume_with_letter():
 
 
 def test_get_publi_info_from_publication_info_with_year():
-    year_not_a_list = InspireRecord({
+    year_not_a_list = {
         'publication_info': [
             {
                 'journal_title': 'Phys.Lett.',
                 'year': '1999'
             }
         ]
-    })
+    }
     cv_latex_html_text = Cv_latex_html_text(
         year_not_a_list, 'cv_latex_html_text', ',')
 
@@ -394,14 +393,14 @@ def test_get_publi_info_from_publication_info_with_year():
 
 
 def test_get_publi_info_from_publication_info_with_journal_issue():
-    journal_issue = InspireRecord({
+    journal_issue = {
         'publication_info': [
             {
                 'journal_title': 'Class.Quant.Grav.',
                 'journal_issue': '10'
             }
         ]
-    })
+    }
     cv_latex_html_text = Cv_latex_html_text(
         journal_issue, 'cv_latex_html_text', ',')
 
@@ -412,14 +411,14 @@ def test_get_publi_info_from_publication_info_with_journal_issue():
 
 
 def test_get_publi_info_from_publication_info_with_page_start():
-    page_start = InspireRecord({
+    page_start = {
         'publication_info': [
             {
                 'journal_title': 'JHEP',
                 'page_start': '190'
             }
         ]
-    })
+    }
     cv_latex_html_text = Cv_latex_html_text(
         page_start, 'cv_latex_html_text', ',')
 
@@ -430,11 +429,11 @@ def test_get_publi_info_from_publication_info_with_page_start():
 
 
 def test_get_publi_info_from_pubinfo_freetext():
-    pubinfo_freetext = InspireRecord({
+    pubinfo_freetext = {
         'publication_info': [
             {'pubinfo_freetext': 'Phys. Lett. 12 (1964) 132-133'}
         ]
-    })
+    }
     cv_latex_html_text = Cv_latex_html_text(
         pubinfo_freetext, 'cv_latex_html_text', ',')
 
@@ -445,7 +444,7 @@ def test_get_publi_info_from_pubinfo_freetext():
 
 
 def test_get_publi_info_from_publication_info_a_list_of_two_elements():
-    publication_info_a_list_of_two_elements = InspireRecord({
+    publication_info_a_list_of_two_elements = {
         'publication_info': [
             {
                 'journal_title': 'Int.J.Theor.Phys.',
@@ -462,7 +461,7 @@ def test_get_publi_info_from_publication_info_a_list_of_two_elements():
                 'year': 1998
             }
         ]
-    })
+    }
     cv_latex_html_text = Cv_latex_html_text(
         publication_info_a_list_of_two_elements, 'cv_latex_html_text', ',')
 

--- a/tests/unit/utils/test_utils_export.py
+++ b/tests/unit/utils/test_utils_export.py
@@ -26,12 +26,11 @@ from __future__ import absolute_import, division, print_function
 
 import mock
 
-from inspirehep.modules.records.api import InspireRecord
 from inspirehep.utils.export import Export
 
 
 def test_get_citation_key_no_external_system_numbers():
-    no_external_system_numbers = InspireRecord({})
+    no_external_system_numbers = {}
 
     expected = ''
     result = Export(no_external_system_numbers)._get_citation_key()
@@ -40,11 +39,11 @@ def test_get_citation_key_no_external_system_numbers():
 
 
 def test_get_citation_key_with_external_system_numbers_from_value():
-    with_external_system_numbers_from_value = InspireRecord({
+    with_external_system_numbers_from_value = {
         'external_system_numbers': [
             {'institute': 'INSPIRETeX', 'value': 'foo'}
         ]
-    })
+    }
 
     expected = 'foo'
     result = Export(with_external_system_numbers_from_value)._get_citation_key()
@@ -55,11 +54,11 @@ def test_get_citation_key_with_external_system_numbers_from_value():
 def test_get_citation_key_no_value_no_obsolete():
     from inspirehep.utils.export import Export
 
-    no_value_no_obsolete = InspireRecord({
+    no_value_no_obsolete = {
         'external_system_numbers': [
             {'institute': 'INSPIRETeX'}
         ]
-    })
+    }
 
     expected = ''
     result = Export(no_value_no_obsolete)._get_citation_key()
@@ -68,13 +67,12 @@ def test_get_citation_key_no_value_no_obsolete():
 
 
 def test_get_citation_key_last_one_wins():
-
-    last_one_wins = InspireRecord({
+    last_one_wins = {
         'external_system_numbers': [
             {'institute': 'INSPIRETeX', 'value': 'foo'},
             {'institute': 'SPIRESTeX', 'value': 'bar'},
         ]
-    })
+    }
 
     expected = 'bar'
     result = Export(last_one_wins)._get_citation_key()
@@ -83,14 +81,14 @@ def test_get_citation_key_last_one_wins():
 
 
 def test_get_citation_key_a_list_selects_first():
-    a_list_selects_first = InspireRecord({
+    a_list_selects_first = {
         'external_system_numbers': [
             {
                 'institute': 'INSPIRETeX',
                 'value': ['foo', 'bar']
             }
         ]
-    })
+    }
 
     expected = 'foo'
     result = Export(a_list_selects_first)._get_citation_key()
@@ -99,11 +97,11 @@ def test_get_citation_key_a_list_selects_first():
 
 
 def test_get_citation_key_trims_spaces():
-    trims_spaces = InspireRecord({
+    trims_spaces = {
         'external_system_numbers': [
             {'institute': 'INSPIRETeX', 'value': 'f o o'}
         ]
-    })
+    }
 
     expected = 'foo'
     result = Export(trims_spaces)._get_citation_key()
@@ -112,7 +110,7 @@ def test_get_citation_key_trims_spaces():
 
 
 def test_get_doi_no_dois():
-    no_dois = InspireRecord({})
+    no_dois = {}
 
     expected = ''
     result = Export(no_dois)._get_doi()
@@ -121,11 +119,11 @@ def test_get_doi_no_dois():
 
 
 def test_get_doi_single_doi():
-    single_doi = InspireRecord({
+    single_doi = {
         'dois': [
             {'value': 'foo'}
         ]
-    })
+    }
 
     expected = 'foo'
     result = Export(single_doi)._get_doi()
@@ -134,13 +132,12 @@ def test_get_doi_single_doi():
 
 
 def test_get_doi_multiple_dois():
-
-    multiple_dois = InspireRecord({
+    multiple_dois = {
         'dois': [
             {'value': 'foo'},
             {'value': 'bar'}
         ]
-    })
+    }
 
     expected = 'foo, bar'
     result = Export(multiple_dois)._get_doi()
@@ -149,14 +146,13 @@ def test_get_doi_multiple_dois():
 
 
 def test_get_doi_removes_duplicates():
-
-    with_duplicates = InspireRecord({
+    with_duplicates = {
         'dois': [
             {'value': 'foo'},
             {'value': 'bar'},
             {'value': 'foo'}
         ]
-    })
+    }
 
     expected = 'foo, bar'
     result = Export(with_duplicates)._get_doi()
@@ -165,7 +161,7 @@ def test_get_doi_removes_duplicates():
 
 
 def test_arxiv_field_no_arxiv_eprints():
-    no_arxiv_eprints = InspireRecord({})
+    no_arxiv_eprints = {}
 
     result = Export(no_arxiv_eprints).arxiv_field
 
@@ -173,11 +169,11 @@ def test_arxiv_field_no_arxiv_eprints():
 
 
 def test_arxiv_field_single_arxiv_eprints():
-    single_arxiv_eprints = InspireRecord({
+    single_arxiv_eprints = {
         'arxiv_eprints': [
             {'value': 'foo'}
         ]
-    })
+    }
 
     expected = {'value': 'foo'}
     result = Export(single_arxiv_eprints).arxiv_field
@@ -186,12 +182,12 @@ def test_arxiv_field_single_arxiv_eprints():
 
 
 def test_arxiv_field_returns_first():
-    returns_first = InspireRecord({
+    returns_first = {
         'arxiv_eprints': [
             {'value': 'foo'},
             {'value': 'bar'}
         ]
-    })
+    }
 
     expected = {'value': 'foo'}
     result = Export(returns_first).arxiv_field
@@ -200,7 +196,7 @@ def test_arxiv_field_returns_first():
 
 
 def test_get_arxiv_no_arxiv_eprints():
-    no_arxiv_eprints = InspireRecord({})
+    no_arxiv_eprints = {}
 
     expected = ''
     result = Export(no_arxiv_eprints)._get_arxiv()
@@ -209,11 +205,11 @@ def test_get_arxiv_no_arxiv_eprints():
 
 
 def test_get_arxiv_no_value():
-    no_value = InspireRecord({
+    no_value = {
         'arxiv_eprints': [
             {'notvalue': 'foo'}
         ]
-    })
+    }
 
     expected = ''
     result = Export(no_value)._get_arxiv()
@@ -222,11 +218,11 @@ def test_get_arxiv_no_value():
 
 
 def test_get_arxiv_value_no_categories():
-    value_no_categories = InspireRecord({
+    value_no_categories = {
         'arxiv_eprints': [
             {'value': 'foo'}
         ]
-    })
+    }
 
     expected = 'foo'
     result = Export(value_no_categories)._get_arxiv()
@@ -235,15 +231,14 @@ def test_get_arxiv_value_no_categories():
 
 
 def test_get_arxiv_single_category():
-
-    single_category = InspireRecord({
+    single_category = {
         'arxiv_eprints': [
             {
                 'value': 'foo',
                 'categories': ['bar']
             }
         ]
-    })
+    }
 
     expected = 'foo [bar]'
     result = Export(single_category)._get_arxiv()
@@ -252,8 +247,7 @@ def test_get_arxiv_single_category():
 
 
 def test_get_arxiv_multiple_categories():
-
-    multiple_categories = InspireRecord({
+    multiple_categories = {
         'arxiv_eprints': [
             {
                 'value': 'foo',
@@ -263,7 +257,7 @@ def test_get_arxiv_multiple_categories():
                 ]
             }
         ]
-    })
+    }
 
     expected = 'foo [bar,baz]'
     result = Export(multiple_categories)._get_arxiv()
@@ -272,8 +266,7 @@ def test_get_arxiv_multiple_categories():
 
 
 def test_get_report_number_no_report_numbers():
-
-    no_report_numbers = InspireRecord({})
+    no_report_numbers = {}
 
     expected = []
     result = Export(no_report_numbers)._get_report_number()
@@ -282,12 +275,11 @@ def test_get_report_number_no_report_numbers():
 
 
 def test_get_report_number_no_value():
-
-    no_value = InspireRecord({
+    no_value = {
         'report_numbers': [
             {'notvalue': 'foo'}
         ]
-    })
+    }
 
     expected = ''
     result = Export(no_value)._get_report_number()
@@ -296,12 +288,11 @@ def test_get_report_number_no_value():
 
 
 def test_get_report_number_single_value():
-
-    single_value = InspireRecord({
+    single_value = {
         'report_numbers': [
             {'value': 'foo'}
         ]
-    })
+    }
 
     expected = 'foo'
     result = Export(single_value)._get_report_number()
@@ -310,13 +301,12 @@ def test_get_report_number_single_value():
 
 
 def test_get_report_number_multiple_values():
-
-    multiple_values = InspireRecord({
+    multiple_values = {
         'report_numbers': [
             {'value': 'foo'},
             {'value': 'bar'}
         ]
-    })
+    }
 
     expected = 'foo, bar'
     result = Export(multiple_values)._get_report_number()
@@ -325,12 +315,11 @@ def test_get_report_number_multiple_values():
 
 
 def test_get_slac_citation_from_arxiv_eprints_no_value():
-
-    from_arxiv_eprints_no_value = InspireRecord({
+    from_arxiv_eprints_no_value = {
         'arxiv_eprints': [
             {'notvalue': 'foo'}
         ]
-    })
+    }
 
     expected = ''
     result = Export(from_arxiv_eprints_no_value)._get_slac_citation()
@@ -339,12 +328,11 @@ def test_get_slac_citation_from_arxiv_eprints_no_value():
 
 
 def test_get_slac_citation_from_arxiv_eprints_with_value():
-
-    from_arxiv_eprints_with_value = InspireRecord({
+    from_arxiv_eprints_with_value = {
         'arxiv_eprints': [
             {'value': 'foo'}
         ]
-    })
+    }
 
     expected = '%%CITATION = FOO;%%'
     result = Export(from_arxiv_eprints_with_value)._get_slac_citation()
@@ -357,7 +345,7 @@ def test_get_slac_citation_from_pubnote():
     #                 by subclasses of Export.
     Export._get_pubnote = lambda self: 'foo'
 
-    from_pubnote = InspireRecord({})
+    from_pubnote = {}
 
     expected = '%%CITATION = foo;%%'
     result = Export(from_pubnote)._get_slac_citation()
@@ -372,12 +360,12 @@ def test_get_slac_citation_from_report_numbers_no_arxiv_eprints():
     #                 by subclasses of Export.
     Export._get_pubnote = lambda self: False
 
-    from_report_numbers_no_arxiv_eprints = InspireRecord({
+    from_report_numbers_no_arxiv_eprints = {
         'report_numbers': [
             {'value': 'foo'},
             {'value': 'bar'}
         ]
-    })
+    }
 
     expected = '%%CITATION = FOO;%%'
     result = Export(from_report_numbers_no_arxiv_eprints)._get_slac_citation()
@@ -392,7 +380,7 @@ def test_get_slac_citation_from_control_number():
     #                 by subclasses of Export.
     Export._get_pubnote = lambda self: False
 
-    from_recid = InspireRecord({'control_number': 1})
+    from_recid = {'control_number': 1}
 
     expected = '%%CITATION = INSPIRE-1;%%'
     result = Export(from_recid)._get_slac_citation()
@@ -406,7 +394,7 @@ def test_get_slac_citation_from_control_number():
 def test_get_citation_number_no_citations(g_e_r):
     g_e_r.return_value = {'citation_count': 0}
 
-    no_citations = InspireRecord({'control_number': 1})
+    no_citations = {'control_number': 1}
 
     expected = ''
     result = Export(no_citations)._get_citation_number()
@@ -420,7 +408,7 @@ def test_get_citation_number_one_citation(g_e_r, strftime):
     strftime.return_value = '02 Feb 1993'
     g_e_r.return_value = {'citation_count': 1}
 
-    one_citation = InspireRecord({'control_number': 1})
+    one_citation = {'control_number': 1}
 
     expected = '1 citation counted in INSPIRE as of 02 Feb 1993'
     result = Export(one_citation)._get_citation_number()
@@ -434,7 +422,7 @@ def test_get_citation_number_two_citations(g_e_r, strftime):
     strftime.return_value = '02 Feb 1993'
     g_e_r.return_value = {'citation_count': 2}
 
-    two_citations = InspireRecord({'control_number': 1})
+    two_citations = {'control_number': 1}
 
     expected = '2 citations counted in INSPIRE as of 02 Feb 1993'
     result = Export(two_citations)._get_citation_number()
@@ -446,7 +434,7 @@ def test_get_citation_number_two_citations(g_e_r, strftime):
 def test_get_citation_number_no_citation_count(g_e_r):
     g_e_r.return_value = {}
 
-    no_citation_count = InspireRecord({'control_number': 1})
+    no_citation_count = {'control_number': 1}
 
     expected = ''
     result = Export(no_citation_count)._get_citation_number()

--- a/tests/unit/utils/test_utils_latex.py
+++ b/tests/unit/utils/test_utils_latex.py
@@ -27,12 +27,11 @@ from __future__ import absolute_import, division, print_function
 import mock
 import pytest
 
-from inspirehep.modules.records.api import InspireRecord
 from inspirehep.utils.latex import Latex
 
 
 def test_format_output_row_unknown_field():
-    record = InspireRecord({})
+    record = {}
     latex = Latex(record, 'latex_eu')
 
     expected = ''
@@ -42,7 +41,7 @@ def test_format_output_row_unknown_field():
 
 
 def test_format_output_row_one_author():
-    record = InspireRecord({})
+    record = {}
     latex = Latex(record, 'latex_eu')
 
     expected = u'  S.~L.~Glashow,\n'
@@ -52,7 +51,7 @@ def test_format_output_row_one_author():
 
 
 def test_format_output_row_between_one_and_eight_authors():
-    record = InspireRecord({})
+    record = {}
     latex = Latex(record, 'latex_eu')
 
     expected = u'  F.~Englert and R.~Brout,\n'
@@ -62,11 +61,11 @@ def test_format_output_row_between_one_and_eight_authors():
 
 
 def test_format_output_row_more_than_eight_authors_collaboration():
-    with_collaboration = InspireRecord({
+    with_collaboration = {
         'collaboration': [
             {'value': 'Supernova Search Team'}
         ]
-    })
+    }
     latex = Latex(with_collaboration, 'latex_eu')
 
     expected = u'  A.~G.~Riess {{\\it et al.}} [Supernova Search Team Collaboration],\n'
@@ -82,11 +81,11 @@ def test_format_output_row_more_than_eight_authors_collaboration():
 
 
 def test_format_output_row_more_than_eight_authors_collaboration_in_collaboration():
-    collaboration_in_collaboration = InspireRecord({
+    collaboration_in_collaboration = {
         'collaboration': [
             {'value': 'The ATLAS Collaboration'}
         ]
-    })
+    }
     latex = Latex(collaboration_in_collaboration, 'latex_eu')
 
     expected = u'  G.~Aad {{\it et al.}} [The ATLAS Collaboration],\n'
@@ -99,7 +98,7 @@ def test_format_output_row_more_than_eight_authors_collaboration_in_collaboratio
 
 
 def test_format_output_row_more_than_eight_authors_no_collaboration():
-    without_collaboration = InspireRecord({})
+    without_collaboration = {}
     latex = Latex(without_collaboration, 'latex_eu')
 
     expected = u'  L.~Cadamuro {\it et al.},\n'
@@ -113,7 +112,7 @@ def test_format_output_row_more_than_eight_authors_no_collaboration():
 
 @pytest.mark.xfail
 def test_format_output_row_more_than_eight_authors_collaboration_an_empty_list():
-    collaboration_an_empty_list = InspireRecord({'collaboration': []})
+    collaboration_an_empty_list = {'collaboration': []}
     latex = Latex(collaboration_an_empty_list, 'latex_eu')
 
     expected = '  0 {\\it et al.}'
@@ -124,7 +123,7 @@ def test_format_output_row_more_than_eight_authors_collaboration_an_empty_list()
 
 @pytest.mark.xfail
 def test_format_output_row_title():
-    record = InspireRecord({})
+    record = {}
     latex = Latex(record, 'latex_eu')
 
     expected = u"  %``Partial Symmetries of Weak Interactions,''\n"
@@ -134,7 +133,7 @@ def test_format_output_row_title():
 
 
 def test_format_output_row_publi_info_not_a_list():
-    record = InspireRecord({})
+    record = {}
     latex = Latex(record, 'latex_eu')
 
     expected = u'  Phys. Lett. 12 (1964) 132-133.\n'
@@ -145,14 +144,14 @@ def test_format_output_row_publi_info_not_a_list():
 
 @pytest.mark.xfail
 def test_format_output_row_publi_info_an_empty_list():
-    record = InspireRecord({})
+    record = {}
     latex = Latex(record, 'latex_eu')
 
     latex._format_output_row('publi_info', [])
 
 
 def test_format_output_row_publi_info_a_list_with_one_element():
-    record = InspireRecord({})
+    record = {}
     latex = Latex(record, 'latex_eu')
 
     expected = u'  Phys.\\ Rev.\\ D {\\bf 73} (2006) 014022\n'
@@ -164,7 +163,7 @@ def test_format_output_row_publi_info_a_list_with_one_element():
 
 
 def test_format_output_row_publi_info_a_list_with_two_elelemts():
-    record = InspireRecord({})
+    record = {}
     latex = Latex(record, 'latex_eu')
 
     expected = u'''  Int.\\ J.\\ Theor.\\ Phys.\\  {\\bf 38} (1999) 1113
@@ -180,11 +179,11 @@ def test_format_output_row_publi_info_a_list_with_two_elelemts():
 
 
 def test_format_output_row_arxiv_with_publi_info():
-    with_publi_info = InspireRecord({
+    with_publi_info = {
         'publication_info': [
             {'journal_title': ''}
         ]
-    })
+    }
     latex = Latex(with_publi_info, 'latex_eu')
 
     expected = u'  [arXiv:1512.01381 [hep-th]].\n'
@@ -194,7 +193,7 @@ def test_format_output_row_arxiv_with_publi_info():
 
 
 def test_format_output_row_arxiv_without_publi_info():
-    without_publi_info = InspireRecord({})
+    without_publi_info = {}
     latex = Latex(without_publi_info, 'latex_eu')
 
     expected = u'  arXiv:1512.01296 [hep-th].\n'
@@ -204,7 +203,7 @@ def test_format_output_row_arxiv_without_publi_info():
 
 
 def test_format_output_row_report_number():
-    record = InspireRecord({})
+    record = {}
     latex = Latex(record, 'latex_eu')
 
     expected = u'  CMS-PAS-TOP-13-007.\n'
@@ -214,7 +213,7 @@ def test_format_output_row_report_number():
 
 
 def test_get_author_from_authors_an_empty_list():
-    authors_an_empty_list = InspireRecord({'authors': []})
+    authors_an_empty_list = {'authors': []}
     latex = Latex(authors_an_empty_list, 'latex_eu')
 
     expected = []
@@ -224,11 +223,11 @@ def test_get_author_from_authors_an_empty_list():
 
 
 def test_get_author_from_authors_a_list_with_one_element():
-    authors_a_list_with_one_element = InspireRecord({
+    authors_a_list_with_one_element = {
         'authors': [
             {'full_name': 'Glashow, S.L.'}
         ]
-    })
+    }
     latex = Latex(authors_a_list_with_one_element, 'latex_eu')
 
     expected = ['S.~L.~Glashow']
@@ -238,12 +237,12 @@ def test_get_author_from_authors_a_list_with_one_element():
 
 
 def test_get_author_from_authors_a_list_with_two_elements():
-    authors_a_list_with_two_elements = InspireRecord({
+    authors_a_list_with_two_elements = {
         'authors': [
             {'full_name': 'Englert, F.'},
             {'full_name': 'Brout, R.'}
         ]
-    })
+    }
     latex = Latex(authors_a_list_with_two_elements, 'latex_eu')
 
     expected = ['F.~Englert', 'R.~Brout']
@@ -253,11 +252,11 @@ def test_get_author_from_authors_a_list_with_two_elements():
 
 
 def test_get_author_from_authors_one_author_with_an_empty_list_of_full_names():
-    one_author_with_an_empty_list_of_full_names = InspireRecord({
+    one_author_with_an_empty_list_of_full_names = {
         'authors': [
             {'full_name': []}
         ]
-    })
+    }
     latex = Latex(one_author_with_an_empty_list_of_full_names, 'latex_eu')
 
     expected = []
@@ -267,11 +266,11 @@ def test_get_author_from_authors_one_author_with_an_empty_list_of_full_names():
 
 
 def test_get_author_from_authors_one_author_with_a_list_of_one_full_name():
-    one_author_with_a_list_of_one_full_name = InspireRecord({
+    one_author_with_a_list_of_one_full_name = {
         'authors': [
             {'full_name': ['Glashow, S.L.']}
         ]
-    })
+    }
     latex = Latex(one_author_with_a_list_of_one_full_name, 'latex_eu')
 
     expected = ['S.~L.~Glashow']
@@ -281,7 +280,7 @@ def test_get_author_from_authors_one_author_with_a_list_of_one_full_name():
 
 
 def test_get_author_from_authors_one_author_with_a_list_of_two_full_names():
-    one_author_with_a_list_of_two_full_names = InspireRecord({
+    one_author_with_a_list_of_two_full_names = {
         'authors': [
             {
                 'full_name': [
@@ -290,7 +289,7 @@ def test_get_author_from_authors_one_author_with_a_list_of_two_full_names():
                 ]
             }
         ]
-    })
+    }
     latex = Latex(one_author_with_a_list_of_two_full_names, 'latex_eu')
 
     expected = ['F.~B.~Englert, R.']
@@ -300,7 +299,7 @@ def test_get_author_from_authors_one_author_with_a_list_of_two_full_names():
 
 
 def test_get_author_from_corporate_author_an_empty_list():
-    corporate_author_an_empty_list = InspireRecord({'corporate_author': []})
+    corporate_author_an_empty_list = {'corporate_author': []}
     latex = Latex(corporate_author_an_empty_list, 'latex_eu')
 
     expected = []
@@ -311,11 +310,11 @@ def test_get_author_from_corporate_author_an_empty_list():
 
 @pytest.mark.xfail
 def test_get_author_from_corporate_author_a_list_with_one_element():
-    corporate_author_a_list_of_one_element = InspireRecord({
+    corporate_author_a_list_of_one_element = {
         'corporate_author': [
             'CMS Collaboration'
         ]
-    })
+    }
     latex = Latex(corporate_author_a_list_of_one_element, 'latex_eu')
 
     expected = ['CMS Collaboration']
@@ -326,12 +325,12 @@ def test_get_author_from_corporate_author_a_list_with_one_element():
 
 @pytest.mark.xfail
 def test_get_author_from_corporate_author_a_list_with_two_elements():
-    corporate_author_a_list_of_two_elements = InspireRecord({
+    corporate_author_a_list_of_two_elements = {
         'corporate_author': [
             'CMS Collaboration',
             'The ATLAS Collaboration'
         ]
-    })
+    }
     latex = Latex(corporate_author_a_list_of_two_elements, 'latex_eu')
 
     expected = ['CMS Collaboration', 'The ATLAS Collaboration']
@@ -341,7 +340,7 @@ def test_get_author_from_corporate_author_a_list_with_two_elements():
 
 
 def test_get_title_no_titles():
-    no_titles = InspireRecord({})
+    no_titles = {}
     latex = Latex(no_titles, 'latex_eu')
 
     expected = ''
@@ -351,7 +350,7 @@ def test_get_title_no_titles():
 
 
 def test_get_title_from_titles_an_empty_list():
-    titles_an_empty_list = InspireRecord({'titles': []})
+    titles_an_empty_list = {'titles': []}
     latex = Latex(titles_an_empty_list, 'latex_eu')
 
     expected = ''
@@ -361,11 +360,11 @@ def test_get_title_from_titles_an_empty_list():
 
 
 def test_get_title_from_titles_a_list_with_one_element():
-    titles_a_list_with_one_element = InspireRecord({
+    titles_a_list_with_one_element = {
         'titles': [
             {'title': 'Partial Symmetries of Weak Interactions'}
         ]
-    })
+    }
     latex = Latex(titles_a_list_with_one_element, 'latex_eu')
 
     expected = 'Partial Symmetries of Weak Interactions'
@@ -375,12 +374,12 @@ def test_get_title_from_titles_a_list_with_one_element():
 
 
 def test_get_title_from_titles_a_list_with_two_elements():
-    titles_a_list_with_two_elements = InspireRecord({
+    titles_a_list_with_two_elements = {
         'titles': [
             {'title': 'Broken Symmetries and the Masses of Gauge Bosons'},
             {'title': 'BROKEN SYMMETRIES AND THE MASSES OF GAUGE BOSONS.'}
         ]
-    })
+    }
     latex = Latex(titles_a_list_with_two_elements, 'latex_eu')
 
     expected = 'Broken Symmetries and the Masses of Gauge Bosons'
@@ -390,11 +389,11 @@ def test_get_title_from_titles_a_list_with_two_elements():
 
 
 def test_get_title_from_titles_not_a_list():
-    titles_not_a_list = InspireRecord({
+    titles_not_a_list = {
         'titles': {
             'title': 'Partial Symmetries of Weak Interactions'
         }
-    })
+    }
     latex = Latex(titles_not_a_list, 'latex_eu')
 
     expected = 'Partial Symmetries of Weak Interactions'
@@ -404,14 +403,14 @@ def test_get_title_from_titles_not_a_list():
 
 
 def test_get_publi_info_no_publication_info():
-    no_publication_info = InspireRecord({})
+    no_publication_info = {}
     latex = Latex(no_publication_info, 'latex_eu')
 
     assert latex._get_publi_info() is None
 
 
 def test_get_publi_info_from_publication_info_an_empty_list():
-    publication_info_an_empty_list = InspireRecord({'publication_info': []})
+    publication_info_an_empty_list = {'publication_info': []}
     latex = Latex(publication_info_an_empty_list, 'latex_eu')
 
     expected = []
@@ -421,11 +420,11 @@ def test_get_publi_info_from_publication_info_an_empty_list():
 
 
 def test_get_publi_info_from_publication_info_with_journal_title_not_a_list():
-    journal_title_not_a_list = InspireRecord({
+    journal_title_not_a_list = {
         'publication_info': [
             {'journal_title': 'Nucl.Phys.'}
         ]
-    })
+    }
     latex = Latex(journal_title_not_a_list, 'latex_eu')
 
     expected = ['Nucl.\\ Phys.\\ ']
@@ -436,11 +435,11 @@ def test_get_publi_info_from_publication_info_with_journal_title_not_a_list():
 
 @pytest.mark.xfail
 def test_get_publi_info_from_publication_info_with_journal_title_an_empty_list():
-    journal_title_an_empty_list = InspireRecord({
+    journal_title_an_empty_list = {
         'publication_info': [
             {'journal_title': []}
         ]
-    })
+    }
     latex = Latex(journal_title_an_empty_list, 'latex_eu')
 
     expected = []
@@ -450,11 +449,11 @@ def test_get_publi_info_from_publication_info_with_journal_title_an_empty_list()
 
 
 def test_get_publi_info_from_publication_info_with_journal_title_a_list_of_one_element():
-    journal_title_a_list_of_one_element = InspireRecord({
+    journal_title_a_list_of_one_element = {
         'publication_info': [
             {'journal_title': ['foo']}
         ]
-    })
+    }
     latex = Latex(journal_title_a_list_of_one_element, 'latex_eu')
 
     expected = ['foo']
@@ -464,11 +463,11 @@ def test_get_publi_info_from_publication_info_with_journal_title_a_list_of_one_e
 
 
 def test_get_publi_info_from_publication_info_with_journal_title_a_list_of_two_elements():
-    journal_title_a_list_of_two_elements = InspireRecord({
+    journal_title_a_list_of_two_elements = {
         'publication_info': [
             {'journal_title': ['foo', 'bar']}
         ]
-    })
+    }
     latex = Latex(journal_title_a_list_of_two_elements, 'latex_eu')
 
     expected = ['bar']
@@ -478,14 +477,14 @@ def test_get_publi_info_from_publication_info_with_journal_title_a_list_of_two_e
 
 
 def test_get_publi_info_from_publication_info_with_journal_volume():
-    journal_volume = InspireRecord({
+    journal_volume = {
         'publication_info': [
             {
                 'journal_title': 'eConf',
                 'journal_volume': 'C050318'
             }
         ]
-    })
+    }
     latex = Latex(journal_volume, 'latex_eu')
 
     expected = ['eConf C {\\bf 050318}']
@@ -495,14 +494,14 @@ def test_get_publi_info_from_publication_info_with_journal_volume():
 
 
 def test_get_publi_info_from_publication_info_with_journal_volume_with_letter():
-    journal_volume_with_letter = InspireRecord({
+    journal_volume_with_letter = {
         'publication_info': [
             {
                 'journal_title': 'Eur.Phys.J.',
                 'journal_volume': 'C73'
             }
         ]
-    })
+    }
     latex = Latex(journal_volume_with_letter, 'latex_eu')
 
     expected = ['Eur.\\ Phys.\\ J.\\ C {\\bf 73}']
@@ -512,14 +511,14 @@ def test_get_publi_info_from_publication_info_with_journal_volume_with_letter():
 
 
 def test_get_publi_info_from_publication_info_with_year_not_a_list():
-    year_not_a_list = InspireRecord({
+    year_not_a_list = {
         'publication_info': [
             {
                 'journal_title': 'Phys.Lett.',
                 'year': '1999'
             }
         ]
-    })
+    }
     latex = Latex(year_not_a_list, 'latex_eu')
 
     expected = ['Phys.\\ Lett.\\  (1999)']
@@ -530,14 +529,14 @@ def test_get_publi_info_from_publication_info_with_year_not_a_list():
 
 @pytest.mark.xfail
 def test_get_publi_info_from_publication_info_with_year_an_empty_list():
-    year_an_empty_list = InspireRecord({
+    year_an_empty_list = {
         'publication_info': [
             {
                 'journal_title': 'Phys.Rev.',
                 'year': []
             }
         ]
-    })
+    }
     latex = Latex(year_an_empty_list, 'latex_eu')
 
     expected = ['Phys.\\ Rev.\\ ']
@@ -547,14 +546,14 @@ def test_get_publi_info_from_publication_info_with_year_an_empty_list():
 
 
 def test_get_publi_info_from_publication_info_with_year_a_list_of_one_element():
-    year_a_list_of_one_element = InspireRecord({
+    year_a_list_of_one_element = {
         'publication_info': [
             {
                 'journal_title': 'JHEP',
                 'year': ['1999']
             }
         ]
-    })
+    }
     latex = Latex(year_a_list_of_one_element, 'latex_eu')
 
     expected = ['JHEP (1999)']
@@ -564,14 +563,14 @@ def test_get_publi_info_from_publication_info_with_year_a_list_of_one_element():
 
 
 def test_get_publi_info_from_publication_info_with_year_a_list_of_two_elements():
-    year_a_list_of_two_elements = InspireRecord({
+    year_a_list_of_two_elements = {
         'publication_info': [
             {
                 'journal_title': 'Phys.Rev.Lett.',
                 'year': ['1999', '2000']
             }
         ]
-    })
+    }
     latex = Latex(year_a_list_of_two_elements, 'latex_eu')
 
     expected = ['Phys.\\ Rev.\\ Lett.\\  (2000)']
@@ -581,14 +580,14 @@ def test_get_publi_info_from_publication_info_with_year_a_list_of_two_elements()
 
 
 def test_get_publi_info_from_publication_info_with_journal_issue_latex_eu():
-    journal_issue = InspireRecord({
+    journal_issue = {
         'publication_info': [
             {
                 'journal_title': 'Int.J.Mod.Phys.',
                 'journal_issue': '29'
             }
         ]
-    })
+    }
     latex_eu = Latex(journal_issue, 'latex_eu')
 
     expected = ['Int.\\ J.\\ Mod.\\ Phys.\\  29, ']
@@ -598,14 +597,14 @@ def test_get_publi_info_from_publication_info_with_journal_issue_latex_eu():
 
 
 def test_get_publi_info_from_publication_info_with_journal_issue_latex_us():
-    journal_issue = InspireRecord({
+    journal_issue = {
         'publication_info': [
             {
                 'journal_title': 'Class.Quant.Grav.',
                 'journal_issue': '10'
             }
         ]
-    })
+    }
     latex_us = Latex(journal_issue, 'latex_us')
 
     expected = ['Class.\\ Quant.\\ Grav.\\ , no. 10']
@@ -615,14 +614,14 @@ def test_get_publi_info_from_publication_info_with_journal_issue_latex_us():
 
 
 def test_get_publi_info_from_publication_info_with_page_start():
-    page_start = InspireRecord({
+    page_start = {
         'publication_info': [
             {
                 'journal_title': 'JHEP',
                 'page_start': '190'
             }
         ]
-    })
+    }
     latex = Latex(page_start, 'latex_eu')
 
     expected = ['JHEP 190']
@@ -632,11 +631,11 @@ def test_get_publi_info_from_publication_info_with_page_start():
 
 
 def test_get_publi_info_from_pubinfo_freetext():
-    pubinfo_freetext = InspireRecord({
+    pubinfo_freetext = {
         'publication_info': [
             {'pubinfo_freetext': 'Phys. Lett. 12 (1964) 132-133'}
         ]
-    })
+    }
     latex = Latex(pubinfo_freetext, 'latex_eu')
 
     expected = 'Phys. Lett. 12 (1964) 132-133'
@@ -646,7 +645,7 @@ def test_get_publi_info_from_pubinfo_freetext():
 
 
 def test_get_publi_info_from_publication_info_a_list_of_two_elements():
-    publication_info_a_list_of_two_elements = InspireRecord({
+    publication_info_a_list_of_two_elements = {
         'publication_info': [
             {
                 'journal_title': 'Int.J.Theor.Phys.',
@@ -663,7 +662,7 @@ def test_get_publi_info_from_publication_info_a_list_of_two_elements():
                 'year': 1998
             }
         ]
-    })
+    }
     latex = Latex(publication_info_a_list_of_two_elements, 'latex_eu')
 
     expected = [
@@ -681,7 +680,7 @@ def test_get_report_number_no_publi_info_yes_arxiv(g_a, g_p_i):
     g_a.return_value = False
     g_p_i.return_value = True
 
-    record = InspireRecord({})
+    record = {}
     latex = Latex(record, 'latex_eu')
 
     assert latex._get_report_number() is None
@@ -693,7 +692,7 @@ def test_get_report_number_yes_publi_info_no_arxiv(g_a, g_p_i):
     g_a.return_value = True
     g_p_i.return_value = False
 
-    record = InspireRecord({})
+    record = {}
     latex = Latex(record, 'latex_eu')
 
     assert latex._get_report_number() is None
@@ -705,7 +704,7 @@ def test_get_report_number_yes_publi_info_yes_arxiv(g_a, g_p_i):
     g_a.return_value = True
     g_p_i.return_value = True
 
-    record = InspireRecord({})
+    record = {}
     latex = Latex(record, 'latex_eu')
 
     assert latex._get_report_number() is None

--- a/tests/unit/workflows/test_workflows_tasks_beard.py
+++ b/tests/unit/workflows/test_workflows_tasks_beard.py
@@ -26,7 +26,6 @@ import requests
 from flask import current_app
 from mock import patch
 
-from inspirehep.modules.records.api import InspireRecord
 from inspirehep.modules.workflows.tasks.beard import (
     get_beard_url,
     prepare_payload,
@@ -54,7 +53,7 @@ def test_get_beard_url_returns_none_when_not_in_configuration():
 
 
 def test_prepare_payload():
-    record = InspireRecord({
+    record = {
         'titles': [
             {
                 'title': 'Effects of top compositeness',
@@ -73,7 +72,7 @@ def test_prepare_payload():
                 'value': 'We investigate the effects of (...)',
             },
         ],
-    })
+    }
 
     expected = {
         'title': 'Effects of top compositeness',

--- a/tests/unit/workflows/test_workflows_tasks_magpie.py
+++ b/tests/unit/workflows/test_workflows_tasks_magpie.py
@@ -26,7 +26,6 @@ import requests
 from flask import current_app
 from mock import patch
 
-from inspirehep.modules.records.api import InspireRecord
 from inspirehep.modules.workflows.tasks.magpie import (
     get_magpie_url,
     prepare_magpie_payload,
@@ -57,7 +56,7 @@ def test_get_magpie_url_returns_none_when_not_in_configuration():
 
 
 def test_prepare_magpie_payload():
-    record = InspireRecord({
+    record = {
         'titles': [
             {
                 'title': 'foo',
@@ -71,7 +70,7 @@ def test_prepare_magpie_payload():
                 'value': 'baz',
             },
         ]
-    })
+    }
 
     expected = {
         'text': 'foo. bar. baz',


### PR DESCRIPTION
## Description
Commit b8e03967 replaced all instances of ``Record`` in unit tests
with ``InspireRecord``, but instead should have replaced them with
simple dictionaries, since we don't need its API in those tests.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.