### PR TITLE
serializers: BibTeX: fail early if no texkey

### DIFF
--- a/inspirehep/modules/records/serializers/schemas/base.py
+++ b/inspirehep/modules/records/serializers/schemas/base.py
@@ -24,15 +24,15 @@
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 from pybtex.database import Entry, Person
 from six import text_type
+
+from inspire_utils.logging import getStackTraceLogger
 
 from ..fields_export import get_authors_with_role, extractor, bibtex_type_and_fields
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = getStackTraceLogger(__name__)
 
 
 class PybtexSchema(object):

--- a/inspirehep/modules/records/serializers/schemas/base.py
+++ b/inspirehep/modules/records/serializers/schemas/base.py
@@ -27,8 +27,6 @@ from __future__ import absolute_import, division, print_function
 from pybtex.database import Entry, Person
 from six import text_type
 
-from inspire_utils.record import get_value
-
 from ..fields_export import get_authors_with_role, extractor, bibtex_type_and_fields
 
 
@@ -49,7 +47,7 @@ class PybtexSchema(object):
             pybtex.database.Entity: Pybtex entity
         """
         doc_type, fields = bibtex_type_and_fields(record)
-        texkey = get_value(record, 'texkeys[0]')
+        texkey = record['texkeys'][0]
 
         template_data = []
 

--- a/inspirehep/modules/records/serializers/schemas/base.py
+++ b/inspirehep/modules/records/serializers/schemas/base.py
@@ -24,10 +24,15 @@
 
 from __future__ import absolute_import, division, print_function
 
+import logging
+
 from pybtex.database import Entry, Person
 from six import text_type
 
 from ..fields_export import get_authors_with_role, extractor, bibtex_type_and_fields
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 class PybtexSchema(object):
@@ -47,7 +52,11 @@ class PybtexSchema(object):
             pybtex.database.Entity: Pybtex entity
         """
         doc_type, fields = bibtex_type_and_fields(record)
-        texkey = record['texkeys'][0]
+        try:
+            texkey = record['texkeys'][0]
+        except KeyError:
+            texkey = str(record['control_number'])
+            LOGGER.error('No texkey for record ID {}'.format(record['control_number']))
 
         template_data = []
 

--- a/tests/integration/test_bibtex_exporting.py
+++ b/tests/integration/test_bibtex_exporting.py
@@ -168,3 +168,25 @@ def test_format_inbook(app):
 
     assert result is not None
     assert pybtex_entries_equal(result, expected)
+
+
+def test_format_article_no_texkey(app):
+    article = get_db_record('lit', 4328)
+    del article['texkeys']
+    expected = ("4328", Entry('article', [
+        ('journal', u'Nucl.Phys.'),
+        ('pages', u'579--588'),
+        ('title', u'Partial Symmetries of Weak Interactions'),
+        ('volume', u'22'),
+        ('year', u'1961'),
+        ('doi', u'10.1016/0029-5582(61)90469-2'),
+    ], persons={
+        'editor': [],
+        'author': [Person(u"Glashow, S.L.")],
+    }))
+
+    schema = PybtexSchema()
+    result = schema.load(article)
+
+    assert result is not None
+    assert pybtex_entries_equal(result, expected)


### PR DESCRIPTION
## Description
Do not pass an empty texkey to the library, instead fail early if that happens.

## Related Issue
https://sentry.inspirehep.net/inspire-sentry/prod/issues/2606/

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
