### PR TITLE
orcid: create a separate logger for orcid

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -29,6 +29,7 @@ import sys
 import pkg_resources
 
 from celery.schedules import crontab
+from logging.config import dictConfig
 
 from invenio_oauthclient.contrib import orcid
 from invenio_records_rest.facets import range_filter, terms_filter
@@ -112,6 +113,28 @@ REST_ENABLE_CORS = True
 # =======
 # To enable file logging set it to e.g. "{sys_prefix}/var/log/inspirehep.log"
 LOGGING_FS_LOGFILE = None
+
+dictConfig({
+    'version': 1,
+    'formatters': {
+        'default': {
+            'format': '[%(asctime)s] %(levelname)s/%(module)s: %(message)s',
+        }
+    },
+    'handlers': {
+        'stdout_handler': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'default',
+        }
+    },
+    'loggers': {
+        'inspirehep.modules.orcid': {
+            'level': 'INFO',
+            'handlers': ['stdout_handler'],
+            'propagate': True,
+        },
+    }
+})
 
 # Accounts
 # ========

--- a/inspirehep/modules/orcid/api.py
+++ b/inspirehep/modules/orcid/api.py
@@ -64,15 +64,18 @@ def push_record_with_orcid(recid, orcid, oauth_token, put_code=None, old_hash=No
 
     new_hash = calculate_hash_for_record(record)
     if new_hash == old_hash:
-        LOGGER.info('Hash unchanged: not pushing #{} as not a meaningful update'.format(recid))
+        LOGGER.info(
+            'Hash unchanged: not pushing #%s as not a meaningful update', recid
+        )
         return put_code, new_hash
 
     try:
         bibtex = _get_bibtex_record(app.config, recid)
     except requests.RequestException:
         bibtex = None
-        LOGGER.error('Pushing record #{} without BibTex, as fetching'
-                     'it failed!'.format(recid))
+        LOGGER.error(
+            'Pushing record #%s without BibTex, as fetching it failed!', recid
+        )
 
     orcid_api = _get_api()
 
@@ -81,11 +84,9 @@ def push_record_with_orcid(recid, orcid, oauth_token, put_code=None, old_hash=No
     ).get_xml()
 
     if put_code:
-        LOGGER.info("Pushing record #{} with put-code {} to ORCID {}.".format(
-            recid,
-            put_code,
-            orcid
-        ))
+        LOGGER.info(
+            "Pushing record #%s with put-code %s onto %s.", recid, put_code, orcid,
+        )
         orcid_api.update_record(
             orcid_id=orcid,
             token=oauth_token,
@@ -96,10 +97,7 @@ def push_record_with_orcid(recid, orcid, oauth_token, put_code=None, old_hash=No
         )
     else:
         LOGGER.info(
-            "No put-code found, pushing new record #{} to ORCID {}.".format(
-                recid,
-                orcid,
-            )
+            "No put-code found, pushing new record #%s to ORCID %s.", recid, orcid,
         )
         put_code = orcid_api.add_record(
             orcid_id=orcid,
@@ -109,7 +107,7 @@ def push_record_with_orcid(recid, orcid, oauth_token, put_code=None, old_hash=No
             content_type='application/orcid+xml',
         )
 
-        LOGGER.info("Record added with put-code {}.".format(put_code))
+    LOGGER.info("Push of %s onto %s completed with put-code %s.", recid, orcid, put_code)
 
     return put_code, new_hash
 
@@ -249,9 +247,8 @@ def get_author_putcodes(orcid, oauth_token):
 
     if errors:
         LOGGER.error(
-            'Failed to match putcodes {} from {} to HEP records.'.format(
-                ', '.join(errors), orcid
-            )
+            'Failed to match putcodes %s from %s to HEP records.',
+            ', '.join(errors), orcid
         )
 
     return author_putcodes

--- a/inspirehep/modules/orcid/tasks.py
+++ b/inspirehep/modules/orcid/tasks.py
@@ -220,6 +220,8 @@ def attempt_push(orcid, rec_id, oauth_token):
         rec_id(int): inspire record's id to push to ORCID.
         oauth_token(string): orcid token.
     """
+    LOGGER.info('Will attempt to push #%s onto %s', rec_id, orcid)
+
     put_code, previous_hash = get_putcode_and_hash_from_redis(orcid, rec_id)
 
     if not put_code:

--- a/inspirehep/modules/orcid/utils.py
+++ b/inspirehep/modules/orcid/utils.py
@@ -46,13 +46,10 @@ from invenio_pidstore.models import PersistentIdentifier
 from invenio_records.models import RecordMetadata
 
 from inspire_dojson.utils import get_recid_from_ref
-from inspire_utils.logging import getStackTraceLogger
 from inspire_utils.record import get_values_for_schema
 from inspire_utils.urls import ensure_scheme
 from inspirehep.modules.search.api import LiteratureSearch
 from inspirehep.utils.record_getter import get_db_records
-
-LOGGER = getStackTraceLogger(__name__)
 
 
 RECID_FROM_INSPIRE_URL = re.compile(

--- a/tests/integration/orcid/test_orcid_api.py
+++ b/tests/integration/orcid/test_orcid_api.py
@@ -33,8 +33,8 @@ from inspirehep.modules.orcid.api import push_record_with_orcid, get_author_putc
 @pytest.fixture
 def mock_logger():
     class MockLogger(object):
-        def error(self, message):
-            self.message = message
+        def error(self, message, *args):
+            self.message = message % args
 
     mock_logger = MockLogger()
 


### PR DESCRIPTION
## Description

**OUTDATED, left for historical reasons:**

*We are currently losing logs for ORCID pushes, for an unknown reason. I tried to troubleshoot but after over a day of coming up blank and discussing with @puntonim we decided that this may be a good opportunity to introduce explicit logging to a file, for now for the `orcid` module. Having the logs for ORCID can enable us to learn about the statistics such as ratio of updates to creations.*

**EDIT:**

This now successfully logs to stderr for the orcid module.

Turns out our problem comes from somewhere in raven/invenio-logging where the loggers are patched. For some reason, when enabling sentry all logs below `LOGGING_SENTRY_LEVEL` are lost. Investigation shows that the propagation on the `inspirehep` logger is disabled which causes messages to not be passed to the root logger. Regardless, the root logger has only the sentry handler registered, so it's unclear if this is the source of the problem of lost logs. It seems also, that the handler is registered twice on `inspirehep`, for no apparent reason, and I'm not sure what causes it exactly.

This matter requires further investigation, but this PR aims to enable logging for ORCID ASAP, to be able to collect information on how we're doing with the push.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
