### PR TITLE
migrator: only set prod record as failed when it's there

### DIFF
--- a/inspirehep/modules/migrator/tasks.py
+++ b/inspirehep/modules/migrator/tasks.py
@@ -340,13 +340,15 @@ def migrate_and_insert_record(raw_record, skip_files=False):
 
     try:
         json_record = marcxml2record(raw_record)
-        if '$schema' in json_record:
-            ensure_valid_schema(json_record)
     except Exception as e:
         LOGGER.exception('Migrator DoJSON Error')
         error = e
         recid = 'No recid extracted'
+        prod_record = None
     else:
+        if '$schema' in json_record:
+            ensure_valid_schema(json_record)
+
         recid = json_record['control_number']
         prod_record = InspireProdRecords(recid=recid)
         prod_record.marcxml = raw_record
@@ -368,9 +370,11 @@ def migrate_and_insert_record(raw_record, skip_files=False):
     if error:
         # Invalid record, will not get indexed.
         error_str = u'{0}: Record {1}: {2}'.format(type(error), recid, e)
-        prod_record.valid = False
-        prod_record.errors = error_str
-        db.session.merge(prod_record)
+        if prod_record:
+            prod_record.valid = False
+            prod_record.errors = error_str
+            db.session.merge(prod_record)
+
         return None
     else:
         prod_record.valid = True


### PR DESCRIPTION
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Fixes #3121

Signed-off-by: David Caro <david@dcaro.es>