### PR TITLE
theme: add api_friendly_error_handler decorator

### DIFF
--- a/inspirehep/modules/theme/views.py
+++ b/inspirehep/modules/theme/views.py
@@ -25,6 +25,7 @@
 from __future__ import absolute_import, division, print_function
 
 from datetime import date
+from functools import wraps
 
 from dateutil.relativedelta import relativedelta
 from flask import (
@@ -192,31 +193,34 @@ def data():
 # Error handlers
 #
 
-def error_render_response(config_template_name, error):
-    if current_app.config.get('RESTFUL_API', False):
-        return jsonify(message=error.name, code=error.code), error.code
+def api_friendly_error_handler(f):
+    @wraps(f)
+    def wrapper(error, *args, **kwargs):
+        if current_app.config.get('RESTFUL_API'):
+            return jsonify(code=error.code, message=error.name), error.code
+        return f(error, *args, **kwargs)
 
-    return render_template(current_app.config[config_template_name]), error.code
-
-
-def unauthorized(e):
-    """Error handler to show a 401.html page in case of a 401 error."""
-    return error_render_response('THEME_401_TEMPLATE', e)
+    return wrapper
 
 
-def insufficient_permissions(e):
-    """Error handler to show a 403.html page in case of a 403 error."""
-    return error_render_response('THEME_403_TEMPLATE', e)
+@api_friendly_error_handler
+def unauthorized(error):
+    return render_template(current_app.config['THEME_401_TEMPLATE']), error.code
 
 
-def page_not_found(e):
-    """Error handler to show a 404.html page in case of a 404 error."""
-    return error_render_response('THEME_404_TEMPLATE', e)
+@api_friendly_error_handler
+def insufficient_permissions(error):
+    return render_template(current_app.config['THEME_403_TEMPLATE']), error.code
 
 
-def internal_error(e):
-    """Error handler to show a 500.html page in case of a 500 error."""
-    return error_render_response('THEME_500_TEMPLATE', e)
+@api_friendly_error_handler
+def page_not_found(error):
+    return render_template(current_app.config['THEME_404_TEMPLATE']), error.code
+
+
+@api_friendly_error_handler
+def internal_error(error):
+    return render_template(current_app.config['THEME_500_TEMPLATE']), error.code
 
 
 #


### PR DESCRIPTION
## Description:
`error_render_response` takes a template name and a Flask exception, which is an unusual combination. IMO a decorator would be better here, since it would also preserve the original Flask-like error handler declaration.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.