### PR TITLE
workflows: get first five recid when fuzzy match

### DIFF
--- a/inspirehep/modules/workflows/tasks/matching.py
+++ b/inspirehep/modules/workflows/tasks/matching.py
@@ -111,7 +111,7 @@ def fuzzy_match(obj, eng):
     similar to the current workflow object's payload in the system.
 
     Also sets the ``matches.fuzzy`` property in ``extra_data`` to the list of
-    control numbers that matched.
+    the first 5 control numbers that matched.
 
     Arguments:
         obj: a workflow object.
@@ -125,7 +125,7 @@ def fuzzy_match(obj, eng):
     fuzzy_match_config = current_app.config['FUZZY_MATCH']
     matches = dedupe_list(match(obj.data, fuzzy_match_config))
     record_ids = [el['_source']['control_number'] for el in matches]
-    obj.extra_data.setdefault('matches', {})['fuzzy'] = record_ids
+    obj.extra_data.setdefault('matches', {})['fuzzy'] = record_ids[0:5]
     return bool(record_ids)
 
 

--- a/tests/integration/workflows/test_arxiv_workflow.py
+++ b/tests/integration/workflows/test_arxiv_workflow.py
@@ -590,11 +590,29 @@ def test_fuzzy_matched_goes_trough_the_workflow(
 
         return custom_continue_workflow
 
+    es_query = {
+        'algorithm': [
+            {
+                'queries': [
+                    {
+                        'path': 'report_numbers.value',
+                        'search_path': 'report_numbers.value.raw',
+                        'type': 'exact',
+                    },
+                ],
+            },
+        ],
+        'doc_type': 'hep',
+        'index': 'records-hep',
+    }
+
     record = record_from_db
     del record['arxiv_eprints']
     rec_id = record['control_number']
 
-    eng_uuid = start('article', [record])
+    with mock.patch.dict(workflow_app.config['FUZZY_MATCH'], es_query):
+        eng_uuid = start('article', [record])
+
     obj_id = WorkflowEngine.from_uuid(eng_uuid).objects[0].id
     obj = workflow_object_class.get(obj_id)
 


### PR DESCRIPTION
Also, refactors the integration test for fuzzy matching mocking the Elastic Search query, since its result depends on the environment.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
