### PR TITLE
orcid: don't rely on self_recid in record in OrcidConverter

### DIFF
--- a/inspirehep/modules/orcid/converter.py
+++ b/inspirehep/modules/orcid/converter.py
@@ -220,7 +220,7 @@ class OrcidConverter(object):
     @property
     def recid(self):
         """Get INSPIRE record ID."""
-        return self.record['self_recid']
+        return self.record['control_number']
 
     @property
     def title_translation(self):


### PR DESCRIPTION
## Description
Don't use `self_recid` as it is not part of the schema, hence shouldn't be relied on. Instead use the `control_number` field.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
