### PR TITLE
records: correctly skip files in create_or_update

### DIFF
--- a/inspirehep/modules/records/api.py
+++ b/inspirehep/modules/records/api.py
@@ -144,7 +144,7 @@ class InspireRecord(Record):
             pid = PersistentIdentifier.get(pid_type, control_number)
             record = super(InspireRecord, cls).get_record(pid.object_uuid)
             record.clear()
-            record.update(data, **kwargs)
+            record.update(data, skip_files=skip_files, **kwargs)
 
             if data.get('legacy_creation_date'):
                 record.model.created = datetime.strptime(data['legacy_creation_date'], '%Y-%m-%d')


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The recent refactor of #3290 omitted to pass the `skip_files` argument to the `update` path in `InspireRecord.create_or_update`. This fixes it.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://sentry.inspirehep.net/inspire-sentry/inspire-qa/issues/71442/

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
