### PR TITLE
workflow: integrate fuzzy matcher in the `article` workflow

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -33,6 +33,8 @@ from celery.schedules import crontab
 from invenio_oauthclient.contrib import orcid
 from invenio_records_rest.facets import range_filter, terms_filter
 
+from inspire_matcher.config import MATCHER_DEFAULT_CONFIGURATION as exact_match
+
 
 # Debug
 # =====
@@ -1634,3 +1636,41 @@ INSPIRE_REF_UPDATER_WHITELISTS = {
     ],
 }
 """Controls which fields are updated when the referred record is updated."""
+
+# Configuration for the matcher
+# =============================
+EXACT_MATCH = exact_match
+EXACT_MATCH['source'] = ['control_number']
+
+FUZZY_MATCH = {
+    'algorithm': [
+        {
+            'queries': [
+                {
+                    'clauses': [
+                        {
+                            'boost': 20,
+                            'path': 'abstracts',
+                        },
+                        {
+                            'boost': 10,
+                            'path': 'authors[:3]',
+                        },
+                        {
+                            'boost': 20,
+                            'path': 'titles',
+                        },
+                        {
+                            'boost': 10,
+                            'path': 'report_numbers',
+                        },
+                    ],
+                    'type': 'fuzzy',
+                }
+            ]
+        }
+    ],
+    'doc_type': 'hep',
+    'index': 'records-hep',
+    'source': ['control_number']
+}

--- a/inspirehep/modules/workflows/actions/match_approval.py
+++ b/inspirehep/modules/workflows/actions/match_approval.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of INSPIRE.
-# Copyright (C) 2014-2017 CERN.
+# Copyright (C) 2018 CERN.
 #
 # INSPIRE is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,11 +20,24 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-"""Inspire workflows."""
+"""Match action for INSPIRE."""
 
 from __future__ import absolute_import, division, print_function
 
-from .author_approval import AuthorApproval  # noqa: F401
-from .hep_approval import HEPApproval        # noqa: F401
-from .match_approval import MatchApproval  # noqa: F401
-from .merge_approval import MergeApproval    # noqa: F401
+from invenio_workflows import ObjectStatus
+
+
+class MatchApproval(object):
+    """Class representing the match action."""
+    name = "Match action"
+
+    @staticmethod
+    def resolve(obj, *args, **kwargs):
+        """Resolve the action taken in the approval action."""
+        value = kwargs.get("request_data", {}).get("match_recid")
+        obj.extra_data["fuzzy_match_approved_id"] = value
+        obj.remove_action()
+        obj.status = ObjectStatus.RUNNING
+        obj.save()
+        obj.continue_workflow(delayed=True)
+        return bool(value)

--- a/inspirehep/modules/workflows/mappings/holdingpen/hep.json
+++ b/inspirehep/modules/workflows/mappings/holdingpen/hep.json
@@ -12,7 +12,7 @@
                         "is-update": {
                             "type": "boolean"
                         },
-                        "record_matches": {
+                        "matches": {
                             "enabled": false,
                             "include_in_all": false,
                             "type": "object"

--- a/inspirehep/modules/workflows/tasks/upload.py
+++ b/inspirehep/modules/workflows/tasks/upload.py
@@ -38,14 +38,14 @@ from inspirehep.utils.schema import ensure_valid_schema
 def store_record(obj, eng):
     """Insert or replace a record."""
     def _get_updated_record(obj):
-        """TODO: use only head_uuid once we have them merger."""
+        """TODO: use only head_uuid once we have the merger."""
         if 'head_uuid' in obj.extra_data:
             updated_record = InspireRecord.get_record(
                 obj.extra_data['head_uuid'],
             )
         else:
             pid_type = get_pid_type_from_schema(obj.data['$schema'])
-            updated_record_id = obj.extra_data['record_matches'][0]
+            updated_record_id = obj.extra_data['matches']['approved']
             updated_record = get_db_record(pid_type, updated_record_id)
 
         return updated_record

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ install_requires = [
     'inspire-crawler~=1.0',
     'inspire-dojson~=58.0,>=58.0.0',
     'inspire-json-merger~=7.0,>=7.0.0',
-    'inspire-matcher~=4.0,>=4.0.0',
+    'inspire-matcher~=4.1,>=4.1.1',
     'inspire-query-parser~=3.0,>=3.1.5',
     'inspire-schemas~=57.0,>=57.0.0',
     'inspire-utils~=2.0,>=2.0.7',
@@ -262,6 +262,7 @@ setup(
             'author_approval = inspirehep.modules.workflows.actions.author_approval:AuthorApproval',
             'hep_approval = inspirehep.modules.workflows.actions.hep_approval:HEPApproval',
             'merge_approval = inspirehep.modules.workflows.actions.merge_approval:MergeApproval',
+            'match_approval = inspirehep.modules.workflows.actions.match_approval:MatchApproval',
         ],
     },
     classifiers=[

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -25,6 +25,7 @@ from __future__ import absolute_import, division, print_function
 import pytest
 
 from invenio_db import db
+from invenio_records.models import RecordMetadata
 from invenio_search import current_search_client as es
 from invenio_workflows import workflow_object_class
 
@@ -116,3 +117,13 @@ def cleanup_workflows_tables(app):
                 obj.delete()
 
         db.session.commit()
+
+
+@pytest.fixture(autouse=True, scope='function')
+def cleanup_literatures(app):
+    recs = RecordMetadata.query.filter(RecordMetadata.json['_collections'].op('?')('Literature')).all()
+    for lit_record in recs:
+        db.session.delete(lit_record)
+
+    db.session.commit()
+    es.indices.refresh('records-hep')

--- a/tests/integration/workflows/helpers/calls.py
+++ b/tests/integration/workflows/helpers/calls.py
@@ -34,7 +34,7 @@ from inspire_dojson import marcxml2record
 from inspirehep.modules.workflows.utils import convert
 
 
-def do_resolve_workflow(app, workflow_id, action='accept_core'):
+def _call_workflow_resolve_api(app, workflow_id, data):
     """Calls to the workflow resolve endpoint.
 
     :param app: flask app to use
@@ -43,11 +43,6 @@ def do_resolve_workflow(app, workflow_id, action='accept_core'):
     'accept')
     """
     client = app.test_client()
-    data = {
-        'value': action,
-        'id': workflow_id,
-    }
-
     login_user_via_session(client, email='cataloger@inspirehep.net')
     return client.post(
         '/api/holdingpen/%s/action/resolve' % workflow_id,
@@ -56,12 +51,33 @@ def do_resolve_workflow(app, workflow_id, action='accept_core'):
     )
 
 
-def do_resolve_manual_merge_wf(app, workflow_id):
-    """Solve the the given workflow's conflicts.
-    """
-    response = do_resolve_workflow(
+def do_resolve_workflow(app, workflow_id, action='accept_core'):
+    data = {'value': action, 'id': workflow_id}
+    response = _call_workflow_resolve_api(
         app=app,
-        workflow_id=workflow_id
+        workflow_id=workflow_id,
+        data=data
+    )
+    assert response.status_code == 200
+    return response
+
+
+def do_resolve_manual_merge_wf(app, workflow_id):
+    """Accept one of the proposed matches."""
+    response = _call_workflow_resolve_api(
+        app=app,
+        workflow_id=workflow_id,
+        data=None
+    )
+    assert response.status_code == 200
+
+
+def do_resolve_matching(app, workflow_id, match_id):
+    data = {'match_recid': match_id}
+    response = _call_workflow_resolve_api(
+        app=app,
+        workflow_id=workflow_id,
+        data=data
     )
     assert response.status_code == 200
 
@@ -77,7 +93,6 @@ def do_accept_core(app, workflow_id):
         workflow_id=workflow_id,
         action='accept_core',
     )
-    assert response.status_code == 200
     response_data = json.loads(response.data)
     assert response_data == {
         'acknowledged': True,
@@ -110,11 +125,12 @@ def do_robotupload_callback(
         ],
     }
 
-    return client.post(
+    response = client.post(
         '/callback/workflows/robotupload',
         data=json.dumps(data),
         content_type='application/json',
     )
+    assert response.status_code == 200
 
 
 def do_webcoll_callback(app, recids, server_name='http://fake.na.me'):
@@ -127,11 +143,12 @@ def do_webcoll_callback(app, recids, server_name='http://fake.na.me'):
     client = app.test_client()
     data = {"recids": recids}
 
-    return client.post(
+    response = client.post(
         '/callback/workflows/webcoll',
         data=data,
         content_type='application/x-www-form-urlencoded',
     )
+    assert response.status_code == 200
 
 
 def generate_record():

--- a/tests/unit/helpers/mocks.py
+++ b/tests/unit/helpers/mocks.py
@@ -49,9 +49,21 @@ class MockObj(object):
         self.id_user = id_user
 
         self.log = MockLog()
+        self.workflow = MockWorkflow('article')
 
     def save(self):
         pass
+
+    def remove_action(self):
+        pass
+
+    def continue_workflow(self, delayed=False):
+        pass
+
+
+class MockWorkflow(object):
+    def __init__(self, name):
+        self.name = name
 
 
 class AttrDict(dict):

--- a/tests/unit/workflows/test_workflows_actions.py
+++ b/tests/unit/workflows/test_workflows_actions.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+from invenio_workflows import ObjectStatus
+
+from inspirehep.modules.workflows.actions import MatchApproval, MergeApproval
+from mocks import MockObj
+
+
+def test_match_approval_gets_match_recid():
+    data = {}
+    extra_data = {}
+    obj = MockObj(data, extra_data)
+
+    ui_data = {'match_recid': 1234}
+    result = MatchApproval.resolve(obj, request_data=ui_data)
+
+    assert result
+    assert 'fuzzy_match_approved_id' in obj.extra_data
+    assert obj.extra_data['fuzzy_match_approved_id'] == 1234
+
+
+def test_match_approval_gets_none():
+    data = {}
+    extra_data = {}
+    obj = MockObj(data, extra_data)
+
+    ui_data = {'request_data': {'match_recid': None}}
+    result = MatchApproval.resolve(obj, ui_data)
+
+    assert not result
+    assert 'fuzzy_match_approved_id' in obj.extra_data
+    assert obj.extra_data['fuzzy_match_approved_id'] is None
+
+
+def test_match_approval_nothing_sent_via_request():
+    data = {}
+    extra_data = {}
+    obj = MockObj(data, extra_data)
+
+    result = MatchApproval.resolve(obj, None)
+
+    assert not result
+    assert 'fuzzy_match_approved_id' in obj.extra_data
+    assert obj.extra_data['fuzzy_match_approved_id'] is None
+    assert obj.status == ObjectStatus.RUNNING
+
+
+def test_merge_approval():
+    data = {}
+    extra_data = {}
+    obj = MockObj(data, extra_data)
+    obj.workflow.name = 'manual_merge'
+
+    result = MergeApproval.resolve(obj)
+
+    assert result
+    assert obj.extra_data['approved']
+    assert not obj.extra_data['auto-approved']

--- a/tests/unit/workflows/test_workflows_tasks_actions.py
+++ b/tests/unit/workflows/test_workflows_tasks_actions.py
@@ -23,13 +23,12 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+from mock import patch
 import pkg_resources
-
 import pytest
 import requests_mock
 from flask import current_app
 from jsonschema import ValidationError
-from mock import patch
 
 from inspire_schemas.api import load_schema, validate
 from inspirehep.modules.workflows.tasks.actions import (


### PR DESCRIPTION
## Description

Changed the step in the workflow that checks if the ingested article is an update, by
performing a fuzzy match. If there is at least a match, the workflow halts, waiting
for human matching confirmation.

All the matches are now stored in `obj.extra_data.matches`, which is a dictionary containing
`exact` matches, `fuzzy` matches, and eventually the `approved` fuzzy match.

A new action called `MatchApproval` has been added to resume the workflow when is halted for
matching approval.

Solves #2527.

Signed-off-by: Antonio Cesarano <cesarano2607@gmail.com>

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
