### PR TITLE
workflows: feature flag for sending refs to legacy

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -55,6 +55,7 @@ FEATURE_FLAG_ENABLE_FUZZY_MATCHER = False
 FEATURE_FLAG_ENABLE_MERGER = False
 FEATURE_FLAG_ENABLE_UPDATE_TO_LEGACY = False
 """This feature flag will prevent to send a ``replace`` update to legacy."""
+FEATURE_FLAG_ENABLE_SENDING_REFERENCES_TO_LEGACY = False
 
 # Default language and timezone
 # =============================

--- a/inspirehep/modules/workflows/tasks/submission.py
+++ b/inspirehep/modules/workflows/tasks/submission.py
@@ -26,6 +26,7 @@ from __future__ import absolute_import, division, print_function
 
 import os
 import logging
+from copy import copy
 from functools import wraps
 from pprint import pformat
 
@@ -218,6 +219,11 @@ def send_robotupload(
             data = obj.extra_data.get(extra_data_key) or {}
         else:
             data = obj.data
+
+        if not current_app.config.get('FEATURE_FLAG_ENABLE_SENDING_REFERENCES_TO_LEGACY'):
+            data = copy(data)
+            data.pop('references', None)
+
         marcxml = record2marcxml(data)
 
         if current_app.debug:


### PR DESCRIPTION
Unlike #3377, the optional removal of references is now done in `send_robotupload` in order not to delete references from the holdingpen and allow their inspection.