### PR TITLE
Fix auto reject

### DIFF
--- a/inspirehep/modules/workflows/tasks/actions.py
+++ b/inspirehep/modules/workflows/tasks/actions.py
@@ -165,8 +165,9 @@ def reject_record(message):
 
 def _is_auto_rejected(workflow_obj):
     relevance_prediction = workflow_obj.extra_data.get('relevance_prediction')
-    classification_results = workflow_obj.extra_data.get('classifier_results')
-    if not relevance_prediction or not classification_results:
+    classification_results = workflow_obj.extra_data.get('classifier_results', {})
+    fulltext_used = classification_results.get('fulltext_used')
+    if not relevance_prediction or not classification_results or not fulltext_used:
         return False
 
     decision = relevance_prediction.get('decision')

--- a/inspirehep/modules/workflows/tasks/classifier.py
+++ b/inspirehep/modules/workflows/tasks/classifier.py
@@ -75,7 +75,7 @@ def classify_paper(taxonomy, rebuild_cache=False, no_cache=False,
             extract_acronyms=extract_acronyms
         )
 
-        fast_mode = False
+        fulltext_used = True
         tmp_pdf = get_pdf_in_workflow(obj)
         try:
             if tmp_pdf:
@@ -92,7 +92,7 @@ def classify_paper(taxonomy, rebuild_cache=False, no_cache=False,
                     obj.log.error("No classification done due to missing data.")
                     return
                 result = get_keywords_from_text(data, **params)
-                fast_mode = True
+                fulltext_used = False
         except ClassifierException as e:
             obj.log.exception(e)
             return
@@ -103,7 +103,7 @@ def classify_paper(taxonomy, rebuild_cache=False, no_cache=False,
         result['complete_output'] = clean_instances_from_data(
             result.get("complete_output", {})
         )
-        result["fast_mode"] = fast_mode
+        result["fulltext_used"] = fulltext_used
 
         # Check if it is not empty output before adding
         if any(result.get("complete_output", {}).values()):

--- a/inspirehep/modules/workflows/tasks/classifier.py
+++ b/inspirehep/modules/workflows/tasks/classifier.py
@@ -27,6 +27,7 @@ from __future__ import absolute_import, division, print_function
 import os
 from functools import wraps
 
+from inspire_utils.record import get_value
 from invenio_classifier import (
     get_keywords_from_local_file,
     get_keywords_from_text,
@@ -81,13 +82,10 @@ def classify_paper(taxonomy, rebuild_cache=False, no_cache=False,
             if tmp_pdf:
                 result = get_keywords_from_local_file(tmp_pdf, **params)
             else:
-                data = []
-                titles = obj.data.get('titles')
-                if titles:
-                    data.extend([t.get('title', '') for t in titles])
-                abstracts = obj.data.get('abstracts')
-                if abstracts:
-                    data.extend([t.get('value', '') for t in abstracts])
+                data = get_value(obj.data, 'titles.title', [])
+                data.extend(get_value(obj.data, 'titles.subtitle', []))
+                data.extend(get_value(obj.data, 'abstracts.value', []))
+                data.extend(get_value(obj.data, 'keywords.value', []))
                 if not data:
                     obj.log.error("No classification done due to missing data.")
                     return

--- a/tests/unit/workflows/test_workflows_tasks_actions.py
+++ b/tests/unit/workflows/test_workflows_tasks_actions.py
@@ -57,12 +57,13 @@ from inspirehep.utils.url import retrieve_uri
 from mocks import MockEng, MockObj, MockFiles
 
 
-def _get_auto_reject_obj(decision, has_core_keywords):
+def _get_auto_reject_obj(decision, has_core_keywords, fulltext_used):
     obj_params = {
         'classifier_results': {
             'complete_output': {
                 'core_keywords': ['something'] if has_core_keywords else [],
             },
+            'fulltext_used': fulltext_used,
         },
         'relevance_prediction': {
             'max_score': '0.222113',
@@ -357,20 +358,32 @@ def test_reject_record(l_w_a):
 @pytest.mark.parametrize(
     'expected,obj',
     [
-        (False, _get_auto_reject_obj('Core', has_core_keywords=False)),
-        (False, _get_auto_reject_obj('Non-Core', has_core_keywords=False)),
-        (True, _get_auto_reject_obj('Rejected', has_core_keywords=False)),
-        (False, _get_auto_reject_obj('Core', has_core_keywords=True)),
-        (False, _get_auto_reject_obj('Non-Core', has_core_keywords=True)),
-        (False, _get_auto_reject_obj('Rejected', has_core_keywords=True)),
+        (False, _get_auto_reject_obj('Core', has_core_keywords=False, fulltext_used=True)),
+        (False, _get_auto_reject_obj('Non-Core', has_core_keywords=False, fulltext_used=True)),
+        (True, _get_auto_reject_obj('Rejected', has_core_keywords=False, fulltext_used=True)),
+        (False, _get_auto_reject_obj('Core', has_core_keywords=True, fulltext_used=True)),
+        (False, _get_auto_reject_obj('Non-Core', has_core_keywords=True, fulltext_used=True)),
+        (False, _get_auto_reject_obj('Rejected', has_core_keywords=True, fulltext_used=True)),
+        (False, _get_auto_reject_obj('Core', has_core_keywords=False, fulltext_used=False)),
+        (False, _get_auto_reject_obj('Non-Core', has_core_keywords=False, fulltext_used=False)),
+        (False, _get_auto_reject_obj('Rejected', has_core_keywords=False, fulltext_used=False)),
+        (False, _get_auto_reject_obj('Core', has_core_keywords=True, fulltext_used=False)),
+        (False, _get_auto_reject_obj('Non-Core', has_core_keywords=True, fulltext_used=False)),
+        (False, _get_auto_reject_obj('Rejected', has_core_keywords=True, fulltext_used=False)),
     ],
     ids=[
-        'Dont reject: No core keywords with core decision',
-        'Dont reject: No core keywords with non-core decision',
-        'Reject: No core keywords with rejected decision',
-        'Dont reject: Core keywords with core decision',
-        'Dont reject: Core keywords with non-core decision',
-        'Dont reject: Core keywords with rejected decision',
+        'Dont reject: No core keywords (from fulltext) with core decision',
+        'Dont reject: No core keywords (from fulltext) with non-core decision',
+        'Reject: No core keywords (from fulltext) with rejected decision',
+        'Dont reject: Core keywords (from fulltext) with core decision',
+        'Dont reject: Core keywords (from fulltext) with non-core decision',
+        'Dont reject: Core keywords (from fulltext) with rejected decision',
+        'Dont reject: No core keywords (not from fulltext) with core decision',
+        'Dont reject: No core keywords (not from fulltext) with non-core decision',
+        'Dont reject: No core keywords (not from fulltext) with rejected decision',
+        'Dont reject: Core keywords (not from fulltext) with core decision',
+        'Dont reject: Core keywords (not from fulltext) with non-core decision',
+        'Dont reject: Core keywords (not from fulltext) with rejected decision',
     ]
 )
 def test__is_auto_rejected(expected, obj):

--- a/tests/unit/workflows/test_workflows_tasks_classifier.py
+++ b/tests/unit/workflows/test_workflows_tasks_classifier.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+from six import binary_type
+from mock import patch
+
+from inspirehep.modules.workflows.tasks.classifier import classify_paper
+from mocks import MockEng, MockObj
+
+
+@patch('inspirehep.modules.workflows.tasks.classifier.get_pdf_in_workflow')
+def test_classify_paper_with_fulltext(get_pdf_in_workflow, tmpdir):
+    obj = MockObj({}, {})
+    eng = MockEng()
+    fulltext = tmpdir.join('fulltext.txt')
+    fulltext.write('Higgs boson')
+    get_pdf_in_workflow.return_value = binary_type(fulltext)
+
+    expected = [
+        {
+            'number': 1,
+            'keyword': 'Higgs particle'
+        }
+    ]
+
+    classify_paper(
+        taxonomy="HEPont.rdf",
+        only_core_tags=False,
+        spires=True,
+        with_author_keywords=True,
+    )(obj, eng)
+
+    assert obj.extra_data['classifier_results']['complete_output']['core_keywords'] == expected
+    assert obj.extra_data['classifier_results']['fulltext_used'] is True
+
+
+@patch('inspirehep.modules.workflows.tasks.classifier.get_pdf_in_workflow')
+def test_classify_paper_with_no_fulltext(get_pdf_in_workflow):
+    data = {
+        'titles': [
+            {
+                'title': 'Some title',
+            },
+        ],
+        'abstracts': [
+            {
+                'value': 'Very interesting paper about the Higgs boson.'
+            },
+        ],
+    }
+    obj = MockObj(data, {})
+    eng = MockEng()
+    get_pdf_in_workflow.return_value = None
+
+    expected = [
+        {
+            'number': 1,
+            'keyword': 'Higgs particle'
+        }
+    ]
+
+    classify_paper(
+        taxonomy="HEPont.rdf",
+        only_core_tags=False,
+        spires=True,
+        with_author_keywords=True,
+    )(obj, eng)
+
+    assert obj.extra_data['classifier_results']['complete_output']['core_keywords'] == expected
+    assert obj.extra_data['classifier_results']['fulltext_used'] is False

--- a/tests/unit/workflows/test_workflows_tasks_classifier.py
+++ b/tests/unit/workflows/test_workflows_tasks_classifier.py
@@ -89,3 +89,39 @@ def test_classify_paper_with_no_fulltext(get_pdf_in_workflow):
 
     assert obj.extra_data['classifier_results']['complete_output']['core_keywords'] == expected
     assert obj.extra_data['classifier_results']['fulltext_used'] is False
+
+
+@patch('inspirehep.modules.workflows.tasks.classifier.get_pdf_in_workflow')
+def test_classify_paper_uses_keywords(get_pdf_in_workflow):
+    data = {
+        'titles': [
+            {
+                'title': 'Some title',
+            },
+        ],
+        'keywords': [
+            {
+                'value': 'Higgs boson',
+            },
+        ],
+    }
+    obj = MockObj(data, {})
+    eng = MockEng()
+    get_pdf_in_workflow.return_value = None
+
+    expected = [
+        {
+            'number': 1,
+            'keyword': 'Higgs particle'
+        }
+    ]
+
+    classify_paper(
+        taxonomy="HEPont.rdf",
+        only_core_tags=False,
+        spires=True,
+        with_author_keywords=True,
+    )(obj, eng)
+
+    assert obj.extra_data['classifier_results']['complete_output']['core_keywords'] == expected
+    assert obj.extra_data['classifier_results']['fulltext_used'] is False


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
* Avoids auto-rejecting records in the workflows in case the keyword extraction has not run on the fulltext, but only on the metadata present in the record.
* Also runs the keyword extraction on subtitles and author keywords.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
