### PR TITLE
global: don't use pytest-flake8

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -41,7 +41,7 @@ services:
       service: test-service_base
     volumes_from:
       - test-static
-    command: bash -c "py.test inspirehep tests/unit && make -C docs html"
+    command: bash -c "flake8 inspirehep tests && py.test tests/unit && make -C docs html"
 
   workflows:
     extends:

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ omit =
   inspirehep/wsgi_with_coverage.py
 
 [tool:pytest]
-addopts = --cov=inspirehep --cov-report=term-missing:skip-covered --flake8
+addopts = --cov=inspirehep --cov-report=term-missing:skip-covered
 
 [flake8]
 ignore = *.py E501 FI12 FI14 FI15 FI16 FI17 FI50 FI51 FI53

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,6 @@ tests_require = [
     'flake8-future-import~=0.0,>=0.4.3',
     'mock~=2.0,>=2.0.0',
     'pytest-cov~=2.0,>=2.5.1',
-    'pytest-flake8~=0.0,>=0.9',
     'pytest-selenium~=1.0,>=1.11.1',
     'pytest~=3.0,>=3.3.0',
     'requests_mock~=1.0,>=1.3.0',


### PR DESCRIPTION
## Description
Remove ``pytest-flake8`` and replace it with just ``flake8`` as the
former is sometimes not finding style violations present in the code.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.