### PR TITLE
migrator.tasks: disable migration on ORCID push

### DIFF
--- a/inspirehep/modules/orcid/tasks.py
+++ b/inspirehep/modules/orcid/tasks.py
@@ -97,7 +97,7 @@ def _link_user_and_token(user, name, orcid, token):
     else:
         # If not, create and put the token entry
         with db.session.begin_nested():
-            db.session.add(RemoteToken.create(
+            RemoteToken.create(
                 user_id=user.id,
                 client_id=get_value(current_app.config, 'ORCID_APP_CREDENTIALS.consumer_key'),
                 token=token,
@@ -107,7 +107,7 @@ def _link_user_and_token(user, name, orcid, token):
                     'full_name': name,
                     'allow_push': True,
                 }
-            ))
+            )
 
 
 def _register_user(name, email, orcid, token):
@@ -133,9 +133,9 @@ def _register_user(name, email, orcid, token):
 
     # Make the user if didn't find existing one
     if not user:
-        user = User()
-        user.email = email
         with db.session.begin_nested():
+            user = User()
+            user.email = email
             db.session.add(user)
 
     _link_user_and_token(user, name, orcid, token)

--- a/tests/integration/migrator/fixtures/dummy.xml
+++ b/tests/integration/migrator/fixtures/dummy.xml
@@ -1,0 +1,13 @@
+<record>
+  <controlfield tag="001">12345</controlfield>
+  <datafield tag="245" ind1=" " ind2=" ">
+    <subfield code="a">On the validity of INSPIRE records</subfield>
+  </datafield>
+  <datafield tag="980" ind1=" " ind2=" ">
+    <subfield code="a">HEP</subfield>
+  </datafield>
+  <datafield tag="700" ind1=" " ind2=" ">
+    <subfield code="a">Carberry, Josiah</subfield>
+    <subfield code="j">ORCID:0000-0002-1825-0097</subfield>
+  </datafield>
+</record>


### PR DESCRIPTION
## Description
Disables ORCID push during migration (however, not continuous migration) by the means of temporarily changing the ORCID push feature flag. This does not interfere with other tasks as they are run in separate processes. The flag is reset in case of errors as well.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
