### PR TITLE
theme: add "show authors and affs" label only once

### DIFF
--- a/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Inspire_Default_HTML_general_macros.tpl
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Inspire_Default_HTML_general_macros.tpl
@@ -54,7 +54,9 @@
 
 {% macro render_record_authors(record, is_brief, number_of_displayed_authors=10, show_affiliations=true, collaboration_only=false) %}
   {% set collaboration_displayed = [] %}
+  {% set author_and_collaboration_displayed = [] %}
   {% if record.collaborations and not record.get('corporate_author') %}
+    {% do author_and_collaboration_displayed.append(1) %}
     {% for collaboration in record.collaborations %}
       {% if collaboration['value'] %}
       <a href="/search?p=collaboration:'{{ collaboration['value'] }}'">{{ collaboration['value'] }}</a>
@@ -72,11 +74,9 @@
       {% endif %}
     {% endfor %}
     {% if record.authors is defined %}
-     ({{ render_author_names(record, record.authors[0], show_affiliation = True) }} <i>et al.</i>)
+      {% do author_and_collaboration_displayed.append(1) %}
+      ({{ render_author_names(record, record.authors[0], show_affiliation = True) }} <i>et al.</i>)
     {% endif %}
-    - <i><a id="authors-show-more" class="authors-show-more" data-toggle="modal" href="" data-target="#authors_{{ record['control_number'] }}">
-      Show {{ record.authors | count }} authors & affiliations
-    </a></i>
   {% endif %}
 
 
@@ -97,9 +97,7 @@
             ({{ render_author_names(record, authors[0], show_affiliation = True) }} <i>et al.</i>)
           {% endif %}
         {% else %}
-        - <i><a id="authors-show-more" class="authors-show-more" data-toggle="modal" href="" data-target="#authors_{{ record['control_number'] }}">
-          Show {{ record.authors | count }} authors & affiliations
-        </a></i>
+          {% do author_and_collaboration_displayed.append(1) %}
         {% endif %}
     {% else %}
         {% if not is_brief and show_affiliations %}
@@ -149,6 +147,11 @@
     {% endif %}
   {% elif record.get('corporate_author') %}
     {{ record.get('corporate_author')|join('; ') }}
+  {% endif %}
+  {% if author_and_collaboration_displayed|length > 0%}
+    <i><a id="authors-show-more" class="authors-show-more" data-toggle="modal" href="" data-target="#authors_{{ record['control_number'] }}">
+     Show {{ record.authors | count }} authors & affiliations
+    </a></i>
   {% endif %}
 {% endmacro %}
 


### PR DESCRIPTION
Signed-off-by: Dinika Saxena <dinika.saxena@cern.ch>

<!--- Provide a general summary of your changes in the Title above -->

## Description
PR #3057 was adding a `Show authors and collaborations` label for records that had an authors field. However, the PR resulted in some records showing this label twice (such as [this](https://labs.inspirehep.net/literature/1603990) one). This PR removes the duplicate labels.

![screenshot from 2017-12-22 20-11-23](https://user-images.githubusercontent.com/11242410/34309922-de226d94-e754-11e7-9838-495e07636796.png)

![screenshot from 2017-12-22 20-09-50](https://user-images.githubusercontent.com/11242410/34309925-e1b32002-e754-11e7-8638-e132f569e6f8.png)


## Related Issue
Properly fixes #3053 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
