### PR TITLE
workflows: addition of rootless merge

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -52,6 +52,9 @@ FEATURE_FLAG_ENABLE_ORCID_PUSH = False
 #   some ORCIDs -> "^(0000-0002-7638-5686|0000-0002-7638-5687)$"
 FEATURE_FLAG_ORCID_PUSH_WHITELIST_REGEX = '.*'
 FEATURE_FLAG_ENABLE_FUZZY_MATCHER = False
+FEATURE_FLAG_ENABLE_MERGER = False
+FEATURE_FLAG_ENABLE_UPDATE_TO_LEGACY = False
+"""This feature flag will prevent to send a ``replace`` update to legacy."""
 
 # Default language and timezone
 # =============================

--- a/inspirehep/modules/workflows/errors.py
+++ b/inspirehep/modules/workflows/errors.py
@@ -103,3 +103,15 @@ class CallbackWorkflowNotInValidationError(CallbackError):
         super(CallbackWorkflowNotInValidationError, self).__init__(**kwargs)
         self.message = 'Workflow {} is not in validation error state.'.format(
             workflow_id)
+
+
+class CallbackWorkflowNotInMergeState(CallbackError):
+    """Workflow not in validation error exception."""
+
+    error_code = 'WORKFLOW_NOT_IN_MERGE_STATE'
+
+    def __init__(self, workflow_id, **kwargs):
+        """Initialize exception."""
+        super(CallbackWorkflowNotInMergeState, self).__init__(**kwargs)
+        self.message = 'Workflow {} is not in merge state.'.format(
+            workflow_id)

--- a/inspirehep/modules/workflows/tasks/submission.py
+++ b/inspirehep/modules/workflows/tasks/submission.py
@@ -196,6 +196,13 @@ def send_robotupload(
     @with_debug_logging
     @wraps(send_robotupload)
     def _send_robotupload(obj, eng):
+        is_update = obj.extra_data.get('is-update')
+
+        if is_update and not current_app.config.get('FEATURE_FLAG_ENABLE_UPDATE_TO_LEGACY', False):
+            obj.log.info(
+                'skipping upload to legacy, feature flag ``FEATURE_FLAG_ENABLE_UPDATE_TO_LEGACY`` is disabled.')
+            return
+
         combined_callback_url = ''
         if callback_url:
             combined_callback_url = os.path.join(

--- a/inspirehep/modules/workflows/tasks/upload.py
+++ b/inspirehep/modules/workflows/tasks/upload.py
@@ -24,6 +24,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+from flask import current_app
+
 from invenio_db import db
 
 from inspirehep.modules.pidstore.utils import get_pid_type_from_schema
@@ -50,7 +52,14 @@ def store_record(obj, eng):
         return updated_record
 
     is_update = obj.extra_data.get('is-update')
+
     if is_update:
+        if not current_app.config.get('FEATURE_FLAG_ENABLE_MERGER', False):
+            obj.log.info(
+                'skipping update record, feature flag ``FEATURE_FLAG_ENABLE_MERGER`` is disabled.'
+            )
+            return
+
         record = _get_updated_record(obj)
         obj.data['control_number'] = record['control_number']
         record.clear()

--- a/inspirehep/modules/workflows/utils/__init__.py
+++ b/inspirehep/modules/workflows/utils/__init__.py
@@ -288,6 +288,21 @@ def get_resolve_validation_callback_url():
     )
 
 
+def get_resolve_merge_conflicts_callback_url():
+    """Resolve validation callback.
+
+    Returns the callback url for resolving the merge conflicts.
+
+    Note:
+        It's using ``inspire_workflows.callback_resolve_merge_conflicts``
+        route.
+    """
+    return url_for(
+        'inspire_workflows.callback_resolve_merge_conflicts',
+        _external=True
+    )
+
+
 def get_validation_errors(data, schema):
     """Creates a ``validation_errors`` dictionary.
 

--- a/tests/integration/workflows/conftest.py
+++ b/tests/integration/workflows/conftest.py
@@ -213,3 +213,58 @@ def record_from_db(workflow_app):
     pid.delete()
     record.delete()
     record.commit()
+
+
+@pytest.fixture
+def record_to_merge(workflow_app):
+    json = {
+        '$schema': 'http://localhost:5000/schemas/records/hep.json',
+        '_collections': [
+            'Literature'
+        ],
+        'authors': [
+            {
+                'full_name': 'Jessica, Jones',
+            },
+        ],
+        'document_type': [
+            'thesis'
+        ],
+        'number_of_pages': 100,
+        'preprint_date': '2016-11-16',
+        'public_notes': [
+            {
+                'source': 'arXiv',
+                'value': '100 pages, 36 figures'
+            }
+        ],
+        'titles': [
+            {
+                'title': 'Alias Investigations'
+            }
+        ],
+        'dois': [
+            {
+                'value': '10.1007/978-3-319-15001-7'
+            }
+        ],
+    }
+    record = InspireRecord.create(json, id_=None, skip_files=True)
+    record.commit()
+    rec_uuid = record.id
+
+    db.session.commit()
+    es.indices.refresh('records-hep')
+
+    yield record
+
+    record = InspireRecord.get_record(rec_uuid)
+    pid = PersistentIdentifier.get(
+        pid_type='lit',
+        pid_value=record['control_number']
+    )
+
+    pid.unassign()
+    pid.delete()
+    record.delete()
+    record.commit()

--- a/tests/integration/workflows/test_arxiv_merge.py
+++ b/tests/integration/workflows/test_arxiv_merge.py
@@ -1,0 +1,389 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Tests for merge and resolve merge conflicts."""
+
+from __future__ import absolute_import, division, print_function
+
+import json
+import mock
+import pytest
+
+from invenio_workflows import (
+    ObjectStatus,
+    WorkflowEngine,
+    start,
+)
+
+
+@pytest.fixture
+def enable_merge_on_update(workflow_app):
+    with mock.patch.dict(workflow_app.config, {'FEATURE_FLAG_ENABLE_MERGER': True}):
+        yield
+
+
+def test_merge_with_disabled_merge_on_update_feature_flag(workflow_app, record_to_merge):
+    record_update = {
+        '$schema': 'http://localhost:5000/schemas/records/hep.json',
+        '_collections': ['Literature'],
+        'document_type': ['article'],
+        'titles': [
+            {'title': 'Jessica Jones'},
+            {'title': 'Luke Cage'},
+            {'title': 'Frank Castle'},
+        ],
+        'dois': [
+            {
+                'value': '10.1007/978-3-319-15001-7'
+            }
+        ],
+    }
+
+    eng_uuid = start('article', [record_update])
+
+    eng = WorkflowEngine.from_uuid(eng_uuid)
+    obj = eng.objects[0]
+
+    assert obj.extra_data.get('callback_url') is None
+    assert obj.extra_data.get('conflicts') is None
+    assert obj.extra_data.get('merged') is True
+
+
+def test_merge_without_conflicts(workflow_app, enable_merge_on_update, record_to_merge):
+    record_update = {
+        '$schema': 'http://localhost:5000/schemas/records/hep.json',
+        '_collections': ['Literature'],
+        'document_type': ['article'],
+        'titles': [
+            {'title': 'Jessica Jones'},
+            {'title': 'Luke Cage'},
+            {'title': 'Frank Castle'},
+        ],
+        'dois': [
+            {
+                'value': '10.1007/978-3-319-15001-7'
+            }
+        ],
+    }
+
+    eng_uuid = start('article', [record_update])
+
+    eng = WorkflowEngine.from_uuid(eng_uuid)
+    obj = eng.objects[0]
+
+    assert obj.status == ObjectStatus.COMPLETED
+    assert obj.extra_data.get('callback_url') is None
+    assert obj.extra_data.get('conflicts') is None
+
+    assert obj.extra_data.get('approved') is True
+    assert obj.extra_data.get('is-update') is True
+    assert obj.extra_data.get('merged') is True
+
+
+def test_merge_with_conflicts(workflow_app, enable_merge_on_update, record_to_merge):
+    record_update = {
+        '$schema': 'http://schemas.stark-industries.com/schemas/records/avengers.json',
+        '_collections': ['Literature'],
+        'document_type': ['article'],
+        'titles': [
+            {'title': 'Jessica Jones'},
+            {'title': 'Luke Cage'},
+            {'title': 'Frank Castle'},
+        ],
+        'authors': [
+            {'full_name': 'Maldacena, J.'},
+            {'full_name': 'Strominger, A.'},
+        ],
+        'abstracts': [
+            {'source': 'arxiv', 'value': 'A basic abstract.'}
+        ],
+        'report_numbers': [{'value': 'DESY-17-036'}],
+        'dois': [
+            {
+                'value': '10.1007/978-3-319-15001-7'
+            }
+        ],
+    }
+
+    eng_uuid = start('article', [record_update])
+
+    eng = WorkflowEngine.from_uuid(eng_uuid)
+    obj = eng.objects[0]
+
+    conflicts = obj.extra_data.get('conflicts')
+
+    assert obj.status == ObjectStatus.HALTED
+    assert len(conflicts) == 1
+    assert obj.extra_data.get('callback_url') is not None
+    assert obj.extra_data.get('is-update') is True
+
+
+def test_merge_without_conflicts_callback_url(workflow_app, enable_merge_on_update, record_to_merge):
+    record_update = {
+        '$schema': 'http://localhost:5000/schemas/records/hep.json',
+        '_collections': ['Literature'],
+        'document_type': ['article'],
+        'titles': [
+            {'title': 'Jessica Jones'},
+            {'title': 'Luke Cage'},
+            {'title': 'Frank Castle'},
+        ],
+        'authors': [
+            {'full_name': 'Maldacena, J.'},
+            {'full_name': 'Strominger, A.'},
+        ],
+        'abstracts': [
+            {'source': 'arxiv', 'value': 'A basic abstract.'}
+        ],
+        'report_numbers': [{'value': 'DESY-17-036'}],
+        'dois': [
+            {
+                'value': '10.1007/978-3-319-15001-7'
+            }
+        ],
+    }
+
+    eng_uuid = start('article', [record_update])
+
+    eng = WorkflowEngine.from_uuid(eng_uuid)
+    obj = eng.objects[0]
+
+    conflicts = obj.extra_data.get('conflicts')
+
+    url = 'http://localhost:5000/callback/workflows/resolve_merge_conflicts'
+
+    assert conflicts is None
+    assert obj.extra_data.get('is-update') is True
+
+    payload = {
+        'id': obj.id,
+        'metadata': obj.data,
+        '_extra_data': obj.extra_data
+    }
+
+    with workflow_app.test_client() as client:
+        response = client.put(
+            url,
+            data=json.dumps(payload),
+            content_type='application/json',
+        )
+
+    assert response.status_code == 400
+
+
+def test_merge_with_conflicts_callback_url(workflow_app, enable_merge_on_update, record_to_merge):
+    record_update = {
+        '$schema': 'http://schemas.stark-industries.com/schemas/avengers.json',
+        '_collections': ['Literature'],
+        'document_type': ['article'],
+        'titles': [
+            {'title': 'Jessica Jones'},
+            {'title': 'Luke Cage'},
+            {'title': 'Frank Castle'},
+        ],
+        'authors': [
+            {'full_name': 'Maldacena, J.'},
+            {'full_name': 'Strominger, A.'},
+        ],
+        'abstracts': [
+            {'source': 'arxiv', 'value': 'A basic abstract.'}
+        ],
+        'report_numbers': [{'value': 'DESY-17-036'}],
+        'dois': [
+            {
+                'value': '10.1007/978-3-319-15001-7'
+            }
+        ],
+    }
+
+    eng_uuid = start('article', [record_update])
+
+    eng = WorkflowEngine.from_uuid(eng_uuid)
+    obj = eng.objects[0]
+
+    conflicts = obj.extra_data.get('conflicts')
+
+    expected_url = 'http://localhost:5000/callback/workflows/resolve_merge_conflicts'
+
+    assert obj.status == ObjectStatus.HALTED
+    assert expected_url == obj.extra_data.get('callback_url')
+    assert len(conflicts) == 1
+    assert obj.extra_data.get('is-update') is True
+
+    payload = {
+        'id': obj.id,
+        'metadata': obj.data,
+        '_extra_data': obj.extra_data
+    }
+
+    with workflow_app.test_client() as client:
+        response = client.put(
+            obj.extra_data.get('callback_url'),
+            data=json.dumps(payload),
+            content_type='application/json',
+        )
+
+    data = json.loads(response.get_data())
+    expected_message = 'Workflow {} has been saved with conflicts.'.format(obj.id)
+
+    assert response.status_code == 200
+    assert expected_message == data['message']
+
+    eng = WorkflowEngine.from_uuid(eng_uuid)
+    obj = eng.objects[0]
+
+    assert obj.status == ObjectStatus.HALTED
+
+
+def test_merge_with_conflicts_callback_url_and_resolve(workflow_app, enable_merge_on_update, record_to_merge):
+    record_update = {
+        '$schema': 'http://schemas.stark-industries.com/schemas/avengers.json',
+        '_collections': ['Literature'],
+        'document_type': ['article'],
+        'titles': [
+            {'title': 'Jessica Jones'},
+            {'title': 'Luke Cage'},
+            {'title': 'Frank Castle'},
+        ],
+        'authors': [
+            {'full_name': 'Maldacena, J.'},
+            {'full_name': 'Strominger, A.'},
+        ],
+        'abstracts': [
+            {'source': 'arxiv', 'value': 'A basic abstract.'}
+        ],
+        'report_numbers': [{'value': 'DESY-17-036'}],
+        'dois': [
+            {
+                'value': '10.1007/978-3-319-15001-7'
+            }
+        ],
+    }
+
+    eng_uuid = start('article', [record_update])
+
+    eng = WorkflowEngine.from_uuid(eng_uuid)
+    obj = eng.objects[0]
+
+    conflicts = obj.extra_data.get('conflicts')
+
+    expected_url = 'http://localhost:5000/callback/workflows/resolve_merge_conflicts'
+
+    assert obj.status == ObjectStatus.HALTED
+    assert expected_url == obj.extra_data.get('callback_url')
+    assert len(conflicts) == 1
+    assert obj.extra_data.get('is-update') is True
+
+    # resolve conflicts
+    obj.data['$schema'] = record_to_merge['$schema']
+    del obj.extra_data['conflicts']
+
+    payload = {
+        'id': obj.id,
+        'metadata': obj.data,
+        '_extra_data': obj.extra_data
+    }
+
+    with workflow_app.test_client() as client:
+        response = client.put(
+            obj.extra_data.get('callback_url'),
+            data=json.dumps(payload),
+            content_type='application/json',
+        )
+    assert response.status_code == 200
+
+    eng = WorkflowEngine.from_uuid(eng_uuid)
+    obj = eng.objects[0]
+
+    conflicts = obj.extra_data.get('conflicts')
+
+    assert obj.status == ObjectStatus.COMPLETED
+    assert conflicts is None
+    assert obj.extra_data.get('approved') is True
+    assert obj.extra_data.get('is-update') is True
+    assert obj.extra_data.get('merged') is True
+
+
+def test_merge_callback_url_with_malformed_workflow(workflow_app, enable_merge_on_update, record_to_merge):
+    record_update = {
+        '$schema': 'http://schemas.stark-industries.com/schemas/avengers.json',
+        '_collections': ['Literature'],
+        'document_type': ['article'],
+        'titles': [
+            {'title': 'Jessica Jones'},
+            {'title': 'Luke Cage'},
+            {'title': 'Frank Castle'},
+        ],
+        'authors': [
+            {'full_name': 'Maldacena, J.'},
+            {'full_name': 'Strominger, A.'},
+        ],
+        'abstracts': [
+            {'source': 'arxiv', 'value': 'A basic abstract.'}
+        ],
+        'report_numbers': [{'value': 'DESY-17-036'}],
+        'dois': [
+            {
+                'value': '10.1007/978-3-319-15001-7'
+            }
+        ],
+    }
+
+    eng_uuid = start('article', [record_update])
+
+    eng = WorkflowEngine.from_uuid(eng_uuid)
+    obj = eng.objects[0]
+
+    conflicts = obj.extra_data.get('conflicts')
+
+    expected_url = 'http://localhost:5000/callback/workflows/resolve_merge_conflicts'
+
+    assert obj.status == ObjectStatus.HALTED
+    assert expected_url == obj.extra_data.get('callback_url')
+    assert len(conflicts) == 1
+    assert obj.extra_data.get('is-update') is True
+
+    payload = {
+        'id': obj.id,
+        'metadata': 'Jessica Jones',
+        '_extra_data': 'Frank Castle'
+    }
+
+    with workflow_app.test_client() as client:
+        response = client.put(
+            obj.extra_data.get('callback_url'),
+            data=json.dumps(payload),
+            content_type='application/json',
+        )
+
+    data = json.loads(response.get_data())
+    expected_message = 'The workflow request is malformed.'
+
+    assert response.status_code == 400
+    assert expected_message == data['message']
+
+    eng = WorkflowEngine.from_uuid(eng_uuid)
+    obj = eng.objects[0]
+
+    assert obj.status == ObjectStatus.HALTED
+    assert obj.extra_data.get('callback_url') is not None
+    assert obj.extra_data.get('conflicts') is not None

--- a/tests/integration/workflows/test_arxiv_workflow.py
+++ b/tests/integration/workflows/test_arxiv_workflow.py
@@ -422,50 +422,6 @@ def test_match_in_holdingpen_different_sources_continues(
     assert not obj.extra_data.get('stopped-matched-holdingpen-wf')
 
 
-@mock.patch(
-    'inspirehep.modules.workflows.tasks.arxiv.download_file_to_workflow',
-    side_effect=fake_download_file,
-)
-@mock.patch(
-    'inspirehep.modules.workflows.tasks.arxiv.is_pdf_link',
-    return_value=True
-)
-@mock.patch(
-    'inspirehep.modules.workflows.tasks.actions.download_file_to_workflow',
-    side_effect=fake_download_file,
-)
-@mock.patch(
-    'inspirehep.modules.workflows.tasks.beard.json_api_request',
-    side_effect=fake_beard_api_request,
-)
-@mock.patch(
-    'inspirehep.modules.workflows.tasks.magpie.json_api_request',
-    side_effect=fake_magpie_api_request,
-)
-def test_arxiv_update_is_not_store_on_legacy_and_labs(
-    mocked_download_arxiv,
-    mocked_api_request_beard,
-    mocked_api_request_magpie,
-    mocked_package_download,
-    workflow_app,
-    mocked_external_services,
-    record_from_db,
-):
-    json = record_from_db
-    eng_uuid = start('article', [json])
-    eng = WorkflowEngine.from_uuid(eng_uuid)
-    obj = eng.objects[0]
-
-    assert obj.status == ObjectStatus.COMPLETED
-    assert obj.extra_data['already-in-holding-pen'] is False
-    assert obj.extra_data['holdingpen_matches'] == []
-    assert obj.extra_data['previously_rejected'] is False
-    assert obj.extra_data['is-update'] is True
-    assert obj.extra_data['matches']['exact']
-    assert obj.extra_data['skipped-robot-upload']
-    assert obj.extra_data['skipped-store-record']
-
-
 def test_article_workflow_stops_when_record_is_not_valid(workflow_app):
     invalid_record = {
         'document_type': [


### PR DESCRIPTION
* Accepts ``is-update`` workflows and passes through the merge step. If
  there are not conflicts the workflow will continue otherwise it'll
  change the status to HALTED and wait for manual merge through the
  editor.

* Adds an endpoint to resolve merge conflicts from the editor.

* Introduces two feature flags ``FEATURE_FLAG_ENABLE_MERGE_ON_UPDATE``
  to allow merges on update  and
  ``FEATURE_FLAG_ENABLE_UPLOAD_TO_LEGACY_ON_UPDATE`` to send a replace
  on legacy on update.

* Removes obsolete step ``STOP_IF_TOO_OLD``.

* closes INSPIR-304

Signed-off-by: Harris Tzovanakis <me@drjova.com>
