### PR TITLE
tests: rewrite the alembic tests

### DIFF
--- a/inspirehep/alembic/402af3fbf68b_rename_inspire_prod_records_table.py
+++ b/inspirehep/alembic/402af3fbf68b_rename_inspire_prod_records_table.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Rename the ``inspire_prod_records`` table.
+
+Note:
+
+    Alembic does not handle correctly the PostgreSQL case in its
+    ``rename_table`` operation, so we have to manually amend some
+    additional database metadata. For more information, please see:
+    http://petegraham.co.uk/rename-postgres-table-with-alembic/
+
+"""
+
+from __future__ import absolute_import, division, print_function
+
+from alembic import op
+
+revision = '402af3fbf68b'
+down_revision = 'd99c70308006'
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    op.rename_table('inspire_prod_records', 'legacy_records_mirror')
+    op.execute('ALTER SEQUENCE inspire_prod_records_recid_seq RENAME TO legacy_records_mirror_recid_seq')
+    op.execute('ALTER INDEX pk_inspire_prod_records RENAME TO pk_legacy_records_mirror')
+    op.execute('ALTER INDEX ix_inspire_prod_records_last_updated RENAME TO ix_legacy_records_mirror_last_updated')
+    op.execute('ALTER INDEX ix_inspire_prod_records_recid RENAME TO ix_legacy_records_mirror_recid')
+    op.execute('ALTER INDEX ix_inspire_prod_records_valid RENAME TO ix_legacy_records_mirror_valid')
+
+
+def downgrade():
+    op.rename_table('legacy_records_mirror', 'inspire_prod_records')
+    op.execute('ALTER SEQUENCE legacy_records_mirror_recid_seq RENAME TO inspire_prod_records_recid_seq')
+    op.execute('ALTER INDEX pk_legacy_records_mirror RENAME TO pk_inspire_prod_records')
+    op.execute('ALTER INDEX ix_legacy_records_mirror_last_updated RENAME TO ix_inspire_prod_records_last_updated')
+    op.execute('ALTER INDEX ix_legacy_records_mirror_recid RENAME TO ix_inspire_prod_records_recid')
+    op.execute('ALTER INDEX ix_legacy_records_mirror_valid RENAME TO ix_inspire_prod_records_valid')

--- a/inspirehep/alembic/d99c70308006_merge_two_alembic_branches.py
+++ b/inspirehep/alembic/d99c70308006_merge_two_alembic_branches.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Merge two alembic branches."""
+
+from __future__ import absolute_import, division, print_function
+
+revision = 'd99c70308006'
+down_revision = ('cb9f81e8251c', 'cb5153afd839')
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/inspirehep/modules/migrator/cli.py
+++ b/inspirehep/modules/migrator/cli.py
@@ -46,7 +46,7 @@ from inspire_schemas.api import validate
 from inspire_utils.helpers import force_list
 
 from inspirehep.utils.schema import ensure_valid_schema
-from .models import InspireProdRecords
+from .models import LegacyRecordsMirror
 from .tasks import (
     add_citation_counts,
     migrate_from_file,
@@ -217,7 +217,7 @@ def reporterrors(output):
 
     click.echo("Reporting broken records into {0}".format(output))
     errors = {}
-    results = InspireProdRecords.query.filter(InspireProdRecords.valid == False) # noqa: ignore=F712
+    results = LegacyRecordsMirror.query.filter(LegacyRecordsMirror.valid == False) # noqa: ignore=F712
     results_length = results.count()
     with click.progressbar(results.yield_per(100), length=results_length) as bar:
         for obj in bar:

--- a/inspirehep/modules/migrator/models.py
+++ b/inspirehep/modules/migrator/models.py
@@ -33,8 +33,8 @@ from invenio_db import db
 from sqlalchemy.ext.hybrid import hybrid_property
 
 
-class InspireProdRecords(db.Model):
-    __tablename__ = 'inspire_prod_records'
+class LegacyRecordsMirror(db.Model):
+    __tablename__ = 'legacy_records_mirror'
 
     recid = db.Column(db.Integer, primary_key=True, index=True)
     last_updated = db.Column(db.DateTime, default=datetime.utcnow, nullable=False, index=True)

--- a/inspirehep/modules/migrator/tasks.py
+++ b/inspirehep/modules/migrator/tasks.py
@@ -63,7 +63,7 @@ from inspirehep.modules.pidstore.utils import (
 from inspirehep.modules.records.receivers import index_after_commit
 from inspirehep.utils.schema import ensure_valid_schema
 
-from .models import InspireProdRecords
+from .models import LegacyRecordsMirror
 
 LOGGER = getStackTraceLogger(__name__)
 
@@ -180,11 +180,11 @@ def migrate_from_mirror(also_migrate=None, wait_for_results=False, skip_files=No
             False,
         )
 
-    query = InspireProdRecords.query.with_entities(InspireProdRecords.recid)
+    query = LegacyRecordsMirror.query.with_entities(LegacyRecordsMirror.recid)
     if also_migrate is None:
-        query = query.filter(InspireProdRecords.valid.is_(None))
+        query = query.filter(LegacyRecordsMirror.valid.is_(None))
     elif also_migrate == 'broken':
-        query = query.filter(InspireProdRecords.valid.isnot(True))
+        query = query.filter(LegacyRecordsMirror.valid.isnot(True))
     elif also_migrate != 'all':
         raise ValueError('"also_migrate" should be either None, "all" or "broken"')
 
@@ -275,7 +275,7 @@ def migrate_recids_from_mirror(prod_recids, skip_files=False):
     for recid in prod_recids:
         with db.session.begin_nested():
             record = migrate_record_from_mirror(
-                InspireProdRecords.query.get(recid),
+                LegacyRecordsMirror.query.get(recid),
                 skip_files=skip_files,
             )
             if record:
@@ -365,14 +365,14 @@ def add_citation_counts(chunk_size=500, request_timeout=120):
 
 def insert_into_mirror(raw_records):
     for raw_record in raw_records:
-        prod_record = InspireProdRecords.from_marcxml(raw_record)
+        prod_record = LegacyRecordsMirror.from_marcxml(raw_record)
         db.session.merge(prod_record)
     db.session.commit()
 
 
 def migrate_and_insert_record(raw_record, skip_files=False):
     """Migrate a record and insert it if valid, or log otherwise."""
-    prod_record = InspireProdRecords.from_marcxml(raw_record)
+    prod_record = LegacyRecordsMirror.from_marcxml(raw_record)
     db.session.merge(prod_record)
     return migrate_record_from_mirror(prod_record, skip_files=skip_files)
 
@@ -381,7 +381,7 @@ def migrate_record_from_mirror(prod_record, skip_files=False):
     """Migrate a mirrored legacy record into an Inspire record.
 
     Args:
-        prod_record(InspireProdRecords): the mirrored record to migrate.
+        prod_record(LegacyRecordsMirror): the mirrored record to migrate.
         skip_files(bool): flag indicating whether the files in the record
             metadata should be copied over from legacy and attach to the
             record.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -147,22 +147,6 @@ def small_app():
 
 
 @pytest.fixture()
-def alembic_app():
-    """Flask application with no records and module scope."""
-    app = create_app(
-        SQLALCHEMY_DATABASE_URI='postgresql+psycopg2://inspirehep:dbpass123@localhost:5432/inspirehep_alembic'
-    )
-    app.config.update({
-        'DEBUG': True,
-    })
-
-    with app.app_context():
-        db.create_all()
-        yield app
-        db.drop_all()
-
-
-@pytest.fixture()
 def app_client(app):
     """Flask test client for the application.
 

--- a/tests/integration/migrator/test_migrator_cli.py
+++ b/tests/integration/migrator/test_migrator_cli.py
@@ -30,7 +30,7 @@ import pytest
 
 from invenio_db import db
 from inspirehep.modules.migrator.cli import migrate
-from inspirehep.modules.migrator.models import InspireProdRecords
+from inspirehep.modules.migrator.models import LegacyRecordsMirror
 from inspirehep.modules.migrator.tasks import populate_mirror_from_file
 
 
@@ -67,7 +67,7 @@ def test_migrate_file_mirror_only(app_cli_runner, api_client):
     file_name = pkg_resources.resource_filename(__name__, os.path.join('fixtures', '1663924.xml'))
 
     result = app_cli_runner.invoke(migrate, ['file', '-w', '-m', '-f', file_name])
-    prod_record = InspireProdRecords.query.get(1663924)
+    prod_record = LegacyRecordsMirror.query.get(1663924)
     response = api_client.get('/literature/1663924')
 
     assert result.exit_code == 0
@@ -111,7 +111,7 @@ def test_migrate_mirror_broken_migrates_invalid(app_cli_runner, api_client):
     assert result.exit_code == 0
     assert response.status_code == 404  # it's broken
 
-    prod_record = InspireProdRecords.query.get(1663927)
+    prod_record = LegacyRecordsMirror.query.get(1663927)
     prod_record.marcxml = prod_record.marcxml.replace('Not a date', '2018')
 
     assert prod_record.valid is False
@@ -142,7 +142,7 @@ def test_migrate_mirror_all_migrates_all(app_cli_runner, api_client):
     assert result.exit_code == 0
     assert response.status_code == 200
 
-    prod_record = InspireProdRecords.query.get(1663924)
+    prod_record = LegacyRecordsMirror.query.get(1663924)
     prod_record.marcxml = prod_record.marcxml.replace('A Status report on', 'A funny joke about')
 
     assert prod_record.valid is True

--- a/tests/integration/migrator/test_migrator_models.py
+++ b/tests/integration/migrator/test_migrator_models.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-from inspirehep.modules.migrator.models import InspireProdRecords
+from inspirehep.modules.migrator.models import LegacyRecordsMirror
 
 
 def test_inspire_prod_records_from_marcxml():
@@ -38,7 +38,7 @@ def test_inspire_prod_records_from_marcxml():
         </record>
         '''
 
-    record = InspireProdRecords.from_marcxml(raw_record)
+    record = LegacyRecordsMirror.from_marcxml(raw_record)
 
     assert record.recid == 1591551
     assert record.marcxml == raw_record
@@ -58,11 +58,11 @@ def test_inspire_prod_records_from_marcxml_raises_for_invalid_recid():
         '''
 
     with pytest.raises(ValueError):
-        InspireProdRecords.from_marcxml(raw_record)
+        LegacyRecordsMirror.from_marcxml(raw_record)
 
 
 def test_inspire_prod_records_error():
-    record = InspireProdRecords(recid='12345')
+    record = LegacyRecordsMirror(recid='12345')
     error = ValueError(u'This is an error with ùnicode')
 
     record.error = error

--- a/tests/integration/migrator/test_migrator_tasks.py
+++ b/tests/integration/migrator/test_migrator_tasks.py
@@ -32,7 +32,7 @@ import pytest
 from invenio_db import db
 from invenio_pidstore.models import PersistentIdentifier
 
-from inspirehep.modules.migrator.models import InspireProdRecords
+from inspirehep.modules.migrator.models import LegacyRecordsMirror
 from inspirehep.modules.migrator.tasks import (
     _build_recid_to_uuid_map,
     migrate_from_file,
@@ -49,9 +49,9 @@ def enable_orcid_push_feature(app):
 @pytest.fixture
 def cleanup():
     yield
-    InspireProdRecords.query.filter(InspireProdRecords.recid == 12345).delete()
+    LegacyRecordsMirror.query.filter(LegacyRecordsMirror.recid == 12345).delete()
     db.session.commit()
-    assert InspireProdRecords.query.filter(InspireProdRecords.recid == 12345).count() == 0
+    assert LegacyRecordsMirror.query.filter(LegacyRecordsMirror.recid == 12345).count() == 0
 
 
 def test_build_recid_to_uuid_map_numeric_pid_allowed_for_lit_and_con(isolated_app):
@@ -104,7 +104,7 @@ def test_migrate_and_insert_record_valid_record(mock_logger, isolated_app):
 
     migrate_and_insert_record(raw_record)
 
-    prod_record = InspireProdRecords.query.filter(InspireProdRecords.recid == 12345).one()
+    prod_record = LegacyRecordsMirror.query.filter(LegacyRecordsMirror.recid == 12345).one()
     assert prod_record.valid is True
     assert prod_record.marcxml == raw_record
 
@@ -128,7 +128,7 @@ def test_migrate_and_insert_record_dojson_error(mock_logger, isolated_app):
 
     migrate_and_insert_record(raw_record)
 
-    prod_record = InspireProdRecords.query.filter(InspireProdRecords.recid == 12345).one()
+    prod_record = LegacyRecordsMirror.query.filter(LegacyRecordsMirror.recid == 12345).one()
     assert prod_record.valid is False
     assert prod_record.marcxml == raw_record
 
@@ -149,7 +149,7 @@ def test_migrate_and_insert_record_invalid_record(mock_logger, isolated_app):
 
     migrate_and_insert_record(raw_record)
 
-    prod_record = InspireProdRecords.query.filter(InspireProdRecords.recid == 12345).one()
+    prod_record = LegacyRecordsMirror.query.filter(LegacyRecordsMirror.recid == 12345).one()
     assert prod_record.valid is False
     assert prod_record.marcxml == raw_record
 
@@ -170,7 +170,7 @@ def test_migrate_and_insert_record_other_exception(mock_logger, isolated_app):
     )
     migrate_and_insert_record(raw_record)
 
-    prod_record = InspireProdRecords.query.filter(InspireProdRecords.recid == 12345).one()
+    prod_record = LegacyRecordsMirror.query.filter(LegacyRecordsMirror.recid == 12345).one()
     assert prod_record.valid is False
     assert prod_record.marcxml == raw_record
 
@@ -192,7 +192,7 @@ def test_orcid_push_disabled_on_migrate_from_mirror(app, cleanup, enable_orcid_p
         migrate_from_file.delay(record_fixture_path, wait_for_results=True)
         mock_attempt_push.assert_not_called()
 
-    prod_record = InspireProdRecords.query.filter(InspireProdRecords.recid == 12345).one()
+    prod_record = LegacyRecordsMirror.query.filter(LegacyRecordsMirror.recid == 12345).one()
     assert prod_record.valid
 
     assert app.config['FEATURE_FLAG_ENABLE_ORCID_PUSH']

--- a/tests/integration/test_alembic.py
+++ b/tests/integration/test_alembic.py
@@ -50,6 +50,15 @@ def test_downgrade(alembic_app):
     ext = alembic_app.extensions['invenio-db']
     ext.alembic.stamp()
 
+    # 402af3fbf68b
+
+    ext.alembic.downgrade(target='d99c70308006')
+
+    assert 'inspire_prod_records' in _get_table_names()
+    assert 'inspire_prod_records_recid_seq' in _get_sequences()
+    assert 'legacy_records_mirror' not in _get_table_names()
+    assert 'legacy_records_mirror_recid_seq' not in _get_sequences()
+
     # cb9f81e8251c & cb5153afd839
 
     ext.alembic.downgrade(target='fddb3cfe7a9c')
@@ -102,6 +111,15 @@ def test_upgrade(alembic_app):
     ext.alembic.upgrade(target='cb5153afd839')
 
     assert 'workflows_record_sources' in _get_table_names()
+
+    # 402af3fbf68b
+
+    ext.alembic.upgrade(target='402af3fbf68b')
+
+    assert 'inspire_prod_records' not in _get_table_names()
+    assert 'inspire_prod_records_recid_seq' not in _get_sequences()
+    assert 'legacy_records_mirror' in _get_table_names()
+    assert 'legacy_records_mirror_recid_seq' in _get_sequences()
 
 
 def _get_indexes(tablename):

--- a/tests/integration/test_alembic.py
+++ b/tests/integration/test_alembic.py
@@ -23,90 +23,108 @@
 from __future__ import absolute_import, division, print_function
 
 import pytest
-from sqlalchemy import inspect
+from sqlalchemy import inspect, text
 
-from invenio_db.utils import drop_alembic_version_table
 from invenio_db import db
+from invenio_db.utils import drop_alembic_version_table
+
+from inspirehep.factory import create_app
 
 
-def test_alembic_revision_fddb3cfe7a9c(alembic_app):
+@pytest.fixture()
+def alembic_app():
+    """Flask application for Alembic tests."""
+    app = create_app(
+        DEBUG=True,
+        SQLALCHEMY_DATABASE_URI='postgresql+psycopg2://inspirehep:dbpass123@localhost:5432/inspirehep_alembic',
+    )
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.drop_all()
+        drop_alembic_version_table()
+
+
+def test_downgrade(alembic_app):
     ext = alembic_app.extensions['invenio-db']
-
-    if db.engine.name == 'sqlite':
-        raise pytest.skip('Upgrades are not supported on SQLite.')
-
-    db.drop_all()
-    drop_alembic_version_table()
-
-    inspector = inspect(db.engine)
-    assert 'inspire_prod_records' not in inspector.get_table_names()
-    assert 'workflows_audit_logging' not in inspector.get_table_names()
-    assert 'workflows_pending_record' not in inspector.get_table_names()
-
-    ext.alembic.upgrade(target='fddb3cfe7a9c')
-    inspector = inspect(db.engine)
-    assert 'inspire_prod_records' in inspector.get_table_names()
-    assert 'workflows_audit_logging' in inspector.get_table_names()
-    assert 'workflows_pending_record' in inspector.get_table_names()
-
-    ext.alembic.downgrade(target='a82a46d12408')
-    inspector = inspect(db.engine)
-    assert 'inspire_prod_records' not in inspector.get_table_names()
-    assert 'workflows_audit_logging' not in inspector.get_table_names()
-    assert 'workflows_pending_record' not in inspector.get_table_names()
-
-    drop_alembic_version_table()
-
-
-def test_alembic_revision_cb9f81e8251c(alembic_app):
-    def get_indexes(tablename):
-        index_names = db.session.execute("select indexname from pg_indexes where tablename='{}'".format(tablename)).fetchall()
-        return [index[0] for index in index_names]
-
-    ext = alembic_app.extensions['invenio-db']
-
-    if db.engine.name == 'sqlite':
-        raise pytest.skip('Upgrades are not supported on SQLite.')
-
     ext.alembic.stamp()
+
+    # cb9f81e8251c & cb5153afd839
 
     ext.alembic.downgrade(target='fddb3cfe7a9c')
 
-    index_names = get_indexes('records_metadata')
-    assert 'idxgindoctype' not in index_names
-    assert 'idxgintitles' not in index_names
-    assert 'idxginjournaltitle' not in index_names
-    assert 'idxgincollections' not in index_names
+    assert 'idxgindoctype' not in _get_indexes('records_metadata')
+    assert 'idxgintitles' not in _get_indexes('records_metadata')
+    assert 'idxginjournaltitle' not in _get_indexes('records_metadata')
+    assert 'idxgincollections' not in _get_indexes('records_metadata')
+
+    assert 'workflows_record_sources' not in _get_table_names()
+
+    # fddb3cfe7a9c
+
+    ext.alembic.downgrade(target='a82a46d12408')
+
+    assert 'inspire_prod_records' not in _get_table_names()
+    assert 'inspire_prod_records_recid_seq' not in _get_sequences()
+    assert 'workflows_audit_logging' not in _get_table_names()
+    assert 'workflows_audit_logging_id_seq' not in _get_sequences()
+    assert 'workflows_pending_record' not in _get_table_names()
+
+
+def test_upgrade(alembic_app):
+    ext = alembic_app.extensions['invenio-db']
+    ext.alembic.stamp()
+    ext.alembic.downgrade(target='a82a46d12408')
+
+    # fddb3cfe7a9c
+
+    ext.alembic.upgrade(target='fddb3cfe7a9c')
+
+    assert 'inspire_prod_records' in _get_table_names()
+    assert 'inspire_prod_records_recid_seq' in _get_sequences()
+    assert 'workflows_audit_logging' in _get_table_names()
+    assert 'workflows_audit_logging_id_seq' in _get_sequences()
+    assert 'workflows_pending_record' in _get_table_names()
+
+    # cb9f81e8251c
 
     ext.alembic.upgrade(target='cb9f81e8251c')
 
-    index_names = get_indexes('records_metadata')
-    assert 'idxgindoctype' in index_names
-    assert 'idxgintitles' in index_names
-    assert 'idxginjournaltitle' in index_names
-    assert 'idxgincollections' in index_names
+    assert 'idxgindoctype' in _get_indexes('records_metadata')
+    assert 'idxgintitles' in _get_indexes('records_metadata')
+    assert 'idxginjournaltitle' in _get_indexes('records_metadata')
+    assert 'idxgincollections' in _get_indexes('records_metadata')
 
-    drop_alembic_version_table()
-
-
-def test_alembic_revision_cb5153afd839(alembic_app):
-    ext = alembic_app.extensions['invenio-db']
-
-    if db.engine.name == 'sqlite':
-        raise pytest.skip('Upgrades are not supported on SQLite.')
-
-    db.drop_all()
-    drop_alembic_version_table()
-
-    inspector = inspect(db.engine)
-    assert 'workflows_record_sources' not in inspector.get_table_names()
-
-    ext.alembic.upgrade(target='cb5153afd839')
-    inspector = inspect(db.engine)
-    assert 'workflows_record_sources' in inspector.get_table_names()
+    # cb5153afd839
 
     ext.alembic.downgrade(target='fddb3cfe7a9c')
-    inspector = inspect(db.engine)
-    assert 'workflows_record_sources' not in inspector.get_table_names()
+    ext.alembic.upgrade(target='cb5153afd839')
 
-    drop_alembic_version_table()
+    assert 'workflows_record_sources' in _get_table_names()
+
+
+def _get_indexes(tablename):
+    query = text('''
+        SELECT indexname
+        FROM pg_indexes
+        WHERE tablename=:tablename
+    ''').bindparams(tablename=tablename)
+
+    return [el.indexname for el in db.session.execute(query)]
+
+
+def _get_sequences():
+    query = text('''
+        SELECT relname
+        FROM pg_class
+        WHERE relkind='S'
+    ''')
+
+    return [el.relname for el in db.session.execute(query)]
+
+
+def _get_table_names():
+    inspector = inspect(db.engine)
+
+    return inspector.get_table_names()

--- a/tests/integration/test_detailed_records.py
+++ b/tests/integration/test_detailed_records.py
@@ -25,7 +25,7 @@ from __future__ import absolute_import, division, print_function
 from invenio_accounts.testutils import login_user_via_session
 from invenio_records.models import RecordMetadata
 
-from inspirehep.modules.migrator.models import InspireProdRecords
+from inspirehep.modules.migrator.models import LegacyRecordsMirror
 
 
 def test_all_records_were_loaded(app):
@@ -38,7 +38,7 @@ def test_all_records_were_loaded(app):
 
 
 def test_all_records_are_valid(app):
-    invalid = InspireProdRecords.query.filter(InspireProdRecords.valid is False).values(InspireProdRecords.recid)
+    invalid = LegacyRecordsMirror.query.filter(LegacyRecordsMirror.valid is False).values(LegacyRecordsMirror.recid)
     recids = [el[0] for el in invalid]
 
     assert recids == []

--- a/tests/integration/test_migrator.py
+++ b/tests/integration/test_migrator.py
@@ -30,7 +30,7 @@ import pytest
 from flask import current_app
 from redis import StrictRedis
 
-from inspirehep.modules.migrator.models import InspireProdRecords
+from inspirehep.modules.migrator.models import LegacyRecordsMirror
 from inspirehep.modules.migrator.tasks import continuous_migration
 from inspirehep.utils.record_getter import get_db_record
 
@@ -99,7 +99,7 @@ def test_continuous_migration_handles_a_single_record(app, record_1502656):
     get_db_record('lit', 1502656)  # Does not raise.
 
     expected = record_1502656
-    result = InspireProdRecords.query.get(1502656).marcxml
+    result = LegacyRecordsMirror.query.get(1502656).marcxml
 
     assert expected == result
 
@@ -116,14 +116,14 @@ def test_continuous_migration_handles_multiple_records(app, record_1502655_and_1
     get_db_record('aut', 1502655)  # Does not raise.
 
     expected = record_1502655_and_1502656[0]
-    result = InspireProdRecords.query.get(1502655).marcxml
+    result = LegacyRecordsMirror.query.get(1502655).marcxml
 
     assert expected == result
 
     get_db_record('lit', 1502656)  # Does not raise.
 
     expected = record_1502655_and_1502656[1]
-    result = InspireProdRecords.query.get(1502656).marcxml
+    result = LegacyRecordsMirror.query.get(1502656).marcxml
 
     assert expected == result
 
@@ -145,6 +145,6 @@ def test_continuous_migration_handles_record_updates(app, record_1502656_and_upd
     assert expected == result
 
     expected = record_1502656_and_update[1]
-    result = InspireProdRecords.query.get(1502656).marcxml
+    result = LegacyRecordsMirror.query.get(1502656).marcxml
 
     assert expected == result


### PR DESCRIPTION
## Description:
The previous implementation of the Alembic tests was lacking in several
regards, most notably test isolation. The approach in this PR side steps
the problem by creating two tests for `upgrade` and `downgrade`, which,
as https://github.com/inspirehep/inspire-next/commit/d578ca6b878fb66caf9e775408b4dbbd56eb3f72 shows, make writing these tests much easier.

Since commit 99aeb65 Alembic's INSPIRE branch has had two heads. This
commit fixes this situation by adding an empty merge migration.

Finally, https://github.com/inspirehep/inspire-next/pull/3267 was missing that SQLAlchemy's ``rename_table`` does not work
out of the box for PostgreSQL tables, and requires the fixes outlined in
http://petegraham.co.uk/rename-postgres-table-with-alembic/.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.