### PR TITLE
docker: clean up pidfile when starting scrapyd

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,7 +137,7 @@ services:
   scrapyd:
     extends:
       service: service_base
-    command: scrapyd
+    command: bash -c "rm -f twistd.pid && exec scrapyd"
     volumes_from:
       - static
 


### PR DESCRIPTION
## Motivation and Context:
Same as https://github.com/inspirehep/inspire-next/pull/3191.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.