### PR TITLE
orcid: add get_literature_recids_by_orcid util

### DIFF
--- a/inspirehep/modules/authors/rest/citations.py
+++ b/inspirehep/modules/authors/rest/citations.py
@@ -24,6 +24,8 @@ from __future__ import absolute_import, division, print_function
 
 import json
 
+from elasticsearch_dsl import Q
+
 from inspirehep.modules.search import LiteratureSearch
 
 
@@ -46,17 +48,13 @@ class AuthorAPICitations(object):
         author_pid = pid.pid_value
         citations = {}
 
-        search = LiteratureSearch().query({
-            "match": {
-                "authors.recid": author_pid
-            }
-        }).params(
-            _source=[
-                "authors.recid",
-                "control_number",
-                "self",
-            ]
-        )
+        query = Q('match', authors__recid=author_pid)
+        search = LiteratureSearch().query('nested', path='authors', query=query)\
+                                   .params(_source=[
+                                       'authors.recid',
+                                       'control_number',
+                                       'self',
+                                   ])
 
         # For each publication co-authored by a given author...
         for result in search.scan():

--- a/inspirehep/modules/authors/rest/coauthors.py
+++ b/inspirehep/modules/authors/rest/coauthors.py
@@ -24,6 +24,8 @@ from __future__ import absolute_import, division, print_function
 
 import json
 
+from elasticsearch_dsl import Q
+
 from inspirehep.modules.search import LiteratureSearch
 
 
@@ -46,17 +48,13 @@ class AuthorAPICoauthors(object):
         author_pid = pid.pid_value
         coauthors = {}
 
-        search = LiteratureSearch().query({
-            "match": {
-                "authors.recid": author_pid
-            }
-        }).params(
-            _source=[
-                "authors.full_name",
-                "authors.recid",
-                "authors.record",
-            ]
-        )
+        query = Q('match', authors__recid=author_pid)
+        search = LiteratureSearch().query('nested', path='authors', query=query)\
+                                   .params(_source=[
+                                       'authors.full_name',
+                                       'authors.recid',
+                                       'authors.record',
+                                   ])
 
         for result in search.scan():
             result_source = result.to_dict()['authors']

--- a/inspirehep/modules/authors/rest/publications.py
+++ b/inspirehep/modules/authors/rest/publications.py
@@ -24,6 +24,8 @@ from __future__ import absolute_import, division, print_function
 
 import json
 
+from elasticsearch_dsl import Q
+
 from inspirehep.modules.search import LiteratureSearch
 from inspirehep.utils.record import get_title
 
@@ -47,23 +49,19 @@ class AuthorAPIPublications(object):
         author_pid = pid.pid_value
         publications = []
 
-        search = LiteratureSearch().query({
-            "match": {
-                "authors.recid": author_pid
-            }
-        }).params(
-            _source=[
-                "accelerator_experiments",
-                "earliest_date",
-                "citation_count",
-                "control_number",
-                "facet_inspire_doc_type",
-                "publication_info",
-                "self",
-                "keywords",
-                "titles",
-            ]
-        )
+        query = Q('match', authors__recid=author_pid)
+        search = LiteratureSearch().query('nested', path='authors', query=query)\
+                                   .params(_source=[
+                                       'accelerator_experiments',
+                                       'citation_count',
+                                       'control_number',
+                                       'earliest_date',
+                                       'facet_inspire_doc_type',
+                                       'keywords',
+                                       'publication_info',
+                                       'self',
+                                       'titles',
+                                   ])
 
         for result in search.scan():
             result_source = result.to_dict()

--- a/inspirehep/modules/authors/rest/stats.py
+++ b/inspirehep/modules/authors/rest/stats.py
@@ -25,6 +25,8 @@ from __future__ import absolute_import, division, print_function
 import json
 from collections import Counter
 
+from elasticsearch_dsl import Q
+
 from inspire_utils.helpers import force_list
 from inspire_utils.record import get_value
 from inspirehep.modules.search import LiteratureSearch
@@ -59,19 +61,15 @@ class AuthorAPIStats(object):
 
         statistics_citations = {}
 
-        search = LiteratureSearch().query({
-            "match": {
-                "authors.recid": author_pid
-            }
-        }).params(
-            _source=[
-                "citation_count",
-                "control_number",
-                "facet_inspire_doc_type",
-                "facet_inspire_categories",
-                "keywords",
-            ]
-        )
+        query = Q('match', authors__recid=author_pid)
+        search = LiteratureSearch().query('nested', path='authors', query=query)\
+                                   .params(_source=[
+                                       'citation_count',
+                                       'control_number',
+                                       'facet_inspire_doc_type',
+                                       'facet_inspire_categories',
+                                       'keywords',
+                                   ])
 
         for result in search.scan():
             result_source = result.to_dict()

--- a/inspirehep/modules/records/mappings/records/hep.json
+++ b/inspirehep/modules/records/mappings/records/hep.json
@@ -276,7 +276,7 @@
                             "type": "string"
                         }
                     },
-                    "type": "object"
+                    "type": "nested"
                 },
                 "book_series": {
                     "properties": {

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -92,18 +92,19 @@ def app():
 
 @pytest.fixture(scope='function')
 def isolated_app(app):
-    """
-    Create an instance of app with db isolation.
-    This means that no changes are persisted to the db because at the end
-    of each test the db is rolled back. This is achieved leveraging nested
-    transactions.
-    Note: probably a neater solution is the one suggested here:
-    http://docs.sqlalchemy.org/en/latest/orm/session_transaction.html#joining-a-session-into-an-external-transaction-such-as-for-test-suites
+    """Flask application with database isolation and function scope.
 
-    See tests/integration/test_db_isolation.py for some examples.
+    When using this fixture no changes will be persisted to the database
+    because at the end of each test the database is rolled back. This is
+    achieved by using a nested transaction. For examples on how to use it,
+    please see tests/integration/test_db_isolation.py.
+
+    Note:
+        A neater solution seems to be the one suggested in https://goo.gl/31EKXq.
+
     """
-    db.session.begin_nested()
-    yield
+    with db.session.begin_nested():
+        yield
     db.session.rollback()
 
 

--- a/tests/integration/orcid/test_orcid_utils.py
+++ b/tests/integration/orcid/test_orcid_utils.py
@@ -25,11 +25,17 @@
 from __future__ import absolute_import, division, print_function
 
 import pytest
+from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 
 from inspire_dojson.utils import get_record_ref
 from inspire_schemas.api import validate
 from inspirehep.modules.migrator.tasks import record_insert_or_replace
-from inspirehep.modules.orcid.utils import _get_api_url_for_recid, get_orcids_for_push
+from inspirehep.modules.orcid.utils import (
+    _get_api_url_for_recid,
+    get_literature_recids_for_orcid,
+    get_orcids_for_push,
+)
+from inspirehep.utils.record_getter import get_db_record
 
 
 @pytest.fixture(scope='function')
@@ -195,3 +201,42 @@ def test_orcids_for_push_orcid_in_author_with_claim(author_in_isolated_app):
 
     assert validate(record, 'hep') is None
     assert list(get_orcids_for_push(record)) == ['0000-0002-1825-0097']
+
+
+def test_get_literature_recids_for_orcid(isolated_app):
+    expected = [1496635]
+    result = get_literature_recids_for_orcid('0000-0003-4792-9178')
+
+    assert expected == result
+
+
+def test_get_literature_recids_for_orcid_raises_if_no_author_is_found(isolated_app):
+    with pytest.raises(NoResultFound):
+        get_literature_recids_for_orcid('THIS-ORCID-DOES-NOT-EXIST')
+
+
+def test_get_literature_recids_for_orcid_raises_if_two_authors_are_found(isolated_app):
+    record = get_db_record('aut', 1061000)
+    record['control_number'] = 1061001
+    record_insert_or_replace(record)
+
+    with pytest.raises(MultipleResultsFound):
+        get_literature_recids_for_orcid('0000-0003-4792-9178')
+
+
+def test_get_literature_recids_for_orcid_still_works_if_author_has_no_ids(isolated_app):
+    record = get_db_record('aut', 1061000)
+    del record['ids']
+    record_insert_or_replace(record)
+
+    with pytest.raises(NoResultFound):
+        get_literature_recids_for_orcid('0000-0003-4792-9178')
+
+
+def test_get_literature_recids_for_orcid_still_works_if_author_has_no_orcid_id(isolated_app):
+    record = get_db_record('aut', 1061000)
+    record['ids'] = [{'schema': 'INSPIRE BAI', 'value': 'Maurizio.Martinelli.1'}]
+    record_insert_or_replace(record)
+
+    with pytest.raises(NoResultFound):
+        get_literature_recids_for_orcid('0000-0003-4792-9178')

--- a/tests/integration/test_db_isolation.py
+++ b/tests/integration/test_db_isolation.py
@@ -32,7 +32,6 @@ from __future__ import absolute_import, division, print_function
 import pytest
 
 from invenio_pidstore.models import PersistentIdentifier
-from invenio_db import db
 
 
 # Test `app` fixture.
@@ -81,25 +80,3 @@ def test_isolated_app_fixture_has_db_isolation_step2(pids_count_in_app, isolated
     # This proves that the step1 and the step2 are isolated.
     # The #PIDs must NOT have incremented.
     assert PersistentIdentifier.query.count() == pids_count_in_app
-
-
-def test_isolated_app_fixture_commit(isolated_app):
-    pids_count = PersistentIdentifier.query.count()
-
-    PersistentIdentifier.create(
-        pid_type='type1',
-        pid_value='value1',
-    )
-    db.session.commit()
-    assert PersistentIdentifier.query.count() == pids_count + 1
-
-
-def test_isolated_app_fixture_rollback(isolated_app):
-    pids_count = PersistentIdentifier.query.count()
-
-    PersistentIdentifier.create(
-        pid_type='type1',
-        pid_value='value1',
-    )
-    db.session.rollback()
-    assert PersistentIdentifier.query.count() == pids_count


### PR DESCRIPTION
## Description:
We record that an author of recid X has claimed a paper of recid Y by
setting ``curated_relation`` to ``True`` in the author signature of Y
that also contains a record reference to X.

In order to later retrieve this information we need to nest this field,
otherwise we would get spurious matches across different signatures.
See also c20f672 for a similar argument for ``publication_info``s.

## Related Issue:
https://its.cern.ch/jira/browse/INSPIR-343

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.