### PR TITLE
workflows: refactor fulltext download

### DIFF
--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -33,13 +33,14 @@ from workflow.patterns.controlflow import (
 from inspirehep.modules.workflows.tasks.refextract import extract_journal_info
 from inspirehep.modules.workflows.tasks.arxiv import (
     arxiv_author_list,
-    arxiv_fulltext_download,
     arxiv_package_download,
     arxiv_plot_extract,
     arxiv_derive_inspire_categories,
+    populate_arxiv_document,
 )
 from inspirehep.modules.workflows.tasks.actions import (
     add_core,
+    download_documents,
     error_workflow,
     fix_submission_number,
     halt_record,
@@ -52,11 +53,11 @@ from inspirehep.modules.workflows.tasks.actions import (
     mark,
     normalize_journal_titles,
     populate_journal_coverage,
+    populate_submission_document,
     refextract,
     reject_record,
     save_workflow,
     set_refereed_and_fix_document_type,
-    submission_fulltext_download,
 )
 
 from inspirehep.modules.workflows.tasks.classifier import (
@@ -119,21 +120,19 @@ ENHANCE_RECORD = [
     IF(
         is_arxiv_paper,
         [
-            arxiv_fulltext_download,
+            populate_arxiv_document,
             arxiv_package_download,
             arxiv_plot_extract,
-            refextract,
             arxiv_derive_inspire_categories,
             arxiv_author_list("authorlist2marcxml.xsl"),
         ]
     ),
     IF(
         is_submission,
-        [
-            submission_fulltext_download,
-            refextract,
-        ]
+        populate_submission_document,
     ),
+    download_documents,
+    refextract,
     normalize_journal_titles,
     extract_journal_info,
     populate_journal_coverage,

--- a/tests/integration/workflows/test_arxiv_workflow.py
+++ b/tests/integration/workflows/test_arxiv_workflow.py
@@ -51,10 +51,14 @@ from utils import get_halted_workflow
 
 
 @mock.patch(
+    'inspirehep.modules.workflows.tasks.arxiv.download_file_to_workflow',
+    side_effect=fake_download_file,
+)
+@mock.patch(
     'inspirehep.modules.workflows.tasks.arxiv.is_pdf_link'
 )
 @mock.patch(
-    'inspirehep.modules.workflows.tasks.arxiv.download_file_to_workflow',
+    'inspirehep.modules.workflows.tasks.actions.download_file_to_workflow',
     side_effect=fake_download_file,
 )
 @mock.patch(
@@ -74,6 +78,7 @@ def test_harvesting_arxiv_workflow_manual_rejected(
     mocked_refextract_extract_refs,
     mocked_api_request_magpie,
     mocked_api_request_beard,
+    mocked_package_download,
     workflow_app,
     mocked_external_services,
 ):
@@ -109,6 +114,10 @@ def test_harvesting_arxiv_workflow_manual_rejected(
     side_effect=fake_download_file,
 )
 @mock.patch(
+    'inspirehep.modules.workflows.tasks.actions.download_file_to_workflow',
+    side_effect=fake_download_file,
+)
+@mock.patch(
     'inspirehep.modules.workflows.tasks.arxiv.is_pdf_link',
     return_value=True
 )
@@ -130,8 +139,9 @@ def test_harvesting_arxiv_workflow_core_record_auto_accepted(
     mocked_refextract_extract_refs,
     mocked_api_request_magpie,
     mocked_api_request_beard,
+    mocked_package_download,
     workflow_app,
-    mocked_external_services
+    mocked_external_services,
 ):
     """Test a full harvesting workflow."""
     record, categories = core_record()
@@ -155,6 +165,10 @@ def test_harvesting_arxiv_workflow_core_record_auto_accepted(
 
 @mock.patch(
     'inspirehep.modules.workflows.tasks.arxiv.download_file_to_workflow',
+    side_effect=fake_download_file,
+)
+@mock.patch(
+    'inspirehep.modules.workflows.tasks.actions.download_file_to_workflow',
     side_effect=fake_download_file,
 )
 @mock.patch(
@@ -184,6 +198,7 @@ def test_harvesting_arxiv_workflow_manual_accepted(
     mocked_api_request_beard,
     mocked_download_utils,
     mocked_download_arxiv,
+    mocked_package_download,
     workflow_app,
     mocked_external_services,
 ):
@@ -224,11 +239,15 @@ def test_harvesting_arxiv_workflow_manual_accepted(
 
 
 @mock.patch(
+    'inspirehep.modules.workflows.tasks.arxiv.download_file_to_workflow',
+    side_effect=fake_download_file,
+)
+@mock.patch(
     'inspirehep.modules.workflows.tasks.arxiv.is_pdf_link',
     return_value=True
 )
 @mock.patch(
-    'inspirehep.modules.workflows.tasks.arxiv.download_file_to_workflow',
+    'inspirehep.modules.workflows.tasks.actions.download_file_to_workflow',
     side_effect=fake_download_file,
 )
 @mock.patch(
@@ -243,6 +262,7 @@ def test_match_in_holdingpen_stops_pending_wf(
     mocked_download_arxiv,
     mocked_api_request_beard,
     mocked_api_request_magpie,
+    mocked_package_download,
     workflow_app,
     mocked_external_services,
 ):
@@ -280,11 +300,15 @@ def test_match_in_holdingpen_stops_pending_wf(
 
 
 @mock.patch(
+    'inspirehep.modules.workflows.tasks.arxiv.download_file_to_workflow',
+    side_effect=fake_download_file,
+)
+@mock.patch(
     'inspirehep.modules.workflows.tasks.arxiv.is_pdf_link',
     return_value=True
 )
 @mock.patch(
-    'inspirehep.modules.workflows.tasks.arxiv.download_file_to_workflow',
+    'inspirehep.modules.workflows.tasks.actions.download_file_to_workflow',
     side_effect=fake_download_file,
 )
 @mock.patch(
@@ -299,6 +323,7 @@ def test_match_in_holdingpen_previously_rejected_wf_stop(
     mocked_download_arxiv,
     mocked_api_request_beard,
     mocked_api_request_magpie,
+    mocked_package_download,
     workflow_app,
     mocked_external_services,
 ):
@@ -329,11 +354,15 @@ def test_match_in_holdingpen_previously_rejected_wf_stop(
 
 
 @mock.patch(
+    'inspirehep.modules.workflows.tasks.arxiv.download_file_to_workflow',
+    side_effect=fake_download_file,
+)
+@mock.patch(
     'inspirehep.modules.workflows.tasks.arxiv.is_pdf_link',
     return_value=True
 )
 @mock.patch(
-    'inspirehep.modules.workflows.tasks.arxiv.download_file_to_workflow',
+    'inspirehep.modules.workflows.tasks.actions.download_file_to_workflow',
     side_effect=fake_download_file,
 )
 @mock.patch(
@@ -348,6 +377,7 @@ def test_match_in_holdingpen_different_sources_continues(
     mocked_download_arxiv,
     mocked_api_request_beard,
     mocked_api_request_magpie,
+    mocked_package_download,
     workflow_app,
     mocked_external_services,
 ):
@@ -376,11 +406,15 @@ def test_match_in_holdingpen_different_sources_continues(
 
 
 @mock.patch(
+    'inspirehep.modules.workflows.tasks.arxiv.download_file_to_workflow',
+    side_effect=fake_download_file,
+)
+@mock.patch(
     'inspirehep.modules.workflows.tasks.arxiv.is_pdf_link',
     return_value=True
 )
 @mock.patch(
-    'inspirehep.modules.workflows.tasks.arxiv.download_file_to_workflow',
+    'inspirehep.modules.workflows.tasks.actions.download_file_to_workflow',
     side_effect=fake_download_file,
 )
 @mock.patch(
@@ -395,6 +429,7 @@ def test_arxiv_update_is_not_store_on_legacy_and_labs(
     mocked_download_arxiv,
     mocked_api_request_beard,
     mocked_api_request_magpie,
+    mocked_package_download,
     workflow_app,
     mocked_external_services,
     record_from_db,


### PR DESCRIPTION
Workflow goes like this.

1. Populate `documents` based on type (submission or arxiv)
2. Download populate documents and replace url with internal url
3. Refaxtract

This also downloads documents for records coming from DESY by default,
in a more clean way.

Signed-off-by: harunurhan <harunurhan17@gmail.com>
