### PR TITLE
workflows: don't check previously rejected on updates

### DIFF
--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -310,16 +310,19 @@ ERROR_WITH_UNEXPECTED_WORKFLOW_PATH = [
 
 # Currently we handle harvests as if all were arxiv, that will have to change.
 PROCESS_HOLDINGPEN_MATCH_HARVEST = [
-    IF(
-        is_marked('previously_rejected'),
+    IF_NOT(
+        is_marked('is-update'),
         IF(
-            has_same_source('previously_rejected_matches'),
-            [
-                mark('approved', False),  # auto-reject
-                save_workflow,
-                stop_processing,
-            ],
-        )
+            is_marked('previously_rejected'),
+            IF(
+                has_same_source('previously_rejected_matches'),
+                [
+                    mark('approved', False),  # auto-reject
+                    save_workflow,
+                    stop_processing,
+                ],
+            )
+        ),
     ),
 
     IF_ELSE(
@@ -445,8 +448,8 @@ class Article(object):
         STOP_IF_TOO_OLD +
         NOTIFY_IF_SUBMISSION +
         MARK_IF_MATCH_IN_HOLDINGPEN +
-        PROCESS_HOLDINGPEN_MATCHES +
         MARK_IF_UPDATE +
+        PROCESS_HOLDINGPEN_MATCHES +
         ENHANCE_RECORD +
         STOP_IF_EXISTING_SUBMISSION +
         HALT_FOR_APPROVAL +


### PR DESCRIPTION
This will not be needed once we have the revival of workflows
mechanism, but for now, we have to ignore the rejected ones if
there's a match in the db.


<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Signed-off-by: David Caro <david@dcaro.es>