### PR TITLE
668 migrator: remove unneeded tasks

### DIFF
--- a/inspirehep/modules/migrator/tasks.py
+++ b/inspirehep/modules/migrator/tasks.py
@@ -155,7 +155,6 @@ def migrate_record_from_legacy(recid):
     db.session.commit()
 
 
-@shared_task(ignore_result=True, queue='migrator')
 def migrate_from_mirror(also_migrate=None, wait_for_results=False, skip_files=None):
     """Migrate legacy records from the local mirror.
 
@@ -211,13 +210,11 @@ def migrate_from_mirror(also_migrate=None, wait_for_results=False, skip_files=No
         print('All migration tasks have been completed.')
 
 
-@shared_task(ignore_result=True, queue='migrator')
 def migrate_from_file(source, wait_for_results=False):
     populate_mirror_from_file(source)
     migrate_from_mirror(wait_for_results=wait_for_results)
 
 
-@shared_task(ignore_result=True, queue='migrator')
 def populate_mirror_from_file(source):
     for i, chunk in enumerate(chunker(split_stream(read_file(source)), CHUNK_SIZE), 1):
         insert_into_mirror(chunk)

--- a/tests/integration/migrator/test_migrator_tasks.py
+++ b/tests/integration/migrator/test_migrator_tasks.py
@@ -189,7 +189,7 @@ def test_orcid_push_disabled_on_migrate_from_mirror(app, cleanup, enable_orcid_p
         mock_get_push_access_tokens.return_value.remote_account.extra_data['orcid'] = '0000-0002-1825-0097'
         mock_get_push_access_tokens.return_value.access_token = 'mytoken'
 
-        migrate_from_file.delay(record_fixture_path, wait_for_results=True)
+        migrate_from_file(record_fixture_path, wait_for_results=True)
         mock_attempt_push.assert_not_called()
 
     prod_record = LegacyRecordsMirror.query.filter(LegacyRecordsMirror.recid == 12345).one()


### PR DESCRIPTION
This module used to have the `@shared_task` decorator applied very
liberally, even for functions that were always called as regular
functions and never scheduled through celery. Now, only functions that
are actually used as tasks have the decorator. This incidentally removes
all tasks synchronously calling other tasks, which is bad practice and
forbidden in Celery 4.*.