### PR TITLE
theme: make the year label in years facet more legible

### DIFF
--- a/inspirehep/modules/theme/static/scss/format/brief-results.scss
+++ b/inspirehep/modules/theme/static/scss/format/brief-results.scss
@@ -197,6 +197,9 @@ article.search-result {
 
   &.literature-facet {
     border-color: $literature-collection;
+    text {
+      font-size: 10px;
+    }
   }
 
   &.authors-facet {


### PR DESCRIPTION
Signed-off-by: Dinika Saxena <dinika.saxena@cern.ch>

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
The font-size on the year facet i literature search results was too small to be legible.

Screenshots:
Present
![screenshot from 2018-02-12 18-06-19](https://user-images.githubusercontent.com/11242410/36109375-8083d8c8-101f-11e8-820b-5f523bfa2662.png)

After  the fix
![screenshot from 2018-02-12 18-06-02](https://user-images.githubusercontent.com/11242410/36109380-844f7534-101f-11e8-8135-a798dc1450ee.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
