### PR TITLE
workflows: add validation errors callback

### DIFF
--- a/inspirehep/modules/workflows/errors.py
+++ b/inspirehep/modules/workflows/errors.py
@@ -33,3 +33,73 @@ class DownloadError(WorkflowsError):
 class MergeError(WorkflowsError):
 
     """Error representing a failed merge in a workflow."""
+
+
+class CallbackError(WorkflowsError):
+    """Callback exception."""
+
+    code = 400
+    error_code = 'CALLBACK_ERROR'
+    errors = None
+    message = 'Workflow callback error.'
+    workflow = None
+
+    def to_dict(self):
+        """Execption to dictionary."""
+        response = {}
+        response['error_code'] = self.error_code
+        if self.errors is not None:
+            response['errors'] = self.errors
+        response['message'] = self.message
+        if self.workflow is not None:
+            response['workflow'] = self.workflow
+        return response
+
+
+class CallbackMalformedError(CallbackError):
+    """Malformed request exception."""
+
+    error_code = 'MALFORMED'
+    message = 'The workflow request is malformed.'
+
+    def __init__(self, errors=None, **kwargs):
+        """Initialize exception."""
+        super(CallbackMalformedError, self).__init__(**kwargs)
+        self.errors = errors
+
+
+class CallbackWorkflowNotFoundError(CallbackError):
+    """Workflow not found exception."""
+
+    code = 404
+    error_code = 'WORKFLOW_NOT_FOUND'
+
+    def __init__(self, workflow_id, **kwargs):
+        """Initialize exception."""
+        super(CallbackWorkflowNotFoundError, self).__init__(**kwargs)
+        self.message = 'The workflow with id "{}" was not found.'.format(
+            workflow_id)
+
+
+class CallbackValidationError(CallbackError):
+    """Validation error exception."""
+
+    error_code = 'VALIDATION_ERROR'
+    message = 'Validation error.'
+
+    def __init__(self, workflow_data, **kwargs):
+        """Initialize exception."""
+        super(CallbackValidationError, self).__init__(**kwargs)
+        self.workflow = workflow_data
+
+
+class CallbackWorkflowNotInValidationError(CallbackError):
+    """Validation workflow not in validation error exception."""
+
+    error_code = 'WORKFLOW_NOT_IN_ERROR_STATE'
+
+    def __init__(self, workflow_id, **kwargs):
+        """Initialize exception."""
+        super(CallbackWorkflowNotInValidationError, self).__init__(**kwargs)
+        self.message = 'Workflow {} is not in validation error state.'.format(
+            workflow_id)

--- a/inspirehep/modules/workflows/loaders.py
+++ b/inspirehep/modules/workflows/loaders.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Workflows loader."""
+
+from __future__ import absolute_import, division, print_function
+
+from flask import request
+from marshmallow import ValidationError
+
+from .errors import CallbackMalformedError
+from .serializers.schemas.json import WorkflowSchemaJSONV1
+
+
+def marshmallow_loader(schema_class, partial=False):
+    """Marshmallow loader."""
+    def schema_loader():
+        request_json = request.get_json()
+        try:
+            result = schema_class(partial=partial).load(request_json)
+        except ValidationError as error:
+            raise CallbackMalformedError(error.messages)
+        return result.data
+    return schema_loader
+
+
+workflow_loader = marshmallow_loader(WorkflowSchemaJSONV1)

--- a/inspirehep/modules/workflows/search.py
+++ b/inspirehep/modules/workflows/search.py
@@ -43,8 +43,11 @@ def holdingpen_search_factory(self, search, **kwargs):
         'metadata.acquisition_source', 'metadata.arxiv_eprints',
         'metadata.arxiv_categories', '_workflow',
         '_extra_data.relevance_prediction', '_extra_data.user_action',
-        '_extra_data.classifier_results.complete_output', '_extra_data.classifier_results.fulltext_used',
-        '_extra_data.journal_coverage', '_extra_data._action', '_extra_data.matches', '_extra_data.crawl_errors'
+        '_extra_data.classifier_results.complete_output',
+        '_extra_data.classifier_results.fulltext_used',
+        '_extra_data.journal_coverage', '_extra_data._action',
+        '_extra_data.matches', '_extra_data.crawl_errors',
+        '_extra_data.validation_errors', '_extra_data.callback_url',
     ]
     search = search.extra(_source={"include": includes})
     return search, urlkwargs

--- a/inspirehep/modules/workflows/serializers/__init__.py
+++ b/inspirehep/modules/workflows/serializers/__init__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Workflows serializers."""
+
+from __future__ import absolute_import, division, print_function

--- a/inspirehep/modules/workflows/serializers/schemas/__init__.py
+++ b/inspirehep/modules/workflows/serializers/schemas/__init__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Workflows schemas."""
+
+from __future__ import absolute_import, division, print_function

--- a/inspirehep/modules/workflows/serializers/schemas/json.py
+++ b/inspirehep/modules/workflows/serializers/schemas/json.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Marshmallow JSON worfklow schema."""
+
+from __future__ import absolute_import, division, print_function
+
+from marshmallow import Schema, fields
+
+
+class WorkflowSchemaJSONV1(Schema):
+    """Schema for workflows."""
+
+    _extra_data = fields.Dict(required=True)
+    _id = fields.Integer(required=True, load_from='id', attribute='id')
+    _workflow = fields.Dict(required=False)
+
+    metadata = fields.Dict(required=True)
+
+    class Meta:
+        strict = True

--- a/tests/integration/workflows/helpers/calls.py
+++ b/tests/integration/workflows/helpers/calls.py
@@ -193,3 +193,25 @@ def core_record():
     assert categories
 
     return json_data, categories
+
+
+def do_validation_callback(app, worfklow_id, metadata, extra_data):
+    """Do a validation callback request.
+
+       Note:
+           If ``malformed`` is true it will make the payload
+           invalid, by removing two required ``keys``; ``id``
+           and ``_extra_data``.
+    """
+    client = app.test_client()
+    payload = {
+        'id': worfklow_id,
+        'metadata': metadata,
+        '_extra_data': extra_data
+    }
+
+    return client.put(
+        '/callback/workflows/resolve_validation_errors',
+        data=json.dumps(payload),
+        content_type='application/json',
+    )


### PR DESCRIPTION
* Adds a callback endpoint for the UI, this will allow the UI to run
  validation and continue the workflow if the record is valid.

* Adds in ``extra_data`` ``callback_url`` and
  ``validation_errors`` fields on callback request and when validation
  task runs.

Signed-off-by: David Caro <david@dcaro.es>
Co-authored-by: Harris Tzovanakis <me@drjova.com>
