### PR TITLE
docker: fix wrong env var name

### DIFF
--- a/services.yml
+++ b/services.yml
@@ -28,7 +28,7 @@ services:
     tty: true
     environment:
       - BASE_USER_UID=${BASE_USER_UID:-1000}
-      - BASE_USER_GIT=${BASE_USER_GIT:-1000}
+      - BASE_USER_GID=${BASE_USER_GID:-1000}
       - LANG=en_US.UTF-8
       - LC_CTYPE=en_US.UTF-8
       - LC_NUMERIC=en_US.UTF-8


### PR DESCRIPTION
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Signed-off-by: David Caro <david@dcaro.es>