### PR TITLE
workflows: fix issue with unprintable keywords

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ install_requires = [
     'invenio-base>=1.0.0a16',
     'invenio-cache>=1.0.0b1',
     'invenio-celery>=1.0.0b3',
-    'invenio-classifier~=1.0,>=1.3.1',
+    'invenio-classifier~=1.0,>=1.3.2',
     'invenio-collections>=1.0.0a4',
     'invenio-config>=1.0.0b3',
     'invenio-db[postgresql,versioning]>=1.0.0b8',


### PR DESCRIPTION
## Description:
Sentry: https://sentry.inspirehep.net/inspire-sentry/prod/issues/6/

~~This doesn't yet contain a fix, just a reproduction (this PR is expected to fail).~~
Fix happened here: https://github.com/inveniosoftware-contrib/invenio-classifier/pull/38

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.