### PR TITLE
workflows: use non-numeric prefix when generating figure names

### DIFF
--- a/inspirehep/modules/workflows/tasks/arxiv.py
+++ b/inspirehep/modules/workflows/tasks/arxiv.py
@@ -171,7 +171,10 @@ def arxiv_plot_extract(obj, eng):
                 plot_name = os.path.basename(plot.get('url'))
                 key = plot_name
                 if plot_name in obj.files.keys:
-                    key = '{number}_{name}'.format(number=index, name=plot_name)
+                    key = 'w{number}_{name}'.format(
+                        number=index,
+                        name=plot_name,
+                    )
                 with open(plot.get('url')) as plot_file:
                     obj.files[key] = plot_file
 


### PR DESCRIPTION
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

That way we avoid the unlikely coincidence where the record id matches
the generated number in the figure name, and `add_figure` mistakes it
for a duplicate.

Signed-off-by: David Caro <david@dcaro.es>