### PR TITLE
Revert "workflows: add hp card for all publisher harvests"

### DIFF
--- a/inspirehep/modules/workflows/templates/inspire_workflows/index.html
+++ b/inspirehep/modules/workflows/templates/inspire_workflows/index.html
@@ -93,16 +93,6 @@
           section_title="all harvests">
         </holding-pen-dashboard-item>
     </div>
-
-    <div class="col-md-3 col-sm-6">
-        <holding-pen-dashboard-item
-          template="{{url_for('static', filename='node_modules/inspirehep-search-js/dist/templates/inspirehep-holdingpen-js/dashboard_stat_block.html')}}"
-          filter_string="workflow_name=HEP&q=!(metadata.acquisition_source.source:arXiv)"
-          secondary_filter="status"
-          section_title="publisher harvests">
-        </holding-pen-dashboard-item>
-    </div>
-
   </div>
 </div>
 {%- endblock -%}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This reverts commit 1d24d5276457dfe8d05c0562e82cc689fb1625aa in order to hide it from both QA and Prod.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
 This is needed due to the fact that the behaviour introduced by the commit is not the intended one and should not be allowed to confuse users until it is fixed.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
