### PR TITLE
gitignore: ignore also symlink to the var folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ lib/
 lib64/
 parts/
 sdist/
-var/
+var
 *.egg-info/
 .installed.cfg
 *.egg


### PR DESCRIPTION
## Description
We currently ignore the var dir. This works well if the project folder is inside the virtual environment. But if the project folder is somewhere else, then you might want to add a symlink to the var folder. Thus, ignoring both the var folder and var symlink is the best solution.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
