### PR TITLE
docker: unpin rabbitmq image

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -237,7 +237,7 @@ services:
         - "curl http://localhost:9200/_cluster/health | grep '.status.:.\\(green\\|yellow\\)'"
 
   test-rabbitmq:
-    image: rabbitmq:3.6.14
+    image: rabbitmq
     healthcheck:
       timeout: 5s
       interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
         - "curl http://localhost:9200/_cluster/health | grep '.status.:.\\(green\\|yellow\\)'"
 
   rabbitmq:
-    image: rabbitmq:3.6.14
+    image: rabbitmq
     healthcheck:
       timeout: 5s
       interval: 5s


### PR DESCRIPTION
## Description
Reverts b2bbcff as the upstream problem has now been solved.
See: https://github.com/docker-library/rabbitmq/issues/217

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.