### PR TITLE
receivers: populate bookautocomplete in Python

### DIFF
--- a/inspirehep/modules/records/mappings/records/hep.json
+++ b/inspirehep/modules/records/mappings/records/hep.json
@@ -490,7 +490,6 @@
                 "imprints": {
                     "properties": {
                         "date": {
-                            "copy_to": "bookautocomplete",
                             "format": "yyyy||yyyy-MM||yyyy-MM-dd",
                             "type": "date"
                         },
@@ -498,7 +497,6 @@
                             "type": "string"
                         },
                         "publisher": {
-                            "copy_to": "bookautocomplete",
                             "type": "string"
                         }
                     },
@@ -522,7 +520,6 @@
                             "type": "string"
                         },
                         "value": {
-                            "copy_to": "bookautocomplete",
                             "fields": {
                                 "raw": {
                                     "analyzer": "lowercase_analyzer",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail --> 
When populating the "bookautocomplete" field of Literature records, retrieving the values supposedly stored in "bookautocomplete" was done as if ES stores JSON objecs, i.e. using `json.get("bookautocomplete", [])`. This always returns `None`, therefore I had to remove `"copy-to":
"bookautocomplete"` from the hep.json mapping. Instead, I retrieve the required values that are assumed to be stored there manually and then appropriately update "bookautocomplete".

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
