### PR TITLE
Abstract legacy URL building

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -1220,6 +1220,7 @@ LEGACY_MATCH_ENDPOINT = "http://inspirehep.net/search"
 BEARD_API_URL = None  # e.g. "http://beard.inspirehep.net/api"
 MAGPIE_API_URL = None  # e.g. "http://magpie.inspirehep.net/api"
 LEGACY_BASE_URL = "http://inspirehep.net"
+LEGACY_RECORD_URL_PATTERN = 'http://inspirehep.net/record/{recid}'
 
 
 # Harvesting and Workflows
@@ -1403,8 +1404,6 @@ WORKFLOWS_UI_REST_DEFAULT_SORT = {
         "noquery": "mostrecent"
     }
 }
-
-AUTHORS_UPDATE_BASE_URL = LEGACY_BASE_URL
 
 # Crawling
 # ========

--- a/inspirehep/modules/authors/tasks.py
+++ b/inspirehep/modules/authors/tasks.py
@@ -24,9 +24,7 @@ from __future__ import absolute_import, division, print_function
 
 import copy
 import datetime
-import os
 
-from flask import current_app
 from sqlalchemy.orm.exc import NoResultFound
 
 from invenio_accounts.models import User
@@ -36,6 +34,7 @@ from inspire_dojson.utils import strip_empty_values
 from inspirehep.modules.forms.utils import filter_empty_elements
 from inspirehep.modules.workflows.utils import with_debug_logging
 from inspirehep.utils.schema import ensure_valid_schema
+from inspirehep.utils.url import get_url_for_record
 
 from .dojson.model import updateform
 
@@ -137,12 +136,14 @@ def update_ticket_context(user, obj):
     subject = u"Your update to author {0} on INSPIRE".format(
         obj.data.get("name").get("preferred_name")
     )
-    record_url = os.path.join(current_app.config["AUTHORS_UPDATE_BASE_URL"], "record",
-                              str(obj.data["control_number"]))
+    record_url = get_url_for_record(
+        obj.data['control_number'],
+        'AUTHORS_UPDATE_BASE_URL'
+    )
     return dict(
         email=user.email,
         url=record_url,
-        bibedit_url=record_url + "/edit",
+        bibedit_url=record_url + '/edit',
         subject=subject,
         user_comment=obj.extra_data.get('formdata', {}).get('extra_comments', ''),
     )

--- a/inspirehep/modules/authors/tasks.py
+++ b/inspirehep/modules/authors/tasks.py
@@ -34,7 +34,7 @@ from inspire_dojson.utils import strip_empty_values
 from inspirehep.modules.forms.utils import filter_empty_elements
 from inspirehep.modules.workflows.utils import with_debug_logging
 from inspirehep.utils.schema import ensure_valid_schema
-from inspirehep.utils.url import get_prod_url_for_recid
+from inspirehep.utils.url import get_legacy_url_for_recid
 
 from .dojson.model import updateform
 
@@ -136,7 +136,7 @@ def update_ticket_context(user, obj):
     subject = u"Your update to author {0} on INSPIRE".format(
         obj.data.get("name").get("preferred_name")
     )
-    record_url = get_prod_url_for_recid(obj.data['control_number'])
+    record_url = get_legacy_url_for_recid(obj.data['control_number'])
     return dict(
         email=user.email,
         url=record_url,

--- a/inspirehep/modules/authors/tasks.py
+++ b/inspirehep/modules/authors/tasks.py
@@ -34,7 +34,7 @@ from inspire_dojson.utils import strip_empty_values
 from inspirehep.modules.forms.utils import filter_empty_elements
 from inspirehep.modules.workflows.utils import with_debug_logging
 from inspirehep.utils.schema import ensure_valid_schema
-from inspirehep.utils.url import get_url_for_record
+from inspirehep.utils.url import get_prod_url_for_recid
 
 from .dojson.model import updateform
 
@@ -136,10 +136,7 @@ def update_ticket_context(user, obj):
     subject = u"Your update to author {0} on INSPIRE".format(
         obj.data.get("name").get("preferred_name")
     )
-    record_url = get_url_for_record(
-        obj.data['control_number'],
-        'AUTHORS_UPDATE_BASE_URL'
-    )
+    record_url = get_prod_url_for_recid(obj.data['control_number'])
     return dict(
         email=user.email,
         url=record_url,

--- a/inspirehep/modules/authors/views.py
+++ b/inspirehep/modules/authors/views.py
@@ -48,7 +48,7 @@ from invenio_workflows_ui.api import WorkflowUIRecord
 from inspire_dojson import marcxml2record
 from inspire_utils.record import get_value
 from inspirehep.modules.forms.form import DataExporter
-from inspirehep.utils.url import get_prod_url_for_recid
+from inspirehep.utils.url import get_legacy_url_for_recid
 
 from .forms import AuthorUpdateForm
 from .permissions import holdingpen_author_permission
@@ -233,7 +233,7 @@ def update(recid):
     data = {}
     if recid:
         try:
-            url = get_prod_url_for_recid(recid) + '/export/xm'
+            url = get_legacy_url_for_recid(recid) + '/export/xm'
             xml = requests.get(url)
             record_regex = re.compile(
                 r"\<record\>.*\<\/record\>", re.MULTILINE + re.DOTALL)

--- a/inspirehep/modules/authors/views.py
+++ b/inspirehep/modules/authors/views.py
@@ -48,7 +48,7 @@ from invenio_workflows_ui.api import WorkflowUIRecord
 from inspire_dojson import marcxml2record
 from inspire_utils.record import get_value
 from inspirehep.modules.forms.form import DataExporter
-from inspirehep.utils.url import get_url_for_record
+from inspirehep.utils.url import get_prod_url_for_recid
 
 from .forms import AuthorUpdateForm
 from .permissions import holdingpen_author_permission
@@ -233,7 +233,7 @@ def update(recid):
     data = {}
     if recid:
         try:
-            url = get_url_for_record(recid, 'AUTHORS_UPDATE_BASE_URL') + '/export/xm'
+            url = get_prod_url_for_recid(recid) + '/export/xm'
             xml = requests.get(url)
             record_regex = re.compile(
                 r"\<record\>.*\<\/record\>", re.MULTILINE + re.DOTALL)

--- a/inspirehep/modules/authors/views.py
+++ b/inspirehep/modules/authors/views.py
@@ -25,14 +25,12 @@
 from __future__ import absolute_import, division, print_function
 
 import copy
-import os
 import re
 
 import requests
 from flask import (
     abort,
     Blueprint,
-    current_app,
     jsonify,
     render_template,
     request,
@@ -50,6 +48,7 @@ from invenio_workflows_ui.api import WorkflowUIRecord
 from inspire_dojson import marcxml2record
 from inspire_utils.record import get_value
 from inspirehep.modules.forms.form import DataExporter
+from inspirehep.utils.url import get_url_for_record
 
 from .forms import AuthorUpdateForm
 from .permissions import holdingpen_author_permission
@@ -234,9 +233,7 @@ def update(recid):
     data = {}
     if recid:
         try:
-            url = os.path.join(
-                current_app.config["AUTHORS_UPDATE_BASE_URL"],
-                "record", str(recid), "export", "xm")
+            url = get_url_for_record(recid, 'AUTHORS_UPDATE_BASE_URL') + '/export/xm'
             xml = requests.get(url)
             record_regex = re.compile(
                 r"\<record\>.*\<\/record\>", re.MULTILINE + re.DOTALL)

--- a/inspirehep/modules/orcid/api.py
+++ b/inspirehep/modules/orcid/api.py
@@ -54,8 +54,6 @@ def push_record_with_orcid(recid, orcid, oauth_token, put_code=None):
     Returns:
         string: the put-code of the updated/inserted item
     """
-    server_name = app.config["SERVER_NAME"]
-
     record = _get_hep_record(app.config, recid)
 
     try:
@@ -68,7 +66,7 @@ def push_record_with_orcid(recid, orcid, oauth_token, put_code=None):
     orcid_api = _get_api()
 
     orcid_xml = OrcidConverter(
-        record, server_name, put_code=put_code, bibtex_citation=bibtex
+        record, app.config['LEGACY_RECORD_URL_PATTERN'], put_code=put_code, bibtex_citation=bibtex
     ).get_xml()
 
     if put_code:
@@ -151,7 +149,7 @@ def _get_bibtex_record(config, recid):
         recid (string): HEP record ID
 
     Returns:
-        dict: BibTeX serialized record
+        string: BibTeX serialized record
     """
     bibtex_response = _get_record_by_mime(config, recid, 'application/x-bibtex')
     return bibtex_response.text

--- a/inspirehep/modules/orcid/utils.py
+++ b/inspirehep/modules/orcid/utils.py
@@ -26,8 +26,8 @@ from __future__ import absolute_import, division, print_function
 
 import re
 
+from six.moves.urllib.parse import urljoin
 from sqlalchemy.orm.exc import NoResultFound
-from urlparse import urljoin
 
 from invenio_db import db
 from invenio_oauthclient.models import (
@@ -37,6 +37,7 @@ from invenio_oauthclient.models import (
 )
 
 from inspire_utils.logging import getStackTraceLogger
+from inspire_utils.urls import ensure_scheme
 from inspirehep.modules.cache.utils import redis_locking_context, RedisLockError
 
 LOGGER = getStackTraceLogger(__name__)
@@ -76,13 +77,10 @@ def _get_api_url_for_recid(server_name, api_endpoint, recid):
     Returns:
         string: API URL for the record
     """
-    if not re.match('^https?://', server_name):
-        server_name = 'http://{}'.format(server_name)
-
     if not api_endpoint.endswith('/'):
         api_endpoint = api_endpoint + '/'
 
-    api_url = urljoin(server_name, api_endpoint)
+    api_url = urljoin(ensure_scheme(server_name), api_endpoint)
     return urljoin(api_url, recid)
 
 

--- a/inspirehep/modules/records/json_ref_loader.py
+++ b/inspirehep/modules/records/json_ref_loader.py
@@ -24,8 +24,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import re
-
 from flask import current_app, url_for
 from jsonref import JsonLoader, JsonRef
 from werkzeug.urls import url_parse
@@ -34,6 +32,7 @@ import jsonresolver
 from jsonresolver.contrib.jsonref import json_loader_factory
 
 from inspire_schemas.utils import load_schema
+from inspire_utils.urls import ensure_scheme
 from inspirehep.modules.pidstore.utils import get_pid_type_from_endpoint
 from inspirehep.utils import record_getter
 
@@ -52,9 +51,7 @@ class AbstractRecordLoader(JsonLoader):
         parsed_uri = url_parse(uri)
         # Add http:// protocol so uri.netloc is correctly parsed.
         server_name = current_app.config.get('SERVER_NAME')
-        if not re.match('^https?://', server_name):
-            server_name = 'http://{}'.format(server_name)
-        parsed_server = url_parse(server_name)
+        parsed_server = url_parse(ensure_scheme(server_name))
 
         if parsed_uri.netloc and parsed_uri.netloc != parsed_server.netloc:
             return super(AbstractRecordLoader, self).get_remote_json(uri,

--- a/inspirehep/modules/workflows/views.py
+++ b/inspirehep/modules/workflows/views.py
@@ -24,8 +24,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import re
-
 from os.path import join
 from flask import Blueprint, jsonify, request, current_app
 
@@ -33,6 +31,7 @@ from invenio_db import db
 from invenio_workflows import workflow_object_class, ObjectStatus
 from invenio_workflows.errors import WorkflowsMissingObject
 
+from inspire_utils.urls import ensure_scheme
 from inspirehep.modules.workflows.models import WorkflowsPendingRecord
 
 blueprint = Blueprint(
@@ -50,9 +49,7 @@ def _get_base_url():
         "LEGACY_ROBOTUPLOAD_URL",
         current_app.config["SERVER_NAME"],
     )
-    if not re.match('^https?://', base_url):
-        base_url = 'http://{}'.format(base_url)
-    return base_url
+    return ensure_scheme(base_url)
 
 
 def _continue_workflow(workflow_id, recid, result=None):

--- a/inspirehep/utils/url.py
+++ b/inspirehep/utils/url.py
@@ -92,7 +92,7 @@ def retrieve_uri(uri, outdir=None):
         yield local_file.name
 
 
-def get_prod_url_for_recid(recid, pattern_config_var='LEGACY_RECORD_URL_PATTERN'):
+def get_legacy_url_for_recid(recid):
     """Get a URL to a record on INSPIRE.
 
     Args:
@@ -102,5 +102,5 @@ def get_prod_url_for_recid(recid, pattern_config_var='LEGACY_RECORD_URL_PATTERN'
     Return:
         text_type: URL
     """
-    pattern = current_app.config[pattern_config_var]
+    pattern = current_app.config['LEGACY_RECORD_URL_PATTERN']
     return record_url_by_pattern(pattern, recid)

--- a/inspirehep/utils/url.py
+++ b/inspirehep/utils/url.py
@@ -32,6 +32,7 @@ from contextlib import contextmanager
 from flask import current_app
 from fs.opener import fsopen
 
+from inspire_utils.urls import record_url_by_pattern
 from inspirehep import __version__
 
 
@@ -89,3 +90,17 @@ def retrieve_uri(uri, outdir=None):
 
         local_file.flush()
         yield local_file.name
+
+
+def get_prod_url_for_recid(recid, pattern_config_var='LEGACY_RECORD_URL_PATTERN'):
+    """Get a URL to a record on INSPIRE.
+
+    Args:
+        recid (Union[int, string]): record ID
+        pattern_config_var (string): config var with the pattern
+
+    Return:
+        text_type: URL
+    """
+    pattern = current_app.config[pattern_config_var]
+    return record_url_by_pattern(pattern, recid)

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ install_requires = [
     'inspire-matcher~=4.0,>=4.0.0',
     'inspire-query-parser~=3.0,>=3.1.5',
     'inspire-schemas~=57.0,>=57.0.0',
-    'inspire-utils~=2.0,>=2.0.5',
+    'inspire-utils~=2.0,>=2.0.6',
     'invenio-access>=1.0.0b1',
     'invenio-accounts>=1.0.0b10',
     'invenio-admin>=1.0.0b4',

--- a/tests/integration/orcid/test_orcid_export.py
+++ b/tests/integration/orcid/test_orcid_export.py
@@ -26,7 +26,6 @@ import json
 import os
 import pkg_resources
 
-from flask import current_app
 from inspirehep.modules.orcid import OrcidConverter
 from lxml import etree
 
@@ -77,7 +76,7 @@ def test_format_article(app, api_client):
                 <common:external-id-relationship>self</common:external-id-relationship>
             </common:external-id>
         </common:external-ids>
-        <work:url>http://localhost:5000/record/4328</work:url>
+        <work:url>http://inspirehep.net/record/4328</work:url>
         <work:contributors>
             <work:contributor>
                 <work:credit-name>Glashow, S.L.</work:credit-name>
@@ -92,7 +91,7 @@ def test_format_article(app, api_client):
 
     result = OrcidConverter(
         article['metadata'],
-        server_name=current_app.config['SERVER_NAME']
+        url_pattern='http://inspirehep.net/record/{recid}',
     ).get_xml()
     assert valid_against_schema(result)
     assert xml_compare(expected, result)
@@ -118,7 +117,7 @@ def test_format_conference_paper(app, api_client):
                 <common:external-id-relationship>self</common:external-id-relationship>
             </common:external-id>
         </common:external-ids>
-        <work:url>http://localhost:5000/record/524480</work:url>
+        <work:url>http://inspirehep.net/record/524480</work:url>
         <work:contributors>
             <work:contributor>
                 <work:credit-name>Hu, Wayne</work:credit-name>
@@ -133,7 +132,7 @@ def test_format_conference_paper(app, api_client):
 
     result = OrcidConverter(
         inproceedings['metadata'],
-        server_name=current_app.config['SERVER_NAME']
+        url_pattern='http://inspirehep.net/record/{recid}',
     ).get_xml()
     assert valid_against_schema(result)
     assert xml_compare(expected, result)
@@ -161,7 +160,7 @@ def test_format_proceedings(app, api_client):
                 <common:external-id-relationship>self</common:external-id-relationship>
             </common:external-id>
         </common:external-ids>
-        <work:url>http://localhost:5000/record/701585</work:url>
+        <work:url>http://inspirehep.net/record/701585</work:url>
         <work:contributors>
             <work:contributor>
                 <work:credit-name>De Roeck, A.</work:credit-name>
@@ -183,7 +182,7 @@ def test_format_proceedings(app, api_client):
 
     result = OrcidConverter(
         proceedings['metadata'],
-        server_name=current_app.config['SERVER_NAME']
+        url_pattern='http://inspirehep.net/record/{recid}',
     ).get_xml()
     assert valid_against_schema(result)
     assert xml_compare(expected, result)
@@ -200,7 +199,7 @@ def test_format_thesis(app, api_client):
             <common:title>MAGIC $\\gamma$-ray observations of distant AGN and a study of source variability and the extragalactic background light using FERMI and air Cherenkov telescopes</common:title>
         </work:title>
         <work:type>dissertation</work:type>
-        <work:url>http://localhost:5000/record/1395663</work:url>
+        <work:url>http://inspirehep.net/record/1395663</work:url>
         <work:contributors>
             <work:contributor>
                 <work:credit-name>Mankuzhiyil, Nijil</work:credit-name>
@@ -215,7 +214,7 @@ def test_format_thesis(app, api_client):
 
     result = OrcidConverter(
         phdthesis['metadata'],
-        server_name=current_app.config['SERVER_NAME']
+        url_pattern='http://inspirehep.net/record/{recid}',
     ).get_xml()
     assert valid_against_schema(result)
     assert xml_compare(expected, result)
@@ -251,7 +250,7 @@ def test_format_book(app, api_client):
                 <common:external-id-value>9780511242960</common:external-id-value>
             </common:external-id>
         </common:external-ids>
-        <work:url>http://localhost:5000/record/736770</work:url>
+        <work:url>http://inspirehep.net/record/736770</work:url>
         <work:contributors>
             <work:contributor>
                 <work:credit-name>Fecko, M.</work:credit-name>
@@ -266,7 +265,7 @@ def test_format_book(app, api_client):
 
     result = OrcidConverter(
         book['metadata'],
-        server_name=current_app.config['SERVER_NAME']
+        url_pattern='http://inspirehep.net/record/{recid}',
     ).get_xml()
     assert valid_against_schema(result)
     assert xml_compare(expected, result)
@@ -300,7 +299,7 @@ def test_format_book_chapter(app, api_client):
                 <common:external-id-relationship>self</common:external-id-relationship>
             </common:external-id>
         </common:external-ids>
-        <work:url>http://localhost:5000/record/1375491</work:url>
+        <work:url>http://inspirehep.net/record/1375491</work:url>
         <work:contributors>
             <work:contributor>
                 <work:credit-name>Bechtle, Philip</work:credit-name>
@@ -329,7 +328,7 @@ def test_format_book_chapter(app, api_client):
 
     result = OrcidConverter(
         inbook['metadata'],
-        server_name=current_app.config['SERVER_NAME']
+        url_pattern='http://inspirehep.net/record/{recid}',
     ).get_xml()
     assert valid_against_schema(result)
     assert xml_compare(expected, result)

--- a/tests/unit/utils/test_utils_url.py
+++ b/tests/unit/utils/test_utils_url.py
@@ -33,7 +33,7 @@ from inspirehep.utils.url import (
     is_pdf_link,
     make_user_agent_string,
     retrieve_uri,
-    get_prod_url_for_recid,
+    get_legacy_url_for_recid,
 )
 
 
@@ -71,28 +71,22 @@ def test_retrieve_uri(tmpdir):
 
 
 @pytest.mark.parametrize(
-    'recid,base,expected',
+    'recid,expected',
     [
-        (12345, None, 'http://inspirehep.net/record/12345'),
-        (12345, 'SOME_OTHER_URL_PATTERN', 'http://labs.inspirehep.net/record/12345'),
-        (text_type(2434), None, 'http://inspirehep.net/record/2434'),
-        (binary_type(3563), None, 'http://inspirehep.net/record/3563'),
+        (12345, 'http://inspirehep.net/record/12345'),
+        (text_type(2434), 'http://inspirehep.net/record/2434'),
+        (binary_type(3563), 'http://inspirehep.net/record/3563'),
     ],
     ids=[
         'integer recid',
-        'custom config var',
         'unicode recid',
         'binary string recid',
     ]
 )
-def test_get_legacy_url_for_record(recid, base, expected):
+def test_get_legacy_url_for_record(recid, expected):
     config = {
         'LEGACY_RECORD_URL_PATTERN': 'http://inspirehep.net/record/{recid}',
-        'SOME_OTHER_URL_PATTERN': 'http://labs.inspirehep.net/record/{recid}',
     }
 
     with patch.dict(current_app.config, config):
-        if base:
-            assert get_prod_url_for_recid(recid, base) == expected
-        else:
-            assert get_prod_url_for_recid(recid) == expected
+        assert get_legacy_url_for_recid(recid) == expected


### PR DESCRIPTION
## Description

- This introduces a `get_prod_url_for_recid` util to make record URLs from recids.
- In addition to this, API of OrcidConverter is changed to keep it flask-less and seperate from the rest of the application. We cannot use the util in there directly, so this proposes to instead pass a URL pattern and uses inspire_utils, which will allow us to seperate it from the main app in the future.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
