### PR TITLE
migrator: ensure $schema is uri in reporterrors

### DIFF
--- a/inspirehep/modules/authors/tasks.py
+++ b/inspirehep/modules/authors/tasks.py
@@ -26,7 +26,7 @@ import copy
 import datetime
 import os
 
-from flask import current_app, url_for
+from flask import current_app
 from sqlalchemy.orm.exc import NoResultFound
 
 from invenio_accounts.models import User
@@ -36,6 +36,7 @@ from inspire_dojson.utils import strip_empty_values
 from inspire_schemas.api import validate
 from inspirehep.modules.forms.utils import filter_empty_elements
 from inspirehep.modules.workflows.utils import with_debug_logging
+from inspirehep.utils.schema import ensure_valid_schema
 
 from .dojson.model import updateform
 
@@ -59,14 +60,12 @@ def formdata_to_model(obj, formdata):
     # ======
     # Schema
     # ======
+
+    # FIXME it's not clear whether $schema is ever present at this stage
     if '$schema' not in data and '$schema' in obj.data:
         data['$schema'] = obj.data.get('$schema')
-
-    if '$schema' in data and not data['$schema'].startswith('http'):
-        data['$schema'] = url_for(
-            'invenio_jsonschemas.get_schema',
-            schema_path="records/{0}".format(data['$schema'])
-        )
+    if '$schema' in data:
+        ensure_valid_schema(data)
 
     author_name = ''
 

--- a/inspirehep/modules/migrator/tasks.py
+++ b/inspirehep/modules/migrator/tasks.py
@@ -36,7 +36,7 @@ import click
 from celery import group, shared_task
 from elasticsearch.helpers import bulk as es_bulk
 from elasticsearch.helpers import scan as es_scan
-from flask import current_app, url_for
+from flask import current_app
 from flask_sqlalchemy import models_committed
 from jsonschema import ValidationError
 from redis import StrictRedis
@@ -59,6 +59,7 @@ from inspirehep.modules.pidstore.minters import inspire_recid_minter
 from inspirehep.modules.pidstore.utils import get_pid_type_from_schema
 from inspirehep.modules.records.api import InspireRecord
 from inspirehep.modules.records.receivers import index_after_commit
+from inspirehep.utils.schema import ensure_valid_schema
 
 from .models import InspireProdRecords
 
@@ -340,10 +341,7 @@ def migrate_and_insert_record(raw_record, skip_files=False):
     try:
         json_record = marcxml2record(raw_record)
         if '$schema' in json_record:
-            json_record['$schema'] = url_for(
-                'invenio_jsonschemas.get_schema',
-                schema_path='records/{0}'.format(json_record['$schema']),
-            )
+            ensure_valid_schema(json_record)
     except Exception as e:
         LOGGER.exception('Migrator DoJSON Error')
         error = e

--- a/inspirehep/modules/workflows/tasks/upload.py
+++ b/inspirehep/modules/workflows/tasks/upload.py
@@ -24,8 +24,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-from flask import url_for
-
 from invenio_db import db
 
 from inspirehep.modules.pidstore.minters import inspire_recid_minter
@@ -33,6 +31,7 @@ from inspirehep.modules.pidstore.utils import get_pid_type_from_schema
 from inspirehep.modules.records.api import InspireRecord
 from inspirehep.modules.workflows.utils import with_debug_logging
 from inspirehep.utils.record_getter import get_db_record
+from inspirehep.utils.schema import ensure_valid_schema
 
 
 @with_debug_logging
@@ -87,12 +86,9 @@ def set_schema(obj, eng):
     else:
         obj.log.debug('Schema already there')
 
-    if not obj.data['$schema'].startswith('http'):
-        old_schema = obj.data['$schema']
-        obj.data['$schema'] = url_for(
-            'invenio_jsonschemas.get_schema',
-            schema_path="records/{0}".format(obj.data['$schema'])
-        )
+    old_schema = obj.data['$schema']
+    ensure_valid_schema(obj.data)
+    if obj.data['$schema'] != old_schema:
         obj.log.debug(
             'Schema changed to %s from %s', obj.data['$schema'], old_schema
         )

--- a/inspirehep/utils/schema.py
+++ b/inspirehep/utils/schema.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+from flask import url_for
+
+
+def ensure_valid_schema(record):
+    """Make sure the ``$schema`` key of the record is valid.
+
+    This is done by setting the correct url to the schema, in case it only
+    contains the schema filename.
+    """
+    if not record['$schema'].startswith('http'):
+        record['$schema'] = url_for(
+            'invenio_jsonschemas.get_schema',
+            schema_path="records/{0}".format(record['$schema'])
+        )

--- a/tests/unit/utils/test_utils_schema.py
+++ b/tests/unit/utils/test_utils_schema.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+from inspirehep.utils.schema import ensure_valid_schema
+
+
+def test_ensure_valid_schema_invalid():
+    record = {
+        '$schema': 'authors.json'
+    }
+
+    expected = {
+        '$schema': 'http://localhost:5000/schemas/records/authors.json'
+    }
+    ensure_valid_schema(record)
+
+    assert record == expected
+
+
+def test_ensure_valid_schema_already_valid():
+    record = {
+        '$schema': 'https://labs.inspirehep.net/schemas/records/authors.json'
+    }
+
+    expected = {
+        '$schema': 'https://labs.inspirehep.net/schemas/records/authors.json'
+    }
+    ensure_valid_schema(record)
+
+    assert record == expected


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
As the `$schema` key of records is now required by the schemas to be a
valid `uri` but inspire-dojson only puts the schema name there, the
`reporterrors` CLI command has to fix this. Otherwise, the invalid
`$schema` format masks the real validation error.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

  