### PR TITLE
workflows: set refereed and fix the document_type

### DIFF
--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -54,6 +54,7 @@ from inspirehep.modules.workflows.tasks.actions import (
     normalize_journal_titles,
     prepare_update_payload,
     refextract,
+    set_refereed_and_fix_document_type,
     submission_fulltext_download,
     save_workflow,
 )
@@ -218,6 +219,7 @@ POSTENHANCE_RECORD = [
     filter_keywords,
     prepare_keywords,
     remove_references,
+    set_refereed_and_fix_document_type,
 ]
 
 


### PR DESCRIPTION
## Description:
After the workflow step that normalizes journal titles has run, set
the ``refereed`` and fix the ``document_type`` keys if needed. This
is required to properly handle HEPCrawl harvests.

## Related Issue
Closes #2863 and closes #2951 

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.