### PR TITLE
migrator: don't create another version on ES

### DIFF
--- a/inspirehep/modules/migrator/tasks.py
+++ b/inspirehep/modules/migrator/tasks.py
@@ -267,6 +267,7 @@ def add_citation_counts(chunk_size=500, request_timeout=120):
                     '_index': index,
                     '_type': doc_type,
                     '_id': str(uuid),
+                    '_version_type': 'force',  # XXX: removed in ES@5
                     'doc': {'citation_count': citation_count}
                 }
 


### PR DESCRIPTION
## Description
Avoid creating another version on Elasticsearch when adding the
citation counts because this creates an inconsistency between
the version in the DB and the version on ES, which means that
an exception will be raised by the indexing receiver since ES
will reject an update if its version is lower than the current.

The specific mechanism used (``_version_type: force``) has been
deprecated in ES@2 and removed in ES@5, so we will need to find
another solution when we will upgrade Elasticsearch.

## Related Issue
Closes https://github.com/inspirehep/inspire-next/issues/3080.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed