### PR TITLE
refextract: correctly generate journal KB

### DIFF
--- a/tests/unit/refextract/test_refextract_utils.py
+++ b/tests/unit/refextract/test_refextract_utils.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+from inspirehep.modules.refextract.utils import KbWriter
+
+
+def test_kb_writer_two_entries(tmpdir):
+    kb_file = tmpdir.join('two_entries.kb')
+
+    with KbWriter(str(kb_file)) as writer:
+        writer.add_entry('Journal of Testing', 'J.Testing')
+        writer.add_entry('J.Testing', 'J.Testing')
+
+    expected = [
+        'JOURNAL OF TESTING---J.Testing\n',
+        'J TESTING---J.Testing\n',
+    ]
+
+    assert expected == kb_file.readlines()
+
+
+def test_kb_writer_unicode(tmpdir):
+    kb_file = tmpdir.join('unicode.kb')
+
+    with KbWriter(str(kb_file)) as writer:
+        writer.add_entry(u'Journal de l\'Académie', 'J.Acad.')
+
+    expected = [
+        'JOURNAL DE L ACADÉMIE---J.Acad.\n',
+    ]
+
+    assert expected == kb_file.readlines()
+
+
+def test_kb_writer_many_lines(tmpdir):
+    kb_file = tmpdir.join('many_lines.kb')
+
+    with KbWriter(str(kb_file)) as writer:
+        for numlines in xrange(100000):
+            writer.add_entry('Journal of Testing', 'J.Testing')
+
+    assert len(kb_file.readlines()) == 100000
+
+
+def test_kb_writer_multiple_runs(tmpdir):
+    kb_file = tmpdir.join('multiple_flushes.kb')
+
+    with KbWriter(str(kb_file)) as writer:
+        writer.add_entry('Journal of Testing', 'J.Testing')
+
+    with KbWriter(str(kb_file)) as writer:
+        writer.add_entry('Second Journal of Testing', 'Sec.J.Testing')
+
+    expected = [
+        'SECOND JOURNAL OF TESTING---Sec.J.Testing\n',
+    ]
+
+    assert expected == kb_file.readlines()


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
* Previously, the journal knowledge base file was opened in write mode
instead of append, which resulted in new writes overwriting previous
ones instead of being appended to them.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
