### PR TITLE
workflows: fix and refactor is_experimental_paper

### DIFF
--- a/inspirehep/utils/record.py
+++ b/inspirehep/utils/record.py
@@ -109,6 +109,28 @@ def get_arxiv_id(record):
     return get_value(record, 'arxiv_eprints.value[0]', default='')
 
 
+def get_inspire_categories(record):
+    """Return all the INSPIRE categories of a record.
+
+    Args:
+        record (InspireRecord): a record.
+
+    Returns:
+        list(str): all the INSPIRE categories of the record.
+
+    Examples:
+        >>> record = {
+        ...     'inspire_categories': [
+        ...         {'term': 'Experiment-HEP'},
+        ...     ],
+        ... }
+        >>> get_inspire_categories(record)
+        ['Experiment-HEP']
+
+    """
+    return get_value(record, 'inspire_categories.term', default=[])
+
+
 def get_source(record):
     """Return the acquisition source of a record.
 

--- a/tests/unit/utils/test_utils_record.py
+++ b/tests/unit/utils/test_utils_record.py
@@ -27,6 +27,7 @@ from inspirehep.utils.record import (
     get_abstract,
     get_arxiv_categories,
     get_arxiv_id,
+    get_inspire_categories,
     get_source,
     get_subtitle,
     get_title,
@@ -95,6 +96,23 @@ def test_get_arxiv_id():
 
     expected = '1612.08928'
     result = get_arxiv_id(record)
+
+    assert expected == result
+
+
+def test_get_inspire_categories():
+    schema = load_schema('hep')
+    subschema = schema['properties']['inspire_categories']
+
+    record = {
+        'inspire_categories': [
+            {'term': 'Experiment-HEP'},
+        ],
+    }
+    assert validate(record['inspire_categories'], subschema) is None
+
+    expected = ['Experiment-HEP']
+    result = get_inspire_categories(record)
 
     assert expected == result
 

--- a/tests/unit/workflows/test_workflows_tasks_actions.py
+++ b/tests/unit/workflows/test_workflows_tasks_actions.py
@@ -434,19 +434,42 @@ def test_is_record_relevant(
     assert is_record_relevant(obj, eng) is expected
 
 
-def test_is_experimental_paper():
-    obj = MockObj({
+def test_is_experimental_paper_returns_true_if_obj_has_an_experimental_arxiv_category():
+    schema = load_schema('hep')
+    subschema = schema['properties']['arxiv_eprints']
+
+    data = {
         'arxiv_eprints': [
-            {'categories': ['hep-ex']},
-        ]
-    }, {})
+            {
+                'categories': [
+                    'hep-ex',
+                ],
+                'value': 'hep-ex/0008040',
+            },
+        ],
+    }  # literature/532168
+    extra_data = {}
+    assert validate(data['arxiv_eprints'], subschema) is None
+
+    obj = MockObj(data, extra_data)
     eng = MockEng()
 
     assert is_experimental_paper(obj, eng)
 
 
-def test_is_experimental_paper_returns_true_if_inspire_categories_in_list():
-    obj = MockObj({'inspire_categories': [{'term': 'Experiment-HEP'}]}, {})
+def test_is_experimental_paper_returns_true_if_obj_has_an_experimental_inspire_category():
+    schema = load_schema('hep')
+    subschema = schema['properties']['inspire_categories']
+
+    data = {
+        'inspire_categories': [
+            {'term': 'Experiment-HEP'},
+        ],
+    }  # literature/532168
+    extra_data = {}
+    assert validate(data['inspire_categories'], subschema) is None
+
+    obj = MockObj(data, extra_data)
     eng = MockEng()
 
     assert is_experimental_paper(obj, eng)
@@ -454,6 +477,24 @@ def test_is_experimental_paper_returns_true_if_inspire_categories_in_list():
 
 def test_is_experimental_paper_returns_false_otherwise():
     obj = MockObj({}, {})
+    eng = MockEng()
+
+    assert not is_experimental_paper(obj, eng)
+
+
+def test_is_experimental_paper_does_not_raise_if_obj_has_no_arxiv_category():
+    schema = load_schema('hep')
+    subschema = schema['properties']['arxiv_eprints']
+
+    data = {
+        'arxiv_eprints': [
+            {'value': '1712.02280'},
+        ],
+    }
+    extra_data = {}
+    assert validate(data['arxiv_eprints'], subschema) is None
+
+    obj = MockObj(data, extra_data)
     eng = MockEng()
 
     assert not is_experimental_paper(obj, eng)


### PR DESCRIPTION
## Description:
Prevent it from throwing an exception when an incoming record has
``arxiv_eprints`` but no ``categories`` inside.

## Related Issue
Sentry: https://sentry.inspirehep.net/inspire-sentry/inspire-qa/issues/59393/

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.