### PR TITLE
migrator: don't try to load record on error

### DIFF
--- a/inspirehep/modules/migrator/tasks.py
+++ b/inspirehep/modules/migrator/tasks.py
@@ -347,10 +347,10 @@ def migrate_and_insert_record(raw_record, skip_files=False):
     except Exception as e:
         LOGGER.exception('Migrator DoJSON Error')
         error = e
-
-    recid = json_record['control_number']
-    prod_record = InspireProdRecords(recid=recid)
-    prod_record.marcxml = raw_record
+    else:
+        recid = json_record['control_number']
+        prod_record = InspireProdRecords(recid=recid)
+        prod_record.marcxml = raw_record
 
     try:
         if not error:


### PR DESCRIPTION
That way when there's a migration error, we don't fail before
handling the error.

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Signed-off-by: David Caro <david@dcaro.es>