### PR TITLE
workflow: raise if match a wf in error or initial state

### DIFF
--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -73,6 +73,7 @@ from inspirehep.modules.workflows.tasks.magpie import (
 )
 from inspirehep.modules.workflows.tasks.matching import (
     stop_processing,
+    raise_if_match_wf_in_error_or_initial,
     match_non_completed_wf_in_holdingpen,
     match_previously_rejected_wf_in_holdingpen,
     exact_match,
@@ -301,6 +302,7 @@ STORE_RECORD = [
 
 
 MARK_IF_MATCH_IN_HOLDINGPEN = [
+    raise_if_match_wf_in_error_or_initial,
     IF_ELSE(
         match_non_completed_wf_in_holdingpen,
         [


### PR DESCRIPTION
If the current workflow matches another workflow which state is
ERROR or INITIAL, then the current workflow raises a WorkflowsError
and goes in ERROR state.
This prevents some race conditions happening in Inspire.

Signed-off-by: Antonio Cesarano <cesarano2607@gmail.com>

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
