### PR TITLE
serializers: handle theses without thesis_info

### DIFF
--- a/inspirehep/modules/records/serializers/fields_export.py
+++ b/inspirehep/modules/records/serializers/fields_export.py
@@ -90,7 +90,7 @@ def bibtex_document_type(doc_type, obj):
     if doc_type in DOCUMENT_TYPE_MAP:
         return DOCUMENT_TYPE_MAP[doc_type]
     # Theses need special treatment, because bibtex differentiates between their types:
-    elif doc_type == 'thesis' and obj['thesis_info']['degree_type'] in ('phd', 'habilitation'):
+    elif doc_type == 'thesis' and get_value(obj, 'thesis_info.degree_type') in ('phd', 'habilitation'):
         return 'phdthesis'
     # Other types of theses (other, bachelor, laurea) don't have separate types in bibtex:
     # We will use the type field (see `get_type`) to indicate the type of diploma.
@@ -260,7 +260,7 @@ def get_arxiv_prefix(data, doc_type):
 
 @extractor('school')
 def get_school(data, doc_type):
-    schools = [school['name'] for school in get_value(data, 'thesis_info.institutions')]
+    schools = [school['name'] for school in get_value(data, 'thesis_info.institutions', [])]
     if schools:
         return ', '.join(schools)
 
@@ -309,8 +309,9 @@ def get_isbn(data, doc_type):
 
 @extractor('type')
 def get_type(data, doc_type):
-    if doc_type == 'mastersthesis' and data['thesis_info']['degree_type'] not in ('master', 'diploma'):
-        return "{} thesis".format(data['thesis_info']['degree_type'].title())
+    degree_type = get_value(data, 'thesis_info.degree_type', 'other')
+    if doc_type == 'mastersthesis' and degree_type not in ('master', 'diploma'):
+        return '{} thesis'.format(degree_type.title())
 
 
 @extractor('edition')


### PR DESCRIPTION
## Description
This fixes an issue where BibTeX generation fails if a thesis record contains no `thesis_info` field.

Example records displaying this issue:

- https://labs.inspirehep.net/api/literature/1646337
- https://labs.inspirehep.net/api/literature/754840

## Related Issue
https://sentry.inspirehep.net/inspire-sentry/prod/issues/1773/

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
