### PR TITLE
workflows: store the record only when we have recid

### DIFF
--- a/inspirehep/modules/workflows/tasks/upload.py
+++ b/inspirehep/modules/workflows/tasks/upload.py
@@ -44,7 +44,9 @@ def store_record(obj, eng):
         record.update(obj.data, files_src_records=[obj])
 
     else:
-        record = InspireRecord.create(obj.data, id_=None)
+        # Skip the files to avoid issues in case the record has already pid
+        # TODO: remove the skip files once labs becomes master
+        record = InspireRecord.create(obj.data, id_=None, skip_files=True)
         # Create persistent identifier.
         created_pid = inspire_recid_minter(str(record.id), record).pid_value
         # Now that we have a recid, we can properly download the documents

--- a/inspirehep/modules/workflows/views.py
+++ b/inspirehep/modules/workflows/views.py
@@ -81,6 +81,7 @@ def _continue_workflow(workflow_id, recid, result=None):
         str(recid)
     )
     workflow_object.extra_data['recid'] = recid
+    workflow_object.data['control_number'] = recid
     workflow_object.extra_data['callback_result'] = result
     workflow_object.save()
     db.session.commit()

--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -26,6 +26,7 @@ from __future__ import absolute_import, division, print_function
 
 from workflow.patterns.controlflow import (
     IF,
+    IF_NOT,
     IF_ELSE,
 )
 
@@ -203,7 +204,7 @@ POSTENHANCE_RECORD = [
 ]
 
 
-SEND_TO_LEGACY_AND_WAIT = [
+SEND_TO_LEGACY = [
     IF_ELSE(
         is_marked('is-update'),
         [
@@ -212,8 +213,15 @@ SEND_TO_LEGACY_AND_WAIT = [
         ],
         [
             send_robotupload(mode="insert"),
-            wait_webcoll,
         ]
+    ),
+]
+
+
+WAIT_FOR_LEGACY_WEBCOLL = [
+    IF_NOT(
+        is_marked('is-update'),
+        wait_webcoll,
     ),
 ]
 
@@ -437,8 +445,9 @@ class Article(object):
                 is_record_accepted,
                 (
                     POSTENHANCE_RECORD +
+                    SEND_TO_LEGACY +
                     STORE_RECORD +
-                    SEND_TO_LEGACY_AND_WAIT +
+                    WAIT_FOR_LEGACY_WEBCOLL +
                     NOTIFY_ACCEPTED +
                     NOTIFY_CURATOR_IF_CORE
                 ),


### PR DESCRIPTION
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Until we use labs as master, we need the recid to be minted on legacy
first, and then store the record locally.

Signed-off-by: David Caro <david@dcaro.es>