### PR TITLE
migrator: fix two bugs

### DIFF
--- a/inspirehep/modules/migrator/tasks.py
+++ b/inspirehep/modules/migrator/tasks.py
@@ -156,7 +156,6 @@ def migrate_record_from_legacy(recid):
 
 
 @shared_task(ignore_result=True, queue='migrator')
-@disable_orcid_push
 def migrate_from_mirror(also_migrate=None, wait_for_results=False, skip_files=None):
     """Migrate legacy records from the local mirror.
 
@@ -267,6 +266,7 @@ def create_index_op(record):
 
 
 @shared_task(ignore_result=False, queue='migrator')
+@disable_orcid_push
 def migrate_recids_from_mirror(prod_recids, skip_files=False):
     models_committed.disconnect(index_after_commit)
 

--- a/inspirehep/modules/migrator/tasks.py
+++ b/inspirehep/modules/migrator/tasks.py
@@ -195,7 +195,8 @@ def migrate_from_mirror(also_migrate=None, wait_for_results=False, skip_files=No
         tasks = []
         migrate_recids_from_mirror.ignore_result = False
 
-    for i, chunk in enumerate(chunker(query.yield_per(CHUNK_SIZE)), 1):
+    chunked_recids = chunker(res.recid for res in query.yield_per(CHUNK_SIZE))
+    for i, chunk in enumerate(chunked_recids, 1):
         print("Scheduled {} records for migration".format(i * CHUNK_SIZE))
         if wait_for_results:
             tasks.append(migrate_recids_from_mirror.s(chunk, skip_files=skip_files))


### PR DESCRIPTION
Fixes a few issues in the migration:
- correctly disables the ORCID push
- `migrate_from_mirror` explicitly passes the `recid`, instead of relying on magic