### PR TITLE
 config: make journal suggester return 10 hits

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -788,7 +788,8 @@ RECORDS_REST_ENDPOINTS = dict(
         },
         suggesters=dict(
             journal_title=dict(completion=dict(
-                field='title_suggest'
+                field='title_suggest',
+                size=10,
             ))
         ),
         list_route='/journals/',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
The journal title suggester only displayed 5 results, and not
necessary the most relevant ones. This is due to the fact that
ES completion suggesters are implemented in such way that
it does not support relevance ordering for the suggesters.
Therefore, the current solution is to simply display more
results, i.e. 10 instead of 5.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/inspirehep/inspire-next/issues/2866.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Signed-off-by: Iuliana Voinea <iuliana.voinea@student.manchester.ac.uk>
