### PR TITLE
workflows: feature flag for reference removal

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -55,6 +55,7 @@ FEATURE_FLAG_ENABLE_FUZZY_MATCHER = False
 FEATURE_FLAG_ENABLE_MERGER = False
 FEATURE_FLAG_ENABLE_UPDATE_TO_LEGACY = False
 """This feature flag will prevent to send a ``replace`` update to legacy."""
+FEATURE_FLAG_ENABLE_SENDING_REFERENCES_TO_LEGACY = False
 
 # Default language and timezone
 # =============================

--- a/inspirehep/modules/workflows/tasks/submission.py
+++ b/inspirehep/modules/workflows/tasks/submission.py
@@ -313,3 +313,11 @@ def prepare_keywords(obj, eng):
     obj.data['keywords'] = keywords
 
     obj.log.debug('Finally got keywords: \n%s', pformat(keywords))
+
+
+@with_debug_logging
+def remove_references(obj, eng):
+    obj.log.info(obj.data)
+    if (not current_app.config.get('FEATURE_FLAG_ENABLE_SENDING_REFERENCES_TO_LEGACY') and
+            'references' in obj.data):
+        del obj.data['references']

--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -96,6 +96,7 @@ from inspirehep.modules.workflows.tasks.submission import (
     create_ticket,
     filter_keywords,
     prepare_keywords,
+    remove_references,
     reply_ticket,
     send_robotupload,
     wait_webcoll,
@@ -229,6 +230,7 @@ POSTENHANCE_RECORD = [
     add_core,
     filter_keywords,
     prepare_keywords,
+    remove_references,
     set_refereed_and_fix_document_type,
     fix_submission_number,
 ]

--- a/tests/integration/workflows/test_workflow_actions.py
+++ b/tests/integration/workflows/test_workflow_actions.py
@@ -437,9 +437,10 @@ def test_refextract_from_pdf(
     citing_record, categories = insert_citing_record()
 
     extra_config = {
-        "BEARD_API_URL": "http://example.com/beard",
-        "MAGPIE_API_URL": "http://example.com/magpie",
+        'BEARD_API_URL': 'http://example.com/beard',
+        'MAGPIE_API_URL': 'http://example.com/magpie',
         'ARXIV_CATEGORIES': categories,
+        'FEATURE_FLAG_ENABLE_SENDING_REFERENCES_TO_LEGACY': True,
     }
 
     schema = load_schema('hep')

--- a/tests/unit/workflows/test_workflows_tasks_submission.py
+++ b/tests/unit/workflows/test_workflows_tasks_submission.py
@@ -33,6 +33,7 @@ from inspirehep.modules.workflows.tasks.submission import (
     create_ticket,
     filter_keywords,
     prepare_keywords,
+    remove_references,
     reply_ticket,
     send_robotupload,
     wait_webcoll,
@@ -625,3 +626,96 @@ def test_prepare_keywords_does_nothing_if_no_keywords_were_predicted():
 
     assert validate(result['keywords'], subschema) is None
     assert expected == result['keywords']
+
+
+def test_remove_references():
+    schema = load_schema('hep')
+    subschema = schema['properties']['references']
+
+    data = {
+        'references': [
+            {
+                'reference': {
+                    'arxiv_eprint': 'hep-th/9710014',
+                    'authors': [
+                        {'full_name': 'Maldacena, J.'},
+                        {'full_name': 'Strominger, A.'},
+                    ],
+                    'label': '1',
+                },
+            },
+        ],
+    }
+    extra_data = {}
+    assert validate(data['references'], subschema) is None
+
+    obj = MockObj(data, extra_data)
+    eng = MockEng()
+
+    assert remove_references(obj, eng) is None
+
+    expected = {}
+    result = obj.data
+
+    assert expected == result
+
+
+def test_remove_references_does_nothing_when_there_are_no_references():
+    data = {}
+    extra_data = {}
+
+    obj = MockObj(data, extra_data)
+    eng = MockEng()
+
+    assert remove_references(obj, eng) is None
+
+    expected = {}
+    result = obj.data
+
+    assert expected == result
+
+
+def test_remove_references_does_nothing_when_feature_flag_is_true():
+    schema = load_schema('hep')
+    subschema = schema['properties']['references']
+
+    data = {
+        'references': [
+            {
+                'reference': {
+                    'arxiv_eprint': 'hep-th/9710014',
+                    'authors': [
+                        {'full_name': 'Maldacena, J.'},
+                        {'full_name': 'Strominger, A.'},
+                    ],
+                    'label': '1',
+                },
+            },
+        ],
+    }
+    extra_data = {}
+    assert validate(data['references'], subschema) is None
+
+    obj = MockObj(data, extra_data)
+    eng = MockEng()
+
+    with patch.dict(current_app.config, {'FEATURE_FLAG_ENABLE_SENDING_REFERENCES_TO_LEGACY': True}):
+        assert remove_references(obj, eng) is None
+
+    expected = {
+        'references': [
+            {
+                'reference': {
+                    'arxiv_eprint': 'hep-th/9710014',
+                    'authors': [
+                        {'full_name': 'Maldacena, J.'},
+                        {'full_name': 'Strominger, A.'},
+                    ],
+                    'label': '1',
+                },
+            },
+        ],
+    }
+    result = obj.data
+
+    assert expected == result


### PR DESCRIPTION
This brings back `remove_references` in the workflows with a twist: a
feature flag controls whether it is active or not.