### PR TITLE
setup: add explicitly the pyOpenSSL dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,9 +54,9 @@ install_requires = [
     'backports.tempfile>=1.0rc1',
     'beard~=0.0,>=0.2.0',
     'celery~=3.0,>=3.1.25',
-    'enum34~=1.0,>=1.1.6',
     'elasticsearch-dsl~=2.0,>=2.2.0',
     'elasticsearch~=2.0,>=2.4.1',
+    'enum34~=1.0,>=1.1.6',
     'flask-shell-ipython~=0.0,>=0.3.0',
     'fs~=0.0,>=0.5.4',
     'inspire-crawler~=2.0',
@@ -104,8 +104,8 @@ install_requires = [
     'requests~=2.0,>=2.18.4',
     'setproctitle~=1.0,>=1.1.10',
     'timeout-decorator~=0.0,>=0.4.0',
-    'workflow~=2.0,>=2.1.3',
     'vcrpy~=1.0,>=1.11.1',
+    'workflow~=2.0,>=2.1.3',
 ]
 
 docs_require = [

--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,7 @@ install_requires = [
     'librabbitmq~=1.0,>=1.6.1',
     'marshmallow~=2.0,>=2.15.0',  # See: inveniosoftware/invenio-records-rest#186
     'plotextractor~=0.0,>=0.1.6',
+    'pyOpenSSL~=17.0,>=17.5.0',
     'pybtex~=0.0,>=0.21',
     'python-redis-lock~=3.0,>=3.2.0',
     'raven[flask]~=6.0,>=6.2.1',


### PR DESCRIPTION
## Description:
Fix an issue in our CI that makes the build of the Docker image used by
the other tests fail.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.