### PR TITLE
workflows: remove extra with_debug_logging

### DIFF
--- a/inspirehep/modules/workflows/tasks/beard.py
+++ b/inspirehep/modules/workflows/tasks/beard.py
@@ -33,7 +33,6 @@ from inspirehep.modules.workflows.utils import json_api_request
 from ..utils import with_debug_logging
 
 
-@with_debug_logging
 def get_beard_url():
     """Return the BEARD URL endpoint, if any."""
     base_url = current_app.config.get('BEARD_API_URL')
@@ -43,7 +42,6 @@ def get_beard_url():
     return '{base_url}/predictor/coreness'.format(base_url=base_url)
 
 
-@with_debug_logging
 def prepare_payload(record):
     """Prepare payload to send to Beard API."""
     payload = dict(title="", abstract="", categories=[])

--- a/inspirehep/modules/workflows/tasks/classifier.py
+++ b/inspirehep/modules/workflows/tasks/classifier.py
@@ -106,7 +106,6 @@ def classify_paper(taxonomy, rebuild_cache=False, no_cache=False,
     return _classify_paper
 
 
-@with_debug_logging
 def clean_instances_from_data(output):
     """Check if specific keys are of InstanceType and replace them with their id."""
     new_output = {}

--- a/inspirehep/modules/workflows/tasks/magpie.py
+++ b/inspirehep/modules/workflows/tasks/magpie.py
@@ -34,7 +34,6 @@ from inspirehep.modules.workflows.utils import json_api_request
 from ..utils import with_debug_logging
 
 
-@with_debug_logging
 def get_magpie_url():
     """Return the Magpie URL endpoint, if any."""
     base_url = current_app.config.get("MAGPIE_API_URL")
@@ -45,7 +44,6 @@ def get_magpie_url():
     )
 
 
-@with_debug_logging
 def prepare_magpie_payload(record, corpus):
     """Prepare payload to send to Magpie API."""
     payload = dict(text="", corpus=corpus)
@@ -56,7 +54,6 @@ def prepare_magpie_payload(record, corpus):
     return payload
 
 
-@with_debug_logging
 def filter_magpie_response(labels, limit):
     """Filter response from Magpie API, keeping most relevant labels."""
     filtered_labels = [

--- a/inspirehep/modules/workflows/tasks/matching.py
+++ b/inspirehep/modules/workflows/tasks/matching.py
@@ -41,7 +41,6 @@ from inspirehep.modules.workflows.tasks.actions import mark
 from ..utils import with_debug_logging
 
 
-@with_debug_logging
 def is_too_old(record, days_ago=5):
     """Return True if the record is more than days_ago days old.
 


### PR DESCRIPTION
## Description:
The ``with_debug_logging`` decorator should only be used when the
decorated function is a workflow step, so that we can trace the
workflow execution from the logs.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.