### PR TITLE
procfile: adapt to new harvests queue

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -22,7 +22,7 @@
 
 web: gunicorn inspirehep.wsgi -c gunicorn.cfg
 cache: redis-server
-worker: celery worker -E -A inspirehep.celery --loglevel=INFO --workdir="${VIRTUAL_ENV}" --autoreload --pidfile="${VIRTUAL_ENV}/worker.pid" --purge -Q celery,migrator
+worker: celery worker -E -A inspirehep.celery --loglevel=INFO --workdir="${VIRTUAL_ENV}" --autoreload --pidfile="${VIRTUAL_ENV}/worker.pid" --purge -Q celery,migrator,harvests
 workermon: celery flower -A inspirehep.celery
 # beat: celery beat -A inspirehep.celery --loglevel=INFO --workdir="${VIRTUAL_ENV}" --pidfile="${VIRTUAL_ENV}/worker_beat.pid"
 # mathoid: node_modules/mathoid/server.js -c mathoid.config.yaml


### PR DESCRIPTION
Add harvests queue in Procfile so that our Docker configuration is in
sync with the native one (following what #3137 introduced).

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>

## Caveats
Keep in mind that although this PR introduces the `harvests` queue, it doesn't set the [`APP_LUST_RUNS_PATH`](https://github.com/david-caro/inspire-next/blob/2ffd1faf37d837911ce29bb5935f000f374dff66/docker-compose.yml#L41) env variable.  

I thought of moving the env-vars from docker-compose to a `.env` file, which is [supported already by Docker-Compose](https://docs.docker.com/compose/environment-variables/#the-env-file). 
This will also allow us to use the same `.env` file from `honcho` which [already supports](http://honcho.readthedocs.io/en/latest/using_procfiles.html#environment-files) that, as well.

But another problem rises, in the sense that some env-vars can't be the same, like:
- `APP_SQLALCHEMY_DATABASE_URI`
- `APP_SEARCH_ELASTIC_HOSTS` 
- `APP_OAIHARVESTER_WORKDIR` 


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
