### PR TITLE
tests.classifier: use a small minimal taxonomy

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -191,7 +191,7 @@ services:
   test-worker:
     extends:
       service: test-service_base
-    command: celery worker -E -A inspirehep.celery --loglevel=INFO --purge --queues celery,migrator,harvests,orcid_push
+    command: celery worker -E -A inspirehep.celery_tests --loglevel=INFO --purge --queues celery,migrator,harvests,orcid_push
     volumes_from:
       - test-static
     healthcheck:

--- a/inspirehep/celery_tests.py
+++ b/inspirehep/celery_tests.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2018 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""INSPIREHEP Celery app instantiation for tests.
+
+This adds a simple ontology file for fast classifier runs.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import logging
+import tempfile
+
+from flask_celeryext import create_celery_app
+
+from .factory import create_app
+
+
+HIGGS_ONTOLOGY = '''<?xml version="1.0" encoding="UTF-8" ?>
+
+<rdf:RDF xmlns="http://www.w3.org/2004/02/skos/core#"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+
+    <Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Higgsparticle">
+        <prefLabel xml:lang="en">Higgs particle</prefLabel>
+        <altLabel xml:lang="en">Higgs boson</altLabel>
+        <hiddenLabel xml:lang="en">Higgses</hiddenLabel>
+        <note xml:lang="en">core</note>
+    </Concept>
+
+</rdf:RDF>
+'''
+HIGGS_ONTOLOGY_FILE = tempfile.NamedTemporaryFile()
+HIGGS_ONTOLOGY_FILE.write(HIGGS_ONTOLOGY)
+HIGGS_ONTOLOGY_FILE.flush()
+
+
+print('Using ontology file %s' % HIGGS_ONTOLOGY_FILE.name)
+celery = create_celery_app(
+    create_app(
+        LOGGING_SENTRY_CELERY=True,
+        HEP_ONTOLOGY_FILE=HIGGS_ONTOLOGY_FILE.name,
+    )
+)
+
+# We don't want to log to Sentry backoff errors
+logging.getLogger('backoff').propagate = 0

--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -1287,6 +1287,9 @@ ARXIV_CATEGORIES = {
         'physics.ins-det',
     ]
 }
+HEP_ONTOLOGY_FILE = "HEPont.rdf"
+"""Name or path of the ontology to use for hep articles keyword extraction."""
+
 RECORDS_DEFAULT_FILE_LOCATION_NAME = "records"
 """Name of default records Location reference."""
 

--- a/inspirehep/modules/workflows/tasks/classifier.py
+++ b/inspirehep/modules/workflows/tasks/classifier.py
@@ -53,7 +53,7 @@ def filter_core_keywords(obj, eng):
     obj.extra_data['classifier_results']["complete_output"] = result
 
 
-def classify_paper(taxonomy, rebuild_cache=False, no_cache=False,
+def classify_paper(taxonomy=None, rebuild_cache=False, no_cache=False,
                    output_limit=20, spires=False,
                    match_mode='full', with_author_keywords=False,
                    extract_acronyms=False, only_core_tags=False,
@@ -62,8 +62,9 @@ def classify_paper(taxonomy, rebuild_cache=False, no_cache=False,
     @with_debug_logging
     @wraps(classify_paper)
     def _classify_paper(obj, eng):
+        from flask import current_app
         params = dict(
-            taxonomy_name=taxonomy,
+            taxonomy_name=taxonomy or current_app.config['HEP_ONTOLOGY_FILE'],
             output_mode='dict',
             output_limit=output_limit,
             spires=spires,

--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -159,7 +159,6 @@ ENHANCE_RECORD = [
     extract_journal_info,
     populate_journal_coverage,
     classify_paper(
-        taxonomy="HEPont.rdf",
         only_core_tags=False,
         spires=True,
         with_author_keywords=True,

--- a/tests/integration/workflows/conftest.py
+++ b/tests/integration/workflows/conftest.py
@@ -43,8 +43,33 @@ from inspirehep.modules.records.api import InspireRecord
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'helpers'))
 
 
+HIGGS_TAXONOMY = '''<?xml version="1.0" encoding="UTF-8" ?>
+
+<rdf:RDF xmlns="http://www.w3.org/2004/02/skos/core#"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+
+    <Concept rdf:about="http://cern.ch/thesauri/HEPontology.rdf#Higgsparticle">
+        <prefLabel xml:lang="en">Higgs particle</prefLabel>
+        <altLabel xml:lang="en">Higgs boson</altLabel>
+        <hiddenLabel xml:lang="en">Higgses</hiddenLabel>
+        <note xml:lang="en">core</note>
+    </Concept>
+
+</rdf:RDF>
+'''
+
+
+@pytest.fixture()
+def higgs_taxonomy(tmpdir):
+    taxonomy = tmpdir.join('HEPont.rdf')
+    taxonomy.write(HIGGS_TAXONOMY)
+    yield str(taxonomy)
+
+
 @pytest.fixture
-def workflow_app():
+def workflow_app(higgs_taxonomy):
     """Flask application with no records and function scope.
 
     .. deprecated:: 2017-09-18
@@ -62,20 +87,21 @@ def workflow_app():
 
         app = create_app(
             BEARD_API_URL="http://example.com/beard",
-            DEBUG=True,
             CELERY_ALWAYS_EAGER=True,
-            CELERY_RESULT_BACKEND='cache',
             CELERY_CACHE_BACKEND='memory',
             CELERY_EAGER_PROPAGATES_EXCEPTIONS=True,
+            CELERY_RESULT_BACKEND='cache',
+            CFG_BIBCATALOG_SYSTEM_RT_URL=RT_URL,
+            DEBUG=True,
+            HEP_ONTOLOGY_FILE=higgs_taxonomy,
             PRODUCTION_MODE=True,
             LEGACY_ROBOTUPLOAD_URL=(
                 'http://localhost:1234'
             ),
             MAGPIE_API_URL="http://example.com/magpie",
-            WORKFLOWS_MATCH_REMOTE_SERVER_URL="http://legacy_search.endpoint/",
             WORKFLOWS_FILE_LOCATION="/",
+            WORKFLOWS_MATCH_REMOTE_SERVER_URL="http://legacy_search.endpoint/",
             WTF_CSRF_ENABLED=False,
-            CFG_BIBCATALOG_SYSTEM_RT_URL=RT_URL
         )
 
     with app.app_context():

--- a/tests/integration/workflows/conftest.py
+++ b/tests/integration/workflows/conftest.py
@@ -43,7 +43,7 @@ from inspirehep.modules.records.api import InspireRecord
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'helpers'))
 
 
-HIGGS_TAXONOMY = '''<?xml version="1.0" encoding="UTF-8" ?>
+HIGGS_ONTOLOGY = '''<?xml version="1.0" encoding="UTF-8" ?>
 
 <rdf:RDF xmlns="http://www.w3.org/2004/02/skos/core#"
     xmlns:dc="http://purl.org/dc/elements/1.1/"
@@ -62,14 +62,14 @@ HIGGS_TAXONOMY = '''<?xml version="1.0" encoding="UTF-8" ?>
 
 
 @pytest.fixture()
-def higgs_taxonomy(tmpdir):
-    taxonomy = tmpdir.join('HEPont.rdf')
-    taxonomy.write(HIGGS_TAXONOMY)
-    yield str(taxonomy)
+def higgs_ontology(tmpdir):
+    ontology = tmpdir.join('HEPont.rdf')
+    ontology.write(HIGGS_ONTOLOGY)
+    yield str(ontology)
 
 
 @pytest.fixture
-def workflow_app(higgs_taxonomy):
+def workflow_app(higgs_ontology):
     """Flask application with no records and function scope.
 
     .. deprecated:: 2017-09-18
@@ -93,7 +93,7 @@ def workflow_app(higgs_taxonomy):
             CELERY_RESULT_BACKEND='cache',
             CFG_BIBCATALOG_SYSTEM_RT_URL=RT_URL,
             DEBUG=True,
-            HEP_ONTOLOGY_FILE=higgs_taxonomy,
+            HEP_ONTOLOGY_FILE=higgs_ontology,
             PRODUCTION_MODE=True,
             LEGACY_ROBOTUPLOAD_URL=(
                 'http://localhost:1234'


### PR DESCRIPTION
This decreases the time of the workflow (unit and integration), and acceptance tests in **~3min**, as the first parsing of the HEPont.rdf is not needed anymore.

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Signed-off-by: David Caro <david@dcaro.es>