### PR TITLE
records: populate full_name_unicode_normalized

### DIFF
--- a/inspirehep/modules/records/mappings/records/hep.json
+++ b/inspirehep/modules/records/mappings/records/hep.json
@@ -211,6 +211,10 @@
                             },
                             "type": "string"
                         },
+                        "full_name_unicode_normalized": {
+                            "index": "not_analyzed",
+                            "type": "string"
+                        },
                         "ids": {
                             "properties": {
                                 "schema": {

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ install_requires = [
     'inspire-dojson~=58.0,>=58.0.0',
     'inspire-json-merger~=7.0,>=7.0.0',
     'inspire-matcher~=4.0,>=4.0.0',
-    'inspire-query-parser~=3.0,>=3.0.0',
+    'inspire-query-parser~=3.0,>=3.1.5',
     'inspire-schemas~=57.0,>=57.0.0',
     'inspire-utils~=2.0,>=2.0.0',
     'invenio-access>=1.0.0b1',


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add `author.full_name_normalized` not analysed field to hep.json. This field is populated by the receivers with the `NFKC` unicode normalized and lowercased `full_name` value. This value is already normalized by `inspire_utils.normalize_name`.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/inspirehep/inspire-query-parser/issues/63

## Related PR
https://github.com/inspirehep/inspire-query-parser/pull/64

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This field is needed in order to  support `exact-author` queries that perform
diacritic expansion and lowercase normalization.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Signed-off-by: Iuliana Voinea <iuliana.voinea@student.manchester.ac.uk>