### PR TITLE
workflows: do the automatic decision before halt

### DIFF
--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -266,6 +266,15 @@ STOP_IF_EXISTING_SUBMISSION = [
 
 
 HALT_FOR_APPROVAL_IF_NEW_OR_STOP_IF_NOT_RELEVANT = [
+    IF_NOT(
+        is_record_relevant,
+        [
+            reject_record('Article automatically rejected'),
+            mark('approved', False),
+            save_workflow,
+            stop_processing,
+        ],
+    ),
     IF_ELSE(
         is_marked('is-update'),
         [
@@ -279,15 +288,6 @@ HALT_FOR_APPROVAL_IF_NEW_OR_STOP_IF_NOT_RELEVANT = [
                 message="Submission halted for curator approval.",
             )
         ),
-    ),
-    IF_NOT(
-        is_record_relevant,
-        [
-            reject_record("Article automatically rejected"),
-            mark('approved', False),  # auto reject
-            save_workflow,
-            stop_processing,
-        ]
     ),
 ]
 


### PR DESCRIPTION
## Description:
Undo a change made in commit 211fb16 to take the automatic decision
before halting, so that we don't show things to curators needlessly.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.