### PR TITLE
 git: remove submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "submodules/inspirehep-search-js"]
-	path = submodules/inspirehep-search-js
-	url = https://github.com/inspirehep/inspirehep-search-js.git


### PR DESCRIPTION
## Description:
The submodule for ``inspirehep-search-js`` is no longer needed. Please
follow the instructions in its repository to develop locally.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.