### PR TITLE
theme: make results height scale with content

### DIFF
--- a/inspirehep/modules/theme/static/scss/format/brief-results.scss
+++ b/inspirehep/modules/theme/static/scss/format/brief-results.scss
@@ -86,7 +86,6 @@ article.search-result {
       width: 80%;
       border-right: 1px solid $silver;
       padding: 15px 0px 10px 20px;
-      min-height: 125px;
 
       .abstract {
         color: $concrete;


### PR DESCRIPTION
Signed-off-by: Dinika <dinika.saxena@cern.ch>

## Related Issue
closes #3041

## Motivation and Context
Currently some panels in the search results have a lot of empty space (shown below) when a record does not contain some fields.
![screenshot from 2017-12-14 18-00-15](https://user-images.githubusercontent.com/11242410/34004867-6adbd926-e0f9-11e7-83ea-983fa9d878d9.png)

The screenshot below shows how they will look after the changes
![screenshot from 2017-12-14 17-59-26](https://user-images.githubusercontent.com/11242410/34004930-a6659f40-e0f9-11e7-8298-0cc283e4b3ce.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
