### PR TITLE
migrator: use logger from inspire-utils

### DIFF
--- a/inspirehep/modules/migrator/tasks.py
+++ b/inspirehep/modules/migrator/tasks.py
@@ -25,7 +25,6 @@
 from __future__ import absolute_import, division, print_function
 
 import gzip
-import logging
 import re
 import zlib
 from collections import Counter
@@ -55,6 +54,7 @@ from inspire_dojson import marcxml2record
 from inspire_dojson.utils import get_recid_from_ref
 from inspire_utils.dedupers import dedupe_list
 from inspire_utils.helpers import force_list
+from inspire_utils.logging import getStackTraceLogger
 from inspire_utils.record import get_value
 from inspirehep.modules.pidstore.minters import inspire_recid_minter
 from inspirehep.modules.pidstore.utils import (
@@ -68,7 +68,7 @@ from inspirehep.utils.schema import ensure_valid_schema
 from .models import InspireProdRecords
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = getStackTraceLogger(__name__)
 
 CHUNK_SIZE = 100
 LARGE_CHUNK_SIZE = 2000


### PR DESCRIPTION
Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>

## Description
Integrates the ``StackTraceLogger`` from ``inspire-utils``, so that we see its behaviour, during the migration. If all goes well, then we can integrate it throughout the project.

## Related Issue
#1371 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
