### PR TITLE
mappings: add mappings for data

### DIFF
--- a/inspirehep/modules/records/mappings/records/data.json
+++ b/inspirehep/modules/records/mappings/records/data.json
@@ -6,7 +6,84 @@
             },
             "date_detection": false,
             "numeric_detection": false,
-            "properties": {}
+            "properties": {
+                "$schema": {
+                    "type": "string"
+                },
+                "_collections": {
+                    "type": "string"
+                },
+                "control_number": {
+                    "type": "integer"
+                },
+                "deleted": {
+                    "type": "boolean"
+                },
+                "deleted_recids": {
+                    "type": "integer"
+                },
+                "deleted_records": {
+                    "properties": {
+                        "$ref": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "dois": {
+                    "properties": {
+                        "material": {
+                            "type": "string"
+                        },
+                        "source": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "fields": {
+                                "raw": {
+                                    "analyzer": "lowercase_analyzer",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "new_recid": {
+                    "type": "integer"
+                },
+                "new_record": {
+                    "properties": {
+                        "$ref": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "self": {
+                    "properties": {
+                        "$ref": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "self_recid": {
+                    "type": "integer"
+                }
+            }
+        }
+    },
+    "settings": {
+        "analysis": {
+            "analyzer": {
+                "lowercase_analyzer": {
+                    "filter": "lowercase",
+                    "tokenizer": "keyword",
+                    "type": "custom"
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
Added mappings for the data records in Elasticsearch. This would add DOIs to the data records in the desired format, making us able to make ES queries on those.

## Motivation and Context
This would help in accounting for citations to data, improving citation counts.

## Checklist:
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
