### PR TITLE
workflows: make arxiv_plot_extract safe to rerun

### DIFF
--- a/inspirehep/modules/workflows/tasks/arxiv.py
+++ b/inspirehep/modules/workflows/tasks/arxiv.py
@@ -146,14 +146,13 @@ def arxiv_plot_extract(obj, eng):
                 current_app.logger.exception(err)
                 return
 
-            lb = LiteratureBuilder(source='arxiv', record=obj.data)
-            for index, plot in enumerate(plots):
-                plot_name = os.path.basename(plot.get('url'))
-                files_keys = obj.files.keys
-                key = plot_name
-                if plot_name in files_keys:
-                    key = '{number}_{name}'.format(number=index, name=plot_name)
+            if 'figures' in obj.data:
+                del obj.data['figures']
 
+            lb = LiteratureBuilder(source='arxiv', record=obj.data)
+            for plot in plots:
+                plot_name = os.path.basename(plot.get('url'))
+                key = plot_name
                 with open(plot.get('url')) as plot_file:
                     obj.files[key] = plot_file
 


### PR DESCRIPTION
* Ensures that no duplicate figures will be added to the workflow
  data if a workflow is restarted.

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
