### PR TITLE
matching: add feature flag for the fuzzy matcher

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -50,6 +50,7 @@ FEATURE_FLAG_ENABLE_ORCID_PUSH = False
 #   none -> "^$"
 #   some ORCIDs -> "^(0000-0002-7638-5686|0000-0002-7638-5687)$"
 FEATURE_FLAG_ORCID_PUSH_WHITELIST_REGEX = '.*'
+FEATURE_FLAG_ENABLE_FUZZY_MATCHER = False
 
 # Default language and timezone
 # =============================

--- a/inspirehep/modules/workflows/tasks/matching.py
+++ b/inspirehep/modules/workflows/tasks/matching.py
@@ -122,6 +122,9 @@ def fuzzy_match(obj, eng):
         ``False`` otherwise.
 
     """
+    if not current_app.config.get('FEATURE_FLAG_ENABLE_FUZZY_MATCHER'):
+        return False
+
     fuzzy_match_config = current_app.config['FUZZY_MATCH']
     matches = dedupe_list(match(obj.data, fuzzy_match_config))
     record_ids = [el['_source']['control_number'] for el in matches]

--- a/tests/integration/workflows/test_arxiv_workflow.py
+++ b/tests/integration/workflows/test_arxiv_workflow.py
@@ -54,6 +54,12 @@ from mocks import (
 from utils import get_halted_workflow
 
 
+@pytest.fixture
+def enable_fuzzy_matcher(workflow_app):
+    with mock.patch.dict(workflow_app.config, {'FEATURE_FLAG_ENABLE_FUZZY_MATCHER': True}):
+        yield
+
+
 @mock.patch(
     'inspirehep.modules.workflows.tasks.arxiv.download_file_to_workflow',
     side_effect=fake_download_file,
@@ -572,6 +578,7 @@ def test_fuzzy_matched_goes_trough_the_workflow(
     workflow_app,
     mocked_external_services,
     record_from_db,
+    enable_fuzzy_matcher,
 ):
     """Test update article fuzzy matched.
 


### PR DESCRIPTION
## Description

Add a feature flag for enabling the fuzzy matcher.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
