### PR TITLE
766 alembic: create index on signature_blocks

### DIFF
--- a/inspirehep/alembic/47bc5e7e1a87_index_signature_block_field.py
+++ b/inspirehep/alembic/47bc5e7e1a87_index_signature_block_field.py
@@ -1,0 +1,34 @@
+#
+# This file is part of Invenio.
+# Copyright (C) 2016-2018 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Index signature_block field"""
+
+from __future__ import absolute_import, division, print_function
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '47bc5e7e1a87'
+down_revision = '17ff155db70d'
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    """Upgrade database."""
+    op.execute('''
+        create function signature_blocks(json jsonb) returns text[] as $$
+        select array_agg(a->>'signature_block') as result from jsonb_array_elements(json->'authors') as a;$$
+        language sql immutable
+        ''')
+    op.execute('create index ix_records_metadata_json_signature_blocks on records_metadata using gin (signature_blocks(json))')
+
+
+def downgrade():
+    """Downgrade database."""
+    op.execute('drop index if exists ix_records_metadata_json_signature_blocks')
+    op.execute('drop function if exists signature_blocks(json jsonb)')

--- a/inspirehep/alembic/cb9f81e8251c_add_record_metadata_indices.py
+++ b/inspirehep/alembic/cb9f81e8251c_add_record_metadata_indices.py
@@ -30,7 +30,7 @@ from alembic import op
 revision = 'cb9f81e8251c'
 down_revision = 'fddb3cfe7a9c'
 branch_labels = ()
-depends_on = None
+depends_on = '07fb52561c5c'
 
 
 def upgrade():


### PR DESCRIPTION
This creates an index on the `signature_block` field of `authors` in `RecordMetadata.json`, which can be used to efficiently get all records for authors with a given signature block. This is useful for author disambiguation. Note that this requires using a custom PostgreSQL function because `authors` is a json array containing objects, so the naive `(json->'authors'->>'signature_block')` doesn't work.