### PR TITLE
forms: collapse links when importing from arXiv

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -237,7 +237,7 @@ services:
         - "curl http://localhost:9200/_cluster/health | grep '.status.:.\\(green\\|yellow\\)'"
 
   test-rabbitmq:
-    image: rabbitmq
+    image: rabbitmq:3.6.14
     healthcheck:
       timeout: 5s
       interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
         - "curl http://localhost:9200/_cluster/health | grep '.status.:.\\(green\\|yellow\\)'"
 
   rabbitmq:
-    image: rabbitmq
+    image: rabbitmq:3.6.14
     healthcheck:
       timeout: 5s
       interval: 5s

--- a/inspirehep/modules/literaturesuggest/static/js/literaturesuggest/literature_submission_form.js
+++ b/inspirehep/modules/literaturesuggest/static/js/literaturesuggest/literature_submission_form.js
@@ -528,8 +528,10 @@ define(function(require, exports, module) {
       this.$formWrapper.show('blind', 1000);
       $actionBar.show('blind', 1000);
 
-      // run checkDepositionType() only when showing the rest of the form
+      // run checkDepositionType() and collapseLinksPanel()
+      // only when showing the rest of the form
       this.checkDepositionType();
+      this.collapseLinksPanel();
     },
 
     /**
@@ -610,6 +612,13 @@ define(function(require, exports, module) {
       })).done(function() {
         that.slideDownPanel();
       });
+    },
+
+    // Collapse the links panel by default if the record is imported from arXiv
+    collapseLinksPanel: function collapseLinksPanel() {
+      if($.trim(this.$arxiv_id_field.val().length) > 0) {
+        $('#collapse-3').prev().find('a.panel-toggle').click();
+      }
     },
 
     /**


### PR DESCRIPTION
## Related Issue:
Closes #1997 

## Notes:
There appears to have been an error while publishing the image for
rabbitmq 3.7.0, so I added a commit to pin the previous version until
a fix is released.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.