### PR TITLE
workflows: source translation for the roots

### DIFF
--- a/inspirehep/modules/workflows/tasks/upload.py
+++ b/inspirehep/modules/workflows/tasks/upload.py
@@ -30,7 +30,10 @@ from invenio_db import db
 
 from inspirehep.modules.records.api import InspireRecord
 from inspirehep.modules.workflows.models import WorkflowsRecordSources
-from inspirehep.modules.workflows.utils import with_debug_logging
+from inspirehep.modules.workflows.utils import (
+    get_source_for_root,
+    with_debug_logging,
+)
 from inspirehep.utils.record import get_source
 from inspirehep.utils.schema import ensure_valid_schema
 
@@ -81,10 +84,11 @@ def store_root(obj, eng):
 
     root = obj.extra_data['merger_root']
     head_uuid = obj.extra_data['head_uuid']
+
     source = get_source(root).lower()
 
     root_record = WorkflowsRecordSources(
-        source=source,
+        source=get_source_for_root(source),
         record_uuid=head_uuid,
         json=root,
     )

--- a/inspirehep/modules/workflows/utils/__init__.py
+++ b/inspirehep/modules/workflows/utils/__init__.py
@@ -253,6 +253,7 @@ def read_wf_record_source(record_uuid, source):
     Return:
         (dict): the given record, if any or None
     """
+    source = get_source_for_root(source)
     entry = WorkflowsRecordSources.query.filter_by(
         record_uuid=str(record_uuid),
         source=source.lower(),
@@ -281,7 +282,9 @@ def insert_wf_record_source(json, record_uuid, source):
         record_uuid(uuid): the record's uuid
         source(string): the source of the record
     """
-    record_source = read_wf_record_source(record_uuid=record_uuid, source=source)
+    source = get_source_for_root(source)
+    record_source = read_wf_record_source(
+        record_uuid=record_uuid, source=source)
     if record_source is None:
         record_source = WorkflowsRecordSources(
             source=source.lower(),
@@ -292,6 +295,23 @@ def insert_wf_record_source(json, record_uuid, source):
     else:
         record_source.json = json
     db.session.commit()
+
+
+def get_source_for_root(source):
+    """Source for the root workflow object.
+
+    Args:
+        source(str): the record source.
+
+    Return:
+        (str): the source for the root workflow object.
+
+    Note:
+        For the time being any workflow with ``acquisition_source.source``
+        different than ``arxiv`` and ``submitter`` will be stored as
+        ``publisher``.
+    """
+    return source if source in ['arxiv', 'submitter'] else 'publisher'
 
 
 def get_resolve_validation_callback_url():

--- a/tests/integration/workflows/test_workflow_utils.py
+++ b/tests/integration/workflows/test_workflow_utils.py
@@ -56,8 +56,40 @@ def test_wf_record_source_read_and_write(dummy_record):
     )
     db.session.commit()
 
-    retrieved_root = read_wf_record_source(record_uuid=dummy_record.id, source='arxiv')
+    retrieved_root = read_wf_record_source(
+        record_uuid=dummy_record.id, source='arxiv')
+
     assert dummy_record == retrieved_root.json
+    assert 'arxiv' == retrieved_root.source
+
+
+def test_wf_record_with_desy_source_read_and_write(dummy_record):
+    insert_wf_record_source(
+        json=dummy_record,
+        record_uuid=dummy_record.id,
+        source='desy'
+    )
+    db.session.commit()
+
+    retrieved_root = read_wf_record_source(
+        record_uuid=dummy_record.id, source='desy')
+
+    assert dummy_record == retrieved_root.json
+    assert 'publisher' == retrieved_root.source
+
+
+def test_wf_record_with_submitter_source_read_and_write(dummy_record):
+    insert_wf_record_source(
+        json=dummy_record,
+        record_uuid=dummy_record.id,
+        source='submitter'
+    )
+    db.session.commit()
+    retrieved_root = read_wf_record_source(
+        record_uuid=dummy_record.id, source='submitter')
+
+    assert dummy_record == retrieved_root.json
+    assert 'submitter' == retrieved_root.source
 
 
 def test_test_wf_record_source_update(dummy_record):

--- a/tests/unit/workflows/test_workflows_utils.py
+++ b/tests/unit/workflows/test_workflows_utils.py
@@ -39,6 +39,7 @@ from inspirehep.modules.workflows.utils import (
     convert,
     download_file_to_workflow,
     get_document_in_workflow,
+    get_source_for_root,
     ignore_timeout_error,
     json_api_request,
 )
@@ -202,3 +203,16 @@ def test_ignore_timeout_decorator(mock_logger):
     f()
 
     assert mock_logger.error.called
+
+
+@pytest.mark.parametrize('source,expected_source', [
+    ('publisher', 'publisher'),
+    ('desy', 'publisher'),
+    ('jessica jones', 'publisher'),
+    ('arxiv', 'arxiv'),
+    ('submitter', 'submitter'),
+])
+def test_get_source_root(source, expected_source):
+    result = get_source_for_root(source)
+
+    assert expected_source == result


### PR DESCRIPTION
* Translates the sources to ``arxiv``, ``publisher`` and ``submitter``.

Signed-off-by: Harris Tzovanakis <me@drjova.com>