### PR TITLE
theme: remove auto-complete by default from the search bar

### DIFF
--- a/inspirehep/modules/theme/templates/inspirehep_theme/typeahead.html
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/typeahead.html
@@ -80,15 +80,6 @@ require(
               scope.placeholder = attrs.placeholder;
               scope.updateQuery = updateQuery;
               scope.collection = attrs.collection;
-
-              $("#search").searchTypeahead({
-                // A server returning a list of values is needed
-                // Also CORS needs to be enabled, e.g with a browser extension
-                value_hints_url: "{{config.get('SEARCH_TYPEAHEAD_HINT_URL')|safe}}",
-                options_sets: parser_config,
-                default_set: "{{config.get('SEARCH_TYPEAHEAD_DEFAULT_SET')}}",
-                suggestion_fn: suggestion_fn
-              });
             }
             function templateUrl(element, attrs) {
               return attrs.template;
@@ -100,15 +91,6 @@ require(
               templateUrl: templateUrl,
               link: link,
             };
-        });
-      {% else %}
-        $("#search").searchTypeahead({
-          // A server returning a list of values is needed
-          // Also CORS needs to be enabled, e.g with a browser extension
-          value_hints_url: "{{config.get('SEARCH_TYPEAHEAD_HINT_URL')|safe}}",
-          options_sets: parser_config,
-          default_set: "{{config.get('SEARCH_TYPEAHEAD_DEFAULT_SET')}}",
-          suggestion_fn: suggestion_fn
         });
       {% endif %}
 


### PR DESCRIPTION
Signed-off-by: Dinika Saxena <dinika.saxena@cern.ch>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Allows typeahead.js to autocomplete only when the `allowAutocomplete` attribute is set to true.

## Related Issue
fixes #2979

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
