### PR TITLE
801 workflows: use texkeys in reference matcher

### DIFF
--- a/inspirehep/modules/records/mappings/records/hep.json
+++ b/inspirehep/modules/records/mappings/records/hep.json
@@ -998,6 +998,12 @@
                     "type": "integer"
                 },
                 "texkeys": {
+                    "fields": {
+                        "raw": {
+                            "index": "not_analyzed",
+                            "type": "string"
+                        }
+                    },
                     "type": "string"
                 },
                 "thesis_info": {

--- a/inspirehep/modules/workflows/config.py
+++ b/inspirehep/modules/workflows/config.py
@@ -49,6 +49,11 @@ WORKFLOWS_REFERENCE_MATCHER_UNIQUE_IDENTIFIERS_CONFIG = {
                     'type': 'exact',
                 },
                 {
+                    'path': 'reference.texkey',
+                    'search_path': 'texkeys.raw',
+                    'type': 'exact',
+                },
+                {
                     'path': 'reference.report_numbers',
                     'search_path': 'report_numbers.value.fuzzy',
                     'type': 'exact',

--- a/tests/integration/workflows/test_workflows_tasks_refextract.py
+++ b/tests/integration/workflows/test_workflows_tasks_refextract.py
@@ -275,3 +275,38 @@ def test_match_references_no_match_when_multiple_match_different_from_previous()
 
     assert get_value(references[0], 'record') is None
     assert validate(references, subschema) is None
+
+
+def test_match_reference_on_texkey():
+    cited_record_json = {
+        '$schema': 'http://localhost:5000/schemas/records/hep.json',
+        '_collections': ['Literature'],
+        'control_number': 1,
+        'document_type': ['article'],
+        'texkeys': [
+            'Giudice:2007fh',
+        ],
+        'titles': [
+            {
+                'title': 'The Strongly-Interacting Light Higgs'
+            }
+        ],
+    }
+
+    TestRecordMetadata.create_from_kwargs(
+        json=cited_record_json, index_name='records-hep')
+
+    reference = {
+        'reference': {
+            'texkey': 'Giudice:2007fh',
+        }
+    }
+
+    schema = load_schema('hep')
+    subschema = schema['properties']['references']
+
+    assert validate([reference], subschema) is None
+    reference = match_reference(reference)
+
+    assert reference['record']['$ref'] == 'http://localhost:5000/api/literature/1'
+    assert validate([reference], subschema) is None


### PR DESCRIPTION
Signed-off-by: Micha Moskovic <michamos@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
