### PR TITLE
orcid.builder: order contributor fields correctly

### DIFF
--- a/inspirehep/modules/orcid/builder.py
+++ b/inspirehep/modules/orcid/builder.py
@@ -237,17 +237,17 @@ class OrcidBuilder(object):
         if role:
             contributor_attributes.append(_WORK('contributor-role', role))
 
-        contributor = _WORK(
-            'contributor',
-            _WORK('credit-name', credit_name),
-            contributor_attributes
-        )
+        contributor = _WORK('contributor')
 
         if orcid:
             contributor.append(self._make_contributor_orcid_field(orcid))
 
+        contributor.append(_WORK('credit-name', credit_name))
+
         if email:
             contributor.append(_WORK('contributor-email', email))
+
+        contributor.append(contributor_attributes)
 
         return contributor
 

--- a/tests/unit/orcid/test_orcid_builder.py
+++ b/tests/unit/orcid/test_orcid_builder.py
@@ -44,17 +44,17 @@ def test_add_author():
     <work:work xmlns:common="http://www.orcid.org/ns/common" xmlns:work="http://www.orcid.org/ns/work">
         <work:contributors>
             <work:contributor>
-                <work:credit-name>Josiah Carberry</work:credit-name>
-                <work:contributor-attributes>
-                    <work:contributor-sequence>first</work:contributor-sequence>
-                    <work:contributor-role>author</work:contributor-role>
-                </work:contributor-attributes>
                 <common:contributor-orcid>
                     <common:uri>http://orcid.org/0000-0002-1825-0097</common:uri>
                     <common:path>0000-0002-1825-0097</common:path>
                     <common:host>orcid.org</common:host>
                 </common:contributor-orcid>
+                <work:credit-name>Josiah Carberry</work:credit-name>
                 <work:contributor-email>j.carberry@orcid.org</work:contributor-email>
+                <work:contributor-attributes>
+                    <work:contributor-sequence>first</work:contributor-sequence>
+                    <work:contributor-role>author</work:contributor-role>
+                </work:contributor-attributes>
             </work:contributor>
         </work:contributors>
     </work:work>
@@ -72,17 +72,17 @@ def test_add_multiple_authors():
     <work:work xmlns:common="http://www.orcid.org/ns/common" xmlns:work="http://www.orcid.org/ns/work">
         <work:contributors>
             <work:contributor>
-                <work:credit-name>Josiah Carberry</work:credit-name>
-                <work:contributor-attributes>
-                    <work:contributor-sequence>first</work:contributor-sequence>
-                    <work:contributor-role>author</work:contributor-role>
-                </work:contributor-attributes>
                 <common:contributor-orcid>
                     <common:uri>http://orcid.org/0000-0002-1825-0097</common:uri>
                     <common:path>0000-0002-1825-0097</common:path>
                     <common:host>orcid.org</common:host>
                 </common:contributor-orcid>
+                <work:credit-name>Josiah Carberry</work:credit-name>
                 <work:contributor-email>j.carberry@orcid.org</work:contributor-email>
+                <work:contributor-attributes>
+                    <work:contributor-sequence>first</work:contributor-sequence>
+                    <work:contributor-role>author</work:contributor-role>
+                </work:contributor-attributes>
             </work:contributor>
             <work:contributor>
                 <work:credit-name>Homer Simpson</work:credit-name>


### PR DESCRIPTION
## Description

- Order fields in the contributor in the correct order so that the record validates
- This version of the builder was manually tested on 10k records migrated from legacy

## Related Issue

Records created by the previous version of the builder would fail validation if the author contained an ORCID.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
