### PR TITLE
workflows: allow rerunning the download document steps

### DIFF
--- a/inspirehep/modules/workflows/tasks/actions.py
+++ b/inspirehep/modules/workflows/tasks/actions.py
@@ -212,6 +212,10 @@ def submission_fulltext_download(obj, eng):
         )
 
         if pdf:
+            obj.data['documents'] = [
+                document for document in obj.data.get('documents', ())
+                if document.get('key') != filename
+            ]
             lb = LiteratureBuilder(source=obj.data['acquisition_source']['source'], record=obj.data)
             lb.add_document(
                 filename,

--- a/inspirehep/modules/workflows/tasks/arxiv.py
+++ b/inspirehep/modules/workflows/tasks/arxiv.py
@@ -86,6 +86,10 @@ def arxiv_fulltext_download(obj, eng):
     )
 
     if pdf:
+        obj.data['documents'] = [
+            document for document in obj.data.get('documents', ())
+            if document.get('key') != filename
+        ]
         lb = LiteratureBuilder(source='arxiv', record=obj.data)
         lb.add_document(
             filename,

--- a/tests/unit/helpers/mocks.py
+++ b/tests/unit/helpers/mocks.py
@@ -87,23 +87,28 @@ class MockFiles(object):
 class MockFileObject(object):
 
     def __init__(self, key):
-        self.obj = {'key': key}
-        self.bucket_id = '0b9dd5d1-feae-4ba5-809d-3a029b0bc110'
+        self.obj = {
+            'key': key,
+            'file': MockSubfile(uri='/dummy/path/%s' % key),
+            'bucket_id': '0b9dd5d1-feae-4ba5-809d-3a029b0bc110',
+        }
 
     def __eq__(self, other):
         return self.obj['key'] == other.obj['key']
 
-    def __getitem__(self, key):
+    def __getattr__(self, key):
         return self.obj[key]
-
-    def __setitem__(self, key, value):
-        self.obj[key] = value
 
     def delete(self):
         pass
 
     def get_version(self):
         return MockObjectVersion()
+
+
+class MockSubfile(object):
+    def __init__(self, uri):
+        self.uri = uri
 
 
 class MockObjectVersion(object):


### PR DESCRIPTION
Make sure to remove the already existing added document if there.

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Signed-off-by: David Caro <david@dcaro.es>