### PR TITLE
548 orcid: don't get the BibTeX through the API

### DIFF
--- a/inspirehep/modules/orcid/utils.py
+++ b/inspirehep/modules/orcid/utils.py
@@ -33,7 +33,6 @@ from itertools import chain
 from elasticsearch_dsl import Q
 from flask import current_app
 from functools import wraps
-from six.moves.urllib.parse import urljoin
 from StringIO import StringIO
 from sqlalchemy import cast, type_coerce
 from sqlalchemy.dialects.postgresql import JSONB
@@ -50,7 +49,6 @@ from invenio_records.models import RecordMetadata
 
 from inspire_dojson.utils import get_recid_from_ref
 from inspire_utils.record import get_values_for_schema
-from inspire_utils.urls import ensure_scheme
 from inspirehep.modules.search.api import LiteratureSearch
 from inspirehep.utils.record_getter import get_db_records
 
@@ -76,24 +74,6 @@ def _split_lists(sequence, chunk_size):
     return [
         sequence[i:i + chunk_size] for i in range(0, len(sequence), chunk_size)
     ]
-
-
-def _get_api_url_for_recid(server_name, api_endpoint, recid):
-    """Return API url for record
-
-    Args:
-        server_name (string): server authority
-        api_endpoint (string): api path
-        recid (string): record ID
-
-    Returns:
-        string: API URL for the record
-    """
-    if not api_endpoint.endswith('/'):
-        api_endpoint = api_endpoint + '/'
-
-    api_url = urljoin(ensure_scheme(server_name), api_endpoint)
-    return urljoin(api_url, recid)
 
 
 def get_orcid_recid_key(orcid, rec_id):

--- a/tests/integration/orcid/cassettes/test_push_record_with_orcid_new.yaml
+++ b/tests/integration/orcid/cassettes/test_push_record_with_orcid_new.yaml
@@ -1,29 +1,5 @@
 interactions:
 - request:
-    body: null
-    headers:
-      Accept: [application/x-bibtex]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-    method: GET
-    uri: https://labs.inspirehep.net/api/literature/4328
-  response:
-    body: {string: !!python/unicode "@article{Glashow:1961tr,\n    author = \"Glashow,\
-        \ S.L.\",\n    journal = \"Nucl.Phys.\",\n    volume = \"22\",\n    pages\
-        \ = \"579--588\",\n    doi = \"10.1016/0029-5582(61)90469-2\",\n    title\
-        \ = \"Partial Symmetries of Weak Interactions\",\n    year = \"1961\"\n}\n"}
-    headers:
-      access-control-allow-origin: ['*']
-      access-control-expose-headers: ['Content-Type, ETag, Link, X-RateLimit-Limit,
-          X-RateLimit-Remaining, X-RateLimit-Reset']
-      content-length: ['243']
-      content-type: [application/x-bibtex]
-      date: ['Wed, 21 Mar 2018 15:00:38 GMT']
-      server: [nginx/1.12.2]
-      strict-transport-security: [max-age=31536000]
-    status: {code: 200, message: OK}
-- request:
     body: !!python/unicode "<work:work xmlns:common=\"http://www.orcid.org/ns/common\"\
       \ xmlns:work=\"http://www.orcid.org/ns/work\"><work:title><common:title>Partial\
       \ Symmetries of Weak Interactions</common:title></work:title><work:journal-title>Nucl.Phys.</work:journal-title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{Glashow:1961tr,\n\

--- a/tests/integration/orcid/cassettes/test_push_record_with_orcid_update.yaml
+++ b/tests/integration/orcid/cassettes/test_push_record_with_orcid_update.yaml
@@ -1,29 +1,5 @@
 interactions:
 - request:
-    body: null
-    headers:
-      Accept: [application/x-bibtex]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-    method: GET
-    uri: https://labs.inspirehep.net/api/literature/4328
-  response:
-    body: {string: !!python/unicode "@article{Glashow:1961tr,\n    author = \"Glashow,\
-        \ S.L.\",\n    journal = \"Nucl.Phys.\",\n    volume = \"22\",\n    pages\
-        \ = \"579--588\",\n    doi = \"10.1016/0029-5582(61)90469-2\",\n    title\
-        \ = \"Partial Symmetries of Weak Interactions\",\n    year = \"1961\"\n}\n"}
-    headers:
-      access-control-allow-origin: ['*']
-      access-control-expose-headers: ['Content-Type, ETag, Link, X-RateLimit-Limit,
-          X-RateLimit-Remaining, X-RateLimit-Reset']
-      content-length: ['243']
-      content-type: [application/x-bibtex]
-      date: ['Wed, 21 Mar 2018 15:05:29 GMT']
-      server: [nginx/1.12.2]
-      strict-transport-security: [max-age=31536000]
-    status: {code: 200, message: OK}
-- request:
     body: !!python/unicode "<work:work xmlns:common=\"http://www.orcid.org/ns/common\"\
       \ xmlns:work=\"http://www.orcid.org/ns/work\" put-code=\"920107\"><work:title><common:title>Partial\
       \ Symmetries of Weak Interactions</common:title></work:title><work:journal-title>Nucl.Phys.</work:journal-title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{Glashow:1961tr,\n\

--- a/tests/integration/orcid/cassettes/test_push_to_orcid_same_with_cache.yaml
+++ b/tests/integration/orcid/cassettes/test_push_to_orcid_same_with_cache.yaml
@@ -2,30 +2,6 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/x-bibtex]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-    method: GET
-    uri: https://labs.inspirehep.net/api/literature/4328
-  response:
-    body: {string: !!python/unicode "@article{Glashow:1961tr,\n    author = \"Glashow,\
-        \ S.L.\",\n    journal = \"Nucl.Phys.\",\n    volume = \"22\",\n    pages\
-        \ = \"579--588\",\n    doi = \"10.1016/0029-5582(61)90469-2\",\n    title\
-        \ = \"Partial Symmetries of Weak Interactions\",\n    year = \"1961\"\n}\n"}
-    headers:
-      access-control-allow-origin: ['*']
-      access-control-expose-headers: ['Content-Type, ETag, Link, X-RateLimit-Limit,
-          X-RateLimit-Remaining, X-RateLimit-Reset']
-      content-length: ['243']
-      content-type: [application/x-bibtex]
-      date: ['Wed, 21 Mar 2018 12:47:18 GMT']
-      server: [nginx/1.12.2]
-      strict-transport-security: [max-age=31536000]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
       Accept: [application/orcid+json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]

--- a/tests/integration/orcid/cassettes/test_push_to_orcid_update_no_cache.yaml
+++ b/tests/integration/orcid/cassettes/test_push_to_orcid_update_no_cache.yaml
@@ -2,30 +2,6 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/x-bibtex]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-    method: GET
-    uri: https://labs.inspirehep.net/api/literature/4328
-  response:
-    body: {string: !!python/unicode "@article{Glashow:1961tr,\n    author = \"Glashow,\
-        \ S.L.\",\n    journal = \"Nucl.Phys.\",\n    volume = \"22\",\n    pages\
-        \ = \"579--588\",\n    doi = \"10.1016/0029-5582(61)90469-2\",\n    title\
-        \ = \"Partial Symmetries of Weak Interactions\",\n    year = \"1961\"\n}\n"}
-    headers:
-      access-control-allow-origin: ['*']
-      access-control-expose-headers: ['Content-Type, ETag, Link, X-RateLimit-Limit,
-          X-RateLimit-Remaining, X-RateLimit-Reset']
-      content-length: ['243']
-      content-type: [application/x-bibtex]
-      date: ['Wed, 21 Mar 2018 14:22:27 GMT']
-      server: [nginx/1.12.2]
-      strict-transport-security: [max-age=31536000]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
       Accept: [application/orcid+json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]

--- a/tests/integration/orcid/cassettes/test_push_to_orcid_update_with_cache.yaml
+++ b/tests/integration/orcid/cassettes/test_push_to_orcid_update_with_cache.yaml
@@ -60,28 +60,4 @@ interactions:
       x-frame-options: [DENY]
       x-xss-protection: [1; mode=block]
     status: {code: 201, message: Created}
-- request:
-    body: null
-    headers:
-      Accept: [application/x-bibtex]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-    method: GET
-    uri: https://labs.inspirehep.net/api/literature/4328
-  response:
-    body: {string: !!python/unicode "@article{Glashow:1961tr,\n    author = \"Glashow,\
-        \ S.L.\",\n    journal = \"Nucl.Phys.\",\n    volume = \"22\",\n    pages\
-        \ = \"579--588\",\n    doi = \"10.1016/0029-5582(61)90469-2\",\n    title\
-        \ = \"Changed\",\n    year = \"1961\"\n}\n"}
-    headers:
-      access-control-allow-origin: ['*']
-      access-control-expose-headers: ['Content-Type, ETag, Link, X-RateLimit-Limit,
-          X-RateLimit-Remaining, X-RateLimit-Reset']
-      content-length: ['243']
-      content-type: [application/x-bibtex]
-      date: ['Wed, 21 Mar 2018 12:47:18 GMT']
-      server: [nginx/1.12.2]
-      strict-transport-security: [max-age=31536000]
-    status: {code: 200, message: OK}
 version: 1

--- a/tests/integration/orcid/cassettes/test_push_to_orcid_with_putcode_but_without_hash.yaml
+++ b/tests/integration/orcid/cassettes/test_push_to_orcid_with_putcode_but_without_hash.yaml
@@ -112,30 +112,6 @@ interactions:
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 - request:
-    body: null
-    headers:
-      Accept: [application/x-bibtex]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-    method: GET
-    uri: https://labs.inspirehep.net/api/literature/4328
-  response:
-    body: {string: !!python/unicode "@article{Glashow:1961tr,\n    author = \"Glashow,\
-        \ S.L.\",\n    journal = \"Nucl.Phys.\",\n    volume = \"22\",\n    pages\
-        \ = \"579--588\",\n    doi = \"10.1016/0029-5582(61)90469-2\",\n    title\
-        \ = \"Partial Symmetries of Weak Interactions\",\n    year = \"1961\"\n}\n"}
-    headers:
-      access-control-allow-origin: ['*']
-      access-control-expose-headers: ['Content-Type, ETag, Link, X-RateLimit-Limit,
-          X-RateLimit-Remaining, X-RateLimit-Reset']
-      content-length: ['243']
-      content-type: [application/x-bibtex]
-      date: ['Thu, 22 Mar 2018 10:28:58 GMT']
-      server: [nginx/1.12.2]
-      strict-transport-security: [max-age=31536000]
-    status: {code: 200, message: OK}
-- request:
     body: !!python/unicode "<work:work xmlns:common=\"http://www.orcid.org/ns/common\"\
       \ xmlns:work=\"http://www.orcid.org/ns/work\" put-code=\"920107\"><work:title><common:title>Partial\
       \ Symmetries of Weak Interactions</common:title></work:title><work:journal-title>Nucl.Phys.</work:journal-title><work:citation><work:citation-type>bibtex</work:citation-type><work:citation-value>@article{Glashow:1961tr,\n\

--- a/tests/integration/orcid/test_orcid_utils.py
+++ b/tests/integration/orcid/test_orcid_utils.py
@@ -31,7 +31,6 @@ from inspire_dojson.utils import get_record_ref
 from inspire_schemas.api import validate
 from inspirehep.modules.records.api import InspireRecord
 from inspirehep.modules.orcid.utils import (
-    _get_api_url_for_recid,
     get_literature_recids_for_orcid,
     get_orcids_for_push,
     get_push_access_tokens,
@@ -66,21 +65,6 @@ def author_in_isolated_app(isolated_app):
     record = InspireRecord.create_or_update(record)
     record.commit()
     yield record['control_number']
-
-
-@pytest.mark.parametrize(
-    'server_name,api_endpoint,recid,expected',
-    [
-        ('inspirehep.net', '/api/literature/', '123', 'http://inspirehep.net/api/literature/123'),
-        ('http://inspirehep.net', '/api/literature/', '123', 'http://inspirehep.net/api/literature/123'),
-        ('https://inspirehep.net', '/api/literature/', '123', 'https://inspirehep.net/api/literature/123'),
-        ('http://inspirehep.net', 'api/literature', '123', 'http://inspirehep.net/api/literature/123'),
-        ('http://inspirehep.net/', '/api/literature', '123', 'http://inspirehep.net/api/literature/123'),
-    ]
-)
-def test_get_api_url_for_recid(server_name, api_endpoint, recid, expected):
-    result = _get_api_url_for_recid(server_name, api_endpoint, recid)
-    assert expected == result
 
 
 def test_orcids_for_push_no_authors(isolated_app):


### PR DESCRIPTION
## Description:
Similarly to df17def, this commit computes the BibTeX representation
of a record directly instead of through the API. Unlike that commit,
this is done for consistency rather than performance.

## Related Issue:
Jira: https://its.cern.ch/jira/browse/INSPIR-548

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.