### PR TITLE
disambiguation: first commit

### DIFF
--- a/inspirehep/modules/disambiguation/__init__.py
+++ b/inspirehep/modules/disambiguation/__init__.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Disambiguation module."""
+
+from __future__ import absolute_import, division, print_function
+
+from .ext import InspireDisambiguation  # noqa: F401

--- a/inspirehep/modules/disambiguation/config.py
+++ b/inspirehep/modules/disambiguation/config.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Disambiguation configuration."""
+
+from __future__ import absolute_import, division, print_function
+
+
+DISAMBIGUATION_MODEL_PATH = '/tmp/inspire-disambiguation-model.pkl'
+"""The path to the model that will be used to run the disambiguation."""

--- a/inspirehep/modules/disambiguation/ext.py
+++ b/inspirehep/modules/disambiguation/ext.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Disambiguation extension."""
+
+from __future__ import absolute_import, division, print_function
+
+from . import config
+
+
+class InspireDisambiguation(object):
+    def __init__(self, app=None):
+        if app:
+            self.init_app(app)
+
+    def init_app(self, app):
+        self.init_config(app)
+        app.extensions['inspire-disambiguation'] = self
+
+    def init_config(self, app):
+        for k in dir(config):
+            if k.startswith('DISAMBIGUATION_'):
+                app.config.setdefault(k, getattr(config, k))

--- a/inspirehep/modules/migrator/tasks.py
+++ b/inspirehep/modules/migrator/tasks.py
@@ -195,8 +195,8 @@ def migrate_from_mirror(also_migrate=None, wait_for_results=False, skip_files=No
         migrate_recids_from_mirror.ignore_result = False
 
     chunked_recids = chunker(res.recid for res in query.yield_per(CHUNK_SIZE))
-    for i, chunk in enumerate(chunked_recids, 1):
-        print("Scheduled {} records for migration".format(i * CHUNK_SIZE))
+    for i, chunk in enumerate(chunked_recids):
+        print("Scheduled {} records for migration".format(i * CHUNK_SIZE + len(chunk)))
         if wait_for_results:
             tasks.append(migrate_recids_from_mirror.s(chunk, skip_files=skip_files))
         else:
@@ -216,9 +216,9 @@ def migrate_from_file(source, wait_for_results=False):
 
 
 def populate_mirror_from_file(source):
-    for i, chunk in enumerate(chunker(split_stream(read_file(source)), CHUNK_SIZE), 1):
+    for i, chunk in enumerate(chunker(split_stream(read_file(source)), CHUNK_SIZE)):
         insert_into_mirror(chunk)
-        print("Inserted {} records into mirror".format(i * CHUNK_SIZE))
+        print("Inserted {} records into mirror".format(i * CHUNK_SIZE + len(chunk)))
 
 
 @shared_task(ignore_result=True)

--- a/setup.py
+++ b/setup.py
@@ -215,6 +215,7 @@ setup(
             'inspire_arxiv = inspirehep.modules.arxiv:InspireArXiv',
             'inspire_authors = inspirehep.modules.authors:InspireAuthors',
             'inspire_crossref = inspirehep.modules.crossref:InspireCrossref',
+            'inspire_disambiguation = inspirehep.modules.disambiguation:InspireDisambiguation',
             'inspire_fixtures = inspirehep.modules.fixtures:InspireFixtures',
             'inspire_forms = inspirehep.modules.forms:InspireForms',
             'inspire_hal = inspirehep.modules.hal:InspireHAL',

--- a/tests/unit/disambiguation/test_disambiguation_ext.py
+++ b/tests/unit/disambiguation/test_disambiguation_ext.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+
+def test_ext(app):
+    assert 'inspire-disambiguation' in app.extensions
+
+
+def test_ext_loads_the_configuration(app):
+    assert 'DISAMBIGUATION_MODEL_PATH' in app.config


### PR DESCRIPTION
## Description:
The attempt to spin this module out as an independent blueprint (https://github.com/inspirehep/inspire-disambiguation) ran into the core issue of how to read/write the records independently of `inspire-next`, and the related issue of how to test code that interacts with the database.

One solution could have been to set up an independent Docker environment, similar to how `hepcrawl` does it. A problem with that approach is the undesirable repetition; the US to bump Celery to version 4 required modifying the same configuration variables in 4 different repositories. One could use the `docker-compose.yml` and `docker-compose.override.yml` pattern documented in https://docs.docker.com/compose/extends/#multiple-compose-files, which instead has the issue of having developers deal with git submodules, a slightly advanced topic. If I had enough time, I probably would have started a refactor to spin out things like the `isolated_app` and the test record factory.

The simplest solution (the one that has the highest chance of achieving something in the next month) is to succumb once again to the powerful allure of the monolith, and just make `disambiguation` a module in `inspire-next`.

Oh, and I added a commit to fix the message that rounded the number of migrated records to the nearest hundred during migration because it annoyed me.

## Related Issue:
Jira: https://its.cern.ch/jira/browse/INSPIR-746

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.