### PR TITLE
migrator: fix add_citation_counts for PID with non numeric values

### DIFF
--- a/inspirehep/modules/migrator/tasks.py
+++ b/inspirehep/modules/migrator/tasks.py
@@ -56,7 +56,10 @@ from inspire_utils.dedupers import dedupe_list
 from inspire_utils.helpers import force_list
 from inspire_utils.record import get_value
 from inspirehep.modules.pidstore.minters import inspire_recid_minter
-from inspirehep.modules.pidstore.utils import get_pid_type_from_schema
+from inspirehep.modules.pidstore.utils import (
+    get_pid_type_from_schema,
+    get_pid_types_from_endpoints,
+)
 from inspirehep.modules.records.api import InspireRecord
 from inspirehep.modules.records.receivers import index_after_commit
 from inspirehep.utils.schema import ensure_valid_schema
@@ -240,13 +243,11 @@ def migrate_chunk(chunk, skip_files=False):
     models_committed.connect(index_after_commit)
 
 
-NUMERIC_PID_TYPES = ('lit', 'con', 'exp', 'jou', 'aut', 'job', 'ins')
-
-
 def _build_recid_to_uuid_map(citations_lookup):
+    numeric_pid_types = get_pid_types_from_endpoints()
     pids = PersistentIdentifier.query.filter(
         PersistentIdentifier.object_type == 'rec',
-        PersistentIdentifier.pid_type.in_(NUMERIC_PID_TYPES)).yield_per(
+        PersistentIdentifier.pid_type.in_(numeric_pid_types)).yield_per(
         1000)
     with click.progressbar(pids) as bar:
         return {

--- a/inspirehep/modules/pidstore/utils.py
+++ b/inspirehep/modules/pidstore/utils.py
@@ -29,6 +29,10 @@ from six import iteritems
 from six.moves.urllib.parse import urlsplit
 
 
+def get_pid_types_from_endpoints():
+    return _get_pid_type_endpoint_map().keys()
+
+
 def _get_pid_type_endpoint_map():
     pid_type_endpoint_map = {}
     for key, value in iteritems(current_app.config['RECORDS_REST_ENDPOINTS']):

--- a/tests/integration/migrator/test_migrator_tasks.py
+++ b/tests/integration/migrator/test_migrator_tasks.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import pytest
+import uuid
+
+from inspirehep.modules.migrator.tasks import _build_recid_to_uuid_map
+from invenio_pidstore.models import PersistentIdentifier
+
+
+def test_build_recid_to_uuid_map_numeric_pid_allowed_for_lit_and_con(isolated_app):
+    pid1 = PersistentIdentifier.create(pid_type='lit', pid_value='123',
+                                       object_type='rec', object_uuid=uuid.uuid4())
+    pid2 = PersistentIdentifier.create(pid_type='con', pid_value='1234',
+                                       object_type='rec', object_uuid=uuid.uuid4())
+    citations_lookup = {
+        pid1.pid_value: 5,
+        pid2.pid_value: 6,
+    }
+    result = _build_recid_to_uuid_map(citations_lookup)
+    assert result.keys().sort() == [pid1.object_uuid, pid2.object_uuid].sort()
+
+
+def test_build_recid_to_uuid_map_numeric_pid_breaks_for_lit(isolated_app):
+    pid1 = PersistentIdentifier.create(pid_type='lit', pid_value='abcdef',
+                                       object_type='rec', object_uuid=uuid.uuid4())
+    citations_lookup = {
+        pid1.pid_value: 5,
+    }
+    with pytest.raises(ValueError):
+        _build_recid_to_uuid_map(citations_lookup)
+
+
+def test_build_recid_to_uuid_map_ignored_types(isolated_app):
+    citations_lookup = {}
+    for type in ('urn', 'tex', 'cust'):
+        pid = PersistentIdentifier.create(
+            pid_type=type, pid_value='abcd', object_type='rec',
+            object_uuid=uuid.uuid4())
+        citations_lookup[pid.pid_value] = 6
+    result = _build_recid_to_uuid_map(citations_lookup)
+    assert result == {}

--- a/tests/unit/pidstore/test_pidstore_utils.py
+++ b/tests/unit/pidstore/test_pidstore_utils.py
@@ -26,6 +26,7 @@ from inspirehep.modules.pidstore.utils import (
     get_endpoint_from_pid_type,
     get_pid_type_from_endpoint,
     get_pid_type_from_schema,
+    get_pid_types_from_endpoints,
 )
 
 
@@ -55,3 +56,8 @@ def test_get_pid_from_schema_supports_relative_urls():
     result = get_pid_type_from_schema('schemas/record/authors.json')
 
     assert expected == result
+
+
+def test_get_pid_types_from_endpoint(app):
+    pid_types = set(('lit', 'con', 'exp', 'jou', 'aut', 'job', 'ins'))
+    assert pid_types.issubset(get_pid_types_from_endpoints())


### PR DESCRIPTION
Fix add_citation_counts task for PID with non numeric values.

## Description
<!--- Describe your changes in detail -->
We are about to introduce PID with string values (like ISBN, URN, ArXiv ID, ...) and the add_citation_counts task assumes that the PID value is always numeric.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
