### PR TITLE
manual_merge: fix conflicts assignment in ``extra_data``

### DIFF
--- a/inspirehep/modules/workflows/tasks/manual_merging.py
+++ b/inspirehep/modules/workflows/tasks/manual_merging.py
@@ -24,8 +24,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import json
-
 from invenio_db import db
 
 from inspire_dojson.utils import get_record_ref
@@ -65,7 +63,7 @@ def merge_records(obj, eng):
     )
 
     obj.data = merged
-    obj.extra_data['conflicts'] = [json.loads(el.to_json()) for el in conflicts]
+    obj.extra_data['conflicts'] = conflicts
     obj.save()
 
 

--- a/tests/integration/workflows/test_workflows_manual_merge.py
+++ b/tests/integration/workflows/test_workflows_manual_merge.py
@@ -54,6 +54,10 @@ def test_manual_merge_existing_records(workflow_app):
     json_head = fake_record('This is the HEAD', 1)
     json_update = fake_record('While this is the update', 2)
 
+    # this two fields will create a merging conflict
+    json_head['core'] = True
+    json_update['core'] = False
+
     head = record_insert_or_replace(json_head)
     update = record_insert_or_replace(json_update)
     head_id = head.id


### PR DESCRIPTION
Signed-off-by: Antonio Cesarano <cesarano2607@gmail.com>

## Description
After the ``inspire-json-merger`` api change, we missed the change of the returned conflicts.

This closes #3018. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
