### PR TITLE
api: remove inspire theme extension

### DIFF
--- a/inspirehep/modules/theme/views.py
+++ b/inspirehep/modules/theme/views.py
@@ -24,11 +24,8 @@
 
 from __future__ import absolute_import, division, print_function
 
-import sys
 from datetime import date
-from functools import wraps
 
-import six
 from dateutil.relativedelta import relativedelta
 from flask import (
     Blueprint,
@@ -322,37 +319,18 @@ def data():
 # Error handlers
 #
 
-def api_friendly_error_handler(f):
-    @wraps(f)
-    def wrapper(error, *args, **kwargs):
-        if current_app.config.get('RESTFUL_API'):
-            # See: https://hynek.me/articles/hasattr/
-            code, name = getattr(error, 'code', None), getattr(error, 'name', None)
-            if code is not None and name is not None:
-                return jsonify(code=error.code, message=error.name), error.code
-            else:
-                six.reraise(*sys.exc_info())
-        return f(error, *args, **kwargs)
-
-    return wrapper
-
-
-@api_friendly_error_handler
 def unauthorized(error):
     return render_template(current_app.config['THEME_401_TEMPLATE']), 401
 
 
-@api_friendly_error_handler
 def insufficient_permissions(error):
     return render_template(current_app.config['THEME_403_TEMPLATE']), 403
 
 
-@api_friendly_error_handler
 def page_not_found(error):
     return render_template(current_app.config['THEME_404_TEMPLATE']), 404
 
 
-@api_friendly_error_handler
 def internal_error(error):
     return render_template(current_app.config['THEME_500_TEMPLATE']), 500
 

--- a/setup.py
+++ b/setup.py
@@ -203,7 +203,6 @@ setup(
         'invenio_base.api_apps': [
             'inspire_records = inspirehep.modules.records.ext:InspireRecords',
             'inspire_search = inspirehep.modules.search:InspireSearch',
-            'inspire_theme = inspirehep.modules.theme:INSPIRETheme',
             'inspire_utils = inspirehep.utils.ext:INSPIREUtils',
             'inspire_workflows = inspirehep.modules.workflows:InspireWorkflows',
             'invenio_collections = invenio_collections:InvenioCollections',

--- a/tests/unit/theme/test_theme_views.py
+++ b/tests/unit/theme/test_theme_views.py
@@ -98,25 +98,3 @@ def test_postfeedback_send_email_failure(delay, app_client):
 
     assert response.status_code == 500
     assert json.loads(response.data) == {'success': False}
-
-
-def test_page_not_found_renders_template_when_in_app(app_client):
-    response = app_client.get('/does-not-exist')
-
-    assert response.status_code == 404
-    assert response.mimetype == 'text/html'
-
-
-def test_page_not_Found_returns_json_when_in_api(api_client):
-    response = api_client.get('/does-not-exist')
-
-    assert response.status_code == 404
-    assert response.mimetype == 'application/json'
-
-    expected = {
-        'code': 404,
-        'message': 'Not Found',
-    }
-    result = json.loads(response.data)
-
-    assert expected == result


### PR DESCRIPTION
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

This was added by the commit
https://github.com/inspirehep/inspire-next/pull/2816/files#diff-2eeaed663bd0d25b7e608891384b7298R198

And was not needed, as actually it also makes sure that the api app
never tries to render a template on error by using jsonify.

Signed-off-by: David Caro <david@dcaro.es>