### PR TITLE
workflows: add data references matcher

### DIFF
--- a/inspirehep/modules/workflows/config.py
+++ b/inspirehep/modules/workflows/config.py
@@ -186,3 +186,24 @@ WORKFLOWS_REFERENCE_MATCHER_JHEP_AND_JCAP_CONFIG = {
 """Configuration for matching records JCAP and JHEP records since
 they have a particular configuration and we have to look at the
 year as well for accurate matching."""
+
+WORKFLOWS_REFERENCE_MATCHER_DATA_CONFIG = {
+    'algorithm': [
+        {
+            'queries': [
+                {
+                    'path': 'reference.dois',
+                    'search_path': 'dois.value.raw',
+                    'type': 'exact',
+                },
+            ],
+        },
+    ],
+    'doc_type': 'data',
+    'index': 'records-data',
+    'source': [
+        'control_number',
+    ]
+}
+"""Configuration for matching data records. Please note that the
+index and doc_type are different for data records."""

--- a/tests/integration/workflows/test_arxiv_merge.py
+++ b/tests/integration/workflows/test_arxiv_merge.py
@@ -72,7 +72,7 @@ def disable_file_upload(workflow_app):
 
 def test_merge_with_disabled_merge_on_update_feature_flag(workflow_app, disable_file_upload):
     factory = TestRecordMetadata.create_from_file(
-        __name__, 'record_for_merging.json')
+        __name__, 'record_for_merging.json', index_name='records-hep')
 
     record_update = RECORD_WITHOUT_CONFLICTS
     record_update.update({
@@ -92,7 +92,7 @@ def test_merge_with_disabled_merge_on_update_feature_flag(workflow_app, disable_
 
 def test_merge_without_conflicts(workflow_app, enable_merge_on_update, disable_file_upload):
     factory = TestRecordMetadata.create_from_file(
-        __name__, 'record_for_merging.json')
+        __name__, 'record_for_merging.json', index_name='records-hep')
 
     record_update = RECORD_WITHOUT_CONFLICTS
     record_update.update({
@@ -116,7 +116,7 @@ def test_merge_without_conflicts(workflow_app, enable_merge_on_update, disable_f
 
 def test_merge_with_conflicts(workflow_app, enable_merge_on_update, disable_file_upload):
     factory = TestRecordMetadata.create_from_file(
-        __name__, 'record_for_merging.json')
+        __name__, 'record_for_merging.json', index_name='records-hep')
 
     record_update = RECORD_WITH_CONFLICTS
     record_update.update({
@@ -138,7 +138,7 @@ def test_merge_with_conflicts(workflow_app, enable_merge_on_update, disable_file
 
 def test_merge_without_conflicts_callback_url(workflow_app, enable_merge_on_update, disable_file_upload):
     factory = TestRecordMetadata.create_from_file(
-        __name__, 'record_for_merging.json')
+        __name__, 'record_for_merging.json', index_name='records-hep')
 
     record_update = RECORD_WITHOUT_CONFLICTS
     record_update.update({
@@ -176,7 +176,7 @@ def test_merge_without_conflicts_callback_url(workflow_app, enable_merge_on_upda
 
 def test_merge_with_conflicts_callback_url(workflow_app, enable_merge_on_update, disable_file_upload):
     factory = TestRecordMetadata.create_from_file(
-        __name__, 'record_for_merging.json')
+        __name__, 'record_for_merging.json', index_name='records-hep')
 
     record_update = RECORD_WITH_CONFLICTS
     record_update.update({
@@ -224,7 +224,7 @@ def test_merge_with_conflicts_callback_url(workflow_app, enable_merge_on_update,
 
 def test_merge_with_conflicts_callback_url_and_resolve(workflow_app, enable_merge_on_update, disable_file_upload):
     factory = TestRecordMetadata.create_from_file(
-        __name__, 'record_for_merging.json')
+        __name__, 'record_for_merging.json', index_name='records-hep')
 
     record_update = RECORD_WITH_CONFLICTS
     record_update.update({
@@ -277,7 +277,7 @@ def test_merge_with_conflicts_callback_url_and_resolve(workflow_app, enable_merg
 
 def test_merge_callback_url_with_malformed_workflow(workflow_app, enable_merge_on_update, disable_file_upload):
     factory = TestRecordMetadata.create_from_file(
-        __name__, 'record_for_merging.json')
+        __name__, 'record_for_merging.json', index_name='records-hep')
 
     record_update = RECORD_WITH_CONFLICTS
     record_update.update({

--- a/tests/integration/workflows/test_workflows_tasks_actions.py
+++ b/tests/integration/workflows/test_workflows_tasks_actions.py
@@ -86,7 +86,7 @@ def insert_journals_in_db(workflow_app):
 @pytest.fixture
 def insert_cited_record(workflow_app):
     """Adds a record with arXiv: 1308.0815 which can be cited by another record.
-    See test_refextract_from_pdf for reference and context.
+    See test_refextract_from_pdf_for_default_config for reference and context.
     Only to be used in conjunction with arXiv: 1407.7587 as it cites this
     record."""
 
@@ -432,7 +432,8 @@ def test_refextract_from_pdf(
     workflow_app,
     mocked_external_services
 ):
-    """Test refextract from PDF by going through the entire workflow."""
+    """Test refextract from PDF and reference matching for default Configuration
+     by going through the entire workflow."""
 
     citing_record, categories = insert_citing_record()
 

--- a/tests/integration/workflows/test_workflows_tasks_actions.py
+++ b/tests/integration/workflows/test_workflows_tasks_actions.py
@@ -32,8 +32,6 @@ import pkg_resources
 import pytest
 
 from invenio_db import db
-from invenio_pidstore.models import PersistentIdentifier
-from invenio_records.models import RecordMetadata
 from inspire_schemas.api import load_schema, validate
 from invenio_search.api import current_search_client as es
 from invenio_workflows import (
@@ -46,6 +44,8 @@ from inspirehep.modules.records.api import InspireRecord
 from inspirehep.modules.workflows.tasks.actions import normalize_journal_titles
 
 from calls import insert_citing_record
+
+from factories.db.invenio_records import TestRecordMetadata
 
 from mocks import (
     fake_beard_api_request,
@@ -81,61 +81,6 @@ def insert_journals_in_db(workflow_app):
     _delete_record('jou', 1936475)
     _delete_record('jou', 1936476)
     es.indices.refresh('records-journals')
-
-
-@pytest.fixture
-def insert_cited_record(workflow_app):
-    """Adds a record with arXiv: 1308.0815 which can be cited by another record.
-    See test_refextract_from_pdf_for_default_config for reference and context.
-    Only to be used in conjunction with arXiv: 1407.7587 as it cites this
-    record."""
-
-    cited_record_json = {
-        '$schema': 'http://localhost:5000/schemas/records/hep.json',
-        '_collections': ['Literature'],
-        'abstracts': [
-            {
-                'source': 'arXiv',
-                'value': 'The effects on the non-relativistic dynamics of a system compound by two electrons interacting by a Coulomb potential and with an external harmonic\r\noscillator potential, confined to move in a two dimensional Euclidean space, are investigated. In particular, it is shown that it is possible to determine\r\nexactly and in a closed form a finite portion of the energy spectrum and the associated eigeinfunctions for the Schrodinger equation describing the relative motion of the electrons, by putting it into the form of a biconfluent Heun equation. In the same framework, another set of solutions of this type can\r\nbe straightforwardly obtained for the case when the two electrons are submitted also to an external constant magnetic field.'
-            }
-        ],
-        'arxiv_eprints': [
-            {
-                'categories': ['quant-ph', 'cond-mat.mes-hall', 'cond-mat.str-el', 'math-ph', 'math.MP'],
-                'value': '1308.0815'
-            }
-        ],
-        'authors': [
-            {'full_name': 'Caruso, F.'},
-            {'full_name': 'Martins, J.'},
-            {'full_name': 'Oguri, V.'},
-        ],
-        'document_type': ['article'],
-        'dois': [
-            {'value': '10.1016/j.aop.2014.04.023'}
-        ],
-        'titles': [
-            {
-                'source': 'arXiv',
-                'title': 'Solving a two-electron quantum dot model in terms of polynomial solutions of a Biconfluent Heun equation'
-            }
-        ],
-    }
-
-    cited_record = InspireRecord.create(cited_record_json, id_=None)
-    cited_record.commit()
-    rec_uuid = cited_record.id
-
-    db.session.commit()
-    es.indices.refresh('records-hep')
-
-    yield
-
-    record = RecordMetadata.query.get(rec_uuid)
-
-    PersistentIdentifier.query.filter(PersistentIdentifier.object_uuid == record.id).delete()
-    db.session.delete(record)
-    db.session.commit()
 
 
 def test_normalize_journal_titles_known_journals_with_ref(workflow_app, insert_journals_in_db):
@@ -428,13 +373,33 @@ def test_refextract_from_pdf(
     mocked_is_pdf_link,
     mocked_package_download,
     mocked_arxiv_download,
-    insert_cited_record,
     workflow_app,
     mocked_external_services
 ):
     """Test refextract from PDF and reference matching for default Configuration
      by going through the entire workflow."""
 
+    cited_record_json = {
+        '$schema': 'http://localhost:5000/schemas/records/hep.json',
+        '_collections': ['Literature'],
+        'arxiv_eprints': [
+            {
+                'categories': ['quant-ph', 'cond-mat.mes-hall', 'cond-mat.str-el', 'math-ph', 'math.MP'],
+                'value': '1308.0815'
+            }
+        ],
+        'control_number': 1000,
+        'document_type': ['article'],
+        'titles': [
+            {
+                'source': 'arXiv',
+                'title': 'Solving a two-electron quantum dot model in terms of polynomial solutions of a Biconfluent Heun equation'
+            }
+        ],
+    }
+
+    TestRecordMetadata.create_from_kwargs(
+        json=cited_record_json, index='records-hep', pid_type='lit')
     citing_record, categories = insert_citing_record()
 
     extra_config = {
@@ -454,5 +419,5 @@ def test_refextract_from_pdf(
     citing_doc_eng = WorkflowEngine.from_uuid(citing_doc_workflow_uuid)
     citing_doc_obj = citing_doc_eng.processed_objects[0]
 
-    assert citing_doc_obj.data['references'][7]['record']['$ref'] == 'http://localhost:5000/api/literature/1'
+    assert citing_doc_obj.data['references'][7]['record']['$ref'] == 'http://localhost:5000/api/literature/1000'
     assert citing_doc_obj.data['references'][0]['raw_refs'][0]['source'] == 'arXiv'

--- a/tests/integration/workflows/test_workflows_tasks_refextract.py
+++ b/tests/integration/workflows/test_workflows_tasks_refextract.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2018 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+from inspire_schemas.api import load_schema, validate
+from inspirehep.modules.workflows.tasks.refextract import match_reference
+
+from factories.db.invenio_records import TestRecordMetadata
+
+
+def test_match_reference_for_jcap_and_jhep_config():
+    """Test reference matcher for the JCAP and JHEP configuration"""
+
+    cited_record_json = {
+        '$schema': 'http://localhost:5000/schemas/records/hep.json',
+        '_collections': ['Literature'],
+        'control_number': 1,
+        'document_type': ['article'],
+        'publication_info': [
+            {
+                'artid': '045',
+                'journal_title': 'JHEP',
+                'journal_volume': '06',
+                'page_start': '045',
+                'year': 2007
+            }
+        ],
+        'titles': [
+            {
+                'title': 'The Strongly-Interacting Light Higgs'
+            }
+        ],
+    }
+
+    TestRecordMetadata.create_from_kwargs(
+        json=cited_record_json, index_name='records-hep')
+
+    reference = {
+        'reference': {
+            'publication_info': {
+                'artid': '045',
+                'journal_title': 'JHEP',
+                'journal_volume': '06',
+                'page_start': '045',
+                'year': 2007
+            }
+        }
+    }
+
+    schema = load_schema('hep')
+    subschema = schema['properties']['references']
+
+    assert validate([reference], subschema) is None
+
+    reference = match_reference(reference)
+
+    assert reference['record']['$ref'] == 'http://localhost:5000/api/literature/1'
+    assert validate([reference], subschema) is None
+
+
+def test_match_reference_for_data_config():
+    """Test reference matcher for the JCAP and JHEP configuration"""
+
+    cited_record_json = {
+        '$schema': 'http://localhost:5000/schemas/records/data.json',
+        '_collections': ['Data'],
+        'control_number': 1,
+        'dois': [
+            {
+                'value': '10.5281/zenodo.11020'
+            }
+        ],
+    }
+
+    TestRecordMetadata.create_from_kwargs(
+        json=cited_record_json, index_name='records-data', pid_type='dat')
+
+    reference = {
+        'reference': {
+            'dois': [
+                '10.5281/zenodo.11020'
+            ],
+            'publication_info': {
+                'year': 2007
+            }
+        }
+    }
+
+    reference = match_reference(reference)
+
+    assert reference['record']['$ref'] == 'http://localhost:5000/api/data/1'


### PR DESCRIPTION
## Description
This adds the capability to match references to data records in the current reference matcher.

## Related Issue
https://its.cern.ch/jira/browse/INSPIR-472

## Motivation and Context
This would improve citation counts.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: Salman Maqbool <salman.maqbool@cern.ch>