### PR TITLE
workflow: don't send updates to legacy and approve them on labs

### DIFF
--- a/inspirehep/modules/workflows/tasks/actions.py
+++ b/inspirehep/modules/workflows/tasks/actions.py
@@ -286,21 +286,6 @@ def submission_fulltext_download(obj, eng):
             obj.log.info('Cannot fetch PDF provided by user from %s', submission_pdf)
 
 
-def prepare_update_payload(extra_data_key="update_payload"):
-    @with_debug_logging
-    @wraps(prepare_update_payload)
-    def _prepare_update_payload(obj, eng):
-        # TODO: Perform auto-merge if possible and update only necessary data
-        # See obj.extra_data["record_matches"] for data on matches
-
-        # FIXME: Just update entire record for now
-        obj.extra_data[extra_data_key] = obj.data
-
-    _prepare_update_payload.__doc__ = (
-        'Prepare the update payload, extra_data_key=%s.' % extra_data_key)
-    return _prepare_update_payload
-
-
 @with_debug_logging
 def refextract(obj, eng):
     """Extract references from various sources and add them to the workflow.

--- a/tests/unit/workflows/test_workflows_tasks_actions.py
+++ b/tests/unit/workflows/test_workflows_tasks_actions.py
@@ -44,7 +44,6 @@ from inspirehep.modules.workflows.tasks.actions import (
     is_submission,
     mark,
     populate_journal_coverage,
-    prepare_update_payload,
     reject_record,
     refextract,
     set_refereed_and_fix_document_type,
@@ -475,36 +474,6 @@ def test_populate_journal_coverage_does_nothing_if_no_journal_is_found(mock_repl
 
     assert populate_journal_coverage(obj, eng) is None
     assert 'journal_coverage' not in obj.extra_data
-
-
-def test_prepare_update_payload():
-    obj = MockObj({}, {})
-    eng = MockEng()
-
-    default_prepare_update_payload = prepare_update_payload()
-
-    assert default_prepare_update_payload(obj, eng) is None
-    assert obj.extra_data['update_payload'] == {}
-
-
-def test_prepare_update_payload_accepts_a_custom_key():
-    obj = MockObj({}, {})
-    eng = MockEng()
-
-    custom_key_prepare_update_payload = prepare_update_payload('custom_key')
-
-    assert custom_key_prepare_update_payload(obj, eng) is None
-    assert obj.extra_data['custom_key'] == {}
-
-
-def test_prepare_update_payload_overwrites():
-    obj = MockObj({'bar': 'baz'}, {'foo': 'foo'})
-    eng = MockEng()
-
-    foo_prepare_update_payload = prepare_update_payload('foo')
-
-    assert foo_prepare_update_payload(obj, eng) is None
-    assert obj.extra_data['foo'] == {'bar': 'baz'}
 
 
 @patch('inspirehep.modules.workflows.tasks.actions.get_pdf_in_workflow')


### PR DESCRIPTION
Signed-off-by: Antonio Cesarano <cesarano2607@gmail.com>

This PR removes the window time in which articles are automatically rejected since we can recognize them now as updates, using the matcher.
Such updates are now being sent back to legacy, potentially overwriting human work.
Thus, updates in this PR are not sent to legacy at all.

## Related Issue
https://github.com/inspirehep/inspire-next/issues/3124

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
