### PR TITLE
Change fuzzy matcher config to use Jaccard Index based validator

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -1675,7 +1675,8 @@ FUZZY_MATCH = {
                     ],
                     'type': 'fuzzy',
                 }
-            ]
+            ],
+            'validator': 'inspire_matcher.validators:authors_titles_validator'
         }
     ],
     'doc_type': 'hep',


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Change fuzzy matcher configuration to use the Jaccard Index based validator for the authors and titles of the resulting possible matches against the given record.

## Related PR
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/inspirehep/inspire-matcher/pull/43

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The current config does not specify a validator, thus the default one will be used which approves of any possible match. Due to the fact that the current ES query that is generated by the fuzzy matcher is too general and returns many irrelevant results, we have to filter out as much as possible the wrong matches.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Signed-off-by: Iuliana Voinea <iuliana.voinea@student.manchester.ac.uk>