### PR TITLE
make_robotupload_xml: handle utf-8 encoded strings

### DIFF
--- a/inspirehep/utils/robotupload.py
+++ b/inspirehep/utils/robotupload.py
@@ -27,6 +27,7 @@ from __future__ import absolute_import, division, print_function
 import os
 
 import requests
+from six import text_type
 from flask import current_app
 
 from .url import make_user_agent_string
@@ -43,11 +44,14 @@ def make_robotupload_marcxml(url, marcxml, mode, **kwargs):
     else:
         base_url = url
 
+    if isinstance(marcxml, text_type):
+        marcxml = marcxml.encode('utf8')
+
     if base_url:
         url = os.path.join(base_url, "batchuploader/robotupload", mode)
         return requests.post(
             url=url,
-            data=marcxml.encode('utf8'),
+            data=marcxml,
             headers=headers,
             params=kwargs,
         )

--- a/tests/unit/utils/test_utils_robotupload.py
+++ b/tests/unit/utils/test_utils_robotupload.py
@@ -78,3 +78,20 @@ def test_make_robotupload_marcxml_handles_unicode():
         )  # record/1503367
 
         make_robotupload_marcxml('http://localhost:5000', snippet, 'insert')
+
+
+def test_make_robotupload_marcxml_handles_non_unicode():
+    with requests_mock.Mocker() as requests_mocker:
+        requests_mocker.register_uri(
+            'POST', 'http://localhost:5000/batchuploader/robotupload/insert'
+        )
+
+        snippet = (
+            u'<record>'
+            u'  <datafield tag="700" ind1=" " ind2=" ">'
+            u'    <subfield code="a">André, M.</subfield>'
+            u'  </datafield>'
+            u'</record>'
+        ).encode('utf-8')  # record/1503367
+
+        make_robotupload_marcxml('http://localhost:5000', snippet, 'insert')


### PR DESCRIPTION
https://sentry.inspirehep.net/inspire-sentry/prod/issues/663/

When passing an xml string that is encoded with utf-8, it was trying
to reencode it twice.

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Signed-off-by: David Caro <david@dcaro.es>