### PR TITLE
authors: validate at the beginning of the workflow

### DIFF
--- a/inspirehep/modules/authors/tasks.py
+++ b/inspirehep/modules/authors/tasks.py
@@ -33,7 +33,6 @@ from invenio_accounts.models import User
 from invenio_oauthclient.models import UserIdentity
 
 from inspire_dojson.utils import strip_empty_values
-from inspire_schemas.api import validate
 from inspirehep.modules.forms.utils import filter_empty_elements
 from inspirehep.modules.workflows.utils import with_debug_logging
 from inspirehep.utils.schema import ensure_valid_schema
@@ -110,8 +109,6 @@ def formdata_to_model(obj, formdata):
     )
 
     data = strip_empty_values(data)
-
-    validate(data, 'authors')
 
     return data
 

--- a/inspirehep/modules/workflows/tasks/actions.py
+++ b/inspirehep/modules/workflows/tasks/actions.py
@@ -241,10 +241,14 @@ def is_submission(obj, eng):
     return False
 
 
-@with_debug_logging
-def validate_record(obj, eng):
-    """Check if the record is schema compliant and stop the workflow in ERROR state it it is not."""
-    validate(obj.data, 'hep')
+def validate_record(schema):
+    @with_debug_logging
+    @wraps(validate_record)
+    def _validate_record(obj, eng):
+        validate(obj.data, schema)
+
+    _validate_record.__doc__ = 'Validate the workflow record against the "%s" schema.' % schema
+    return _validate_record
 
 
 @with_debug_logging

--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -450,7 +450,7 @@ PRE_PROCESSING = [
     # Make sure schema is set for proper indexing in Holding Pen
     set_schema,
     INIT_MARKS,
-    validate_record
+    validate_record('hep')
 ]
 
 

--- a/inspirehep/modules/workflows/workflows/author.py
+++ b/inspirehep/modules/workflows/workflows/author.py
@@ -31,6 +31,7 @@ from inspirehep.modules.workflows.tasks.actions import (
     in_production_mode,
     is_marked,
     is_record_accepted,
+    validate_record,
 )
 
 from inspirehep.modules.workflows.tasks.submission import (
@@ -126,6 +127,7 @@ class Author(object):
     workflow = [
         # Make sure schema is set for proper indexing in Holding Pen
         set_schema,
+        validate_record('authors'),
         IF_ELSE(
             is_marked('is-update'),
             SEND_UPDATE_NOTIFICATION,

--- a/tests/integration/workflows/conftest.py
+++ b/tests/integration/workflows/conftest.py
@@ -149,6 +149,26 @@ def mocked_external_services(workflow_app):
                 '/ticket/new.*'
             ),
             status_code=200,
+            text='RT/3.8.7 200 Ok\n\n# Ticket 1 created.\n# Ticket 1 updated.'
+        )
+        requests_mocker.register_uri(
+            requests_mock.ANY,
+            re.compile(
+                '.*' +
+                workflow_app.config['CFG_BIBCATALOG_SYSTEM_RT_URL'] +
+                '/ticket/.*/comment'
+            ),
+            status_code=200,
+        )
+        requests_mocker.register_uri(
+            requests_mock.ANY,
+            re.compile(
+                '.*' +
+                workflow_app.config['CFG_BIBCATALOG_SYSTEM_RT_URL'] +
+                '/ticket/.*/edit'
+            ),
+            status_code=200,
+            text='Irrelevant part 1 of message \nIrrelevant part 2 of message \n# Ticket 1 updated.'
         )
 
         yield

--- a/tests/integration/workflows/test_authors_workflow.py
+++ b/tests/integration/workflows/test_authors_workflow.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2018 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+from invenio_workflows import (
+    ObjectStatus,
+    start,
+    workflow_object_class,
+)
+
+from jsonschema import ValidationError
+
+
+def test_authors_workflow_stops_when_record_is_not_valid(workflow_app):
+    invalid_record = {
+        'name': {
+            'preferred_name': 'John Smith',
+            'value': 'Smith, John'
+        }
+    }
+
+    obj = workflow_object_class.create(
+        data=invalid_record,
+        data_type='authors',
+        id_user=1,
+    )
+    obj_id = obj.id
+
+    with pytest.raises(ValidationError):
+        start('author', invalid_record, obj_id)
+
+    obj = workflow_object_class.get(obj_id)
+
+    assert obj.status == ObjectStatus.ERROR
+    assert '_error_msg' in obj.extra_data
+    assert 'required' in obj.extra_data['_error_msg']
+
+
+def test_authors_workflow_continues_when_record_is_valid(workflow_app, mocked_external_services):
+    valid_record = {
+        '_collections': ['Authors'],
+        'name': {
+            'preferred_name': 'John Smith',
+            'value': 'Smith, John'
+        }
+    }
+
+    obj = workflow_object_class.create(
+        data=valid_record,
+        data_type='authors',
+        id_user=1,
+    )
+
+    start('author', valid_record, obj.id)
+
+    obj = workflow_object_class.get(obj.id)
+
+    assert obj.status == ObjectStatus.HALTED
+    assert '_error_msg' not in obj.extra_data


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I removed the validation from the submission form and added it to the beginning of the authors workflow. If the record is not valid, a `ValidationaError` is raised, its message is stored in `obj.extra_data['_error_msg']` in order to help with identifying which part of the record is not schema compliant, the workflow is stopped, put in `ERROR` state. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is required because so far, if a record was not valid either in hepcrawl or submission form, a `ValidationError` would be raised before the workflow started and the actual record was lost. Moreover, it was hard to identify such errors because they were rather silent and required some investigation on Sentry to be brought to light.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
