### PR TITLE
migrator: propagate legacy_creation_date to the DB

### DIFF
--- a/inspirehep/modules/migrator/tasks.py
+++ b/inspirehep/modules/migrator/tasks.py
@@ -276,26 +276,25 @@ def add_citation_counts(chunk_size=500, request_timeout=120):
 
 def record_insert_or_replace(json):
     """Insert or replace a record."""
-    control_number = json.get('control_number', json.get('recid'))
-    if control_number:
-        pid_type = get_pid_type_from_schema(json['$schema'])
-        try:
-            pid = PersistentIdentifier.get(pid_type, control_number)
-            record = InspireRecord.get_record(pid.object_uuid)
-            record.clear()
-            record.update(json)
-            record.commit()
-        except PIDDoesNotExistError:
-            record = InspireRecord.create(json, id_=None)
-            # Create persistent identifier.
-            inspire_recid_minter(str(record.id), json)
+    pid_type = get_pid_type_from_schema(json['$schema'])
+    control_number = json['control_number']
 
-        if json.get('deleted'):
-            new_recid = get_recid_from_ref(json.get('new_record'))
-            if not new_recid:
-                record.delete()
+    try:
+        pid = PersistentIdentifier.get(pid_type, control_number)
+        record = InspireRecord.get_record(pid.object_uuid)
+        record.clear()
+        record.update(json)
+        record.commit()
+    except PIDDoesNotExistError:
+        record = InspireRecord.create(json, id_=None)
+        inspire_recid_minter(str(record.id), json)
 
-        return record
+    if json.get('deleted'):
+        new_recid = get_recid_from_ref(json.get('new_record'))
+        if not new_recid:
+            record.delete()
+
+    return record
 
 
 def migrate_and_insert_record(raw_record):

--- a/inspirehep/modules/migrator/tasks.py
+++ b/inspirehep/modules/migrator/tasks.py
@@ -28,6 +28,7 @@ import gzip
 import re
 import zlib
 from collections import Counter
+from datetime import datetime
 from itertools import chain
 
 import click
@@ -284,9 +285,13 @@ def record_insert_or_replace(json):
         record = InspireRecord.get_record(pid.object_uuid)
         record.clear()
         record.update(json)
+        if json.get('legacy_creation_date'):
+            record.model.created = datetime.strptime(json['legacy_creation_date'], '%Y-%m-%d')
         record.commit()
     except PIDDoesNotExistError:
         record = InspireRecord.create(json, id_=None)
+        if json.get('legacy_creation_date'):
+            record.model.created = datetime.strptime(json['legacy_creation_date'], '%Y-%m-%d')
         inspire_recid_minter(str(record.id), json)
 
     if json.get('deleted'):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Previously, this was put into the record JSON in `legacy_creation_date`, but the migrator should put this into the `created` field of the InspireRecord object instead. Thus, the 'legacy_creation_date' field
is now removed altogether from the record.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/inspirehep/inspire-next/issues/1922.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
inspirehep/inspire-schemas#92 introduces a field to host the `creation_date` from legacy (which is exported in the XME format). The corresponding database column should be populated.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Signed-off-by: Iuliana Voinea <iuliana.voinea@student.manchester.ac.uk>