### PR TITLE
orcid: return all results in get_literature_recids

### DIFF
--- a/inspirehep/modules/orcid/utils.py
+++ b/inspirehep/modules/orcid/utils.py
@@ -260,6 +260,6 @@ def get_literature_recids_for_orcid(orcid):
 
     query = Q('match', authors__curated_relation=True) & Q('match', authors__recid=author_recid)
     search_by_curated_author = LiteratureSearch().query('nested', path='authors', query=query)\
-                                                 .params(_source=['control_number'])
+                                                 .params(_source=['control_number'], size=9999)
 
     return [el['control_number'] for el in search_by_curated_author]


### PR DESCRIPTION
## Description:
Previously the query was returning only the first 10 results, per
ES' defaults. It's ok to use ``size=9999`` because we don't expect
any author to have signed that many papers; if this in the future
becomes a problem we should start using the Scroll API.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.