### PR TITLE
utils: fix (again) is_pdf_url

### DIFF
--- a/inspirehep/utils/url.py
+++ b/inspirehep/utils/url.py
@@ -65,14 +65,11 @@ def is_pdf_link(url):
     except requests.exceptions.RequestException:
         return False
 
-    try:
-        first_significant_line = next(response.iter_lines(1))
-        while not first_significant_line.strip():
-            first_significant_line = next(response.iter_lines(1))
-    except StopIteration:
+    significant_lines = [line for line in response.iter_lines(10) if line.strip()]
+    if not significant_lines:
         return False
 
-    return first_significant_line.startswith('%PDF')
+    return significant_lines[0].startswith('%PDF')
 
 
 def copy_file(src_file, dst_file, buffer_size=io.DEFAULT_BUFFER_SIZE):


### PR DESCRIPTION
## Description:
The fix introduced in 7ac57d7 worked for the Holdingpen case, but
does not work when we are in the context of an HTTP request, such
as when we are validating a form submission.

This has been tested manually locally.

## Related Issue
Sentry: https://sentry.inspirehep.net/inspire-sentry/prod/issues/78022/

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.