### PR TITLE
utils: add get_db_records util

### DIFF
--- a/tests/integration/test_records.py
+++ b/tests/integration/test_records.py
@@ -43,7 +43,7 @@ from inspire_schemas.api import validate
 from inspirehep.modules.records.api import InspireRecord
 from inspirehep.modules.records.tasks import merge_merged_records, update_refs
 from inspirehep.modules.migrator.tasks import record_insert_or_replace
-from inspirehep.utils.record_getter import get_db_record, get_es_records
+from inspirehep.utils.record_getter import get_db_record
 
 from utils import _delete_record
 
@@ -361,22 +361,6 @@ def test_references_can_be_updated(app, records_to_be_merged):
         pointing_record, 'accelerator_experiments[0].record.$ref')
 
     assert expected == result
-
-
-def test_get_es_records_handles_empty_lists(app):
-    get_es_records('lit', [])  # Does not raise.
-
-
-def test_get_es_records_accepts_lists_of_integers(app):
-    records = get_es_records('lit', [4328])
-
-    assert len(records) == 1
-
-
-def test_get_es_records_accepts_lists_of_strings(app):
-    records = get_es_records('lit', ['4328'])
-
-    assert len(records) == 1
 
 
 def test_records_files_attached_correctly(app):

--- a/tests/integration/utils/test_record_getter.py
+++ b/tests/integration/utils/test_record_getter.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+from inspirehep.utils.record_getter import get_db_records, get_es_records
+
+
+def test_get_es_records_handles_empty_lists(app):
+    assert get_es_records('lit', []) == []
+
+
+def test_get_es_records_accepts_lists_of_integers(app):
+    records = get_es_records('lit', [4328])
+
+    assert len(records) == 1
+
+
+def test_get_es_records_accepts_lists_of_strings(app):
+    records = get_es_records('lit', ['4328'])
+
+    assert len(records) == 1
+
+
+def test_get_es_records_finds_right_results(app):
+    literature = [1498175, 1090628]
+    authors = [983059]
+
+    results = get_es_records('lit', literature + authors)
+    recids = {result['control_number'] for result in results}
+
+    assert len(results) == len(literature)
+    assert recids == set(literature)
+
+
+def test_get_db_records_handles_empty_lists(app):
+    assert list(get_db_records('lit', [])) == []
+
+
+def test_get_db_records_accepts_lists_of_integers(app):
+    records = list(get_db_records('lit', [4328]))
+
+    assert len(records) == 1
+
+
+def test_get_db_records_accepts_lists_of_strings(app):
+    records = list(get_db_records('lit', ['4328']))
+
+    assert len(records) == 1
+
+
+def test_get_db_records_finds_right_results(app):
+    literature = [1498175, 1090628]
+    authors = [983059]
+
+    results = list(get_db_records('lit', literature + authors))
+    recids = {result['control_number'] for result in results}
+
+    assert len(results) == len(literature)
+    assert recids == set(literature)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
* Adds a `get_db_records` util to get several records at once given a PID type and a list of recids.
* Also refactors the tests for `get_es_records`
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is useful for #3223.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
