### PR TITLE
forms: fix orcid validation after API update

### DIFF
--- a/inspirehep/modules/forms/validation_utils.py
+++ b/inspirehep/modules/forms/validation_utils.py
@@ -72,7 +72,7 @@ def ORCIDValidator(form, field):
                               current_app.config["ORCID_APP_CREDENTIALS"]["consumer_secret"])
         try:
             result = api.search("orcid:" + orcid_id)
-            if result['orcid-search-results']["num-found"] == 0:
+            if result["num-found"] == 0:
                 raise StopValidation(msg)
         except RequestException:
             return

--- a/tests/unit/forms/test_forms_validation_utils.py
+++ b/tests/unit/forms/test_forms_validation_utils.py
@@ -78,7 +78,18 @@ def test_doi_syntax_validator_raises_on_invalid_dois():
 
 @patch('inspirehep.modules.forms.validation_utils.orcid.MemberAPI')
 def test_orcid_validator_accepts_existing_orcids(mock_member_api):
-    mock_orcid_api = MockOrcidAPI({'orcid-search-results': {'num-found': 1}})
+    mock_orcid_api = MockOrcidAPI({
+        'num-found': 1,
+        'result': [
+            {
+                'orcid-identifier': {
+                    'host': 'orcid.org',
+                    'path': '0000-0003-1032-3957',
+                    'uri': 'http://orcid.org/0000-0003-1032-3957',
+                },
+            },
+        ],
+    })
     mock_member_api.return_value = mock_orcid_api
 
     config = {
@@ -96,7 +107,7 @@ def test_orcid_validator_accepts_existing_orcids(mock_member_api):
 
 @patch('inspirehep.modules.forms.validation_utils.orcid.MemberAPI')
 def test_orcid_validator_raises_on_non_existing_orcids(mock_member_api):
-    mock_orcid_api = MockOrcidAPI({'orcid-search-results': {'num-found': 0}})
+    mock_orcid_api = MockOrcidAPI({'num-found': 0, 'result': []})
     mock_member_api.return_value = mock_orcid_api
 
     config = {


### PR DESCRIPTION
## Description:
Resubmits https://github.com/inspirehep/inspire-next/pull/3220 against the `prod` branch so that we can hotfix this error on production: https://sentry.inspirehep.net/inspire-sentry/prod/issues/50311/.

## Related Issue:
Closes https://github.com/inspirehep/inspire-next/pull/3220.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.