### PR TITLE
forms: add, populate and validate ORCID field

### DIFF
--- a/inspirehep/modules/authors/forms.py
+++ b/inspirehep/modules/authors/forms.py
@@ -562,11 +562,7 @@ class AuthorUpdateForm(INSPIREForm):
     def __init__(self, *args, **kwargs):
         """Constructor."""
         super(AuthorUpdateForm, self).__init__(*args, **kwargs)
-        is_update = kwargs.pop('is_update', False)
         is_review = kwargs.pop('is_review', False)
-        if is_update:
-            self.orcid.widget = HiddenInput()
-            self.orcid.validators = []
         if is_review:
             self.bai.widget = TextInput()
             self.bai.flags = Flags()


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add, populate and validate ORDCID field in "authors/recid/update" form.
The field behaves precisely like the one in the "authos/new" form.

The addition of the field was done by removing a simple check of the `is-update` field that hid the ORCID field in the case of an update form.

The validation - which was previously broken - has already been fixed by @szymonlopaciuk [here](https://github.com/inspirehep/inspire-next/pull/3236).

The implementation for the field population was already in place as one can see [here](https://github.com/inspirehep/inspire-next/blob/master/inspirehep/modules/authors/views.py#L235) where the `try ... except ...` statement is importing the record's xml from **legacy** and converting the data to the appropriate format to then populate the form fields (hint: check the `convert_for_form(data)` function). HOWEVER, I am not sure this is desirable or if the field should instead be populated from what we have in labs and NOT in legacy. **Someone should check this!**

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The user might wish to update an author's ORCID as well.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Signed-off-by: Iuliana Voinea <iuliana.voinea@student.manchester.ac.uk>