### PR TITLE
651 Revert "workflows: remove the remove_references step"

### DIFF
--- a/inspirehep/modules/workflows/tasks/submission.py
+++ b/inspirehep/modules/workflows/tasks/submission.py
@@ -319,3 +319,10 @@ def prepare_keywords(obj, eng):
     obj.data['keywords'] = keywords
 
     obj.log.debug('Finally got keywords: \n%s', pformat(keywords))
+
+
+@with_debug_logging
+def remove_references(obj, eng):
+    obj.log.info(obj.data)
+    if 'references' in obj.data:
+        del obj.data['references']

--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -96,6 +96,7 @@ from inspirehep.modules.workflows.tasks.submission import (
     create_ticket,
     filter_keywords,
     prepare_keywords,
+    remove_references,
     reply_ticket,
     send_robotupload,
     wait_webcoll,
@@ -229,6 +230,7 @@ POSTENHANCE_RECORD = [
     add_core,
     filter_keywords,
     prepare_keywords,
+    remove_references,
     set_refereed_and_fix_document_type,
     fix_submission_number,
 ]

--- a/tests/unit/workflows/test_workflows_tasks_submission.py
+++ b/tests/unit/workflows/test_workflows_tasks_submission.py
@@ -33,6 +33,7 @@ from inspirehep.modules.workflows.tasks.submission import (
     create_ticket,
     filter_keywords,
     prepare_keywords,
+    remove_references,
     reply_ticket,
     send_robotupload,
     wait_webcoll,
@@ -747,3 +748,50 @@ def test_prepare_keywords_does_nothing_if_no_keywords_were_predicted():
 
     assert validate(result['keywords'], subschema) is None
     assert expected == result['keywords']
+
+
+def test_remove_references():
+    schema = load_schema('hep')
+    subschema = schema['properties']['references']
+
+    data = {
+        'references': [
+            {
+                'reference': {
+                    'arxiv_eprint': 'hep-th/9710014',
+                    'authors': [
+                        {'full_name': 'Maldacena, J.'},
+                        {'full_name': 'Strominger, A.'},
+                    ],
+                    'label': '1',
+                },
+            },
+        ],
+    }
+    extra_data = {}
+    assert validate(data['references'], subschema) is None
+
+    obj = MockObj(data, extra_data)
+    eng = MockEng()
+
+    assert remove_references(obj, eng) is None
+
+    expected = {}
+    result = obj.data
+
+    assert expected == result
+
+
+def test_remove_references_does_nothing_when_there_are_no_references():
+    data = {}
+    extra_data = {}
+
+    obj = MockObj(data, extra_data)
+    eng = MockEng()
+
+    assert remove_references(obj, eng) is None
+
+    expected = {}
+    result = obj.data
+
+    assert expected == result


### PR DESCRIPTION
https://its.cern.ch/jira/browse/INSPIR-651


<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

This reverts commit c4258a2c468efe7a55a9689a259eb4da98c2ebdc.

See issue https://its.cern.ch/jira/browse/INSPIR-651