### PR TITLE
workflows: Better document selection

### DIFF
--- a/inspirehep/modules/workflows/tasks/actions.py
+++ b/inspirehep/modules/workflows/tasks/actions.py
@@ -24,7 +24,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import os
 import re
 from functools import wraps
 
@@ -357,15 +356,12 @@ def refextract(obj, eng):
     pdf_references, text_references = [], []
     source = get_value(obj.data, 'acquisition_source.source')
 
-    tmp_pdf = get_pdf_in_workflow(obj)
-    if tmp_pdf:
-        try:
-            pdf_references = extract_references_from_pdf(tmp_pdf, source)
-        except TimeoutError:
-            obj.log.error('Timeout when extracting references from PDF.')
-        finally:
-            if os.path.exists(tmp_pdf):
-                os.unlink(tmp_pdf)
+    with get_pdf_in_workflow(obj) as tmp_pdf:
+        if tmp_pdf:
+            try:
+                pdf_references = extract_references_from_pdf(tmp_pdf, source)
+            except TimeoutError:
+                obj.log.error('Timeout when extracting references from PDF.')
 
     text = get_value(obj.extra_data, 'formdata.references')
     if text:

--- a/inspirehep/modules/workflows/tasks/actions.py
+++ b/inspirehep/modules/workflows/tasks/actions.py
@@ -53,7 +53,7 @@ from inspirehep.modules.workflows.tasks.refextract import (
 )
 from inspirehep.modules.workflows.utils import (
     download_file_to_workflow,
-    get_pdf_in_workflow,
+    get_document_in_workflow,
     log_workflows_action,
     with_debug_logging,
 )
@@ -355,10 +355,10 @@ def refextract(obj, eng):
     pdf_references, text_references = [], []
     source = get_value(obj.data, 'acquisition_source.source')
 
-    with get_pdf_in_workflow(obj) as tmp_pdf:
-        if tmp_pdf:
+    with get_document_in_workflow(obj) as tmp_document:
+        if tmp_document:
             try:
-                pdf_references = extract_references_from_pdf(tmp_pdf, source)
+                pdf_references = extract_references_from_pdf(tmp_document, source)
             except TimeoutError:
                 obj.log.error('Timeout when extracting references from PDF.')
 

--- a/inspirehep/modules/workflows/tasks/actions.py
+++ b/inspirehep/modules/workflows/tasks/actions.py
@@ -316,23 +316,22 @@ def populate_submission_document(obj, eng):
 
 @with_debug_logging
 def download_documents(obj, eng):
-    documents = obj.data.get('documents')
-    if documents:
-        for document in documents:
-            filename = document['key']
-            url = document['url']
-            downloaded = download_file_to_workflow(
-                workflow=obj,
-                name=filename,
-                url=url,
-            )
-            if downloaded:
-                document['url'] = '/api/files/{bucket}/{key}'.format(
-                    bucket=obj.files[filename].bucket_id, key=filename)
-                obj.log.info('Document downloaded from %s', url)
-            else:
-                obj.log.error(
-                    'Cannot download document from %s', url)
+    documents = obj.data.get('documents', [])
+    for document in documents:
+        filename = document['key']
+        url = document['url']
+        downloaded = download_file_to_workflow(
+            workflow=obj,
+            name=filename,
+            url=url,
+        )
+        if downloaded:
+            document['url'] = '/api/files/{bucket}/{key}'.format(
+                bucket=obj.files[filename].bucket_id, key=filename)
+            obj.log.info('Document downloaded from %s', url)
+        else:
+            obj.log.error(
+                'Cannot download document from %s', url)
 
 
 @with_debug_logging

--- a/inspirehep/modules/workflows/tasks/arxiv.py
+++ b/inspirehep/modules/workflows/tasks/arxiv.py
@@ -124,8 +124,8 @@ def arxiv_plot_extract(obj, eng):
     tarball = obj.files[filename]
 
     if tarball:
-        with TemporaryDirectory(prefix='plot_extract') as scratch_space:
-            tarball_file = retrieve_uri(tarball.file.uri, outdir=scratch_space)
+        with TemporaryDirectory(prefix='plot_extract') as scratch_space, \
+                retrieve_uri(tarball.file.uri, outdir=scratch_space) as tarball_file:
             try:
                 plots = process_tarball(
                     tarball_file,
@@ -227,11 +227,8 @@ def arxiv_author_list(stylesheet="authorlist2marcxml.xsl"):
             )
             return
 
-        with TemporaryDirectory(prefix='author_list') as scratch_space:
-            tarball_file = retrieve_uri(
-                tarball.file.uri,
-                outdir=scratch_space,
-            )
+        with TemporaryDirectory(prefix='author_list') as scratch_space, \
+                retrieve_uri(tarball.file.uri, outdir=scratch_space) as tarball_file:
             try:
                 file_list = untar(tarball_file, scratch_space)
             except InvalidTarball:

--- a/inspirehep/modules/workflows/tasks/classifier.py
+++ b/inspirehep/modules/workflows/tasks/classifier.py
@@ -35,7 +35,7 @@ from invenio_classifier.errors import ClassifierException
 from invenio_classifier.reader import KeywordToken
 
 from ..proxies import antihep_keywords
-from ..utils import with_debug_logging, get_pdf_in_workflow
+from ..utils import with_debug_logging, get_document_in_workflow
 
 
 @with_debug_logging
@@ -76,10 +76,10 @@ def classify_paper(taxonomy, rebuild_cache=False, no_cache=False,
         )
 
         fulltext_used = True
-        with get_pdf_in_workflow(obj) as tmp_pdf:
+        with get_document_in_workflow(obj) as tmp_document:
             try:
-                if tmp_pdf:
-                    result = get_keywords_from_local_file(tmp_pdf, **params)
+                if tmp_document:
+                    result = get_keywords_from_local_file(tmp_document, **params)
                 else:
                     data = get_value(obj.data, 'titles.title', [])
                     data.extend(get_value(obj.data, 'titles.subtitle', []))

--- a/inspirehep/modules/workflows/utils/__init__.py
+++ b/inspirehep/modules/workflows/utils/__init__.py
@@ -155,15 +155,33 @@ def with_debug_logging(func):
 
 @contextmanager
 @with_debug_logging
-def get_pdf_in_workflow(obj):
-    """Return the fullpath to the PDF attached to a workflow object"""
-    for filename in obj.files.keys:
-        if filename.endswith('.pdf'):
-            with retrieve_uri(obj.files[filename].file.uri) as local_file:
-                yield local_file
+def get_document_in_workflow(obj):
+    """Context manager giving the path to the document attached to a workflow object.
 
-    obj.log.info('No PDF available')
-    yield None
+    Arg:
+        obj: workflow object
+
+    Returns:
+        Optional[str]: The path to a local copy of the document.  If no
+        documents are present, it retuns None.  If several documents are
+        present, it prioritizes the fulltext. If several documents with the
+        same priority are present, it takes the first one and logs an error.
+    """
+    documents = obj.data.get('documents', [])
+    fulltexts = [document for document in documents if document.get('fulltext')]
+    documents = fulltexts or documents
+
+    if not documents:
+        obj.log.info('No document available')
+        yield None
+        return
+    elif len(documents) > 1:
+        obj.log.error('More than one document in workflow, first one used')
+
+    key = documents[0]['key']
+    obj.log.info('Using document with key "%s"', key)
+    with retrieve_uri(obj.files[key].file.uri) as local_file:
+        yield local_file
 
 
 @backoff.on_exception(backoff.expo, requests.packages.urllib3.exceptions.ProtocolError, max_tries=5)

--- a/inspirehep/utils/references.py
+++ b/inspirehep/utils/references.py
@@ -22,7 +22,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import os
 from contextlib import contextmanager
 
 from flask import current_app
@@ -124,9 +123,5 @@ def local_refextract_kbs_path():
     """Get the path to the temporary refextract kbs from the application config.
     """
     journal_kb_path = current_app.config.get('REFEXTRACT_JOURNAL_KB_PATH')
-    temp_journal_kb_path = retrieve_uri(journal_kb_path)
-    try:
+    with retrieve_uri(journal_kb_path) as temp_journal_kb_path:
         yield {'journals': temp_journal_kb_path}
-    finally:
-        if os.path.exists(temp_journal_kb_path):
-            os.unlink(temp_journal_kb_path)

--- a/tests/unit/utils/test_utils_url.py
+++ b/tests/unit/utils/test_utils_url.py
@@ -22,11 +22,13 @@
 
 from __future__ import absolute_import, division, print_function
 
+import os
 import requests_mock
 from flask import current_app
 from mock import patch
+from six import binary_type
 
-from inspirehep.utils.url import is_pdf_link, make_user_agent_string
+from inspirehep.utils.url import is_pdf_link, make_user_agent_string, retrieve_uri
 
 
 def test_is_pdf_link_handles_empty_requests():
@@ -47,3 +49,16 @@ def test_make_user_agent_string():
 
         user_agent_with_component = make_user_agent_string("submission")
         assert user_agent_with_component == "InspireHEP-0.1.0 (+http://inspirehep.net;) [submission]"
+
+
+def test_retrieve_uri(tmpdir):
+    test_file = tmpdir.join('file.txt')
+    test_file.write('some content')
+
+    uri = 'file://' + binary_type(test_file)
+
+    with retrieve_uri(uri) as local_path, open(local_path) as local_file:
+        path_copy = local_path
+        assert local_file.read() == 'some content'
+
+    assert not os.path.exists(path_copy)

--- a/tests/unit/workflows/test_workflows_tasks_actions.py
+++ b/tests/unit/workflows/test_workflows_tasks_actions.py
@@ -627,13 +627,13 @@ def test_populate_journal_coverage_does_nothing_if_no_journal_is_found(mock_repl
     assert 'journal_coverage' not in obj.extra_data
 
 
-@patch('inspirehep.modules.workflows.tasks.actions.get_pdf_in_workflow')
-def test_refextract_from_pdf(mock_get_pdf_in_workflow):
-    mock_get_pdf_in_workflow.return_value.__enter__.return_value = pkg_resources.resource_filename(
+@patch('inspirehep.modules.workflows.tasks.actions.get_document_in_workflow')
+def test_refextract_from_pdf(mock_get_document_in_workflow):
+    mock_get_document_in_workflow.return_value.__enter__.return_value = pkg_resources.resource_filename(
         __name__,
         os.path.join('fixtures', '1704.00452.pdf'),
     )
-    mock_get_pdf_in_workflow.return_value.__exit__.return_value = None
+    mock_get_document_in_workflow.return_value.__exit__.return_value = None
 
     schema = load_schema('hep')
     subschema = schema['properties']['acquisition_source']
@@ -649,10 +649,10 @@ def test_refextract_from_pdf(mock_get_pdf_in_workflow):
     assert obj.data['references'][0]['raw_refs'][0]['source'] == 'arXiv'
 
 
-@patch('inspirehep.modules.workflows.tasks.actions.get_pdf_in_workflow')
-def test_refextract_from_text(mock_get_pdf_in_workflow):
-    mock_get_pdf_in_workflow.return_value.__enter__.return_value = None
-    mock_get_pdf_in_workflow.return_value.__exit__.return_value = None
+@patch('inspirehep.modules.workflows.tasks.actions.get_document_in_workflow')
+def test_refextract_from_text(mock_get_document_in_workflow):
+    mock_get_document_in_workflow.return_value.__enter__.return_value = None
+    mock_get_document_in_workflow.return_value.__exit__.return_value = None
 
     schema = load_schema('hep')
     subschema = schema['properties']['acquisition_source']

--- a/tests/unit/workflows/test_workflows_tasks_actions.py
+++ b/tests/unit/workflows/test_workflows_tasks_actions.py
@@ -52,7 +52,6 @@ from inspirehep.modules.workflows.tasks.actions import (
     set_refereed_and_fix_document_type,
     shall_halt_workflow,
 )
-from inspirehep.utils.url import retrieve_uri
 
 from mocks import MockEng, MockObj, MockFiles
 
@@ -630,12 +629,11 @@ def test_populate_journal_coverage_does_nothing_if_no_journal_is_found(mock_repl
 
 @patch('inspirehep.modules.workflows.tasks.actions.get_pdf_in_workflow')
 def test_refextract_from_pdf(mock_get_pdf_in_workflow):
-    mock_get_pdf_in_workflow.return_value = retrieve_uri(
-        pkg_resources.resource_filename(
-            __name__,
-            os.path.join('fixtures', '1704.00452.pdf'),
-        )
+    mock_get_pdf_in_workflow.return_value.__enter__.return_value = pkg_resources.resource_filename(
+        __name__,
+        os.path.join('fixtures', '1704.00452.pdf'),
     )
+    mock_get_pdf_in_workflow.return_value.__exit__.return_value = None
 
     schema = load_schema('hep')
     subschema = schema['properties']['acquisition_source']
@@ -653,7 +651,8 @@ def test_refextract_from_pdf(mock_get_pdf_in_workflow):
 
 @patch('inspirehep.modules.workflows.tasks.actions.get_pdf_in_workflow')
 def test_refextract_from_text(mock_get_pdf_in_workflow):
-    mock_get_pdf_in_workflow.return_value = None
+    mock_get_pdf_in_workflow.return_value.__enter__.return_value = None
+    mock_get_pdf_in_workflow.return_value.__exit__.return_value = None
 
     schema = load_schema('hep')
     subschema = schema['properties']['acquisition_source']

--- a/tests/unit/workflows/test_workflows_tasks_classifier.py
+++ b/tests/unit/workflows/test_workflows_tasks_classifier.py
@@ -29,14 +29,14 @@ from inspirehep.modules.workflows.tasks.classifier import classify_paper
 from mocks import MockEng, MockObj
 
 
-@patch('inspirehep.modules.workflows.tasks.classifier.get_pdf_in_workflow')
-def test_classify_paper_with_fulltext(get_pdf_in_workflow, tmpdir):
+@patch('inspirehep.modules.workflows.tasks.classifier.get_document_in_workflow')
+def test_classify_paper_with_fulltext(get_document_in_workflow, tmpdir):
     obj = MockObj({}, {})
     eng = MockEng()
     fulltext = tmpdir.join('fulltext.txt')
     fulltext.write('Higgs boson')
-    get_pdf_in_workflow.return_value.__enter__.return_value = binary_type(fulltext)
-    get_pdf_in_workflow.return_value.__exit__.return_value = None
+    get_document_in_workflow.return_value.__enter__.return_value = binary_type(fulltext)
+    get_document_in_workflow.return_value.__exit__.return_value = None
 
     expected = [
         {
@@ -56,8 +56,8 @@ def test_classify_paper_with_fulltext(get_pdf_in_workflow, tmpdir):
     assert obj.extra_data['classifier_results']['fulltext_used'] is True
 
 
-@patch('inspirehep.modules.workflows.tasks.classifier.get_pdf_in_workflow')
-def test_classify_paper_with_no_fulltext(get_pdf_in_workflow):
+@patch('inspirehep.modules.workflows.tasks.classifier.get_document_in_workflow')
+def test_classify_paper_with_no_fulltext(get_document_in_workflow):
     data = {
         'titles': [
             {
@@ -72,8 +72,8 @@ def test_classify_paper_with_no_fulltext(get_pdf_in_workflow):
     }
     obj = MockObj(data, {})
     eng = MockEng()
-    get_pdf_in_workflow.return_value.__enter__.return_value = None
-    get_pdf_in_workflow.return_value.__exit__.return_value = None
+    get_document_in_workflow.return_value.__enter__.return_value = None
+    get_document_in_workflow.return_value.__exit__.return_value = None
 
     expected = [
         {
@@ -93,8 +93,8 @@ def test_classify_paper_with_no_fulltext(get_pdf_in_workflow):
     assert obj.extra_data['classifier_results']['fulltext_used'] is False
 
 
-@patch('inspirehep.modules.workflows.tasks.classifier.get_pdf_in_workflow')
-def test_classify_paper_uses_keywords(get_pdf_in_workflow):
+@patch('inspirehep.modules.workflows.tasks.classifier.get_document_in_workflow')
+def test_classify_paper_uses_keywords(get_document_in_workflow):
     data = {
         'titles': [
             {
@@ -109,8 +109,8 @@ def test_classify_paper_uses_keywords(get_pdf_in_workflow):
     }
     obj = MockObj(data, {})
     eng = MockEng()
-    get_pdf_in_workflow.return_value.__enter__.return_value = None
-    get_pdf_in_workflow.return_value.__exit__.return_value = None
+    get_document_in_workflow.return_value.__enter__.return_value = None
+    get_document_in_workflow.return_value.__exit__.return_value = None
 
     expected = [
         {

--- a/tests/unit/workflows/test_workflows_tasks_classifier.py
+++ b/tests/unit/workflows/test_workflows_tasks_classifier.py
@@ -35,7 +35,8 @@ def test_classify_paper_with_fulltext(get_pdf_in_workflow, tmpdir):
     eng = MockEng()
     fulltext = tmpdir.join('fulltext.txt')
     fulltext.write('Higgs boson')
-    get_pdf_in_workflow.return_value = binary_type(fulltext)
+    get_pdf_in_workflow.return_value.__enter__.return_value = binary_type(fulltext)
+    get_pdf_in_workflow.return_value.__exit__.return_value = None
 
     expected = [
         {
@@ -71,7 +72,8 @@ def test_classify_paper_with_no_fulltext(get_pdf_in_workflow):
     }
     obj = MockObj(data, {})
     eng = MockEng()
-    get_pdf_in_workflow.return_value = None
+    get_pdf_in_workflow.return_value.__enter__.return_value = None
+    get_pdf_in_workflow.return_value.__exit__.return_value = None
 
     expected = [
         {
@@ -107,7 +109,8 @@ def test_classify_paper_uses_keywords(get_pdf_in_workflow):
     }
     obj = MockObj(data, {})
     eng = MockEng()
-    get_pdf_in_workflow.return_value = None
+    get_pdf_in_workflow.return_value.__enter__.return_value = None
+    get_pdf_in_workflow.return_value.__exit__.return_value = None
 
     expected = [
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* The selection of the document used for further metadata extraction
(references, keywords) is now based on the `documents` metadata instead
of the file extension.
* Also refactors the `retrieve_uri` into a context manager, and does the minor refactor suggested in https://github.com/inspirehep/inspire-next/pull/3167/files#r166949783.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
