### PR TITLE
manual_merge: save the correct roots after merging

### DIFF
--- a/inspirehep/modules/workflows/utils/__init__.py
+++ b/inspirehep/modules/workflows/utils/__init__.py
@@ -216,6 +216,19 @@ def read_wf_record_source(record_uuid, source):
     return entry
 
 
+def read_all_wf_record_sources(record_uuid):
+    """Retrieve all ``WorkflowRecordSource`` for a given record id.
+
+    Args:
+        record_uuid(string): the uuid of the record
+
+    Return:
+        (list): the ``WorkflowRecordSource``s related to ``record_uuid``
+    """
+    entries = list(WorkflowsRecordSources.query.filter_by(record_id=str(record_uuid)))
+    return entries
+
+
 def insert_wf_record_source(json, record_uuid, source):
     """Stores a record in the WorkflowRecordSource table in the db.
 

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ install_requires = [
     'flask-shell-ipython~=0.0,>=0.3.0',
     'inspire-crawler~=1.0',
     'inspire-dojson~=57.0,>=57.0.3',
-    'inspire-json-merger~=6.0,>=6.0.0',
+    'inspire-json-merger~=6.0,>=6.0.1',
     'inspire-matcher~=3.0,>=3.0.0',
     'inspire-query-parser~=2.0,>=2.0.0',
     'inspire-schemas~=56.0,>=56.0.3',

--- a/tests/integration/workflows/test_workflow_utils.py
+++ b/tests/integration/workflows/test_workflow_utils.py
@@ -29,6 +29,7 @@ from invenio_db import db
 from inspirehep.modules.records.api import InspireRecord
 from inspirehep.modules.workflows.utils import (
     insert_wf_record_source,
+    read_all_wf_record_sources,
     read_wf_record_source,
 )
 
@@ -91,3 +92,21 @@ def test_wf_record_source_does_not_match_db_content(dummy_record):
     db.session.commit()  # write in the db
     retrieved_root = read_wf_record_source(record_uuid=dummy_record.id, source='Elsevier')
     assert retrieved_root is None
+
+
+def test_read_all_wf_record_sources(dummy_record):
+    insert_wf_record_source(
+        json=dummy_record,
+        record_uuid=dummy_record.id,
+        source='arXiv'
+    )
+
+    insert_wf_record_source(
+        json=dummy_record,
+        record_uuid=dummy_record.id,
+        source='Elsevier'
+    )
+    db.session.commit()
+
+    entries = read_all_wf_record_sources(dummy_record.id)
+    assert len(entries) == 2


### PR DESCRIPTION
Signed-off-by: Antonio Cesarano <cesarano2607@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
1. Bump ``inspire-json-merger``
2. After merging, saves as root the union of the merged records' roots

## Description
After the manual merge is performed, the roots of both records head and update are
retrieved and merged in according to their source.
If two roots with the same source exist, then the update's one is skipped.

## Motivation and Context
Bump ``inspire-json-merger`` allows merging records with empty source.
Saving the union of the roots is the right operation to do, instead of saving the ``head`` and the ``update`` as root like we were doing before.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
