### PR TITLE
migrator: rename InspireProdRecords

### DIFF
--- a/inspirehep/alembic/402af3fbf68b_rename_inspire_prod_records_table.py
+++ b/inspirehep/alembic/402af3fbf68b_rename_inspire_prod_records_table.py
@@ -1,0 +1,44 @@
+#
+# This file is part of Invenio.
+# Copyright (C) 2016 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Rename inspire_prod_records table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '402af3fbf68b'
+down_revision = 'd99c7038006e'
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    """Upgrade database."""
+    op.rename_table('inspire_prod_records', 'legacy_records_mirror')
+
+
+def downgrade():
+    """Downgrade database."""
+    op.rename_table('legacy_records_mirror', 'inspire_prod_records')

--- a/inspirehep/alembic/d99c70308006e_merge_two_alembic_branches.py
+++ b/inspirehep/alembic/d99c70308006e_merge_two_alembic_branches.py
@@ -1,0 +1,44 @@
+#
+# This file is part of Invenio.
+# Copyright (C) 2016 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Merge two alembic branches"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd99c7038006e'
+down_revision = ('cb9f81e8251c','cb5153afd839')
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    """Upgrade database."""
+    pass
+
+
+def downgrade():
+    """Downgrade database."""
+    pass

--- a/inspirehep/modules/migrator/cli.py
+++ b/inspirehep/modules/migrator/cli.py
@@ -42,7 +42,7 @@ from inspire_schemas.api import validate
 from inspire_utils.helpers import force_list
 
 from inspirehep.utils.schema import ensure_valid_schema
-from .models import InspireProdRecords
+from .models import LegacyRecordsMirror
 from .tasks import (
     add_citation_counts,
     migrate,
@@ -137,7 +137,7 @@ def reporterrors(output):
 
     click.echo("Reporting broken records into {0}".format(output))
     errors = {}
-    results = InspireProdRecords.query.filter(InspireProdRecords.valid == False) # noqa: ignore=F712
+    results = LegacyRecordsMirror.query.filter(LegacyRecordsMirror.valid == False) # noqa: ignore=F712
     results_length = results.count()
     with click.progressbar(results.yield_per(100), length=results_length) as bar:
         for obj in bar:

--- a/inspirehep/modules/migrator/models.py
+++ b/inspirehep/modules/migrator/models.py
@@ -31,8 +31,9 @@ from invenio_db import db
 from sqlalchemy.ext.hybrid import hybrid_property
 
 
-class InspireProdRecords(db.Model):
-    __tablename__ = 'inspire_prod_records'
+class LegacyRecordsMirror(db.Model):
+    # the model has a different name from the table for compatibility
+    __tablename__ = 'legacy_records_mirror'
 
     recid = db.Column(db.Integer, primary_key=True, index=True)
     last_updated = db.Column(db.DateTime, default=datetime.utcnow, nullable=False, index=True)

--- a/inspirehep/modules/migrator/tasks.py
+++ b/inspirehep/modules/migrator/tasks.py
@@ -66,7 +66,7 @@ from inspirehep.modules.records.api import InspireRecord
 from inspirehep.modules.records.receivers import index_after_commit
 from inspirehep.utils.schema import ensure_valid_schema
 
-from .models import InspireProdRecords
+from .models import LegacyRecordsMirror
 
 
 LOGGER = getStackTraceLogger(__name__)
@@ -143,7 +143,7 @@ def remigrate_records(only_broken=True, skip_files=None):
             False,
         )
 
-    query = db.session.query(InspireProdRecords)
+    query = db.session.query(LegacyRecordsMirror)
     if only_broken:
         query = query.filter_by(valid=False)
 
@@ -388,7 +388,7 @@ def migrate_and_insert_record(raw_record, skip_files=False):
         LOGGER.exception('Migrator Record Insert Error')
         _store_migrator_error(recid, raw_record, e)
     else:
-        prod_record = InspireProdRecords(recid=recid)
+        prod_record = LegacyRecordsMirror(recid=recid)
         prod_record.marcxml = raw_record
         prod_record.valid = True
         db.session.merge(prod_record)
@@ -401,7 +401,7 @@ def _get_recid(raw_record):
 
 def _store_migrator_error(recid, marcxml, error):
     error_str = u'{0}: Record {1}: {2}'.format(type(error), recid, error)
-    prod_record = InspireProdRecords(recid=recid)
+    prod_record = LegacyRecordsMirror(recid=recid)
     prod_record.valid = False
     prod_record.marcxml = marcxml
     prod_record.errors = error_str

--- a/tests/integration/migrator/test_migrator_tasks.py
+++ b/tests/integration/migrator/test_migrator_tasks.py
@@ -32,7 +32,7 @@ import pytest
 from invenio_db import db
 from invenio_pidstore.models import PersistentIdentifier
 
-from inspirehep.modules.migrator.models import InspireProdRecords
+from inspirehep.modules.migrator.models import LegacyRecordsMirror
 from inspirehep.modules.migrator.tasks import (
     _build_recid_to_uuid_map,
     migrate,
@@ -50,9 +50,9 @@ def enable_orcid_push_feature(app):
 @pytest.fixture
 def cleanup():
     yield
-    InspireProdRecords.query.filter(InspireProdRecords.recid == 12345).delete()
+    LegacyRecordsMirror.query.filter(LegacyRecordsMirror.recid == 12345).delete()
     db.session.commit()
-    assert InspireProdRecords.query.filter(InspireProdRecords.recid == 12345).count() == 0
+    assert LegacyRecordsMirror.query.filter(LegacyRecordsMirror.recid == 12345).count() == 0
 
 
 def test_build_recid_to_uuid_map_numeric_pid_allowed_for_lit_and_con(isolated_app):
@@ -105,7 +105,7 @@ def test_migrate_and_insert_record_valid_record(mock_logger, isolated_app):
 
     migrate_and_insert_record(raw_record)
 
-    prod_record = InspireProdRecords.query.filter(InspireProdRecords.recid == 12345).one()
+    prod_record = LegacyRecordsMirror.query.filter(LegacyRecordsMirror.recid == 12345).one()
     assert prod_record.valid is True
     assert prod_record.marcxml == raw_record
 
@@ -129,7 +129,7 @@ def test_migrate_and_insert_record_dojson_error(mock_logger, isolated_app):
 
     migrate_and_insert_record(raw_record)
 
-    prod_record = InspireProdRecords.query.filter(InspireProdRecords.recid == 12345).one()
+    prod_record = LegacyRecordsMirror.query.filter(LegacyRecordsMirror.recid == 12345).one()
     assert prod_record.valid is False
     assert prod_record.marcxml == raw_record
 
@@ -150,7 +150,7 @@ def test_migrate_and_insert_record_invalid_record(mock_logger, isolated_app):
 
     migrate_and_insert_record(raw_record)
 
-    prod_record = InspireProdRecords.query.filter(InspireProdRecords.recid == 12345).one()
+    prod_record = LegacyRecordsMirror.query.filter(LegacyRecordsMirror.recid == 12345).one()
     assert prod_record.valid is False
     assert prod_record.marcxml == raw_record
 
@@ -172,7 +172,7 @@ def test_migrate_and_insert_record_other_exception(mock_logger, isolated_app):
 
     migrate_and_insert_record(raw_record)
 
-    prod_record = InspireProdRecords.query.filter(InspireProdRecords.recid == 12345).one()
+    prod_record = LegacyRecordsMirror.query.filter(LegacyRecordsMirror.recid == 12345).one()
     assert prod_record.valid is False
     assert prod_record.marcxml == raw_record
 
@@ -191,7 +191,7 @@ def test_orcid_push_disabled_on_migrate(app, cleanup, enable_orcid_push_feature)
         migrate.delay(record_fixture_path, wait_for_results=True)
         attempt_push.assert_not_called()
 
-    prod_record = InspireProdRecords.query.filter(InspireProdRecords.recid == 12345).one()
+    prod_record = LegacyRecordsMirror.query.filter(LegacyRecordsMirror.recid == 12345).one()
     assert prod_record.valid
 
     assert app.config['FEATURE_FLAG_ENABLE_ORCID_PUSH']
@@ -208,7 +208,7 @@ def test_orcid_push_disabled_on_migrate_chunk(app, cleanup, enable_orcid_push_fe
         migrate_chunk([open(record_fixture_path).read()])
         attempt_push.assert_not_called()
 
-    prod_record = InspireProdRecords.query.filter(InspireProdRecords.recid == 12345).one()
+    prod_record = LegacyRecordsMirror.query.filter(LegacyRecordsMirror.recid == 12345).one()
     assert prod_record.valid
 
     assert app.config['FEATURE_FLAG_ENABLE_ORCID_PUSH']

--- a/tests/integration/test_alembic.py
+++ b/tests/integration/test_alembic.py
@@ -110,3 +110,29 @@ def test_alembic_revision_cb5153afd839(alembic_app):
     assert 'workflows_record_sources' not in inspector.get_table_names()
 
     drop_alembic_version_table()
+
+
+def test_alembic_revision_402af3fbf68b(alembic_app):
+    ext = alembic_app.extensions['invenio-db']
+
+    if db.engine.name == 'sqlite':
+        raise pytest.skip('Upgrades are not supported on SQLite.')
+
+    db.drop_all()
+    drop_alembic_version_table()
+
+    inspector = inspect(db.engine)
+    assert 'inspire_prod_records' not in inspector.get_table_names()
+    assert 'legacy_records_mirror' not in inspector.get_table_names()
+
+    ext.alembic.upgrade(target='402af3fbf68b')
+    inspector = inspect(db.engine)
+    assert 'inspire_prod_records' not in inspector.get_table_names()
+    assert 'legacy_records_mirror' in inspector.get_table_names()
+
+    ext.alembic.downgrade(target='d99c7038006e')
+    inspector = inspect(db.engine)
+    assert 'inspire_prod_records' in inspector.get_table_names()
+    assert 'legacy_records_mirror' not in inspector.get_table_names()
+
+    drop_alembic_version_table()

--- a/tests/integration/test_detailed_records.py
+++ b/tests/integration/test_detailed_records.py
@@ -25,7 +25,7 @@ from __future__ import absolute_import, division, print_function
 from invenio_accounts.testutils import login_user_via_session
 from invenio_records.models import RecordMetadata
 
-from inspirehep.modules.migrator.models import InspireProdRecords
+from inspirehep.modules.migrator.models import LegacyRecordsMirror
 
 
 def test_all_records_were_loaded(app):
@@ -38,7 +38,7 @@ def test_all_records_were_loaded(app):
 
 
 def test_all_records_are_valid(app):
-    invalid = InspireProdRecords.query.filter(InspireProdRecords.valid is False).values(InspireProdRecords.recid)
+    invalid = LegacyRecordsMirror.query.filter(LegacyRecordsMirror.valid is False).values(LegacyRecordsMirror.recid)
     recids = [el[0] for el in invalid]
 
     assert recids == []

--- a/tests/integration/test_migrator.py
+++ b/tests/integration/test_migrator.py
@@ -30,7 +30,7 @@ import pytest
 from flask import current_app
 from redis import StrictRedis
 
-from inspirehep.modules.migrator.models import InspireProdRecords
+from inspirehep.modules.migrator.models import LegacyRecordsMirror
 from inspirehep.modules.migrator.tasks import continuous_migration
 from inspirehep.utils.record_getter import get_db_record
 
@@ -99,7 +99,7 @@ def test_continuous_migration_handles_a_single_record(app, record_1502656):
     get_db_record('lit', 1502656)  # Does not raise.
 
     expected = record_1502656
-    result = InspireProdRecords.query.get(1502656).marcxml
+    result = LegacyRecordsMirror.query.get(1502656).marcxml
 
     assert expected == result
 
@@ -116,14 +116,14 @@ def test_continuous_migration_handles_multiple_records(app, record_1502655_and_1
     get_db_record('aut', 1502655)  # Does not raise.
 
     expected = record_1502655_and_1502656[0]
-    result = InspireProdRecords.query.get(1502655).marcxml
+    result = LegacyRecordsMirror.query.get(1502655).marcxml
 
     assert expected == result
 
     get_db_record('lit', 1502656)  # Does not raise.
 
     expected = record_1502655_and_1502656[1]
-    result = InspireProdRecords.query.get(1502656).marcxml
+    result = LegacyRecordsMirror.query.get(1502656).marcxml
 
     assert expected == result
 
@@ -145,6 +145,6 @@ def test_continuous_migration_handles_record_updates(app, record_1502656_and_upd
     assert expected == result
 
     expected = record_1502656_and_update[1]
-    result = InspireProdRecords.query.get(1502656).marcxml
+    result = LegacyRecordsMirror.query.get(1502656).marcxml
 
     assert expected == result


### PR DESCRIPTION
This renames InspireProdRecords to LegacyRecordsMirror, which makes the
content of the table more clear. This is part of the `migrator` CLI
refactor that will use the `mirror` terminology.