### PR TITLE
workflows: add validation at the beginning of the workflow

### DIFF
--- a/inspirehep/modules/literaturesuggest/tasks.py
+++ b/inspirehep/modules/literaturesuggest/tasks.py
@@ -202,7 +202,6 @@ def formdata_to_model(obj, formdata):
         orcid=form_fields.get('orcid'),
         method='submitter'
     )
-    builder.validate_record()
 
     return builder.record
 

--- a/inspirehep/modules/workflows/tasks/actions.py
+++ b/inspirehep/modules/workflows/tasks/actions.py
@@ -240,7 +240,7 @@ def stop_in_error_if_record_not_valid(obj, eng):
         validate(obj.data, 'hep')
     except ValidationError as err:
         obj.log.error(err.message)
-        obj.extra_data['_error_message'] = err.message
+        obj.extra_data['_error_msg'] = err.message
         obj.status = ObjectStatus.ERROR
         raise WorkflowsError('The record contained in the workflow is not schema compliant.')
 
@@ -402,7 +402,7 @@ def error_workflow(message):
     @wraps(error_workflow)
     def _error_workflow(obj, eng):
         obj.log.error(message)
-        obj.extra_data['_error_message'] = message
+        obj.extra_data['_error_msg'] = message
         obj.status = ObjectStatus.ERROR
         raise WorkflowsError(message)
 

--- a/inspirehep/modules/workflows/tasks/actions.py
+++ b/inspirehep/modules/workflows/tasks/actions.py
@@ -239,8 +239,8 @@ def stop_in_error_if_record_not_valid(obj, eng):
         validate(obj.data, 'hep')
     except ValidationError as err:
         message = 'The record contained in the workflow is not schema compliant: \n' + err.message
-        error_workflow_fct = error_workflow(message)
-        error_workflow_fct(obj, eng)
+        obj.log.error(message)
+        raise WorkflowsError(message)
 
 
 @with_debug_logging

--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -49,7 +49,7 @@ from inspirehep.modules.workflows.tasks.actions import (
     is_record_accepted,
     is_record_relevant,
     is_submission,
-    is_valid,
+    stop_in_error_if_record_not_valid,
     mark,
     normalize_journal_titles,
     populate_journal_coverage,
@@ -323,12 +323,6 @@ ERROR_WITH_UNEXPECTED_WORKFLOW_PATH = [
     save_workflow,
 ]
 
-ERROR_WITH_INVALID_RECORD = [
-    mark('invalid-record', True),
-    error_workflow('Workflow record is not schema compliant.'),
-    save_workflow,
-]
-
 
 # Currently we handle harvests as if all were arxiv, that will have to change.
 PROCESS_HOLDINGPEN_MATCH_HARVEST = [
@@ -446,7 +440,6 @@ INIT_MARKS = [
     mark('already-in-holding-pen', None),
     mark('previously_rejected', None),
     mark('is-update', None),
-    mark('invalid-record', None),
     mark('stopped-matched-holdingpen-wf', None),
     mark('approved', None),
     mark('unexpected-workflow-path', None),
@@ -458,11 +451,7 @@ PRE_PROCESSING = [
     # Make sure schema is set for proper indexing in Holding Pen
     set_schema,
     INIT_MARKS,
-    IF_NOT(
-        is_valid,
-        ERROR_WITH_INVALID_RECORD,
-
-    ),
+    stop_in_error_if_record_not_valid
 ]
 
 

--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -49,6 +49,7 @@ from inspirehep.modules.workflows.tasks.actions import (
     is_record_accepted,
     is_record_relevant,
     is_submission,
+    is_valid,
     mark,
     normalize_journal_titles,
     populate_journal_coverage,
@@ -322,6 +323,12 @@ ERROR_WITH_UNEXPECTED_WORKFLOW_PATH = [
     save_workflow,
 ]
 
+ERROR_WITH_INVALID_RECORD = [
+    mark('invalid-record', True),
+    error_workflow('Workflow record is not schema compliant.'),
+    save_workflow,
+]
+
 
 # Currently we handle harvests as if all were arxiv, that will have to change.
 PROCESS_HOLDINGPEN_MATCH_HARVEST = [
@@ -439,6 +446,7 @@ INIT_MARKS = [
     mark('already-in-holding-pen', None),
     mark('previously_rejected', None),
     mark('is-update', None),
+    mark('invalid-record', None),
     mark('stopped-matched-holdingpen-wf', None),
     mark('approved', None),
     mark('unexpected-workflow-path', None),
@@ -450,6 +458,11 @@ PRE_PROCESSING = [
     # Make sure schema is set for proper indexing in Holding Pen
     set_schema,
     INIT_MARKS,
+    IF_NOT(
+        is_valid,
+        ERROR_WITH_INVALID_RECORD,
+
+    ),
 ]
 
 

--- a/tests/integration/workflows/test_arxiv_workflow.py
+++ b/tests/integration/workflows/test_arxiv_workflow.py
@@ -433,14 +433,14 @@ def test_article_workflow_error_raises_when_record_is_not_valid(workflow_app):
     )
     obj_id = obj.id
 
-    with pytest.raises(WorkflowsError):
+    with pytest.raises(WorkflowsError, message='Expecting WorkflowsError',
+                       match='The record contained in the workflow is not schema compliant.'):
         start('article', invalid_record, obj_id)
 
     obj = workflow_object_class.get(obj_id)
 
     assert obj.status == ObjectStatus.ERROR
-    assert obj.extra_data['invalid-record'] is True
-    assert obj.extra_data['_error_message'] == 'Workflow record is not schema compliant.'
+    assert obj.extra_data['_error_message'] == "u'_collections' is a required property"
 
 
 def test_article_workflow_when_record_is_valid(workflow_app):
@@ -459,5 +459,4 @@ def test_article_workflow_when_record_is_valid(workflow_app):
     obj = eng.objects[0]
 
     assert obj.status != ObjectStatus.ERROR
-    assert obj.extra_data['invalid-record'] is None
     assert '_error_message' not in obj.extra_data

--- a/tests/integration/workflows/test_arxiv_workflow.py
+++ b/tests/integration/workflows/test_arxiv_workflow.py
@@ -433,14 +433,17 @@ def test_article_workflow_error_raises_when_record_is_not_valid(workflow_app):
     )
     obj_id = obj.id
 
-    with pytest.raises(WorkflowsError, message='Expecting WorkflowsError',
-                       match='The record contained in the workflow is not schema compliant.'):
+    with pytest.raises(
+            WorkflowsError,
+            message='Expecting WorkflowsError',
+            match='The record contained in the workflow is not schema compliant.'
+    ):
         start('article', invalid_record, obj_id)
 
     obj = workflow_object_class.get(obj_id)
 
     assert obj.status == ObjectStatus.ERROR
-    assert obj.extra_data['_error_message'] == "u'_collections' is a required property"
+    assert '_error_msg' in obj.extra_data
 
 
 def test_article_workflow_when_record_is_valid(workflow_app):
@@ -459,4 +462,4 @@ def test_article_workflow_when_record_is_valid(workflow_app):
     obj = eng.objects[0]
 
     assert obj.status != ObjectStatus.ERROR
-    assert '_error_message' not in obj.extra_data
+    assert '_error_msg' not in obj.extra_data

--- a/tests/integration/workflows/test_arxiv_workflow.py
+++ b/tests/integration/workflows/test_arxiv_workflow.py
@@ -416,7 +416,7 @@ def test_arxiv_update_is_not_store_on_legacy_and_labs(
     assert obj.extra_data['skipped-store-record']
 
 
-def test_article_workflow_error_raises_when_record_is_not_valid(workflow_app):
+def test_article_workflow_raises_when_record_is_not_valid(workflow_app):
     invalid_record = {
         "titles": [
             {"title": "A title"}
@@ -433,21 +433,18 @@ def test_article_workflow_error_raises_when_record_is_not_valid(workflow_app):
     )
     obj_id = obj.id
 
-    with pytest.raises(
-            WorkflowsError,
-            message='Expecting WorkflowsError',
-            match='The record contained in the workflow is not schema compliant.'
-    ):
+    with pytest.raises(WorkflowsError):
         start('article', invalid_record, obj_id)
 
     obj = workflow_object_class.get(obj_id)
 
     assert obj.status == ObjectStatus.ERROR
-    assert '_error_msg' in obj.extra_data
+    assert 'not schema compliant' in obj.extra_data['_error_msg']
+    assert '_collections' in obj.extra_data['_error_msg']
 
 
 def test_article_workflow_when_record_is_valid(workflow_app):
-    invalid_record = {
+    valid_record = {
         "_collections": ["Literature"],
         "titles": [
             {"title": "A title"}
@@ -457,7 +454,7 @@ def test_article_workflow_when_record_is_valid(workflow_app):
         ],
     }
 
-    eng_uuid = start('article', [invalid_record])
+    eng_uuid = start('article', [valid_record])
     eng = WorkflowEngine.from_uuid(eng_uuid)
     obj = eng.objects[0]
 

--- a/tests/unit/workflows/test_workflows_tasks_actions.py
+++ b/tests/unit/workflows/test_workflows_tasks_actions.py
@@ -43,6 +43,7 @@ from inspirehep.modules.workflows.tasks.actions import (
     is_record_accepted,
     is_record_relevant,
     is_submission,
+    is_valid,
     mark,
     populate_journal_coverage,
     refextract,
@@ -397,6 +398,34 @@ def test_is_submission_returns_false_if_obj_has_falsy_acquisition_source():
     eng = MockEng()
 
     assert not is_submission(obj, eng)
+
+
+def test_is_valid():
+    obj = MockObj({
+        '_collections': ['Literature'],
+        'document_type': ['article'],
+        'titles': [{'title': 'a title'}]}, {})
+    eng = MockEng()
+
+    assert is_valid(obj, eng)
+
+
+def test_is_valid_returns_false_if_record_is_not_schema_compliant():
+    obj = MockObj({
+        'document_type': ['article'],
+        'titles': [{'title': 'a title'}]}, {})
+    eng = MockEng()
+
+    assert not is_valid(obj, eng)
+
+
+def test_is_valid_returns_false_if_record_doesn_not_have_all_mandatory_fields():
+    obj = MockObj({
+        'document_type': ['article'],
+        'titles': [{'title': 'a title'}]}, {})
+    eng = MockEng()
+
+    assert not is_valid(obj, eng)
 
 
 def test_fix_submission_number():

--- a/tests/unit/workflows/test_workflows_tasks_actions.py
+++ b/tests/unit/workflows/test_workflows_tasks_actions.py
@@ -43,7 +43,6 @@ from inspirehep.modules.workflows.tasks.actions import (
     is_record_accepted,
     is_record_relevant,
     is_submission,
-    is_valid,
     mark,
     populate_journal_coverage,
     refextract,
@@ -398,34 +397,6 @@ def test_is_submission_returns_false_if_obj_has_falsy_acquisition_source():
     eng = MockEng()
 
     assert not is_submission(obj, eng)
-
-
-def test_is_valid():
-    obj = MockObj({
-        '_collections': ['Literature'],
-        'document_type': ['article'],
-        'titles': [{'title': 'a title'}]}, {})
-    eng = MockEng()
-
-    assert is_valid(obj, eng)
-
-
-def test_is_valid_returns_false_if_record_is_not_schema_compliant():
-    obj = MockObj({
-        'document_type': ['article'],
-        'titles': [{'title': 'a title'}]}, {})
-    eng = MockEng()
-
-    assert not is_valid(obj, eng)
-
-
-def test_is_valid_returns_false_if_record_doesn_not_have_all_mandatory_fields():
-    obj = MockObj({
-        'document_type': ['article'],
-        'titles': [{'title': 'a title'}]}, {})
-    eng = MockEng()
-
-    assert not is_valid(obj, eng)
 
 
 def test_fix_submission_number():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I removed the validation from the submission form and added it to the beginning of the workflow. If the record is not valid, the workflow is stopped, put in `ERROR` state, and the received `ValidationaError` is caught and its message is stored in `obj.extra_data[_error_msg]` in order to help with identifying which part of the record is not schema compliant. Then, a `WorkflowsError` is raised with a custom message (`The record contained in the workflow is not schema compliant.` ) in order to clarify what went wrong.

## Related PR
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/inspirehep/hepcrawl/pull/223/

Records harvested by DESY spider will now be validated at the beginning of the workflow.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is required because so far, if a record was not valid either in hepcrawl or submission form, a `ValidationError` would be thrown and the actual record would be lost. Moreover, it was hard to identify such errors because they were rather silent and required some investigation on Sentry to be brought to light.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
