### PR TITLE
authors.tasks.update_ticket_context: require recid

### DIFF
--- a/inspirehep/modules/authors/tasks.py
+++ b/inspirehep/modules/authors/tasks.py
@@ -141,7 +141,7 @@ def update_ticket_context(user, obj):
         obj.data.get("name").get("preferred_name")
     )
     record_url = os.path.join(current_app.config["AUTHORS_UPDATE_BASE_URL"], "record",
-                              str(obj.data.get("control_number", "")))
+                              str(obj.data["control_number"]))
     return dict(
         email=user.email,
         url=record_url,

--- a/tests/unit/authors/test_authors_tasks.py
+++ b/tests/unit/authors/test_authors_tasks.py
@@ -50,6 +50,16 @@ def data():
 
 
 @pytest.fixture()
+def data_no_recid():
+    return {
+        "name": {
+            "preferred_name": "John Doe"
+        },
+        "bai": "John.Doe.1"
+    }
+
+
+@pytest.fixture()
 def unicode_data():
     return {
         'bai': 'Diego.Martinez.Santos.1',
@@ -129,6 +139,16 @@ def test_update_ticket_context_handles_unicode(unicode_data, extra_data, user):
         }
         ctx = update_ticket_context(user, obj)
         assert ctx == expected
+
+
+def test_update_ticket_context_fail_no_recid(data_no_recid, extra_data, user):
+    config = {
+        'AUTHORS_UPDATE_BASE_URL': 'http://inspirehep.net'
+    }
+    obj = MockObj(data_no_recid, extra_data)
+    with patch.dict(current_app.config, config):
+        with pytest.raises(KeyError):
+            update_ticket_context(user, obj)
 
 
 def test_reply_ticket_context(data, extra_data, user):


### PR DESCRIPTION
## Description

Current implementation proceeds silently if no control_number appears in the record.
This forces the control_number to be there.

## Motivation and Context

For https://github.com/inspirehep/inspire-next/pull/3204, it would require accommodating for this 'feature', while it does not seem necessary/right.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
