### PR TITLE
theme: display links to pdf for literature records in detailed view

### DIFF
--- a/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Inspire_HTML_detailed_macros.tpl
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Inspire_HTML_detailed_macros.tpl
@@ -198,6 +198,17 @@
     <a href="{{ external_system_identifier['url_link'] }}">{{ external_system_identifier['url_name'] }}</a>
   {% endfor %}
 
+  {% if record.get('documents') %}
+    {% for document in record.documents %}
+      {% if not viewInDisplayed %}
+        View in:
+        {% do viewInDisplayed.append(1) %}
+      {% endif %}
+      {{ comma() }}
+      <a href="{{ document['url'] }}">PDF</a>
+    {% endfor %}
+  {% endif %}
+
 {% endmacro %}
 
 {% macro record_references(record) %}


### PR DESCRIPTION
Signed-off-by: Dinika Saxena <dinika.saxena@cern.ch>

## Related Issue
closes #2703

## Motivation and Context
Displays link to the pdf when records have a `documents` key.

![screenshot from 2018-01-16 14-14-55](https://user-images.githubusercontent.com/11242410/34990924-1e4158dc-fac8-11e7-8189-ec00b0ec0bfb.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
