### PR TITLE
migrator: use a special queue for the one-off migrations

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -199,7 +199,7 @@ services:
   test-worker:
     extends:
       service: test-service_base
-    command: celery worker -E -A inspirehep.celery --loglevel=INFO --purge
+    command: celery worker -E -A inspirehep.celery --loglevel=INFO --purge -Q celery,migrator
     volumes_from:
       - test-static
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,7 @@ services:
   worker:
     extends:
       service: service_base
-    command: celery worker -E -A inspirehep.celery --loglevel=INFO --purge
+    command: celery worker -E -A inspirehep.celery --loglevel=INFO --purge -Q cerely,migrator
     volumes_from:
       - static
     depends_on:

--- a/inspirehep/modules/migrator/tasks.py
+++ b/inspirehep/modules/migrator/tasks.py
@@ -103,7 +103,7 @@ def split_stream(stream):
             buf.append(row)
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, queue='migrator')
 def remigrate_records(only_broken=True, skip_files=None):
     """Remigrate records.
 
@@ -126,7 +126,7 @@ def remigrate_records(only_broken=True, skip_files=None):
         migrate_chunk.delay(records, skip_files=skip_files)
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, queue='migrator')
 def migrate(source, wait_for_results=False, skip_files=None):
     """Main migration function."""
     if skip_files is None:
@@ -204,7 +204,12 @@ def create_index_op(record):
     }
 
 
-@shared_task(ignore_result=False, compress='zlib', acks_late=True)
+@shared_task(
+    ignore_result=False,
+    compress='zlib',
+    acks_late=True,
+    queue='migrator',
+)
 def migrate_chunk(chunk, skip_files=False):
     models_committed.disconnect(index_after_commit)
 


### PR DESCRIPTION
This will help in order to avoid starving the regular workflows.
Requires changes in the celery config in puppet.

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Signed-off-by: David Caro <david@dcaro.es>