### PR TITLE
setup: pin new versions of inspire-crawler and hepcrawl

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ install_requires = [
     'elasticsearch~=2.0,>=2.4.1',
     'flask-shell-ipython~=0.0,>=0.3.0',
     'fs~=0.0,>=0.5.4',
-    'inspire-crawler~=1.0',
+    'inspire-crawler~=2.0',
     'inspire-dojson~=58.0,>=58.0.0',
     'inspire-json-merger~=7.0,>=7.0.0',
     'inspire-matcher~=4.1,>=4.1.1',
@@ -126,7 +126,7 @@ extras_require = {
         'ipdb~=0.0,>=0.10.3',
     ],
     'crawler-node': [
-        'hepcrawl~=9.0,>=9.0',
+        'hepcrawl~=10.0,>=10.0.5',
     ],
     'docs': docs_require,
     'tests': tests_require,


### PR DESCRIPTION
Signed-off-by: Antonio Cesarano <cesarano2607@gmail.com>

This commit pins the new versions of `inspire-crawler` and `hepcrawl` to start workflows in ERROR state.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
