### PR TITLE
workflows: look at proceedings in set_refereed_...

### DIFF
--- a/inspirehep/modules/workflows/tasks/actions.py
+++ b/inspirehep/modules/workflows/tasks/actions.py
@@ -500,14 +500,17 @@ def set_refereed_and_fix_document_type(obj, eng):
         journal.get('refereed') and not journal.get('proceedings') for journal in journals)
     is_published_in_a_refereed_journal_that_also_publishes_proceedings = any(
         journal.get('refereed') and journal.get('proceedings') for journal in journals)
-    is_not_a_conference_paper = 'conference paper' not in obj.data['document_type']
+    is_not_a_conference_paper_nor_proceedings = not {'conference paper', 'proceedings'}.intersection(
+        obj.data['document_type']
+    )
 
     is_published_exclusively_in_non_refereed_journals = all(
         not journal.get('refereed', True) for journal in journals)
 
     if is_published_in_a_refereed_journal_that_does_not_publish_proceedings:
         obj.data['refereed'] = True
-    elif is_not_a_conference_paper and is_published_in_a_refereed_journal_that_also_publishes_proceedings:
+    elif (is_not_a_conference_paper_nor_proceedings and
+          is_published_in_a_refereed_journal_that_also_publishes_proceedings):
         obj.data['refereed'] = True
     elif is_published_exclusively_in_non_refereed_journals:
         obj.data['refereed'] = False


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Previously `set_refereed_and_fix_document_type` was considering
`conference paper`s, but not `proceeding`s. Now also `proceeding`s are
taken into account.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
