### PR TITLE
migrate: allow skipping files creation

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -1152,6 +1152,16 @@ Note:
   ``InspireRecord.update`` takes precedence on this config variable.
 
 """
+RECORDS_MIGRATION_SKIP_FILES = False
+"""Disable the downloading of files at record migration time.
+
+Note:
+
+  This variable takes precedence over ``RECORDS_SKIP_FILES``, but can be
+  overriden by the ``skip_files`` parameters of the ``remigrate_records``,
+  ``migrate`` and ``continuous_migration`` from the
+  ``inspirehep.modules.migrator.tasks`` module.
+"""
 
 JSONSCHEMAS_HOST = "localhost:5000"
 JSONSCHEMAS_REPLACE_REFS = True


### PR DESCRIPTION
We need a way to disable the creation of the files only at migration
time, so the rest of creation flows still add files (harvesting,
submission) while the migration does not try to pull them in.

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

This allows to skip the files creation only on migration while still
creating them on record ingestion and other record creation flows.

Signed-off-by: David Caro <david@dcaro.es>