### PR TITLE
workflow: don't set `core` field if record is auto-approved

### DIFF
--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -69,8 +69,6 @@ from inspirehep.modules.workflows.tasks.magpie import (
     guess_experiments,
 )
 from inspirehep.modules.workflows.tasks.matching import (
-    belongs_to_relevant_category,
-    set_coreness_in_extra_data,
     stop_processing,
     match_non_completed_wf_in_holdingpen,
     match_previously_rejected_wf_in_holdingpen,
@@ -78,6 +76,8 @@ from inspirehep.modules.workflows.tasks.matching import (
     previously_rejected,
     has_same_source,
     stop_matched_holdingpen_wfs,
+    auto_approve,
+    set_core_in_extra_data,
 )
 from inspirehep.modules.workflows.tasks.upload import store_record, set_schema
 from inspirehep.modules.workflows.tasks.submission import (
@@ -154,10 +154,10 @@ ENHANCE_RECORD = [
         is_submission,
         mark('auto-approved', False),
         IF_ELSE(
-            belongs_to_relevant_category,
+            auto_approve,
             [
                 mark('auto-approved', True),
-                set_coreness_in_extra_data,
+                set_core_in_extra_data,
             ],
             mark('auto-approved', False),
         ),


### PR DESCRIPTION
This closes #3125.

Signed-off-by: Antonio Cesarano <cesarano2607@gmail.com>

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
