### PR TITLE
records: don't fire ORCID receiver when no recid

### DIFF
--- a/inspirehep/modules/records/receivers.py
+++ b/inspirehep/modules/records/receivers.py
@@ -138,6 +138,10 @@ def push_to_orcid(sender, record, *args, **kwargs):
     if not is_hep(record) or not current_app.config['FEATURE_FLAG_ENABLE_ORCID_PUSH']:
         return
 
+    # Ensure there is a control number. This is not always the case because of broken store_record.
+    if not 'control_number' in record:
+        return
+
     task_name = current_app.config['ORCID_PUSH_TASK_ENDPOINT']
 
     for orcid in get_orcids_for_push(record):

--- a/tests/integration/records/test_records_receivers.py
+++ b/tests/integration/records/test_records_receivers.py
@@ -140,6 +140,12 @@ def raw_record(app):
 
 
 @pytest.fixture(scope='function')
+def raw_record_with_no_control_number(raw_record):
+    del raw_record['control_number']
+    yield raw_record
+
+
+@pytest.fixture(scope='function')
 def record(raw_record):
     with mock.patch('inspirehep.modules.records.receivers.Task') as mocked_Task:
         mocked_Task.return_value = mocked_Task
@@ -219,6 +225,13 @@ def test_orcid_push_not_triggered_on_create_record_without_allow_push(mocked_Tas
 
 @mock.patch('inspirehep.modules.records.receivers.Task')
 def test_orcid_push_not_triggered_on_create_record_without_token(mocked_Task, app, raw_record, user_without_token):
+    migrate_and_insert_record(raw_record, skip_files=True)
+
+    mocked_Task.assert_not_called()
+
+
+@mock.patch('inspirehep.modules.records.receivers.Task')
+def test_orcid_push_not_triggered_on_create_record_without_control_number(mocked_Task, app, raw_record_with_no_control_number, user_with_permission, enable_orcid_push_feature):
     migrate_and_insert_record(raw_record, skip_files=True)
 
     mocked_Task.assert_not_called()


### PR DESCRIPTION
Signed-off-by: Micha Moskovic <michamos@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
