### PR TITLE
mappings: make publication_info.year a date

### DIFF
--- a/inspirehep/modules/records/mappings/records/hep.json
+++ b/inspirehep/modules/records/mappings/records/hep.json
@@ -702,7 +702,8 @@
                             "type": "string"
                         },
                         "year": {
-                            "type": "integer"
+                            "format": "yyyy",
+                            "type": "date"
                         }
                     },
                     "type": "nested"
@@ -881,7 +882,8 @@
                                             "type": "string"
                                         },
                                         "year": {
-                                            "type": "integer"
+                                            "format": "yyyy",
+                                            "type": "date"
                                         }
                                     },
                                     "type": "object"


### PR DESCRIPTION
For being able to support range queries with ES date rounding, while
also having all date fields, with date type (see
inspirehep/inspire-query-parser#75).

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>

## Related Issue
https://github.com/inspirehep/inspire-query-parser/pull/75

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
