### PR TITLE
redis: add locked context manager

### DIFF
--- a/inspirehep/modules/cache/errors.py
+++ b/inspirehep/modules/cache/errors.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2017-2018 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Errors for the cache module."""
+
+
+class RedisLockError(Exception):
+    pass

--- a/inspirehep/modules/cache/utils.py
+++ b/inspirehep/modules/cache/utils.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2017-2018 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from contextlib import contextmanager
+
+from redis import StrictRedis
+from redis_lock import Lock
+
+from inspire_utils.config import load_config
+
+from .errors import RedisLockError
+
+
+@contextmanager
+def redis_locking_context(lock_name, expire=120, auto_renewal=True):
+    """Locked Context Manager to perform operations on Redis."""
+    if not lock_name:
+        raise RedisLockError('Lock name not specified.')
+
+    config = load_config()
+    redis_url = config.get('CACHE_REDIS_URL')
+
+    redis = StrictRedis.from_url(redis_url)
+    lock = Lock(redis, lock_name, expire=expire, auto_renewal=auto_renewal)
+
+    if lock.acquire(blocking=False):
+        try:
+            yield redis
+        finally:
+            lock.release()
+    else:
+        RuntimeError('Can not acquire Redis lock for %s', lock_name)

--- a/inspirehep/modules/orcid/tasks.py
+++ b/inspirehep/modules/orcid/tasks.py
@@ -27,14 +27,14 @@ from __future__ import absolute_import, division, print_function
 from flask import current_app
 from celery import shared_task
 from celery.utils.log import get_task_logger
-from redis import StrictRedis
-from redis_lock import Lock
 from simplejson import loads
 from invenio_oauthclient.utils import oauth_get_user, oauth_link_external_id
 from invenio_oauthclient.models import RemoteToken, User, RemoteAccount, UserIdentity
 from invenio_db import db
 from inspire_utils.record import get_value
 from invenio_oauthclient.errors import AlreadyLinkedError
+
+from inspirehep.modules.cache.utils import redis_locking_context
 
 logger = get_task_logger(__name__)
 
@@ -45,17 +45,13 @@ def legacy_orcid_arrays():
     Yields:
         list: user data in the form of [orcid, token, email, name]
     """
-    redis_url = current_app.config.get('CACHE_REDIS_URL')
-    r = StrictRedis.from_url(redis_url)
-    lock = Lock(r, 'import_legacy_orcid_tokens', expire=120, auto_renewal=True)
-    if lock.acquire(blocking=False):
-        try:
+    try:
+        with redis_locking_context('import_legacy_orcid_tokens') as r:
             while r.llen('legacy_orcid_tokens'):
                 yield loads(r.lrange('legacy_orcid_tokens', 0, 1)[0])
                 r.lpop('legacy_orcid_tokens')
-        finally:
-            lock.release()
-    else:
+
+    except RuntimeError:
         logger.info("Import_legacy_orcid_tokens already executed. Skipping.")
 
 

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ install_requires = [
     'inspire-matcher~=4.0,>=4.0.0',
     'inspire-query-parser~=3.0,>=3.1.5',
     'inspire-schemas~=57.0,>=57.0.0',
-    'inspire-utils~=2.0,>=2.0.0',
+    'inspire-utils~=2.0,>=2.0.5',
     'invenio-access>=1.0.0b1',
     'invenio-accounts>=1.0.0b10',
     'invenio-admin>=1.0.0b4',

--- a/tests/integration/cache/test_utils.py
+++ b/tests/integration/cache/test_utils.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2017-2018 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+import mock
+import pytest
+
+from inspirehep.modules.cache.utils import redis_locking_context
+from inspirehep.modules.cache.errors import RedisLockError
+
+
+@mock.patch(
+    'inspirehep.modules.cache.utils.load_config',
+    return_value={'CACHE_REDIS_URL': 'redis://test-redis:6379/0'}
+)
+def test_redis_locking_context_write_string_in_redis(app):
+    with redis_locking_context('my_lock') as redis:
+        redis.set('key', 'value')
+        assert redis.get('key') == 'value'
+
+
+@mock.patch(
+    'inspirehep.modules.cache.utils.load_config',
+    return_value={'CACHE_REDIS_URL': 'redis://test-redis:6379/0'}
+)
+def test_redis_locking_context_write_integer(app):
+    with redis_locking_context('my_lock') as redis:
+        redis.set('key', 1)
+        assert redis.get('key') == '1'
+
+
+@mock.patch(
+    'inspirehep.modules.cache.utils.load_config',
+    return_value={'CACHE_REDIS_URL': 'redis://test-redis:6379/0'}
+)
+def test_redis_locking_context_with_no_lock_name_raises_error(app):
+    with pytest.raises(RedisLockError):
+        with redis_locking_context(None):
+            pytest.fail()


### PR DESCRIPTION
This commit adds a context manager to perform operations on Redis without
instantiating it and lock it.

Signed-off-by: Antonio Cesarano <cesarano2607@gmail.com>

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
