### PR TITLE
forms: refactor authors update form

### DIFF
--- a/inspirehep/modules/authors/core.py
+++ b/inspirehep/modules/authors/core.py
@@ -1,0 +1,166 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2018 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Core functions for authors."""
+
+from __future__ import absolute_import, division, print_function
+
+
+def convert_for_form(author_record):
+    """Convert author data model form field names.
+
+    TODO: This might be better in a different file and as a dojson conversion.
+    """
+    record_keys = author_record.keys()
+
+    keys_to_setters_mapping = {
+        'advisors': _set_advisors,
+        'arxiv_categories': _set_research_field,
+        'ids': _set_ids_schema_based_fields,
+        'name': _set_name_based_fields,
+        'native_name': _set_native_name,
+        'positions': _set_institution_history_and_public_emails,
+        'urls': _set_websites_based_fields,
+    }
+
+    for key in record_keys:
+        if key in keys_to_setters_mapping:
+            keys_to_setters_mapping[key](author_record)
+
+
+def _set_advisors(author_record):
+    advisors = author_record['advisors']
+    author_record['advisors'] = []
+    for advisor in advisors:
+        adv = dict(degree_type=advisor.get('degree_type', ''), name=advisor.get('name', ''))
+        author_record['advisors'].append(adv)
+
+
+def _set_ids_schema_based_fields(author_record):
+    schema_to_field_mappings = {
+        'ORCID': 'orcid',
+        'INSPIRE BAI': 'bai',
+        'INSPIRE ID': 'inspireid',
+    }
+
+    for current_id in author_record['ids']:
+        try:
+            field = schema_to_field_mappings[current_id['schema']]
+            author_record[field] = current_id['value']
+        except KeyError:
+            # Protect against cases when there is no value in metadata
+            pass
+
+
+def _set_institution_history_and_public_emails(author_record):
+    author_record['institution_history'] = []
+    author_record['public_emails'] = []
+
+    for position in author_record['positions']:
+        if not any(
+                [
+                    key in position
+                    for key in ('institution', '_rank', 'start_year', 'end_year')
+                ]
+        ):
+            if 'emails' in position:
+                for email in position['emails']:
+                    author_record['public_emails'].append(
+                        {
+                            'email': email,
+                            'original_email': email
+                        }
+                    )
+            continue
+
+        pos = dict(name=position.get('institution', {}).get('name'))
+
+        rank = position.get('_rank', '')
+        if rank:
+            pos['rank'] = rank
+
+        _set_int_or_skip(pos, 'start_year', position.get('start_date', ''))
+        _set_int_or_skip(pos, 'end_year', position.get('end_date', ''))
+        pos['current'] = True if position.get('current') else False
+        pos['old_emails'] = position.get('old_emails', [])
+
+        if position.get('emails'):
+            pos['emails'] = position['emails']
+            for email in position['emails']:
+                author_record['public_emails'].append(
+                    {
+                        'email': email,
+                        'original_email': email
+                    }
+                )
+        author_record['institution_history'].append(pos)
+    author_record['institution_history'].reverse()
+
+
+def _set_int_or_skip(provided_dict, key, provided_int):
+    try:
+        provided_dict[key] = int(provided_int)
+    except ValueError:
+        pass
+
+
+def _set_name_based_fields(author_record):
+    author_record['full_name'] = author_record['name'].get('value')
+
+    try:
+        author_name = author_record['name'].get('value')
+        author_record['given_names'] = author_name.split(',')[1].strip() or ''
+    except IndexError:
+        author_record['given_names'] = ''
+
+    author_record['family_name'] = author_record['name'].get('value').split(',')[0].strip()
+    author_record['display_name'] = author_record["name"].get('preferred_name')
+
+
+def _set_native_name(author_record):
+    author_record['native_name'] = author_record['native_name'][0]
+
+
+def _set_research_field(author_record):
+    author_record['research_field'] = author_record['arxiv_categories']
+
+
+def _set_websites_based_fields(author_record):
+    author_record['websites'] = []
+
+    description_to_field_mappings = {
+        'twitter': 'twitter_url',
+        'blog': 'blog_url',
+        'linkedin': 'linkedin_url',
+    }
+
+    for url in author_record['urls']:
+        if not url.get('description'):
+            author_record['websites'].append({'webpage': url['value']})
+        else:
+            try:
+                field = description_to_field_mappings[url['description'].lower()]
+                author_record[field] = url['value']
+            except KeyError:
+                # Protect against cases when there is no value in metadata
+                pass
+    del author_record['urls']

--- a/inspirehep/modules/authors/utils.py
+++ b/inspirehep/modules/authors/utils.py
@@ -30,6 +30,9 @@ import re
 import numpy as np
 from beard.utils.strings import asciify
 from beard.clustering import block_phonetic
+from lxml.etree import fromstring, tostring
+
+from inspire_dojson import marcxml2record
 
 
 _bai_parentheses_cleaner = \
@@ -106,6 +109,25 @@ def bai(name):
     bai = _bai_spaces.sub(".", bai)
 
     return bai
+
+
+def get_author_record_from_xml_response(xml_content):
+    """Return record contained in XML if collection is 'authors'.
+
+    Args:
+        xml_content (str): Legacy response XML content.
+
+    Returns:
+        dict: JSON author record contained in the XML.
+
+        None: if record collection is not 'authors'.
+    """
+    xml = fromstring(xml_content)
+    collections_datafields = xml.xpath("//*[local-name() = 'datafield'][@*[local-name()='tag' and .='980']]//*[local-name()='subfield']")
+    collections = [el.text for el in collections_datafields]
+    if 'HEPNAMES' in collections:
+        xml_record = xml.xpath("//*[local-name() = 'record']")[0]
+        return marcxml2record(tostring(xml_record))
 
 
 def phonetic_blocks(full_names, phonetic_algorithm='nysiis'):

--- a/tests/unit/authors/test_authors_core.py
+++ b/tests/unit/authors/test_authors_core.py
@@ -1,0 +1,292 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2018 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+from inspirehep.modules.authors.core import convert_for_form
+
+
+def test_convert_for_form_without_name_urls_fc_positions_advisors_and_ids():
+    without_name_urls_fc_positions_advisors_and_ids = {}
+    convert_for_form(without_name_urls_fc_positions_advisors_and_ids)
+
+    assert {} == without_name_urls_fc_positions_advisors_and_ids
+
+
+def test_convert_for_form_advisors():
+    record = {
+        'advisors': [
+            {
+                'degree_type': 'other',
+                'name': 'Avignone, Frank T.',
+                'curated_relation': False
+            }
+        ]
+    }
+    convert_for_form(record)
+
+    expected = [
+        {
+            'degree_type': 'other',
+            'name': 'Avignone, Frank T.'
+        }
+    ]
+
+    assert expected == record['advisors']
+
+
+def test_convert_for_form_ids():
+    record = {
+        'ids': [
+            {
+                'schema': 'ORCID',
+                'value': '0000-0001-7761-7242'
+            },
+            {
+                'schema': 'INSPIRE BAI',
+                'value': 'Takeshi.Furukawa.1'
+            },
+            {
+                'schema': 'INSPIRE ID',
+                'value': 'INSPIRE-00086433'
+            }
+        ]
+    }
+
+    convert_for_form(record)
+
+    expected_record = {
+        'ids': [
+            {
+                'schema': 'ORCID',
+                'value': '0000-0001-7761-7242'
+            },
+            {
+                'schema': 'INSPIRE BAI',
+                'value': 'Takeshi.Furukawa.1'
+            },
+            {
+                'schema': 'INSPIRE ID',
+                'value': 'INSPIRE-00086433'
+            }
+        ],
+        'orcid': '0000-0001-7761-7242',
+        'bai': 'Takeshi.Furukawa.1',
+        'inspireid': 'INSPIRE-00086433'
+    }
+
+    assert expected_record == record
+
+
+def test_convert_for_form_institution_history_and_public_emails():
+    record = {
+        'positions': [
+            {
+                'emails': [
+                    'michael.abbott@uct.ac.za',
+                ],
+                'institution': {'name': 'Tokyo Metropolitan U.'},
+                '_rank': 'JUNIOR',
+                'start_date': '2010',
+                'end_date': '2011',
+                'current': True,
+                'old_emails': [
+                    'oldemail1@exmaple.com',
+                    'oldemail2@exmaple.com'
+                ]
+            },
+            {
+                'emails': [
+                    'abbott@theory.tifr.res.in'
+                ],
+                'institution': {'name': 'Manchester Metropolitan University'},
+                '_rank': 'SENIOR',
+            },
+            {
+                'old_emails': [
+                    'abbott@het.brown.edu'
+                ]
+            }
+        ]
+    }
+
+    convert_for_form(record)
+
+    expected_public_emails = [
+        {
+            'email': 'michael.abbott@uct.ac.za',
+            'original_email': 'michael.abbott@uct.ac.za'
+        },
+        {
+            'email': 'abbott@theory.tifr.res.in',
+            'original_email': 'abbott@theory.tifr.res.in'
+        }
+    ]
+
+    expected_institution_history = [
+        {
+            'name': 'Manchester Metropolitan University',
+            'rank': 'SENIOR',
+            'current': False,
+            'old_emails': [],
+            'emails': [
+                'abbott@theory.tifr.res.in'
+            ],
+        },
+        {
+            'name': 'Tokyo Metropolitan U.',
+            'rank': 'JUNIOR',
+            'start_year': 2010,
+            'end_year': 2011,
+            'current': True,
+            'old_emails': [
+                'oldemail1@exmaple.com',
+                'oldemail2@exmaple.com'
+            ],
+            'emails': [
+                'michael.abbott@uct.ac.za',
+            ],
+        }
+    ]
+
+    assert expected_public_emails == record['public_emails']
+    assert expected_institution_history == record['institution_history']
+
+
+def test_convert_for_form_public_emails_only():
+    current_and_old_emails = {
+        'positions': [
+            {
+                'emails': [
+                    'michael.abbott@uct.ac.za'
+                ]
+            },
+            {
+                'emails': [
+                    'abbott@theory.tifr.res.in'
+                ]
+            },
+            {
+                'old_emails': [
+                    'abbott@het.brown.edu'
+                ]
+            }
+        ]
+    }
+    convert_for_form(current_and_old_emails)
+
+    expected = [
+        {
+            'email': 'michael.abbott@uct.ac.za',
+            'original_email': 'michael.abbott@uct.ac.za'
+        },
+        {
+            'email': 'abbott@theory.tifr.res.in',
+            'original_email': 'abbott@theory.tifr.res.in'
+        }
+    ]
+
+    assert expected == current_and_old_emails['public_emails']
+
+
+def test_convert_for_form_names():
+    record = {
+        'name': {
+            'value': 'Lusignoli, Maurizio',
+            'preferred_name': 'Maurizio Musignoli'
+        },
+        'native_name': [
+            'Lusignoli, Maurizzio',
+            'LLusignoli, Maurizo'
+        ]
+    }
+
+    convert_for_form(record)
+
+    expected_record = {
+        'name': {
+            'value': 'Lusignoli, Maurizio',
+            'preferred_name': 'Maurizio Musignoli'
+        },
+        'full_name': 'Lusignoli, Maurizio',
+        'given_names': 'Maurizio',
+        'family_name': 'Lusignoli',
+        'display_name': 'Maurizio Musignoli',
+        'native_name': 'Lusignoli, Maurizzio'
+    }
+
+    assert expected_record == record
+
+
+def test_convert_for_form_research_field():
+    record = {
+        'arxiv_categories': [
+            'astro-ph',
+            'hep-ex',
+            'hep-ph'
+        ]
+    }
+
+    convert_for_form(record)
+
+    expected_research_field = [
+        'astro-ph',
+        'hep-ex',
+        'hep-ph'
+    ]
+
+    assert expected_research_field == record['research_field']
+
+
+def test_convert_for_form_urls():
+    record = {
+        'urls': [
+            {
+                'value': 'http://example.com'
+            },
+            {
+                'description': 'TWITTER',
+                'value': 'http://twitter.com'
+            },
+            {
+                'description': 'BLOG',
+                'value': 'http://blog.com'
+            },
+            {
+                'description': 'LINKEDIN',
+                'value': 'http://linkedin.com'
+            }
+        ],
+    }
+
+    convert_for_form(record)
+
+    expected_record = {
+        'websites': [
+            {'webpage': 'http://example.com'}
+        ],
+        'twitter_url': 'http://twitter.com',
+        'blog_url': 'http://blog.com',
+        'linkedin_url': 'http://linkedin.com'
+    }
+
+    assert expected_record == record

--- a/tests/unit/authors/test_authors_views.py
+++ b/tests/unit/authors/test_authors_views.py
@@ -22,72 +22,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-from inspirehep.modules.authors.views import convert_for_form, get_inspire_url
-
-
-def test_convert_for_form_without_name_urls_fc_positions_advisors_and_ids():
-    without_name_urls_fc_positions_advisors_and_ids = {}
-    convert_for_form(without_name_urls_fc_positions_advisors_and_ids)
-
-    assert {} == without_name_urls_fc_positions_advisors_and_ids
-
-
-def test_convert_for_form_public_emails():
-    current_and_old_emails = {
-        'positions': [
-            {
-                "emails": [
-                    "michael.abbott@uct.ac.za"
-                ]
-            },
-            {
-                "emails": [
-                    "abbott@theory.tifr.res.in"
-                ]
-            },
-            {
-                "old_emails": [
-                    "abbott@het.brown.edu"
-                ]
-            }
-        ]
-    }
-    convert_for_form(current_and_old_emails)
-
-    expected = [
-        {
-            "email": "michael.abbott@uct.ac.za",
-            "original_email": "michael.abbott@uct.ac.za"
-        },
-        {
-            "email": "abbott@theory.tifr.res.in",
-            "original_email": "abbott@theory.tifr.res.in"
-        }
-    ]
-
-    assert expected == current_and_old_emails['public_emails']
-
-
-def test_convert_for_form_advisors():
-    record = {
-        'advisors': [
-            {
-                'degree_type': 'other',
-                'name': 'Avignone, Frank T.',
-                'curated_relation': False
-            }
-        ]
-    }
-    convert_for_form(record)
-
-    expected = [
-        {
-            'degree_type': 'other',
-            'name': 'Avignone, Frank T.'
-        }
-    ]
-
-    assert expected == record['advisors']
+from inspirehep.modules.authors.views import get_inspire_url
 
 
 def test_get_inspire_url_with_bai():


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Search for the record in the db at first in order to populate the form instead of requesting XML straight from Legacy through a GET request. When the author schema will be completed and Labs will contain all author records from Legacy, we'll also be able to remove the request to Legacy altogether (as Legacy will be shut down in the future). Moreover, use `lxml` library to process the XML response from Legacy, instead of regular expressions.

Also, a wrong recid in the path will create a workflow object in ERROR state because it will fail validation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Previously, it was possible to submit author updates to existing literature records and tickets were being created for it.  Needless to say, this was a waste of time for the curators. `authors/0/update` redirected to the `authors/new` form, while a non-existent recid in any collection ('lit', 'aut', ...etc) would redirect to a 404 not found page.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Signed-off-by: Iuliana Voinea <iuliana.voinea@student.manchester.ac.uk>