### PR TITLE
error_pages: adjust feedback email address

### DIFF
--- a/inspirehep/modules/theme/templates/inspirehep_theme/errors/500.html
+++ b/inspirehep/modules/theme/templates/inspirehep_theme/errors/500.html
@@ -8,7 +8,7 @@
       <h1>500</h1>
       <h4>Sorry, our servers are having some issues processing your request. </h4>
         <p>The error has been reported to our developers and we will solve it very soon!</p>
-    <p>If you have any questions, please email <a href="mailto:info@inspirehep.net">info@inspirehep.net</a>.</p>
+    <p>If you have any questions, please email <a href="mailto:feedback@inspirehep.net">feedback@inspirehep.net</a>.</p>
     </div>
 
     <div class="row-fluid error-container" align="center">


### PR DESCRIPTION
Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
the html error page (500+ statuses) currently shows an email address that does not exist/bounces

Adjusting this to a working and monitored email address as discussed on gitter/inspire-next

> > feedback@inspirehep.net ? Or perhaps @StellaCh knows...
> I'd suggest to keep it simple and use feedback for the time being and soon, when we'll launch the public beta, we can revisit the issue of the emails



## Description
<!--- Describe your changes in detail -->

simple text replacement, no functional changes

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
