### PR TITLE
mappings: hep-titles improvements

### DIFF
--- a/inspirehep/modules/records/mappings/records/hep.json
+++ b/inspirehep/modules/records/mappings/records/hep.json
@@ -1036,6 +1036,16 @@
                     "properties": {
                         "full_title": {
                             "analyzer": "title",
+                            "fields": {
+                                "search": {
+                                    "analyzer": "title_search_analyzer",
+                                    "type": "string"
+                                },
+                                "raw": {
+                                    "index": "not_analyzed",
+                                    "type": "string"
+                                }
+                            },
                             "type": "string"
                         },
                         "source": {
@@ -1097,7 +1107,19 @@
                     ],
                     "filter": [
                         "lowercase_normalizer",
-                        "ascii_normalizer"
+                        "ascii_normalizer",
+                        "porter_stem"
+                    ],
+                    "tokenizer": "icu_tokenizer",
+                    "type": "custom"
+                },
+                "title_search_analyzer": {
+                    "char_filter": [
+                        "tex_normalizer"
+                    ],
+                    "filter": [
+                        "lowercase",
+                        "bishingle_filter"
                     ],
                     "tokenizer": "icu_tokenizer",
                     "type": "custom"
@@ -1122,6 +1144,12 @@
                 },
                 "lowercase_normalizer": {
                     "type": "lowercase"
+                },
+                "bishingle_filter": {
+                    "type": "shingle",
+                    "min_shingle_size": 2,
+                    "max_shingle_size": 2,
+                    "output_unigrams": false
                 }
             }
         }

--- a/tests/integration/api/v1/test_common_serializers.py
+++ b/tests/integration/api/v1/test_common_serializers.py
@@ -35,9 +35,9 @@ def test_literature_recids_serializer(api_client):
 
     response_json = json.loads(response.data)
 
-    assert response_json['hits']['total'] == 2
+    assert response_json['hits']['total'] == 3
 
-    expected_recids = {1373790, 701585}
+    expected_recids = {1407506, 1373790, 701585}
     response_recids = set([recid for recid in response_json['hits']['recids']])
 
     assert response_recids == expected_recids


### PR DESCRIPTION
* Add ``titles.full_title.search`` which uses 2-shingles so that we
  have improved relevance. e.g. a search for 'n-body' should not match
  'Exact n-d scattering...three-body...'.
* In ``title`` analyzer, enable stemming (add ``porter_stem`` in token
  filters).

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>

## Related Issue
https://github.com/inspirehep/inspire-next/issues/3048

## Motivation and Context
The second change is for being able to get results for ``separation`` when searching for ``separable``, as in the related issue.

Specifically, both of the chages are directed towards this query `f t N-body and t separable`, but in general improve our searching, as at least the 2-shingles (i.e. bigrams) are suggested by [ElasticSearch for finding associated words](https://www.elastic.co/guide/en/elasticsearch/guide/current/shingles.html).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
