### PR TITLE
forms: fix autocomplete when conference doesn't have address[0]citie…

### DIFF
--- a/inspirehep/modules/forms/static/js/forms/conferences_typeahead.js
+++ b/inspirehep/modules/forms/static/js/forms/conferences_typeahead.js
@@ -50,8 +50,9 @@ define([
           url: '/api/conferences?q=conferenceautocomplete:%QUERY*',
           filter: function(response) {
             return $.map(response.hits.hits, function(el) {
-              el.metadata.city = el.metadata.address[0].cities[0];
-              el.metadata.country = el.metadata.address[0].country_code;
+              obj = el.metadata.address.find(function (obj) { return obj.hasOwnProperty('cities') });
+              el.metadata.city = obj.cities ? obj.cities[0] : '';
+              el.metadata.country = obj.country_code ? obj.country_code : '';
               el.metadata.title = el.metadata.titles[0].title;
               return el.metadata
             }).sort(function(x, y) {


### PR DESCRIPTION
Signed-off-by: Dinika Saxena <dinika.saxena@cern.ch>

## Description
Fixes autocomplete in literature submission form when the first object in address field of conferences does not contain the `cities` key

As a side note, same issue will appear in the [conferences template](https://github.com/inspirehep/inspire-next/blob/21a41c975d84bc82c81531b1d57ef63bd949f678/inspirehep/modules/theme/templates/inspirehep_theme/format/record/Conference_HTML_detailed.tpl#L97)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
