### PR TITLE
mappings: add page_artid to publication_info

### DIFF
--- a/inspirehep/modules/records/mappings/records/hep.json
+++ b/inspirehep/modules/records/mappings/records/hep.json
@@ -628,6 +628,7 @@
                 "publication_info": {
                     "properties": {
                         "artid": {
+                            "copy_to": "publication_info.page_artid",
                             "type": "string"
                         },
                         "cnum": {
@@ -679,10 +680,14 @@
                         "material": {
                             "type": "string"
                         },
+                        "page_artid": {
+                            "type": "string"
+                        },
                         "page_end": {
                             "type": "string"
                         },
                         "page_start": {
+                            "copy_to": "publication_info.page_artid",
                             "type": "string"
                         },
                         "parent_isbn": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add new `publication_info.artid_and_page_start` field to enable easier queries based on `publication_info.artid` and `publication_info.page_start`. Because the data is ambiguous, the 2 fields are sometimes populated with the same value, different values or one of them is not populated at all.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
 By using `copy_to` to copy the *values* stored in each one of the 2 fields to `publication_info.artid_and_page_start`, we can now query a single field instead of all the possible combinations of the other 2 fields. This is needed for more accurate number ( keeping track of citations, references etc).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Signed-off-by: Iuliana Voinea <iuliana.voinea@student.manchester.ac.uk>