### PR TITLE
search: show the selected sort option in the select box

### DIFF
--- a/inspirehep/modules/search/views.py
+++ b/inspirehep/modules/search/views.py
@@ -123,7 +123,7 @@ def sorted_options(sort_options):
     return [
         dict(
             title=v['title'],
-            value=('-{0}'.format(k)
+            value=('{0}'.format(k)
                    if v.get('default_order', 'asc') == 'desc' else k),
         )
         for k, v in


### PR DESCRIPTION
Signed-off-by: Dinika <dinika.saxena@cern.ch>

## Description
Along with [#56](https://github.com/inspirehep/inspirehep-search-js/pull/56/files) in inspirehep-search-js this pr fixes #3047

## Related Issue
closes #3047 

## Motivation and Context
[Invenio-search](https://github.com/inveniosoftware/invenio-search-js/blob/master/src/invenio-search-js/directives/invenioSearchSelectBox.js#L96) sets the value of the selected option as the current value without the dash prepending it. This results in modified option.value. However, since Angular relies on the original value (with the dash), the title of the selected option is not rendered in the select box.
To evade the mis-match between the previous and the new option.value, I decided to not add the dash to the sort options in the first place. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
