### PR TITLE
procfile: add queue celery,migrator option

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -22,7 +22,7 @@
 
 web: gunicorn inspirehep.wsgi -c gunicorn.cfg
 cache: redis-server
-worker: celery worker -E -A inspirehep.celery --loglevel=INFO --workdir="${VIRTUAL_ENV}" --autoreload --pidfile="${VIRTUAL_ENV}/worker.pid" --purge
+worker: celery worker -E -A inspirehep.celery --loglevel=INFO --workdir="${VIRTUAL_ENV}" --autoreload --pidfile="${VIRTUAL_ENV}/worker.pid" --purge -Q celery,migrator
 workermon: celery flower -A inspirehep.celery
 # beat: celery beat -A inspirehep.celery --loglevel=INFO --workdir="${VIRTUAL_ENV}" --pidfile="${VIRTUAL_ENV}/worker_beat.pid"
 # mathoid: node_modules/mathoid/server.js -c mathoid.config.yaml


### PR DESCRIPTION
Update Procfile so that it matches our Docker configuration as per
inspirehep/inspire-next#3077.

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>

## Description
This was the issue that caused the migration of records hanging in macOS. Records were being inserted into the default `celery` named queue, but in #3077 they were inserted into a `migrator` named queue.

### Suggestion
@david-caro @jacquerie
Since the commands that are executed in the Procfile are the same (or _should be_ the same) in each Docker Compose service, we could have them centralized in a configuration file, from which our `docker-compose.yml` and `Procfile` are either _reading_ or _being generated from_.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
