### PR TITLE
setup: unpin Celery

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup_requires = []
 install_requires = [
     'Babel~=2.0,>=2.5.1',
     'Flask-Breadcrumbs~=0.0,>=0.4.0',
-    'Flask-CeleryExt~=0.0,>=0.3.0',
+    'Flask-CeleryExt~=0.0,>=0.3.1',
     'Flask-Gravatar~=0.0,>=0.4.2',
     'Flask-Login~=0.0,>=0.4.0',
     'Flask~=0.0,>=0.12.2',
@@ -53,7 +53,7 @@ install_requires = [
     'backoff~=1.0,>=1.4.3',
     'backports.tempfile>=1.0rc1',
     'beard~=0.0,>=0.2.0',
-    'celery~=3.0,>=3.1.25,<3.1.26',
+    'celery~=3.0,>=3.1.26post2',
     'elasticsearch-dsl~=2.0,>=2.2.0',
     'elasticsearch~=2.0,>=2.4.1',
     'enum34~=1.0,>=1.1.6',


### PR DESCRIPTION
## Description:
Since inveniosoftware/flask-celeryext#31 was merged we can undo
commit 109bf7c and bump the version of Flask-CeleryExt.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.