### PR TITLE
Cleanup the workflow object at the start

### DIFF
--- a/inspirehep/modules/authors/tasks.py
+++ b/inspirehep/modules/authors/tasks.py
@@ -22,105 +22,30 @@
 
 from __future__ import absolute_import, division, print_function
 
-import copy
-import datetime
 import os
 
-from flask import current_app, url_for
-from sqlalchemy.orm.exc import NoResultFound
+from flask import current_app
 
-from invenio_accounts.models import User
-from invenio_oauthclient.models import UserIdentity
-
-from inspire_dojson.utils import strip_empty_values
-from inspire_schemas.api import validate
-from inspirehep.modules.forms.utils import filter_empty_elements
 from inspirehep.modules.workflows.utils import with_debug_logging
-
-from .dojson.model import updateform
-
-
-def formdata_to_model(obj, formdata):
-    """Manipulate form data to match authors data model."""
-    form_fields = copy.deepcopy(formdata)
-
-    filter_empty_elements(
-        form_fields,
-        ['institution_history', 'advisors',
-         'websites', 'experiments']
-    )
-    data = updateform.do(form_fields)
-
-    # ===========
-    # Collections
-    # ===========
-    data['_collections'] = ['Authors']
-
-    # ======
-    # Schema
-    # ======
-    if '$schema' not in data and '$schema' in obj.data:
-        data['$schema'] = obj.data.get('$schema')
-
-    if '$schema' in data and not data['$schema'].startswith('http'):
-        data['$schema'] = url_for(
-            'invenio_jsonschemas.get_schema',
-            schema_path="records/{0}".format(data['$schema'])
-        )
-
-    author_name = ''
-
-    if 'family_name' in form_fields and form_fields['family_name']:
-        author_name = form_fields['family_name'].strip() + ', '
-    if 'given_names' in form_fields and form_fields['given_names']:
-        author_name += form_fields['given_names']
-
-    if author_name:
-        data.get('name', {})['value'] = author_name
-
-    # Add comments to extra data
-    if 'extra_comments' in form_fields and form_fields['extra_comments']:
-        data.setdefault('_private_notes', []).append({
-            'source': 'submitter',
-            'value': form_fields['extra_comments']
-        })
-
-    data['stub'] = False
-
-    # ==========
-    # Submitter Info
-    # ==========
-    try:
-        user_email = User.query.get(obj.id_user).email
-    except AttributeError:
-        user_email = ''
-    try:
-        orcid = UserIdentity.query.filter_by(
-            id_user=obj.id_user,
-            method='orcid'
-        ).one().id
-    except NoResultFound:
-        orcid = ''
-    data['acquisition_source'] = dict(
-        email=user_email,
-        datetime=datetime.datetime.utcnow().isoformat(),
-        method="submitter",
-        orcid=orcid,
-        submission_number=str(obj.id),
-        internal_uid=int(obj.id_user),
-    )
-
-    data = strip_empty_values(data)
-
-    validate(data, 'authors')
-
-    return data
 
 
 @with_debug_logging
 def curation_ticket_needed(obj, eng):
     """Check if the a curation ticket is needed."""
     return obj.extra_data.get("ticket", False)
+
+
+def _get_user_comment(workflow_object):
+    user_comment = next(
+        (
+            note.get('value')
+            for note in workflow_object.data.get('_private_notes', [])
+            if note.get('source') == 'submitter'
+        ),
+        '',
+    )
+
+    return user_comment
 
 
 def new_ticket_context(user, obj):
@@ -132,7 +57,7 @@ def new_ticket_context(user, obj):
         email=user.email,
         object=obj,
         subject=subject,
-        user_comment=obj.extra_data.get('formdata', {}).get('extra_comments', ''),
+        user_comment=_get_user_comment(obj),
     )
 
 
@@ -141,14 +66,17 @@ def update_ticket_context(user, obj):
     subject = u"Your update to author {0} on INSPIRE".format(
         obj.data.get("name").get("preferred_name")
     )
-    record_url = os.path.join(current_app.config["AUTHORS_UPDATE_BASE_URL"], "record",
-                              str(obj.data.get("control_number", "")))
+    record_url = os.path.join(
+        current_app.config["AUTHORS_UPDATE_BASE_URL"],
+        "record",
+        str(obj.data.get("control_number", "")),
+    )
     return dict(
         email=user.email,
         url=record_url,
         bibedit_url=record_url + "/edit",
         subject=subject,
-        user_comment=obj.extra_data.get('formdata', {}).get('extra_comments', ''),
+        user_comment=_get_user_comment(obj),
     )
 
 
@@ -180,5 +108,5 @@ def curation_ticket_context(user, obj):
         recid=recid,
         subject=subject,
         record_url=record_url,
-        user_comment=obj.extra_data.get('formdata', {}).get('extra_comments', ''),
+        user_comment=_get_user_comment(obj),
     )

--- a/inspirehep/modules/authors/views.py
+++ b/inspirehep/modules/authors/views.py
@@ -24,6 +24,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import copy
 import os
 import re
 
@@ -279,6 +280,10 @@ def submitupdate():
     )
     workflow_object.data = data
     workflow_object.extra_data = extra_data
+    workflow_object.extra_data['source_data'] = {
+        'data': copy.deepcopy(data),
+        'extra_data': copy.deepcopy(extra_data),
+    }
     workflow_object.save()
     db.session.commit()
 
@@ -314,6 +319,10 @@ def submitnew():
     )
     workflow_object.data = data
     workflow_object.extra_data = extra_data
+    workflow_object.extra_data['source_data'] = {
+        'data': copy.deepcopy(data),
+        'extra_data': copy.deepcopy(extra_data),
+    }
     workflow_object.save()
     db.session.commit()
 
@@ -372,7 +381,6 @@ def reviewhandler():
     visitor.visit(form)
 
     workflow_object = workflow_object_class.get(objectid)
-    workflow_object.data = formdata_to_model(workflow_object, visitor.data)
     data, _ = formdata_to_model(
         formdata=visitor.data,
         id_workflow=workflow_object.id,
@@ -381,7 +389,6 @@ def reviewhandler():
     workflow_object.data = data
     workflow_object.extra_data["approved"] = True
     workflow_object.extra_data["ticket"] = request.form.get('ticket') == "True"
-    workflow_object.extra_data['formdata'] = visitor.data
     workflow_object.save()
     db.session.commit()
 

--- a/inspirehep/modules/authors/views.py
+++ b/inspirehep/modules/authors/views.py
@@ -24,7 +24,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import copy
 import os
 import re
 
@@ -53,7 +52,7 @@ from inspirehep.modules.forms.form import DataExporter
 
 from .forms import AuthorUpdateForm
 from .permissions import holdingpen_author_permission
-from .tasks import formdata_to_model
+from .utils import formdata_to_model
 
 
 blueprint = Blueprint(
@@ -265,16 +264,21 @@ def submitupdate():
     form = AuthorUpdateForm(formdata=request.form, is_update=True)
     visitor = DataExporter()
     visitor.visit(form)
+    id_user = current_user.get_id()
 
     workflow_object = workflow_object_class.create(
         data={},
-        id_user=current_user.get_id(),
+        id_user=id_user,
         data_type="authors"
     )
-
-    workflow_object.extra_data['formdata'] = copy.deepcopy(visitor.data)
-    workflow_object.extra_data['is-update'] = True
-    workflow_object.data = formdata_to_model(workflow_object, visitor.data)
+    data, extra_data = formdata_to_model(
+        formdata=visitor.data,
+        id_workflow=workflow_object.id,
+        id_user=id_user,
+        is_update=True,
+    )
+    workflow_object.data = data
+    workflow_object.extra_data = extra_data
     workflow_object.save()
     db.session.commit()
 
@@ -295,15 +299,21 @@ def submitnew():
     form = AuthorUpdateForm(formdata=request.form)
     visitor = DataExporter()
     visitor.visit(form)
+    id_user = current_user.get_id()
 
     workflow_object = workflow_object_class.create(
         data={},
-        id_user=current_user.get_id(),
+        id_user=id_user,
         data_type="authors"
     )
-    workflow_object.extra_data['formdata'] = copy.deepcopy(visitor.data)
-    workflow_object.extra_data['is-update'] = False
-    workflow_object.data = formdata_to_model(workflow_object, visitor.data)
+    data, extra_data = formdata_to_model(
+        formdata=visitor.data,
+        id_workflow=workflow_object.id,
+        id_user=id_user,
+        is_update=False,
+    )
+    workflow_object.data = data
+    workflow_object.extra_data = extra_data
     workflow_object.save()
     db.session.commit()
 
@@ -362,10 +372,16 @@ def reviewhandler():
     visitor.visit(form)
 
     workflow_object = workflow_object_class.get(objectid)
+    workflow_object.data = formdata_to_model(workflow_object, visitor.data)
+    data, _ = formdata_to_model(
+        formdata=visitor.data,
+        id_workflow=workflow_object.id,
+        id_user=current_user.get_id(),
+    )
+    workflow_object.data = data
     workflow_object.extra_data["approved"] = True
     workflow_object.extra_data["ticket"] = request.form.get('ticket') == "True"
     workflow_object.extra_data['formdata'] = visitor.data
-    workflow_object.data = formdata_to_model(workflow_object, visitor.data)
     workflow_object.save()
     db.session.commit()
 

--- a/inspirehep/modules/literaturesuggest/normalizers.py
+++ b/inspirehep/modules/literaturesuggest/normalizers.py
@@ -74,19 +74,19 @@ def check_journal_existence(title):
     return db.session.execute(query)
 
 
-def normalize_formdata(obj, formdata):
-    formdata = normalize_provided_doi(obj, formdata)
-    formdata = get_user_orcid(obj, formdata)
-    formdata = get_user_email(obj, formdata)
-    formdata = split_page_range_article_id(obj, formdata)
-    formdata = normalize_journal_title(obj, formdata)
-    formdata = remove_english_language(obj, formdata)
-    formdata = find_book_id(obj, formdata)
+def normalize_formdata(id_user, formdata):
+    formdata = normalize_provided_doi(formdata)
+    formdata = get_user_orcid(id_user, formdata)
+    formdata = get_user_email(id_user, formdata)
+    formdata = split_page_range_article_id(formdata)
+    formdata = normalize_journal_title(formdata)
+    formdata = remove_english_language(formdata)
+    formdata = find_book_id(formdata)
 
     return formdata
 
 
-def normalize_provided_doi(obj, formdata):
+def normalize_provided_doi(formdata):
     try:
         doi = formdata.get('doi')
         formdata['doi'] = normalize_doi(doi)
@@ -96,26 +96,26 @@ def normalize_provided_doi(obj, formdata):
     return formdata
 
 
-def get_user_email(obj, formdata):
+def get_user_email(id_user, formdata):
     try:
-        formdata['email'] = User.query.get(obj.id_user).email
+        formdata['email'] = User.query.get(id_user).email
     except AttributeError:
         formdata['email'] = None
 
     return formdata
 
 
-def get_user_orcid(obj, formdata):
+def get_user_orcid(id_user, formdata):
     try:
         formdata['orcid'] = UserIdentity.query.filter_by(
-            id_user=obj.id_user, method='orcid').one().id
+            id_user=id_user, method='orcid').one().id
     except NoResultFound:
         formdata['orcid'] = None
 
     return formdata
 
 
-def split_page_range_article_id(obj, formdata):
+def split_page_range_article_id(formdata):
     page_range_article_id = formdata.get('page_range_article_id')
 
     if page_range_article_id:
@@ -127,7 +127,7 @@ def split_page_range_article_id(obj, formdata):
     return formdata
 
 
-def normalize_journal_title(obj, formdata):
+def normalize_journal_title(formdata):
     if formdata.get('type_of_doc') == 'book' or formdata.get('type_of_doc') == 'chapter':
         result = check_journal_existence(formdata.get('series_title'))
         if result.rowcount > 0:
@@ -137,7 +137,7 @@ def normalize_journal_title(obj, formdata):
     return formdata
 
 
-def find_book_id(obj, formdata):
+def find_book_id(formdata):
     if formdata.get('type_of_doc') == 'chapter':
         if not formdata.get('parent_book'):
             result = list(check_book_existence(formdata.get('book_title')))
@@ -146,7 +146,7 @@ def find_book_id(obj, formdata):
     return formdata
 
 
-def remove_english_language(obj, formdata):
+def remove_english_language(formdata):
     if formdata.get('language') == 'en':
         del formdata['language']
         del formdata['title_translation']

--- a/inspirehep/modules/literaturesuggest/tasks.py
+++ b/inspirehep/modules/literaturesuggest/tasks.py
@@ -22,203 +22,37 @@
 
 from __future__ import absolute_import, division, print_function
 
-import copy
-import datetime
-
 from idutils import is_arxiv_post_2007
 
-from inspire_schemas.api import LiteratureBuilder
-from inspire_utils.helpers import force_list
 from inspire_utils.record import get_value
-from inspirehep.modules.forms.utils import filter_empty_elements
 from inspirehep.modules.workflows.utils import with_debug_logging
 from inspirehep.utils.record import get_title
 
 
-def formdata_to_model(obj, formdata):
-    """Manipulate form data to match literature data model."""
-    def _is_arxiv_url(url):
-        return 'arxiv.org' in url
-
-    form_fields = copy.deepcopy(formdata)
-    filter_empty_elements(
-        form_fields, ['authors', 'supervisors', 'report_numbers']
+def _get_user_comment(workflow_object):
+    user_comment = next(
+        (
+            note.get('value')
+            for note in workflow_object.data.get('_private_notes', [])
+            if note.get('source') == 'submitter'
+        ),
+        '',
     )
 
-    builder = LiteratureBuilder(source='submitter')
-
-    for author in form_fields.get('authors', []):
-        builder.add_author(builder.make_author(
-            author['full_name'],
-            affiliations=force_list(author['affiliation'])
-            if author['affiliation'] else None,
-            roles=['author']
-        ))
-
-    for supervisor in form_fields.get('supervisors', []):
-        builder.add_author(builder.make_author(
-            supervisor['full_name'],
-            affiliations=force_list(supervisor['affiliation'])
-            if author['affiliation'] else None,
-            roles=['supervisor']
-        ))
-
-    builder.add_title(title=form_fields.get('title'))
-
-    document_type = 'conference paper' if form_fields.get('conf_name') \
-        else form_fields.get('type_of_doc', [])
-    if document_type == 'chapter':
-        document_type = 'book chapter'
-
-    builder.add_document_type(
-        document_type=document_type
-    )
-
-    builder.add_abstract(
-        abstract=form_fields.get('abstract'),
-        source='arXiv' if form_fields.get('categories') else None
-    )
-
-    if form_fields.get('arxiv_id') and form_fields.get('categories'):
-        builder.add_arxiv_eprint(
-            arxiv_id=form_fields.get('arxiv_id'),
-            arxiv_categories=form_fields.get('categories').split()
-        )
-
-    builder.add_doi(doi=form_fields.get('doi'))
-
-    builder.add_inspire_categories(
-        subject_terms=form_fields.get('subject_term'),
-        source='user'
-    )
-
-    for key in ('extra_comments', 'nonpublic_note',
-                'hidden_notes', 'conf_name', 'references'):
-        builder.add_private_note(
-            private_notes=form_fields.get(key)
-        )
-
-    year = form_fields.get('year')
-    try:
-        year = int(year)
-    except (TypeError, ValueError):
-        year = None
-
-    builder.add_preprint_date(
-        preprint_date=form_fields.get('preprint_created')
-    )
-
-    if form_fields.get('type_of_doc') == 'thesis':
-        builder.add_thesis(
-            defense_date=form_fields.get('defense_date'),
-            degree_type=form_fields.get('degree_type'),
-            institution=form_fields.get('institution'),
-            date=form_fields.get('thesis_date')
-        )
-
-    if form_fields.get('type_of_doc') == 'chapter':
-        if not form_fields.get('journal_title'):
-            builder.add_book_series(title=form_fields.get('series_title'))
-
-    if form_fields.get('type_of_doc') == 'book':
-            if form_fields.get('journal_title'):
-                form_fields['volume'] = form_fields.get('series_volume')
-            else:
-                builder.add_book_series(title=form_fields.get('series_title'),
-                                        volume=form_fields.get('series_volume')
-                                        )
-            builder.add_book(
-                publisher=form_fields.get('publisher_name'),
-                place=form_fields.get('publication_place'),
-                date=form_fields.get('publication_date'))
-
-    builder.add_publication_info(
-        year=year,
-        cnum=form_fields.get('conference_id'),
-        journal_issue=form_fields.get('issue'),
-        journal_title=form_fields.get('journal_title'),
-        journal_volume=form_fields.get('volume'),
-        page_start=form_fields.get('start_page'),
-        page_end=form_fields.get('end_page'),
-        artid=form_fields.get('artid'),
-        parent_record=form_fields.get('parent_book')
-    )
-
-    builder.add_accelerator_experiments_legacy_name(
-        legacy_name=form_fields.get('experiment')
-    )
-
-    language = form_fields.get('other_language') \
-        if form_fields.get('language') == 'oth' \
-        else form_fields.get('language')
-    builder.add_language(language=language)
-
-    if form_fields.get('title_translation'):
-        builder.add_title_translation(
-            title=form_fields['title_translation'],
-            language='en',
-        )
-
-    builder.add_title(
-        title=form_fields.get('title_arXiv'),
-        source='arXiv'
-    )
-
-    builder.add_title(
-        title=form_fields.get('title_crossref'),
-        source='crossref'
-    )
-
-    builder.add_license(url=form_fields.get('license_url'))
-
-    builder.add_public_note(public_note=form_fields.get('public_notes'))
-
-    builder.add_public_note(
-        public_note=form_fields.get('note'),
-        source='arXiv' if form_fields.get('categories') else 'CrossRef'
-    )
-
-    form_url = form_fields.get('url')
-    form_additional_url = form_fields.get('additional_url')
-    if form_url and not _is_arxiv_url(form_url):
-        obj.extra_data['submission_pdf'] = form_url
-        if not form_additional_url:
-            builder.add_url(url=form_url)
-
-    if form_additional_url and not _is_arxiv_url(form_additional_url):
-        builder.add_url(url=form_additional_url)
-
-    [builder.add_report_number(
-        report_number=report_number.get('report_number')
-    ) for report_number in form_fields.get('report_numbers', [])]
-
-    builder.add_collaboration(collaboration=form_fields.get('collaboration'))
-
-    builder.add_acquisition_source(
-        datetime=datetime.datetime.utcnow().isoformat(),
-        submission_number=obj.id,
-        internal_uid=int(obj.id_user),
-        email=form_fields.get('email'),
-        orcid=form_fields.get('orcid'),
-        method='submitter'
-    )
-    builder.validate_record()
-
-    return builder.record
+    return user_comment
 
 
 def new_ticket_context(user, obj):
     """Context for literature new tickets."""
     title = get_title(obj.data)
     subject = u"Your suggestion to INSPIRE: {0}".format(title)
-    user_comment = obj.extra_data.get('formdata', {}).get('extra_comments', '')
+    user_comment = _get_user_comment(obj)
     identifiers = get_value(obj.data, "external_system_numbers.value") or []
     return dict(
         email=user.email,
         title=title,
         identifier=identifiers or "",
         user_comment=user_comment,
-        references=obj.extra_data.get('formdata', {}).get('references'),
         object=obj,
         subject=subject
     )
@@ -249,22 +83,20 @@ def curation_ticket_context(user, obj):
         "doi:{0}".format(doi)
         for doi in get_value(obj.data, 'dois.value') or []
     ]
-    link_to_pdf = obj.extra_data.get('formdata', {}).get('url')
+    link_to_pdf = obj.extra_data.get('submission_pdf')
 
     subject = ' '.join(filter(
         lambda x: x is not None,
         arxiv_ids + dois + report_numbers + ['(#{0})'.format(recid)]
     ))
 
-    references = obj.extra_data.get('formdata').get('references')
-    user_comment = obj.extra_data.get('formdata', {}).get('extra_comments', '')
+    user_comment = _get_user_comment(obj)
 
     return dict(
         recid=recid,
         record_url=record_url,
         link_to_pdf=link_to_pdf,
         email=user.email,
-        references=references,
         user_comment=user_comment,
         subject=subject
     )

--- a/inspirehep/modules/literaturesuggest/templates/literaturesuggest/tickets/curation_core.html
+++ b/inspirehep/modules/literaturesuggest/templates/literaturesuggest/tickets/curation_core.html
@@ -30,8 +30,3 @@ Record url: {{ record_url|safe }}
 User comments:
   {{ user_comment|safe }}
 {% endif %}
-
-{% if references %}
-References:
-  {{ references|safe }}
-{% endif %}

--- a/inspirehep/modules/literaturesuggest/templates/literaturesuggest/tickets/curator_submitted.html
+++ b/inspirehep/modules/literaturesuggest/templates/literaturesuggest/tickets/curator_submitted.html
@@ -23,7 +23,3 @@
   User comments:
   {{ user_comment|safe }}
 {% endif %}
-{%- if references %}
-  References:
-  {{ references|safe }}
-{% endif %}

--- a/inspirehep/modules/literaturesuggest/utils.py
+++ b/inspirehep/modules/literaturesuggest/utils.py
@@ -1,0 +1,209 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import copy
+import datetime
+
+from inspire_schemas.api import LiteratureBuilder
+from inspire_utils.helpers import force_list
+
+from inspirehep.modules.forms.utils import filter_empty_elements
+
+
+def formdata_to_model(formdata, id_workflow, id_user):
+    """Generate the record model dict and extra_data dict from the form data.
+
+    Returns:
+        tuple(dict, dict): tuple containing the dict representaion of a record
+            and the extra_data to create a new workflow.
+    """
+    def _is_arxiv_url(url):
+        return 'arxiv.org' in url
+
+    builder = LiteratureBuilder(source='submitter')
+    extra_data = {}
+
+    form_fields = copy.deepcopy(formdata)
+    filter_empty_elements(
+        form_fields, ['authors', 'supervisors', 'report_numbers']
+    )
+
+    for author in form_fields.get('authors', []):
+        builder.add_author(builder.make_author(
+            author['full_name'],
+            affiliations=force_list(author['affiliation'])
+            if author['affiliation'] else None,
+            roles=['author']
+        ))
+
+    for supervisor in form_fields.get('supervisors', []):
+        builder.add_author(builder.make_author(
+            supervisor['full_name'],
+            affiliations=force_list(supervisor['affiliation'])
+            if author['affiliation'] else None,
+            roles=['supervisor']
+        ))
+
+    builder.add_title(title=form_fields.get('title'))
+
+    document_type = 'conference paper' if form_fields.get('conf_name') \
+        else form_fields.get('type_of_doc', [])
+    if document_type == 'chapter':
+        document_type = 'book chapter'
+
+    builder.add_document_type(
+        document_type=document_type
+    )
+
+    builder.add_abstract(
+        abstract=form_fields.get('abstract'),
+        source='arXiv' if form_fields.get('categories') else None
+    )
+
+    if form_fields.get('arxiv_id') and form_fields.get('categories'):
+        builder.add_arxiv_eprint(
+            arxiv_id=form_fields.get('arxiv_id'),
+            arxiv_categories=form_fields.get('categories').split()
+        )
+
+    builder.add_doi(doi=form_fields.get('doi'))
+
+    builder.add_inspire_categories(
+        subject_terms=form_fields.get('subject_term'),
+        source='user'
+    )
+
+    for key in ('extra_comments', 'nonpublic_note',
+                'hidden_notes', 'conf_name', 'references'):
+        builder.add_private_note(
+            private_notes=form_fields.get(key)
+        )
+
+    year = form_fields.get('year')
+    try:
+        year = int(year)
+    except (TypeError, ValueError):
+        year = None
+
+    builder.add_preprint_date(
+        preprint_date=form_fields.get('preprint_created')
+    )
+
+    if form_fields.get('type_of_doc') == 'thesis':
+        builder.add_thesis(
+            defense_date=form_fields.get('defense_date'),
+            degree_type=form_fields.get('degree_type'),
+            institution=form_fields.get('institution'),
+            date=form_fields.get('thesis_date')
+        )
+
+    if form_fields.get('type_of_doc') == 'chapter':
+        if not form_fields.get('journal_title'):
+            builder.add_book_series(title=form_fields.get('series_title'))
+
+    if form_fields.get('type_of_doc') == 'book':
+        if form_fields.get('journal_title'):
+            form_fields['volume'] = form_fields.get('series_volume')
+        else:
+            builder.add_book_series(title=form_fields.get('series_title'),
+                                    volume=form_fields.get('series_volume')
+                                    )
+        builder.add_book(
+            publisher=form_fields.get('publisher_name'),
+            place=form_fields.get('publication_place'),
+            date=form_fields.get('publication_date'))
+
+    builder.add_publication_info(
+        year=year,
+        cnum=form_fields.get('conference_id'),
+        journal_issue=form_fields.get('issue'),
+        journal_title=form_fields.get('journal_title'),
+        journal_volume=form_fields.get('volume'),
+        page_start=form_fields.get('start_page'),
+        page_end=form_fields.get('end_page'),
+        artid=form_fields.get('artid'),
+        parent_record=form_fields.get('parent_book')
+    )
+
+    builder.add_accelerator_experiments_legacy_name(
+        legacy_name=form_fields.get('experiment')
+    )
+
+    language = form_fields.get('other_language') \
+        if form_fields.get('language') == 'oth' \
+        else form_fields.get('language')
+    builder.add_language(language=language)
+
+    if form_fields.get('title_translation'):
+        builder.add_title_translation(
+            title=form_fields['title_translation'],
+            language='en',
+        )
+
+    builder.add_title(
+        title=form_fields.get('title_arXiv'),
+        source='arXiv'
+    )
+
+    builder.add_title(
+        title=form_fields.get('title_crossref'),
+        source='crossref'
+    )
+
+    builder.add_license(url=form_fields.get('license_url'))
+
+    builder.add_public_note(public_note=form_fields.get('public_notes'))
+
+    builder.add_public_note(
+        public_note=form_fields.get('note'),
+        source='arXiv' if form_fields.get('categories') else 'CrossRef'
+    )
+
+    form_url = form_fields.get('url')
+    form_additional_url = form_fields.get('additional_url')
+    if form_url and not _is_arxiv_url(form_url):
+        extra_data['submission_pdf'] = form_url
+        if not form_additional_url:
+            builder.add_url(url=form_url)
+
+    if form_additional_url and not _is_arxiv_url(form_additional_url):
+        builder.add_url(url=form_additional_url)
+
+    [builder.add_report_number(
+        report_number=report_number.get('report_number')
+    ) for report_number in form_fields.get('report_numbers', [])]
+
+    builder.add_collaboration(collaboration=form_fields.get('collaboration'))
+
+    builder.add_acquisition_source(
+        datetime=datetime.datetime.utcnow().isoformat(),
+        submission_number=id_workflow,
+        internal_uid=int(id_user),
+        email=form_fields.get('email'),
+        orcid=form_fields.get('orcid'),
+        method='submitter'
+    )
+    builder.validate_record()
+
+    return builder.record, extra_data

--- a/inspirehep/modules/literaturesuggest/views.py
+++ b/inspirehep/modules/literaturesuggest/views.py
@@ -100,6 +100,10 @@ def submit():
     )
     workflow_object.data = data
     workflow_object.extra_data = extra_data
+    workflow_object.extra_data['source_data'] = {
+        'data': copy.deepcopy(data),
+        'extra_data': copy.deepcopy(extra_data),
+    }
     workflow_object.save()
     db.session.commit()
 

--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -40,6 +40,7 @@ from inspirehep.modules.workflows.tasks.arxiv import (
 )
 from inspirehep.modules.workflows.tasks.actions import (
     add_core,
+    cleanup_workflow,
     error_workflow,
     halt_record,
     is_record_relevant,
@@ -434,6 +435,8 @@ INIT_MARKS = [
 PRE_PROCESSING = [
     # Make sure schema is set for proper indexing in Holding Pen
     set_schema,
+    cleanup_workflow,
+    save_workflow,
     INIT_MARKS,
 ]
 

--- a/inspirehep/modules/workflows/workflows/author.py
+++ b/inspirehep/modules/workflows/workflows/author.py
@@ -27,10 +27,12 @@ from __future__ import absolute_import, division, print_function
 from workflow.patterns.controlflow import IF, IF_ELSE, IF_NOT
 
 from inspirehep.modules.workflows.tasks.actions import (
+    cleanup_workflow,
     halt_record,
     in_production_mode,
     is_marked,
     is_record_accepted,
+    save_workflow,
 )
 
 from inspirehep.modules.workflows.tasks.submission import (
@@ -126,6 +128,8 @@ class Author(object):
     workflow = [
         # Make sure schema is set for proper indexing in Holding Pen
         set_schema,
+        cleanup_workflow,
+        save_workflow,
         IF_ELSE(
             is_marked('is-update'),
             SEND_UPDATE_NOTIFICATION,

--- a/tests/integration/literaturesuggest/test_literaturesuggest_normalizers.py
+++ b/tests/integration/literaturesuggest/test_literaturesuggest_normalizers.py
@@ -33,10 +33,6 @@ from inspirehep.modules.migrator.tasks import record_insert_or_replace
 from inspirehep.utils.record_getter import get_db_record
 
 
-class MockObj(object):
-    pass
-
-
 @pytest.fixture
 def book_with_another_document_type(app):
     """Temporarily add another document type to a book record."""
@@ -59,7 +55,6 @@ def test_check_book_existence_handles_multiple_document_types(book_with_another_
 
 
 def test_find_book_id(app):
-    obj = MockObj()
     formdata = {
         'book_title': 'The Large Hadron Collider',
         'parent_book': '',
@@ -71,13 +66,12 @@ def test_find_book_id(app):
         'parent_book': 'http://localhost:5000/api/literature/1373790',
         'type_of_doc': 'chapter',
     }
-    result = find_book_id(obj, formdata)
+    result = find_book_id(formdata)
 
     assert expected == result
 
 
 def test_normalize_to_journal_title_converts_from_series_title(app):
-    obj = MockObj()
     formdata = {
         'journal_title': '',
         'series_title': 'Physical Review',
@@ -89,6 +83,6 @@ def test_normalize_to_journal_title_converts_from_series_title(app):
         'series_title': 'Physical Review',
         'type_of_doc': 'book',
     }
-    result = normalize_journal_title(obj, formdata)
+    result = normalize_journal_title(formdata)
 
     assert expected == result

--- a/tests/unit/authors/test_authors_tasks.py
+++ b/tests/unit/authors/test_authors_tasks.py
@@ -41,11 +41,21 @@ from mocks import MockObj
 @pytest.fixture()
 def data():
     return {
-        "control_number": 123,
-        "name": {
-            "preferred_name": "John Doe"
+        'control_number': 123,
+        'name': {
+            'preferred_name': 'John Doe'
         },
-        "bai": "John.Doe.1"
+        'bai': 'John.Doe.1',
+        '_private_notes': [
+            {
+                'value': 'not user comment',
+                'source': 'arxiv',
+            },
+            {
+                'value': 'good user comment',
+                'source': 'submitter',
+            },
+        ],
     }
 
 
@@ -57,18 +67,25 @@ def unicode_data():
         'name': {
             'preferred_name': u'Diego Martínez',
         },
+        '_private_notes': [
+            {
+                'value': 'not user comment',
+                'source': 'arxiv',
+            },
+            {
+                'value': u'good user comment from user Diego Martínez',
+                'source': 'submitter',
+            },
+        ],
     }
 
 
 @pytest.fixture()
 def extra_data():
     return {
-        "formdata": {
-            "extra_comments": "Foo bar"
-        },
-        "reason": "Test reason",
-        "url": "http://example.com",
-        "recid": 123
+        'reason': 'Test reason',
+        'url': 'http://example.com',
+        'recid': 123,
     }
 
 
@@ -84,7 +101,7 @@ def test_new_ticket_context(data, extra_data, user):
     assert isinstance(ctx['object'], MockObj)
     assert ctx['email'] == 'foo@bar.com'
     assert ctx['subject'] == 'Your suggestion to INSPIRE: author John Doe'
-    assert ctx['user_comment'] == 'Foo bar'
+    assert ctx['user_comment'] == 'good user comment'
 
 
 def test_new_ticket_context_handles_unicode(unicode_data, extra_data, user):
@@ -94,7 +111,7 @@ def test_new_ticket_context_handles_unicode(unicode_data, extra_data, user):
     assert isinstance(ctx['object'], MockObj)
     assert ctx['email'] == 'foo@bar.com'
     assert ctx['subject'] == u'Your suggestion to INSPIRE: author Diego Martínez'
-    assert ctx['user_comment'] == 'Foo bar'
+    assert ctx['user_comment'] == u'good user comment from user Diego Martínez'
 
 
 def test_update_ticket_context(data, extra_data, user):
@@ -107,7 +124,7 @@ def test_update_ticket_context(data, extra_data, user):
             'url': 'http://inspirehep.net/record/123',
             'bibedit_url': 'http://inspirehep.net/record/123/edit',
             'email': 'foo@bar.com',
-            'user_comment': 'Foo bar',
+            'user_comment': 'good user comment',
             'subject': 'Your update to author John Doe on INSPIRE',
         }
         ctx = update_ticket_context(user, obj)
@@ -124,7 +141,7 @@ def test_update_ticket_context_handles_unicode(unicode_data, extra_data, user):
             'url': 'http://inspirehep.net/record/123',
             'bibedit_url': 'http://inspirehep.net/record/123/edit',
             'email': 'foo@bar.com',
-            'user_comment': 'Foo bar',
+            'user_comment': u'good user comment from user Diego Martínez',
             'subject': u'Your update to author Diego Martínez on INSPIRE',
         }
         ctx = update_ticket_context(user, obj)
@@ -146,7 +163,7 @@ def test_curation_ticket_context(data, extra_data, user):
     ctx = curation_ticket_context(user, obj)
     assert isinstance(ctx['object'], MockObj)
     assert ctx['recid'] == 123
-    assert ctx['user_comment'] == 'Foo bar'
+    assert ctx['user_comment'] == 'good user comment'
     assert ctx['subject'] == 'Curation needed for author John Doe [John.Doe.1]'
     assert ctx['email'] == 'foo@bar.com'
     assert ctx['record_url'] == 'http://example.com'
@@ -156,7 +173,7 @@ def test_curation_ticket_context_handles_unicode(unicode_data, extra_data, user)
     obj = MockObj(unicode_data, extra_data)
     ctx = curation_ticket_context(user, obj)
     assert isinstance(ctx['object'], MockObj)
-    assert ctx['user_comment'] == 'Foo bar'
+    assert ctx['user_comment'] == u'good user comment from user Diego Martínez'
     assert ctx['subject'] == u'Curation needed for author Diego Martínez [Diego.Martinez.Santos.1]'
     assert ctx['email'] == 'foo@bar.com'
     assert ctx['record_url'] == 'http://example.com'

--- a/tests/unit/literaturesuggest/test_literaturesuggest_normalizers.py
+++ b/tests/unit/literaturesuggest/test_literaturesuggest_normalizers.py
@@ -28,12 +28,7 @@ from inspirehep.modules.literaturesuggest.normalizers import (
 )
 
 
-class DummyObj(object):
-    pass
-
-
 def test_split_page_range_article_id():
-    obj = DummyObj()
     formdata = {'page_range_article_id': '789-890'}
 
     expected = {
@@ -42,13 +37,12 @@ def test_split_page_range_article_id():
         'page_range_article_id': '789-890',
         'start_page': '789',
     }
-    result = split_page_range_article_id(obj, formdata)
+    result = split_page_range_article_id(formdata)
 
     assert expected == result
 
 
 def test_remove_english_language():
-    obj = DummyObj()
     formdata = {
         'language': 'en',
         'title_translation': (
@@ -58,6 +52,6 @@ def test_remove_english_language():
     }
 
     expected = {}
-    result = remove_english_language(obj, formdata)
+    result = remove_english_language(formdata)
 
     assert expected == result

--- a/tests/unit/literaturesuggest/test_literaturesuggest_utils.py
+++ b/tests/unit/literaturesuggest/test_literaturesuggest_utils.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+from mock import patch
+
+from inspire_schemas.api import LiteratureBuilder, load_schema, validate
+from inspirehep.modules.literaturesuggest.utils import formdata_to_model
+
+
+def test_formdata_to_model_ignores_arxiv_pdf():
+    formdata = {
+        'type_of_doc': 'article',
+        'title': 'Test title',
+        'url': 'https://arxiv.org/pdf/1511.04200.pdf'
+    }
+
+    _, extra_data = formdata_to_model(formdata=formdata, id_workflow=1, id_user=1)
+
+    expected_extra_data = {}
+
+    assert extra_data == expected_extra_data
+
+
+def test_formdata_to_model_ignores_arxiv_additional_url():
+    formdata = {
+        'type_of_doc': 'article',
+        'title': 'Test title',
+        'additional_url': 'https://arxiv.org/abs/1511.04200'
+    }
+
+    data, _ = formdata_to_model(formdata=formdata, id_workflow=1, id_user=1)
+
+    assert 'urls' not in data
+
+
+def test_formdata_to_model_only_pdf():
+    formdata = {
+        'type_of_doc': 'article',
+        'title': 'Test title',
+        'url': 'https://ora.ox.ac.uk/content01.pdf'
+    }
+
+    _, extra_data = formdata_to_model(formdata=formdata, id_workflow=1, id_user=1)
+
+    expected_extra_data = {
+        'submission_pdf': 'https://ora.ox.ac.uk/content01.pdf'
+    }
+
+    assert expected_extra_data == extra_data
+
+
+def test_formdata_to_model_only_additional_url():
+    formdata = {
+        'type_of_doc': 'article',
+        'title': 'Test title',
+        'additional_url': 'https://ora.ox.ac.uk/splash_page.html'
+    }
+
+    data, extra_data = formdata_to_model(formdata=formdata, id_workflow=1, id_user=1)
+
+    expected_urls = [{
+        'value': 'https://ora.ox.ac.uk/splash_page.html'
+    }]
+
+    assert expected_urls == data['urls']
+    assert 'submission_pdf' not in extra_data
+
+
+def test_formdata_to_model_pdf_and_additional_url():
+    formdata = {
+        'type_of_doc': 'article',
+        'title': 'Test title',
+        'url': 'https://ora.ox.ac.uk/content01.pdf',
+        'additional_url': 'https://ora.ox.ac.uk/splash_page.html'
+    }
+
+    data, extra_data = formdata_to_model(formdata=formdata, id_workflow=1, id_user=1)
+
+    expected_extra_data = {
+        'submission_pdf': 'https://ora.ox.ac.uk/content01.pdf'
+    }
+
+    expected_urls = [{
+        'value': 'https://ora.ox.ac.uk/splash_page.html'
+    }]
+
+    assert expected_extra_data == extra_data
+    assert expected_urls == data['urls']
+
+
+@patch.object(LiteratureBuilder, 'validate_record')
+def test_formdata_to_model_only_book(mock_validate_record):
+    schema = load_schema('hep')
+    subschema = schema['properties']['book_series']
+
+    formdata = {
+        'series_title': 'Astrophysics No2',
+        'series_volume': 'Universe',
+        'type_of_doc': 'book',
+    }
+
+    expected_book_series = [
+        {
+            'title': 'Astrophysics No2',
+            'volume': 'Universe',
+        },
+    ]
+    data, _ = formdata_to_model(formdata=formdata, id_workflow=1, id_user=1)
+
+    assert validate(data['book_series'], subschema) is None
+    assert expected_book_series == data['book_series']
+
+
+@patch.object(LiteratureBuilder, 'validate_record')
+def test_formdata_to_model_only_thesis(mock_validate_record):
+    schema = load_schema('hep')
+    subschema = schema['properties']['thesis_info']
+
+    formdata = {
+        'defense_date': '2010-03-03',
+        'degree_type': 'phd',
+        'institution': 'Harvard',
+        'thesis_date': '2011-05-03',
+        'type_of_doc': 'thesis',
+    }
+
+    expected_thesis_info = {
+        'date': '2011-05-03',
+        'defense_date': '2010-03-03',
+        'degree_type': 'phd',
+        'institutions': [
+            {'name': 'Harvard'},
+        ],
+    }
+    data, _ = formdata_to_model(formdata=formdata, id_workflow=1, id_user=1)
+
+    assert validate(data['thesis_info'], subschema) is None
+    assert expected_thesis_info == data['thesis_info']
+
+
+@patch.object(LiteratureBuilder, 'validate_record')
+def test_formdata_to_model_only_chapter(mock_validate_record):
+    schema = load_schema('hep')
+    book_series_subschema = schema['properties']['book_series']
+    publication_info_subschema = schema['properties']['publication_info']
+
+    formdata = {
+        'end_page': '1200',
+        'parent_book': 'http://localhost:5000/api/literature/1373790',
+        'series_title': 'Astrophysics',
+        'start_page': '150',
+        'type_of_doc': 'chapter',
+    }
+
+    expected_book_series = [
+        {'title': 'Astrophysics'},
+    ]
+    expected_publication_info = [
+        {
+            'page_end': '1200',
+            'page_start': '150',
+            'parent_record': {
+                '$ref': 'http://localhost:5000/api/literature/1373790',
+            },
+        },
+    ]
+    data, _ = formdata_to_model(formdata=formdata, id_workflow=1, id_user=1)
+
+    assert validate(data['book_series'], book_series_subschema) is None
+    assert expected_book_series == data['book_series']
+
+    assert validate(data['publication_info'], publication_info_subschema) is None
+    assert expected_publication_info == data['publication_info']


### PR DESCRIPTION
If there's the data with what the workflow was started on it, use it
to clean up any changes that were made on the previous run.

Closes 3071
Depends on #3081 (not really, but without it it's useless).

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->