### PR TITLE
records: allow to skip downloading the files

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -1136,6 +1136,16 @@ RECORDS_VALIDATION_TYPES = {
     'array': (list, tuple),
 }
 
+RECORDS_SKIP_FILES = False
+"""Disable the downloading of files at record creation and update times.
+
+Note:
+
+  The ``skip_files`` parameter passed to ``InspireRecord.create`` or
+  ``InspireRecord.update`` takes precedence on this config variable.
+
+"""
+
 JSONSCHEMAS_HOST = "localhost:5000"
 JSONSCHEMAS_REPLACE_REFS = True
 JSONSCHEMAS_LOADER_CLS = 'inspirehep.modules.records.json_ref_loader.SCHEMA_LOADER_CLS'

--- a/inspirehep/modules/records/api.py
+++ b/inspirehep/modules/records/api.py
@@ -71,13 +71,23 @@ class InspireRecord(Record):
                 record in the list that has it in it's files iterator before
                 downloading them, for example to merge existing
                 records.
+            skip_files(bool): if ``True`` it will skip the files retrieval
+                described above. Note also that, if not passed, it will fall
+                back to the value of the ``RECORDS_SKIP_FILES`` configuration
+                variable.
+
         """
+        config_skip_files = current_app.config.get('RECORDS_SKIP_FILES')
+
         files_src_records = kwargs.pop('files_src_records', ())
+        skip_files = kwargs.pop('skip_files', config_skip_files)
+
         new_record = super(InspireRecord, cls).create(*args, **kwargs)
-        new_record.download_documents_and_figures(
-            src_records=files_src_records,
-        )
-        new_record.commit()
+
+        if not skip_files:
+            new_record.download_documents_and_figures(src_records=files_src_records)
+            new_record.commit()
+
         return new_record
 
     def update(self, *args, **kwargs):
@@ -91,13 +101,21 @@ class InspireRecord(Record):
                 files for the documents and figures from this record's files
                 iterator before downloading them, for example to merge existing
                 records.
+            skip_files(bool): if ``True`` it will skip the files retrieval
+                described above. Note also that, if not passed, it will fall
+                back to the value of the ``RECORDS_SKIP_FILES`` configuration
+                variable.
+
         """
+        config_skip_files = current_app.config.get('RECORDS_SKIP_FILES')
+
         files_src_records = kwargs.pop('files_src_records', ())
+        skip_files = kwargs.pop('skip_files', config_skip_files)
+
         super(InspireRecord, self).update(*args, **kwargs)
-        self.download_documents_and_figures(
-            only_new=True,
-            src_records=files_src_records,
-        )
+
+        if not skip_files:
+            self.download_documents_and_figures(src_records=files_src_records, only_new=True)
 
     def merge(self, other):
         """Redirect pidstore of current record to the other InspireRecord.


### PR DESCRIPTION
## Description
Adds two ways to skip downloading the files:

* Setting the configuration variable ``RECORDS_SKIP_FILES``.
* Passing the ``skip_files`` parameter to the ``create`` and
  ``update`` methods in ``InspireRecord``.

Note that the latter has precedence, and that by default the
previous behavior (downloading the files) is preserved.

## Related Issue
Supersedes https://github.com/inspirehep/inspire-next/pull/2948.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.