### PR TITLE
docker: add health check for the worker node

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -87,7 +87,7 @@ services:
       test-redis:
         condition: service_healthy
       test-worker:
-        condition: service_started
+        condition: service_healthy
       selenium:
         condition: service_started
       test-web:
@@ -113,7 +113,7 @@ services:
       test-redis:
         condition: service_healthy
       test-worker:
-        condition: service_started
+        condition: service_healthy
       selenium:
         condition: service_started
       test-web:
@@ -138,7 +138,7 @@ services:
       test-redis:
         condition: service_healthy
       test-worker:
-        condition: service_started
+        condition: service_healthy
       selenium:
         condition: service_started
       test-web:
@@ -162,7 +162,7 @@ services:
       test-redis:
         condition: service_healthy
       test-worker:
-        condition: service_started
+        condition: service_healthy
       selenium:
         condition: service_started
       test-web:
@@ -194,6 +194,15 @@ services:
     command: celery worker -E -A inspirehep.celery --loglevel=INFO --purge --queues celery,migrator,harvests,orcid_push
     volumes_from:
       - test-static
+    healthcheck:
+      timeout: 5s
+      interval: 5s
+      retries: 5
+      test:
+        - "CMD"
+        - "bash"
+        - "-c"
+        - "/virtualenv/bin/celery --broker=amqp://guest:guest@test-rabbitmq:5672// inspect ping | grep OK"
     depends_on:
       test-database:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,15 @@ services:
     command: celery worker -E -A inspirehep.celery --loglevel=INFO --purge --queues celery,migrator,harvests,orcid_push
     volumes_from:
       - static
+    healthcheck:
+      timeout: 5s
+      interval: 5s
+      retries: 5
+      test:
+        - "CMD"
+        - "bash"
+        - "-c"
+        - "/virtualenv/bin/celery --broker=amqp://guest:guest@rabbitmq:5672// inspect ping | grep OK"
     depends_on:
       database:
         condition: service_healthy


### PR DESCRIPTION
This prevents the worker from starting up after the tests started
and cleaning up any pending jobs.

Signed-off-by: David Caro <david@dcaro.es>