### PR TITLE
800 literaturesuggest: no refs in private notes

### DIFF
--- a/inspirehep/modules/literaturesuggest/tasks.py
+++ b/inspirehep/modules/literaturesuggest/tasks.py
@@ -93,7 +93,7 @@ def formdata_to_model(obj, formdata):
     )
 
     for key in ('extra_comments', 'nonpublic_note',
-                'hidden_notes', 'conf_name', 'references'):
+                'hidden_notes', 'conf_name'):
         builder.add_private_note(
             private_notes=form_fields.get(key)
         )


### PR DESCRIPTION
This is no longer needed because refextract now also runs on the
references in the form.

Signed-off-by: Micha Moskovic <michamos@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
