### PR TITLE
disambiguation: don't expect a signature_block

### DIFF
--- a/inspirehep/modules/disambiguation/core/db/readers.py
+++ b/inspirehep/modules/disambiguation/core/db/readers.py
@@ -95,7 +95,7 @@ def get_signatures_matching_a_phonetic_encoding(phonetic_encoding):
         record = record.to_dict()
         publication = _build_publication(record)
         for author in record.get('authors', []):
-            if author['signature_block'] == phonetic_encoding:
+            if author.get('signature_block') == phonetic_encoding:
                 yield _build_signature(author, publication)
 
 
@@ -118,7 +118,7 @@ def _build_signature(author, publication):
         'author_name': author['full_name'],
         'publication': publication,
         'publication_id': publication['publication_id'],
-        'signature_block': author['signature_block'],
+        'signature_block': author.get('signature_block'),
         'signature_uuid': author['uuid'],
     }
 

--- a/tests/integration/disambiguation/fixtures/1662077.json
+++ b/tests/integration/disambiguation/fixtures/1662077.json
@@ -1,0 +1,14296 @@
+{
+    "$schema": "https://qa.inspirehep.net/schemas/records/hep.json",
+    "_collections": [
+        "Literature"
+    ],
+    "_desy_bookkeeping": [
+        {
+            "identifier": "D18-kj13g"
+        },
+        {
+            "date": "2018-03-21",
+            "expert": "Z",
+            "status": "fullabs"
+        },
+        {
+            "date": "2018-03-27",
+            "expert": "Z",
+            "status": "printed"
+        },
+        {
+            "date": "2018-04-03",
+            "expert": "Z",
+            "status": "final"
+        }
+    ],
+    "abstracts": [
+        {
+            "source": "arXiv",
+            "value": "To investigate the nature of the $\\psi(3770)$ resonance and to measure the cross section for $e^+e^- \\to D\\bar{D}$, a cross-section scan data sample, distributed among 41 center-of-mass energy points from 3.73 to 3.89~GeV, was taken with the BESIII detector operated at the BEPCII collider in the year 2010. By analyzing the large angle Bhabha scattering events, we measure the integrated luminosity of the data sample at each center-of-mass energy point. The total integrated luminosity of the data sample is $76.16\\pm0.04\\pm0.61$~pb$^{-1}$, where the first uncertainty is statistical and the second systematic."
+        }
+    ],
+    "accelerator_experiments": [
+        {
+            "legacy_name": "BEPC-BES-III",
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/experiments/1239436"
+            }
+        }
+    ],
+    "acquisition_source": {
+        "datetime": "2018-03-13T03:06:41.124980",
+        "method": "hepcrawl",
+        "source": "arXiv",
+        "submission_number": "935919"
+    },
+    "arxiv_eprints": [
+        {
+            "categories": [
+                "hep-ex"
+            ],
+            "value": "1803.03802"
+        }
+    ],
+    "authors": [
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Ablikim, Medina",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00059665"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-3935-619X"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1019329"
+            },
+            "signature_block": "ABLACANm",
+            "uuid": "6a851215-823f-4a2e-9db8-04a25373d345"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903088"
+                    },
+                    "value": "Novosibirsk, IYF"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Achasov, Mikhail N",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00426027"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Novosibirsk 630090, Russia"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1035105"
+            },
+            "signature_block": "ACASAVm",
+            "uuid": "e0589e1f-6df9-402f-bbd9-7f7e735be81e"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/912519"
+                    },
+                    "value": "Helmholtz Inst., Mainz"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Ahmed, Samer Ali Nasher",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00455329"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Johann-Joachim-Becher-Weg 45, D-55099 Mainz, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1421593"
+            },
+            "signature_block": "AHNADs",
+            "uuid": "aae8a97b-4996-422b-bea7-8a0e2516eb43"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903173"
+                    },
+                    "value": "Ruhr U., Bochum"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Albrecht, Malte",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447780"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "D-44780 Bochum, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325231"
+            },
+            "signature_block": "ALBRACHTm",
+            "uuid": "9f03c0bc-9d99-47f3-8fc5-13870eba8059"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903297"
+                    },
+                    "value": "Turin U."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902889"
+                    },
+                    "value": "INFN, Turin"
+                }
+            ],
+            "full_name": "Alekseev, Maxim",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "M.Alekseev.2"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "University of Turin, I-10125, Turin, Italy"
+                },
+                {
+                    "value": "INFN, I-10125, Turin, Italy"
+                }
+            ],
+            "signature_block": "ALACSAFm",
+            "uuid": "b3959adb-ee4e-4dc8-b50e-61824937d8ef"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903297"
+                    },
+                    "value": "Turin U."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902889"
+                    },
+                    "value": "INFN, Turin"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Amoroso, Antonio",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447778"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "University of Turin, I-10125, Turin, Italy"
+                },
+                {
+                    "value": "INFN, I-10125, Turin, Italy"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1043457"
+            },
+            "signature_block": "ANARASa",
+            "uuid": "f4ef8880-30d2-43e9-a31e-f201881b9120"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "An, Fenfen",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00409224"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1256715"
+            },
+            "signature_block": "ANf",
+            "uuid": "1b9a9bff-d679-4fc6-9de1-e1d681f5be87"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "An, Qi",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446010"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1056374"
+            },
+            "signature_block": "ANq",
+            "uuid": "760e6110-2162-496f-9351-e63ce0536fe4"
+        },
+        {
+            "full_name": "Bai, Yu",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "Y.Bai.9"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Nanjing 211100, People's Republic of China"
+                }
+            ],
+            "signature_block": "By",
+            "uuid": "7bbc3ce7-54b2-498e-829d-943fbcef0299"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902780"
+                    },
+                    "value": "Dubna, JINR"
+                }
+            ],
+            "full_name": "Bakina, Olga",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "O.Bakina.2"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "141980 Dubna, Moscow region, Russia"
+                }
+            ],
+            "signature_block": "BACANo",
+            "uuid": "fc0e0a0f-d9a2-431b-94c7-7f6598f82074"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902807"
+                    },
+                    "value": "Frascati"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Baldini Ferroli, Rinaldo",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00042596"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "INFN Laboratori Nazionali di Frascati, I-00044, Frascati, Italy"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1028331"
+            },
+            "signature_block": "FARALr",
+            "uuid": "87ec0161-62f3-4d77-aa79-bdb1bd1759fb"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1238006"
+                    },
+                    "value": "Peking U., Beijing"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Ban, Yong",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00170030"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100871, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1017488"
+            },
+            "signature_block": "BANy",
+            "uuid": "69658ee0-8199-425c-91f6-545a67d826bb"
+        },
+        {
+            "full_name": "Begzsuren, Khurelbaatar",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "K.Begzsuren.2"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Peace Ave. 54B, Ulaanbaatar 13330, Mongolia"
+                }
+            ],
+            "signature_block": "BAGSARANk",
+            "uuid": "0de68537-d7d7-424d-a26b-03937ab4b1de"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902874"
+                    },
+                    "value": "Indiana U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Bennett, Dan",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446725"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Bloomington, Indiana 47405, USA"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325246"
+            },
+            "signature_block": "BANATd",
+            "uuid": "2253c934-bcc7-43b6-8118-728d4d2a0f10"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902719"
+                    },
+                    "value": "Carnegie Mellon U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Bennett, Jake",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00404075"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Pittsburgh, Pennsylvania 15213, USA"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1071644"
+            },
+            "signature_block": "BANATj",
+            "uuid": "93e1201c-5ed3-41b3-afde-8d003368078a"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/911853"
+                    },
+                    "value": "Mainz U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Berger, Niklaus",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00049561"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Johann-Joachim-Becher-Weg 45, D-55099 Mainz, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1023475"
+            },
+            "signature_block": "BARGARn",
+            "uuid": "dcf32ab5-700f-4b35-b443-fe2a65699f73"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902807"
+                    },
+                    "value": "Frascati"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Bertani, Monica",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00316508"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "INFN Laboratori Nazionali di Frascati, I-00044, Frascati, Italy"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1016548"
+            },
+            "signature_block": "BARTANm",
+            "uuid": "ec0c530d-c99b-4c70-9c82-0939b7c6472b"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/905268"
+                    },
+                    "value": "INFN, Ferrara"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Bettoni, Diego",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00145205"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "INFN Sezione di Ferrara, I-44122, Ferrara, Italy"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1016481"
+            },
+            "signature_block": "BATANd",
+            "uuid": "f989091b-d5fb-4c4a-b5ef-e1077304f6ee"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903297"
+                    },
+                    "value": "Turin U."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902889"
+                    },
+                    "value": "INFN, Turin"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Bianchi, Fabrizio",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00066870"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "University of Turin, I-10125, Turin, Italy"
+                },
+                {
+                    "value": "INFN, I-10125, Turin, Italy"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1016417"
+            },
+            "signature_block": "BANCf",
+            "uuid": "7bb1de85-ddc0-4880-99ff-77276521d9e6"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902780"
+                    },
+                    "value": "Dubna, JINR"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Boger, Evgeny",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446022"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "141980 Dubna, Moscow region, Russia"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1256717"
+            },
+            "signature_block": "BAGARe",
+            "uuid": "08e8ddf3-3b65-44b1-9da3-5b094f5e778c"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902780"
+                    },
+                    "value": "Dubna, JINR"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Boyko, Igor",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00211696"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "141980 Dubna, Moscow region, Russia"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1067241"
+            },
+            "signature_block": "BYCi",
+            "uuid": "9e3f0041-4a5d-4f74-905d-7411617e2de8"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902719"
+                    },
+                    "value": "Carnegie Mellon U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Briere, Roy",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00069238"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Pittsburgh, Pennsylvania 15213, USA"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1015311"
+            },
+            "signature_block": "BRARr",
+            "uuid": "63b77550-4ed0-4ab9-8f99-2fa754d8d423"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904858"
+                    },
+                    "value": "Wuhan U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Cai, Hao",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446700"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Wuhan 430072, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325218"
+            },
+            "signature_block": "Ch",
+            "uuid": "d7ad32a9-61e4-46dc-bc93-c2f4a298ae05"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Cai, Xiao",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00408568"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-2244-0392"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1068260"
+            },
+            "signature_block": "Cx",
+            "uuid": "3aa21855-9a10-4776-8bc0-275956697a5f"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/910170"
+                    },
+                    "value": "Ankara U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Cakir, Orhan",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00211923"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Ankara University, 06100 Tandogan, Ankara, Turkey"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1014754"
+            },
+            "signature_block": "CACARo",
+            "uuid": "9179e755-fbe7-4deb-bd5f-f2885ba71e60"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902807"
+                    },
+                    "value": "Frascati"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Calcaterra, Alessandro",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00070588"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "INFN Laboratori Nazionali di Frascati, I-00044, Frascati, Italy"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1014746"
+            },
+            "signature_block": "CALCATARa",
+            "uuid": "3903e2d5-9e30-44f9-beaf-ef95f0efe2ea"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Cao, Guofu",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00408722"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-3714-3665"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1067219"
+            },
+            "signature_block": "Cg",
+            "uuid": "33722919-01f4-4e19-98f3-8014118462d5"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1392572"
+                    },
+                    "value": "Istanbul Bilgi U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Cetin, Serkant Ali",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00186619"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Istanbul Bilgi University, 34060 Eyup, Istanbul, Turkey"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1014153"
+            },
+            "signature_block": "CATANs",
+            "uuid": "aded6840-a395-4f0d-b111-1d904260eae0"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902889"
+                    },
+                    "value": "INFN, Turin"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Chai, Junying",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00469691"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-9795-9220"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "INFN, I-10125, Turin, Italy"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1422848"
+            },
+            "signature_block": "Cj",
+            "uuid": "67ce4d32-8c78-46bd-90ae-4ad48592b2a7"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Chang, Jinfan",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00410244"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-3328-3214"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1042592"
+            },
+            "signature_block": "CANGj",
+            "uuid": "c3a0c17c-78a8-4763-b5e8-dd6f5d6387e7"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "full_name": "Chang, Wanling",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "W.Chang.2"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "signature_block": "CANGw",
+            "uuid": "91c3c9db-555b-45c4-80bc-0ef42632595a"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902780"
+                    },
+                    "value": "Dubna, JINR"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Chelkov, Georgy",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00212473"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "141980 Dubna, Moscow region, Russia"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1013911"
+            },
+            "signature_block": "CALCAVg",
+            "uuid": "4157d4cd-4fad-4237-be08-c0aeeef272dd"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Chen, Gang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00072526"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1013886"
+            },
+            "signature_block": "CANg",
+            "uuid": "1050defe-4b2a-425f-87f0-07275f36d22a"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Chen, Hesheng",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00072533"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-8672-8227"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1013882"
+            },
+            "signature_block": "CANh",
+            "uuid": "eb3ba36a-1524-4bcb-b3dc-3e50a0abe502"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Chen, Jiangchuan",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00043183"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-3991-6847"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1246059"
+            },
+            "signature_block": "CANj",
+            "uuid": "f9b56a60-1671-4116-89a7-c6b4e8810a51"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Chen, Mary",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446045"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-2725-6036"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1323032"
+            },
+            "signature_block": "CANm",
+            "uuid": "51615dc9-8a38-4614-9309-1c7b5900c0ea"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1121481"
+                    },
+                    "value": "U. South China, Hengyang"
+                }
+            ],
+            "full_name": "Chen, Pingliang",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "P.Chen.10"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hengyang 421001, People's Republic of China"
+                }
+            ],
+            "signature_block": "CANp",
+            "uuid": "d5ff2cc7-a6c6-495a-a3e4-a4dd92d4f6f5"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904118"
+                    },
+                    "value": "Nanjing U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Chen, Shenjian",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00072626"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Nanjing 210093, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1013856"
+            },
+            "signature_block": "CANs",
+            "uuid": "b058d3b3-8273-4530-a70c-f4a905a3d95c"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904070"
+                    },
+                    "value": "Lanzhou U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Chen, Xurong",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00145145"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Lanzhou 730000, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1037638"
+            },
+            "signature_block": "CANx",
+            "uuid": "d43412f8-0470-46d9-ab5d-fa3431d4ad98"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Chen, Yuanbo",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00388032"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-9135-7723"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029199"
+            },
+            "signature_block": "CANy",
+            "uuid": "d73d18ae-34e8-41a7-97a0-14939d51e972"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1238006"
+                    },
+                    "value": "Peking U., Beijing"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Chu, xinkun",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446741"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-5214-3482"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100871, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325232"
+            },
+            "signature_block": "Cx",
+            "uuid": "aeb853b5-2a79-4098-b2a3-761d8b5c5582"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/905268"
+                    },
+                    "value": "INFN, Ferrara"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Cibinetto, Gianluigi",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00059535"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-3491-6231"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "INFN Sezione di Ferrara, I-44122, Ferrara, Italy"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1019348"
+            },
+            "signature_block": "CABANATg",
+            "uuid": "11ef79fe-a7f7-4b68-90f1-330c4942029d"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902889"
+                    },
+                    "value": "INFN, Turin"
+                }
+            ],
+            "full_name": "Cossio, Fabio",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "F.Cossio.2"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "INFN, I-10125, Turin, Italy"
+                }
+            ],
+            "signature_block": "CASf",
+            "uuid": "de520f37-941e-4cfe-9093-2b4cd7a487ba"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Dai, Hongliang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446291"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-1770-3848"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1042593"
+            },
+            "signature_block": "Dh",
+            "uuid": "7d6fb9a6-b95e-41eb-953a-1001e33381c0"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904740"
+                    },
+                    "value": "Shanghai Jiaotong U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Dai, JianPing",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446075"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-4802-4485"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Shanghai 200240, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1256756"
+            },
+            "signature_block": "Dj",
+            "uuid": "34532048-5c47-47b5-9994-c867ce99fdf1"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/912519"
+                    },
+                    "value": "Helmholtz Inst., Mainz"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Dbeyssi, Alaa",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00457580"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Johann-Joachim-Becher-Weg 45, D-55099 Mainz, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1078380"
+            },
+            "signature_block": "DBYSa",
+            "uuid": "dde275ad-d18a-461d-9b2e-3e8380144a78"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902780"
+                    },
+                    "value": "Dubna, JINR"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Dedovich, Dmitry",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00213224"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "141980 Dubna, Moscow region, Russia"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1067145"
+            },
+            "signature_block": "DADAVACHd",
+            "uuid": "1cbc47d5-5a1d-42d9-8e20-0f607dccb019"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Deng, Ziyan",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00409975"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-0440-3870"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029205"
+            },
+            "signature_block": "DANGz",
+            "uuid": "583e1259-2155-4b61-929c-1155f1c76190"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/911853"
+                    },
+                    "value": "Mainz U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Denig, Achim",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00030080"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Johann-Joachim-Becher-Weg 45, D-55099 Mainz, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1041276"
+            },
+            "signature_block": "DANAGa",
+            "uuid": "65fe80ff-22b8-4599-bdfe-05d29bbe8610"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902780"
+                    },
+                    "value": "Dubna, JINR"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Denysenko, Igor",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446087"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "141980 Dubna, Moscow region, Russia"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1067140"
+            },
+            "signature_block": "DANASANCi",
+            "uuid": "484aa0b8-d081-42ff-964b-ba66c21d5f3b"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903297"
+                    },
+                    "value": "Turin U."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902889"
+                    },
+                    "value": "INFN, Turin"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Destefanis, Marco",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446569"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "University of Turin, I-10125, Turin, Italy"
+                },
+                {
+                    "value": "INFN, I-10125, Turin, Italy"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1058296"
+            },
+            "signature_block": "DASTAFANm",
+            "uuid": "e8daa4d5-91e5-467e-ac19-678f41b10524"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903297"
+                    },
+                    "value": "Turin U."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902889"
+                    },
+                    "value": "INFN, Turin"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "De Mori, Francesca",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00378258"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-3951-272X"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "University of Turin, I-10125, Turin, Italy"
+                },
+                {
+                    "value": "INFN, I-10125, Turin, Italy"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1040273"
+            },
+            "signature_block": "MARf",
+            "uuid": "1b409a11-e6de-4a3e-88b7-ad90033c13a2"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/907454"
+                    },
+                    "value": "Liaoning U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Ding, Yong",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446751"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Shenyang 110036, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1028264"
+            },
+            "signature_block": "DANGy",
+            "uuid": "ce142f43-3c2b-4f4f-bf7a-af1bc7e17c38"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/906082"
+                    },
+                    "value": "Nankai U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Dong, Chao",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446763"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-2499-2310"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Tianjin 300071, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325236"
+            },
+            "signature_block": "DANGc",
+            "uuid": "3291a40b-8bed-4c4c-9e9b-2149a781e133"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Dong, Jing",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446779"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-5761-0158"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1316442"
+            },
+            "signature_block": "DANGj",
+            "uuid": "abb5ad3d-4cdc-4cf5-a59c-da10a6c17baa"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Dong, Liaoyuan",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00145241"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-4773-5050"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1028343"
+            },
+            "signature_block": "DANGl",
+            "uuid": "e76ed404-2e0f-4c7b-a073-084b9195b848"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Dong, Mingyi",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446308"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-4359-3091"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1067121"
+            },
+            "signature_block": "DANGm",
+            "uuid": "a1fdcbce-0155-4007-beba-0a1daac5d8d2"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904118"
+                    },
+                    "value": "Nanjing U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Dou, Zhenglei",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00467609"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Nanjing 210093, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1331494"
+            },
+            "signature_block": "Dz",
+            "uuid": "743d22ab-24b0-464e-9ee2-45e7763c4cc5"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904424"
+                    },
+                    "value": "Zhengzhou U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Du, Shuxian",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00387894"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Zhengzhou 450001, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029207"
+            },
+            "signature_block": "Ds",
+            "uuid": "779932cb-300c-46b6-ba5d-84115e86a011"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Duan, Pengfei",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00457923"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-0980-3611"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1063622"
+            },
+            "signature_block": "DANp",
+            "uuid": "70f51e61-fce6-4e61-8550-86f1775c8e20"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Fang, Jian",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00409948"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-9906-296X"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1246189"
+            },
+            "signature_block": "FANGj",
+            "uuid": "e0c89dde-8cde-4bd7-9240-8320818892d8"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Fang, Shuangshi",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00172607"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-5731-4113"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029208"
+            },
+            "signature_block": "FANGs",
+            "uuid": "cf28d0fe-6398-428f-ac49-43be2127d455"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Fang, Yi",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446795"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-5140-0731"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325063"
+            },
+            "signature_block": "FANGy",
+            "uuid": "047176fc-e016-4e58-abd3-e7459aa3a006"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/905268"
+                    },
+                    "value": "INFN, Ferrara"
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902797"
+                    },
+                    "value": "Ferrara U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Farinelli, Riccardo",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00455290"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "INFN Sezione di Ferrara, I-44122, Ferrara, Italy"
+                },
+                {
+                    "value": "University of Ferrara, I-44122, Ferrara, Italy"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1035912"
+            },
+            "signature_block": "FARANALr",
+            "uuid": "db0e8e4e-5906-4741-b0e7-d87ef6e76966"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/907892"
+                    },
+                    "value": "Piemonte Orientale U., Alessandria"
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902889"
+                    },
+                    "value": "INFN, Turin"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Fava, Luciano",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446804"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "University of Eastern Piedmont, I-15121, Alessandria, Italy"
+                },
+                {
+                    "value": "INFN, I-10125, Turin, Italy"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1010295"
+            },
+            "signature_block": "FAVl",
+            "uuid": "c2e3a098-f0a1-4194-a3b9-c8cb5d0f8f59"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/911853"
+                    },
+                    "value": "Mainz U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Fegan, Stuart",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00483788"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-2523-5247"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Johann-Joachim-Becher-Weg 45, D-55099 Mainz, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1403300"
+            },
+            "signature_block": "FAGANs",
+            "uuid": "fdfc4643-95d6-4674-a311-536330dbef0a"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903173"
+                    },
+                    "value": "Ruhr U., Bochum"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Feldbauer, Florian",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446690"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "D-44780 Bochum, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1256800"
+            },
+            "signature_block": "FALDBARf",
+            "uuid": "912502e5-6083-41c4-a0f3-cde6c13cfc51"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902807"
+                    },
+                    "value": "Frascati"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Felici, Giulietto",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00258427"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "INFN Laboratori Nazionali di Frascati, I-00044, Frascati, Italy"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1010199"
+            },
+            "signature_block": "FALACg",
+            "uuid": "c527234c-763a-449a-ae61-7bede351b620"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Feng, Changqing",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446090"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1056375"
+            },
+            "signature_block": "FANGc",
+            "uuid": "e7f90ebf-5c04-4945-bb37-b168d7e4d081"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/905268"
+                    },
+                    "value": "INFN, Ferrara"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Fioravanti, Elisa",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00144561"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "INFN Sezione di Ferrara, I-44122, Ferrara, Italy"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1061016"
+            },
+            "signature_block": "FARAVANTe",
+            "uuid": "b20b4c16-fe5f-43f3-ba9b-2d6fcf7d7cd0"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903173"
+                    },
+                    "value": "Ruhr U., Bochum"
+                }
+            ],
+            "full_name": "Fritsch, Miriam",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "Miriam.Fritsch.1"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "D-44780 Bochum, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1028276"
+            },
+            "signature_block": "FRATSm",
+            "uuid": "93e5f7aa-333e-4e71-a300-529b35ddfd7c"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Fu, Chengdong",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00409932"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-1155-6819"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029209"
+            },
+            "signature_block": "Fc",
+            "uuid": "948bf69a-efec-44af-a7f0-3f33889f9118"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Gao, Qing",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446812"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-3356-9853"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325364"
+            },
+            "signature_block": "Gq",
+            "uuid": "5622fa2a-3ce4-4f89-92fc-5eba3a112724"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Gao, Xinlei",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00454730"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1353581"
+            },
+            "signature_block": "Gx",
+            "uuid": "83a10d76-bcda-442d-b6dc-5bf3984094d5"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904826"
+                    },
+                    "value": "Tsinghua U., Beijing"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Gao, Yuanning",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00257210"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100084, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1008921"
+            },
+            "signature_block": "Gy",
+            "uuid": "ec77ea7a-801b-4e5b-bdfd-bce8a38bc379"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1279835"
+                    },
+                    "value": "CCNU, Wuhan, Inst. Part. Phys."
+                }
+            ],
+            "full_name": "Gao, Yonggui",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "Y.Gao.10"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Wuhan 430079, People's Republic of China"
+                }
+            ],
+            "signature_block": "Gy",
+            "uuid": "7b7e4e44-b6d2-40f5-aaac-f0cb3cd4d6ba"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Gao, Zhen",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00454743"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1353582"
+            },
+            "signature_block": "Gz",
+            "uuid": "aaa0b11a-d9f4-4ac1-979d-ef3ec33fff2a"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/911853"
+                    },
+                    "value": "Mainz U."
+                }
+            ],
+            "full_name": "Garillon, Brice",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "B.Garillon.2"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Johann-Joachim-Becher-Weg 45, D-55099 Mainz, Germany"
+                }
+            ],
+            "signature_block": "GARALANb",
+            "uuid": "150e3b83-169d-4802-99b8-8af5d0947980"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/905268"
+                    },
+                    "value": "INFN, Ferrara"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Garzia, Isabella",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00264053"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "INFN Sezione di Ferrara, I-44122, Ferrara, Italy"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1073313"
+            },
+            "signature_block": "GARSi",
+            "uuid": "4c612ac5-7f46-4fee-99f4-287e272d1464"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903010"
+                    },
+                    "value": "Minnesota U."
+                }
+            ],
+            "full_name": "Gilman, Alexander",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "A.Gilman.2"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Minneapolis, Minnesota 55455, USA"
+                }
+            ],
+            "signature_block": "GALNANa",
+            "uuid": "6f47f4c8-b204-4531-a414-38e7c987624f"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903807"
+                    },
+                    "value": "Darmstadt, GSI"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Goetzen, Klaus",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00043099"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "D-64291 Darmstadt, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1028277"
+            },
+            "signature_block": "GATSANk",
+            "uuid": "f69774c5-3f7c-424d-8149-f1d36dca4655"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/906082"
+                    },
+                    "value": "Nankai U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Gong, Li",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00454755"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Tianjin 300071, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1353583"
+            },
+            "signature_block": "GANGl",
+            "uuid": "e9d0d8a9-85f9-45f6-8584-a7613eea82d8"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Gong, Wenxuan",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00410177"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-1557-4379"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1042596"
+            },
+            "signature_block": "GANGw",
+            "uuid": "c9673307-2818-473a-a30d-78d5ee4b2a10"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/911853"
+                    },
+                    "value": "Mainz U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Gradl, Wolfgang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00060008"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Johann-Joachim-Becher-Weg 45, D-55099 Mainz, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1019274"
+            },
+            "signature_block": "GRADLw",
+            "uuid": "3823341b-de4b-4803-bd3c-a84bd125341d"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903297"
+                    },
+                    "value": "Turin U."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902889"
+                    },
+                    "value": "INFN, Turin"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Greco, Michela",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00204382"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "University of Turin, I-10125, Turin, Italy"
+                },
+                {
+                    "value": "INFN, I-10125, Turin, Italy"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1069910"
+            },
+            "signature_block": "GRACm",
+            "uuid": "810ebf30-b647-49c5-bb74-1bbbb785d1ce"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904118"
+                    },
+                    "value": "Nanjing U."
+                }
+            ],
+            "full_name": "Gu, Limin",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "L.Gu.6"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Nanjing 210093, People's Republic of China"
+                }
+            ],
+            "signature_block": "Gl",
+            "uuid": "bf4b80c2-2b4c-4389-9632-45f8fb3d74a5"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Gu, Minhao",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00408466"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-1823-9496"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1074605"
+            },
+            "signature_block": "Gm",
+            "uuid": "60fd1473-8613-4f9d-894c-8112567b9bba"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904005"
+                    },
+                    "value": "Guangxi U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Gu, Yunting",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00409916"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Nanning 530004, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029212"
+            },
+            "signature_block": "Gy",
+            "uuid": "4c8c2d1f-21b1-4602-9904-0b9866c09905"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Guo, Aiqiang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446828"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1067006"
+            },
+            "signature_block": "Ga",
+            "uuid": "f2a1e33f-7451-461b-8da0-89191ea92e7b"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/905718"
+                    },
+                    "value": "Nanjing Normal U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Guo, Libo",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446832"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Nanjing 210023, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1058463"
+            },
+            "signature_block": "Gl",
+            "uuid": "41b8b4fc-88cd-4a78-b68f-e3654f8f2f5c"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Guo, Rupan",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00459524"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-3785-2859"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1421695"
+            },
+            "signature_block": "Gr",
+            "uuid": "800c19b7-0de5-4fe0-b46b-3f76541ab926"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/911853"
+                    },
+                    "value": "Mainz U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Guo, Yuping",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446850"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-2185-9714"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Johann-Joachim-Becher-Weg 45, D-55099 Mainz, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1067005"
+            },
+            "signature_block": "Gy",
+            "uuid": "521fce48-3d47-4ec5-8990-ec4c09ff7169"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902780"
+                    },
+                    "value": "Dubna, JINR"
+                }
+            ],
+            "full_name": "Guskov, Alexey",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "A.Guskov.2"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "141980 Dubna, Moscow region, Russia"
+                }
+            ],
+            "signature_block": "GASCAVa",
+            "uuid": "321e4869-ce84-4d8b-8952-6bbbff3ecbb2"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904316"
+                    },
+                    "value": "Groningen, KVI"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Haddadi, Zahra",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446864"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "NL-9747 AA Groningen, The Netherlands"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325262"
+            },
+            "signature_block": "HADADz",
+            "uuid": "756cdfa1-8e2f-46d0-bba7-f2e3cdbc5a35"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904858"
+                    },
+                    "value": "Wuhan U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Han, Shuang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446870"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-9082-6487"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Wuhan 430072, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325219"
+            },
+            "signature_block": "HANs",
+            "uuid": "ac54a845-ee33-4a12-8f32-63e51763f80c"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904857"
+                    },
+                    "value": "Henan Normal U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Hao, Xiqing",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00409758"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Xinxiang 453007, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1045389"
+            },
+            "signature_block": "Hx",
+            "uuid": "aaff009f-aace-4374-b0e3-a387e5c6e095"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902838"
+                    },
+                    "value": "Hawaii U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Harris, Frederick A",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00276120"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Honolulu, Hawaii 96822, USA"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1006646"
+            },
+            "signature_block": "HARf",
+            "uuid": "38e4a507-c1bf-4e80-95db-cfe6a8cf1035"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "He, Kanglin",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00204759"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-8930-4825"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029216"
+            },
+            "signature_block": "Hk",
+            "uuid": "bcd0eb30-c8ab-4de7-97dc-42b94317a711"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1386600"
+                    },
+                    "value": "USTL, Anshan"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "He, Xiqin",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00469030"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Anshan 114051, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1427355"
+            },
+            "signature_block": "Hx",
+            "uuid": "089b99d7-2f0a-4cc1-89d7-7343c4ad75ea"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903173"
+                    },
+                    "value": "Ruhr U., Bochum"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Heinsius, Fritz-Herbert",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00089523"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "D-44780 Bochum, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1006295"
+            },
+            "signature_block": "HANSf",
+            "uuid": "f8a4f3e4-a3ff-4cb0-90c6-bdd4f6e51509"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903173"
+                    },
+                    "value": "Ruhr U., Bochum"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Held, Thomas",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00043087"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "D-44780 Bochum, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1028278"
+            },
+            "signature_block": "HALDt",
+            "uuid": "e7d91e07-bbf5-42a6-84e2-b004da7f584e"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Heng, Yuekun",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00409811"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-8483-690X"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029217"
+            },
+            "signature_block": "HANGy",
+            "uuid": "b6c9e1bc-c791-4669-ad66-65becdf6fe8f"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903173"
+                    },
+                    "value": "Ruhr U., Bochum"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Holtmann, Tobias",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00469653"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "D-44780 Bochum, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1422236"
+            },
+            "signature_block": "HALTNANt",
+            "uuid": "dc778561-b4bb-451d-b87f-7d6ace51944b"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Hou, Zhilong",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00408821"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1066963"
+            },
+            "signature_block": "Hz",
+            "uuid": "7cd4b49e-5609-4e2c-a78d-10bccebc442d"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Hu, Haiming",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00388126"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-9958-379X"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1005440"
+            },
+            "signature_block": "Hh",
+            "uuid": "a86aa0e1-be5a-4053-9ed7-aa8d71cc2f89"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904740"
+                    },
+                    "value": "Shanghai Jiaotong U."
+                }
+            ],
+            "full_name": "Hu, Jifeng",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "Ji.Feng.Hu.1"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Shanghai 200240, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1066962"
+            },
+            "signature_block": "Hj",
+            "uuid": "5bf80b7c-e65f-48ee-b9f7-7b2f28524af8"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Hu, Tao",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00374829"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-1620-983X"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1005431"
+            },
+            "signature_block": "Ht",
+            "uuid": "62a92836-078c-490c-99f8-8f66f8927f1b"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Hu, Yu",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00449383"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-2033-381X"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1339662"
+            },
+            "signature_block": "Hy",
+            "uuid": "36162420-c064-4178-aa02-9f13183d2dac"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Huang, Guangshun",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00226675"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029097"
+            },
+            "signature_block": "HANGg",
+            "uuid": "1df3f584-320a-46b6-8bd9-a0aa3aa4e6f8"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904857"
+                    },
+                    "value": "Henan Normal U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Huang, Jinshu",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446902"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Xinxiang 453007, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325599"
+            },
+            "signature_block": "HANGj",
+            "uuid": "8a740642-dca4-480f-95c9-3881949e65ac"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904187"
+                    },
+                    "value": "Shandong U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Huang, Xingtao",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00319779"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Jinan 250100, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029219"
+            },
+            "signature_block": "HANGx",
+            "uuid": "5b9ad1e2-d08a-4be3-a989-791d09f1f3f5"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904118"
+                    },
+                    "value": "Nanjing U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Huang, Xiaozhong",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00459170"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-6617-3807"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Nanjing 210093, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1382377"
+            },
+            "signature_block": "HANGx",
+            "uuid": "6ef2febf-1563-4087-92e9-a8e509b3396c"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/907454"
+                    },
+                    "value": "Liaoning U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Huang, Zhiling",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00469670"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Shenyang 110036, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1422238"
+            },
+            "signature_block": "HANGz",
+            "uuid": "14e8b77c-5f2d-4736-9d3a-a8c88a928f93"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903141"
+                    },
+                    "value": "Punjab U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Hussain, Talab",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446120"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Lahore-54590, Pakistan"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1074596"
+            },
+            "signature_block": "HASANt",
+            "uuid": "a6eefb6b-a93d-4f4f-906d-6e2c1d5cab77"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903314"
+                    },
+                    "value": "Uppsala U."
+                }
+            ],
+            "full_name": "Ikegami Andersson, Walter",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "W.Ikegami.Andersson.2"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Box 516, SE-75120 Uppsala, Sweden"
+                }
+            ],
+            "signature_block": "ANDARSANw",
+            "uuid": "b56735a2-b1aa-4194-a15b-30a2b2423964"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "full_name": "Irshad, Muzaffar",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "M.Irshad.2"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "signature_block": "IRSADm",
+            "uuid": "6444f7a2-d8f9-42d8-9b49-526fcb4d7834"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Ji, Quan",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00408908"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-4391-4390"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1066924"
+            },
+            "signature_block": "Jq",
+            "uuid": "db6c2e78-0af9-4e4d-8ab9-f9e633ef5a14"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904857"
+                    },
+                    "value": "Henan Normal U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Ji, Qingping",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446311"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-6585-6497"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Xinxiang 453007, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1256721"
+            },
+            "signature_block": "Jq",
+            "uuid": "00e0f58b-b7bd-444e-b38d-97cf92d69a37"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Ji, Xiaobin",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00396733"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-6337-5040"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029220"
+            },
+            "signature_block": "Jx",
+            "uuid": "280b6381-96cf-4f1c-9e08-2461a3a2dc8b"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Ji, Xiaolu",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00394069"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-1913-1997"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1066922"
+            },
+            "signature_block": "Jx",
+            "uuid": "db4f01ca-8cf0-45fc-85de-97c0fa95f275"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Jiang, Xiaoshan",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00409782"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-5685-4249"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029221"
+            },
+            "signature_block": "JANGx",
+            "uuid": "73196118-829d-4b3d-87f7-bf8af431fbf4"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/906082"
+                    },
+                    "value": "Nankai U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Jiang, Xingyu",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00449427"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-7004-7718"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Tianjin 300071, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029222"
+            },
+            "signature_block": "JANGx",
+            "uuid": "4ae8b6e2-bb45-47ea-a91a-a5b70d457569"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904187"
+                    },
+                    "value": "Shandong U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Jiao, Jianbin",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446130"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Jinan 250100, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029223"
+            },
+            "signature_block": "Jj",
+            "uuid": "5b0faa43-d573-425b-8409-dc6f023ef7ea"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/912390"
+                    },
+                    "value": "Huangshan U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Jiao, Zheng",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446144"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Huangshan 245000, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1074593"
+            },
+            "signature_block": "Jz",
+            "uuid": "d5192ef3-2c1a-4748-b0dd-eb44e6a8f2e2"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Jin, Dapeng",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00409736"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-3235-9291"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029224"
+            },
+            "signature_block": "JANd",
+            "uuid": "985979cd-aa62-45df-86e4-eb23fe1df21e"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Jin, Shan",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00216225"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-5076-7803"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029225"
+            },
+            "signature_block": "JANs",
+            "uuid": "ed8f318f-6c1c-4d76-8f22-b3a8dfc5d078"
+        },
+        {
+            "full_name": "Jin, Yi",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "Yi.Jin.1"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Jinan 250022, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1392409"
+            },
+            "signature_block": "JANy",
+            "uuid": "a43b8dfd-96fd-44ac-836f-952b590c94e2"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903314"
+                    },
+                    "value": "Uppsala U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Johansson, Tord",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00093582"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Box 516, SE-75120 Uppsala, Sweden"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1004272"
+            },
+            "signature_block": "JANSANt",
+            "uuid": "34bc5d4f-3085-4757-bc3d-157311e0a69b"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903010"
+                    },
+                    "value": "Minnesota U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Julin, Andy",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446924"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Minneapolis, Minnesota 55455, USA"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325241"
+            },
+            "signature_block": "JALANa",
+            "uuid": "82c612eb-33bc-4d07-a915-941e98d8c94b"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904316"
+                    },
+                    "value": "Groningen, KVI"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Kalantar-Nayestanaki, Nasser",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00391323"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "NL-9747 AA Groningen, The Netherlands"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1037342"
+            },
+            "signature_block": "NYASTANACn",
+            "uuid": "831e9bac-acdb-4660-aea0-0fac95bb7869"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/906082"
+                    },
+                    "value": "Nankai U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Kang, Xiaoshen",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446941"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-7293-7116"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Tianjin 300071, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325237"
+            },
+            "signature_block": "CANGx",
+            "uuid": "ebc6273f-3d93-4552-aed6-8133cb2bbd10"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904316"
+                    },
+                    "value": "Groningen, KVI"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Kavatsyuk, Myroslav",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447766"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "NL-9747 AA Groningen, The Netherlands"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1040599"
+            },
+            "signature_block": "CAVATSACm",
+            "uuid": "10a4a207-cad0-4496-89ee-ee3e826229d5"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Ke, Bai-Cian",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446953"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325267"
+            },
+            "signature_block": "Cb",
+            "uuid": "c75f3f62-c5e1-4d0d-8574-ab0632574af0"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "full_name": "Khan, Tabassum",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "T.Khan.2"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "signature_block": "CANt",
+            "uuid": "7ecf3c0b-2d9e-485d-ba3c-aa5486d774c7"
+        },
+        {
+            "full_name": "Khoukaz, Alfons",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "A.Khoukaz.2"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Wilhelm-Klemm-Str. 9, 48149 Muenster, Germany"
+                }
+            ],
+            "signature_block": "CACa",
+            "uuid": "a557c0af-b844-4fb0-9f98-56084a8cb648"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/911853"
+                    },
+                    "value": "Mainz U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Kiese, Patric",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00389358"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Johann-Joachim-Becher-Weg 45, D-55099 Mainz, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1266875"
+            },
+            "signature_block": "CASp",
+            "uuid": "b2cd2423-29ea-45f5-a36a-f15b77aa335e"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903807"
+                    },
+                    "value": "Darmstadt, GSI"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Kliemt, Ralf",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00518707"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "D-64291 Darmstadt, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1369285"
+            },
+            "signature_block": "CLANTr",
+            "uuid": "f4ab6873-ea2f-41be-a6f5-28cb5abb0427"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903384"
+                    },
+                    "value": "Giessen U."
+                }
+            ],
+            "full_name": "Koch, Leonard",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "L.Koch.1"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "II. Physikalisches Institut, Heinrich-Buff-Ring 16, D-35392 Giessen, Germany"
+                }
+            ],
+            "signature_block": "CACHl",
+            "uuid": "963b8162-739e-4694-a032-69f83f4252f6"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1392572"
+                    },
+                    "value": "Istanbul Bilgi U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Kolcu, Onur Bugra",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446977"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Istanbul Bilgi University, 34060 Eyup, Istanbul, Turkey"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325266"
+            },
+            "signature_block": "CALCo",
+            "uuid": "6071b45e-5b12-4c86-90cf-4ba864f9f12d"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903173"
+                    },
+                    "value": "Ruhr U., Bochum"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Kopf, Bertram",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447750"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "D-44780 Bochum, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1049286"
+            },
+            "signature_block": "CAPFb",
+            "uuid": "c775bec0-af9d-40da-8402-36289848ce28"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902838"
+                    },
+                    "value": "Hawaii U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Kornicer, Mihajlo",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446156"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Honolulu, Hawaii 96822, USA"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1061243"
+            },
+            "signature_block": "CARNACARm",
+            "uuid": "640dba1c-552c-41e4-ac82-6690726cafcf"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903173"
+                    },
+                    "value": "Ruhr U., Bochum"
+                }
+            ],
+            "full_name": "Kuemmel, Miriam",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "M.Kuemmel.2"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "D-44780 Bochum, Germany"
+                }
+            ],
+            "signature_block": "CANALm",
+            "uuid": "28e2ae0e-0749-43d0-b1df-0b20ce6187c4"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903173"
+                    },
+                    "value": "Ruhr U., Bochum"
+                }
+            ],
+            "full_name": "Kuessner, Meike",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "M.Kuessner.1"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "D-44780 Bochum, Germany"
+                }
+            ],
+            "signature_block": "CASNARm",
+            "uuid": "2f62a7fc-8148-4bbe-8b2e-e77b394a5c40"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903314"
+                    },
+                    "value": "Uppsala U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Kupsc, Andrzej",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446160"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Box 516, SE-75120 Uppsala, Sweden"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1001518"
+            },
+            "signature_block": "CAPSCa",
+            "uuid": "f0945682-edbd-46e8-9f5f-64d347ac992b"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "full_name": "Kurth, Matt",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "M.Kurth.3"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "signature_block": "CARTHm",
+            "uuid": "11f95320-2eea-4ccf-8f64-5baad2099a70"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903384"
+                    },
+                    "value": "Giessen U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "K\\\"uhn, Wolfgang Kuehn",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00175151"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "II. Physikalisches Institut, Heinrich-Buff-Ring 16, D-35392 Giessen, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1001634"
+            },
+            "signature_block": "Cw",
+            "uuid": "3e91ec46-d342-4e58-8049-9f44b105c267"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903384"
+                    },
+                    "value": "Giessen U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Lange, Jens Soeren",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00401180"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "II. Physikalisches Institut, Heinrich-Buff-Ring 16, D-35392 Giessen, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1280005"
+            },
+            "signature_block": "LANGj",
+            "uuid": "0cdb5c38-b311-4c11-ab61-a974234f7f10"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902874"
+                    },
+                    "value": "Indiana U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Lara, Manuel",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446171"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Bloomington, Indiana 47405, USA"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1261590"
+            },
+            "signature_block": "LARm",
+            "uuid": "c51f1404-73e1-4db3-97cf-ac8b68b4db39"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/912519"
+                    },
+                    "value": "Helmholtz Inst., Mainz"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Larin, Paul",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446183"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Johann-Joachim-Becher-Weg 45, D-55099 Mainz, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1256722"
+            },
+            "signature_block": "LARANp",
+            "uuid": "269eb9d7-d7f2-43ba-8d6f-68624d0fd223"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902889"
+                    },
+                    "value": "INFN, Turin"
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "full_name": "Lavezzi, Lia",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "L.Lavezzi.2"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "INFN, I-10125, Turin, Italy"
+                },
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "signature_block": "LAVASl",
+            "uuid": "2b7b85db-dc33-4f47-b45f-47be8e67fc04"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903173"
+                    },
+                    "value": "Ruhr U., Bochum"
+                }
+            ],
+            "full_name": "Leiber, Stefan",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "S.Leiber.2"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "D-44780 Bochum, Germany"
+                }
+            ],
+            "signature_block": "LABARs",
+            "uuid": "caade813-36dc-4b19-bb43-3305e987c4b8"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/911853"
+                    },
+                    "value": "Mainz U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Leithoff, Heinrich",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00469731"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Johann-Joachim-Becher-Weg 45, D-55099 Mainz, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1423257"
+            },
+            "signature_block": "LATAFh",
+            "uuid": "fd09cd1e-bfb3-43ed-8e25-63b8bce223d4"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903314"
+                    },
+                    "value": "Uppsala U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Li, Cui",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446990"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Box 516, SE-75120 Uppsala, Sweden"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325256"
+            },
+            "signature_block": "Lc",
+            "uuid": "475cce4b-9361-47f0-afe1-092c88b9226a"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Li, Cheng",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00182265"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1065808"
+            },
+            "signature_block": "Lc",
+            "uuid": "5a4d7d3b-c3c7-4d91-992f-a170a3a52a0c"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904424"
+                    },
+                    "value": "Zhengzhou U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Li, Demin",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00436791"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Zhengzhou 450001, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1000369"
+            },
+            "signature_block": "Ld",
+            "uuid": "08847ed4-0345-4b34-be31-8bdccbe655b0"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Li, Fei",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447641"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-7427-0730"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1326091"
+            },
+            "signature_block": "Lf",
+            "uuid": "6fb0582b-2110-45ad-beb8-cda783302dea"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1238006"
+                    },
+                    "value": "Peking U., Beijing"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Li, Fengyun",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00467627"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100871, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1415319"
+            },
+            "signature_block": "Lf",
+            "uuid": "a3d815a8-7f31-4475-a195-dae88d0dc792"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Li, Gang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00240095"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-2207-8832"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1044783"
+            },
+            "signature_block": "Lg",
+            "uuid": "da6fd1d0-7be4-420a-92e2-1efc0d562026"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Li, Haibo",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00101560"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-6940-8093"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1000363"
+            },
+            "signature_block": "Lh",
+            "uuid": "38ee6137-b0eb-4bb3-8455-41e1ebab2f1d"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Li, Huijing",
+            "ids": [
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-9275-4739"
+                },
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "Hui.Jing.Li.1"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1340356"
+            },
+            "signature_block": "Lh",
+            "uuid": "93a5f078-ac1c-464d-9730-6bcf2f633ad1"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Li, Jiacai",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447005"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1327681"
+            },
+            "signature_block": "Lj",
+            "uuid": "1c0625bf-f433-42ac-9cc7-fe38f83651f2"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904407"
+                    },
+                    "value": "Suzhou, Soochow U."
+                }
+            ],
+            "full_name": "Li, Jingwen",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "J.Li.47"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Suzhou 215006, People's Republic of China"
+                }
+            ],
+            "signature_block": "Lj",
+            "uuid": "8fd96641-15da-40a2-8b64-1dd086398b28"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1283410"
+                    },
+                    "value": "SYSU, Guangzhou"
+                }
+            ],
+            "full_name": "Li, Kaijie",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "K.Li.8"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Guangzhou 510275, People's Republic of China"
+                }
+            ],
+            "signature_block": "Lk",
+            "uuid": "ed9ffe70-6402-4951-b872-cf152ec022ba"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904986"
+                    },
+                    "value": "Hangzhou Normal U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Li, Kang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447021"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hangzhou 310036, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325261"
+            },
+            "signature_block": "Lk",
+            "uuid": "c96a27e1-a93e-4c4a-89ba-bbdccbf6fc5a"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Li, Ke",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447015"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325229"
+            },
+            "signature_block": "Lk",
+            "uuid": "03128326-b5d3-4d57-b9c5-adf4399c4c6c"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/911225"
+                    },
+                    "value": "Beijing Inst. Petrochem. Tech."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Li, Lei",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00358161"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 102617, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1190386"
+            },
+            "signature_block": "Ll",
+            "uuid": "fa9db6ae-e58c-4dc6-9f1b-0aed73ccddf5"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Li, Peilian",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00637566"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1496345"
+            },
+            "signature_block": "Lp",
+            "uuid": "2e7c9484-3e48-4f3f-aa52-5906c4e11894"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/905335"
+                    },
+                    "value": "CCAST World Lab, Beijing"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Li, Peirong",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00450012"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-1603-3646"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100190, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1340425"
+            },
+            "signature_block": "Lp",
+            "uuid": "37d5a6a9-e7a3-49f9-9203-fa506f7fb484"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904187"
+                    },
+                    "value": "Shandong U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Li, Qiyun",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00450029"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Jinan 250100, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1340426"
+            },
+            "signature_block": "Lq",
+            "uuid": "0a4073ad-3d38-47c7-8e34-d49919e26739"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904187"
+                    },
+                    "value": "Shandong U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Li, Teng",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447037"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Jinan 250100, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325230"
+            },
+            "signature_block": "Lt",
+            "uuid": "d1011d48-8a10-4331-b8d3-7407973f8f0e"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Li, Weidong",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00395587"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-0633-4346"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029230"
+            },
+            "signature_block": "Lw",
+            "uuid": "e4271e7a-d0ae-41e1-882e-11933189befe"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Li, Weiguo",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00164381"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-4836-712X"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1000330"
+            },
+            "signature_block": "Lw",
+            "uuid": "c0263a50-0498-4228-a771-0ac72af81c21"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904187"
+                    },
+                    "value": "Shandong U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Li, Xiaoling",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00387788"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Jinan 250100, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029231"
+            },
+            "signature_block": "Lx",
+            "uuid": "cba1cdbc-2ee9-4a81-8dbb-31213a9f2784"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Li, Xiaonan",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00409563"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-2857-0219"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1000326"
+            },
+            "signature_block": "Lx",
+            "uuid": "fdf0f59c-25e6-4e40-8ed2-ff2e33fe08ff"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/906082"
+                    },
+                    "value": "Nankai U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Li, Xue-Qian",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00101628"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Tianjin 300071, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1000322"
+            },
+            "signature_block": "Lx",
+            "uuid": "858ecdb5-037d-49dc-835f-90c6b890d052"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1283410"
+                    },
+                    "value": "SYSU, Guangzhou"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Li, Zhibing",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446205"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Guangzhou 510275, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1066801"
+            },
+            "signature_block": "Lz",
+            "uuid": "32487fc4-ad9b-4bfb-b102-8c13465c56d9"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Liang, Hao",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447046"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325257"
+            },
+            "signature_block": "LANGh",
+            "uuid": "05727cf1-2bf3-4e0a-8bdc-beb2c091eeae"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904226"
+                    },
+                    "value": "Sichuan U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Liang, Yongfei",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00411357"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Chengdu 610064, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029233"
+            },
+            "signature_block": "LANGy",
+            "uuid": "245028c6-b901-4d97-9ff4-74062ca6aec9"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903384"
+                    },
+                    "value": "Giessen U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Liang, Yutie",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446218"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "II. Physikalisches Institut, Heinrich-Buff-Ring 16, D-35392 Giessen, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1066799"
+            },
+            "signature_block": "LANGy",
+            "uuid": "5594b107-e15a-45f9-b3c6-35bb9c7def11"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904983"
+                    },
+                    "value": "Guangxi Normal U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Liao, Guangrui",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00449414"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-7683-8799"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Guilin 541004, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1066798"
+            },
+            "signature_block": "Lg",
+            "uuid": "41c87c7d-e0be-42ba-8c2e-28116f7b70d8"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "full_name": "Liao, Longzhou",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "L.Liao.3"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "signature_block": "Ll",
+            "uuid": "152d6718-caa2-49dc-9f71-f57d4f8dd534"
+        },
+        {
+            "full_name": "Libby, Jim",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "J.Libby.1"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Chennai 600036, India"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1000294"
+            },
+            "signature_block": "LABYj",
+            "uuid": "17d146a9-a33a-47b1-8f38-e0fab3df8c67"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1283410"
+                    },
+                    "value": "SYSU, Guangzhou"
+                }
+            ],
+            "full_name": "Lin, Chuangxin",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "C.Lin.1"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Guangzhou 510275, People's Republic of China"
+                }
+            ],
+            "signature_block": "LANc",
+            "uuid": "ff9a14a1-362f-4779-ab1c-1e2d35c7b586"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/912519"
+                    },
+                    "value": "Helmholtz Inst., Mainz"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Lin, Dexu",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447051"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Johann-Joachim-Becher-Weg 45, D-55099 Mainz, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325243"
+            },
+            "signature_block": "LANd",
+            "uuid": "edc7fa8c-84c9-4444-8309-2177b360729d"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904740"
+                    },
+                    "value": "Shanghai Jiaotong U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Liu, Bing",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00469744"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Shanghai 200240, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1423258"
+            },
+            "signature_block": "Lb",
+            "uuid": "12a172b3-19ac-40db-a791-444f2c1a83c5"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Liu, Beijiang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00409714"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-9664-5230"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1247300"
+            },
+            "signature_block": "Lb",
+            "uuid": "ad7cad43-0def-4ac2-9e97-448ac3d43fca"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Liu, Chunxiu",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00387526"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-6781-148X"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029236"
+            },
+            "signature_block": "Lc",
+            "uuid": "0857a8d4-39e5-4be8-9f3f-55eca0a03f8a"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Liu, Dong",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00467674"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1415622"
+            },
+            "signature_block": "Ld",
+            "uuid": "e616586b-f5bc-4933-b481-eaeec9270d90"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904740"
+                    },
+                    "value": "Shanghai Jiaotong U."
+                }
+            ],
+            "full_name": "Liu, Dianyu",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "D.Liu.20"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Shanghai 200240, People's Republic of China"
+                }
+            ],
+            "signature_block": "Ld",
+            "uuid": "291f9fa0-49ca-4f8a-8451-830e3a35e22f"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904654"
+                    },
+                    "value": "Shanxi U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Liu, Fuhu",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00280294"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Taiyuan 030006, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1340974"
+            },
+            "signature_block": "Lf",
+            "uuid": "c2c1852c-5479-4d6a-9694-816bac38824f"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Liu, Fang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00392159"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-8072-0926"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1247093"
+            },
+            "signature_block": "Lf",
+            "uuid": "a3c31ccf-2584-42c6-b360-e274e251b9a7"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1279835"
+                    },
+                    "value": "CCNU, Wuhan, Inst. Part. Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Liu, Feng",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00182357"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Wuhan 430079, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1065814"
+            },
+            "signature_block": "Lf",
+            "uuid": "c1a61922-1467-4824-aa13-6784f310fbc4"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904005"
+                    },
+                    "value": "Guangxi U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Liu, Hongbang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446220"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Nanning 530004, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1057528"
+            },
+            "signature_block": "Lh",
+            "uuid": "d97a18fb-cb6b-4dec-9008-abcb68f9975f"
+        },
+        {
+            "full_name": "Liu, Hengjun",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "H.Liu.1"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Nanjing 211100, People's Republic of China"
+                }
+            ],
+            "signature_block": "Lh",
+            "uuid": "eb9b28fe-1bcd-4990-ba34-f545095560eb"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Liu, Huaimin",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00040117"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-9975-2602"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029237"
+            },
+            "signature_block": "Lh",
+            "uuid": "6756192c-1ba0-49a3-ad8b-8412066c425f"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Liu, Huanhuan",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00450248"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-6658-1993"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1344723"
+            },
+            "signature_block": "Lh",
+            "uuid": "4474e3a9-4bd4-4206-a628-fa125030948c"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/911257"
+                    },
+                    "value": "Henan U. Sci. Technol."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Liu, Huihui",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447060"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Luoyang 471003, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325255"
+            },
+            "signature_block": "Lh",
+            "uuid": "1b6c0e97-ddda-4adf-92ad-b49e40dd5c2c"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Liu, Jianbei",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00219262"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1070889"
+            },
+            "signature_block": "Lj",
+            "uuid": "ec680adf-29fb-4007-9c71-cef3fe014318"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Liu, Jingyi",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00450260"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-6650-5496"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1344817"
+            },
+            "signature_block": "Lj",
+            "uuid": "4bf56a29-aa8a-4fce-a9b0-d11aa7ad9d4f"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904826"
+                    },
+                    "value": "Tsinghua U., Beijing"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Liu, Kai",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447658"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100084, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325227"
+            },
+            "signature_block": "Lk",
+            "uuid": "e20e0be5-1271-4713-8d05-cf8adc383981"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/907454"
+                    },
+                    "value": "Liaoning U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Liu, Kuiyong",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447099"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Shenyang 110036, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1025154"
+            },
+            "signature_block": "Lk",
+            "uuid": "6227c3dc-8c8e-4f07-bca2-766eb54b0737"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1279835"
+                    },
+                    "value": "CCNU, Wuhan, Inst. Part. Phys."
+                }
+            ],
+            "full_name": "Liu, Ke",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "K.Liu.2"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Wuhan 430079, People's Republic of China"
+                }
+            ],
+            "signature_block": "Lk",
+            "uuid": "b55fee15-8cac-403d-9584-f39a986f81f5"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1238006"
+                    },
+                    "value": "Peking U., Beijing"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Liu, Landiao",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00450287"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100871, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1344823"
+            },
+            "signature_block": "Ll",
+            "uuid": "38d8b310-14b8-4889-b904-ab05ac7a1344"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Liu, Qian",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447100"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325268"
+            },
+            "signature_block": "Lq",
+            "uuid": "d4740613-93de-4f1c-ac6d-08b29bf6784e"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Liu, Shubin",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446231"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1056376"
+            },
+            "signature_block": "Ls",
+            "uuid": "db266138-b1e8-4730-b20f-b4128a05c9b9"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904070"
+                    },
+                    "value": "Lanzhou U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Liu, Xiang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00037883"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-7481-4662"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Lanzhou 730000, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1031755"
+            },
+            "signature_block": "Lx",
+            "uuid": "178e88c0-50fb-4495-ac5b-913e6b1c520b"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/906082"
+                    },
+                    "value": "Nankai U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Liu, Yu-Bin",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00369009"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Tianjin 300071, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/999983"
+            },
+            "signature_block": "Ly",
+            "uuid": "bf770464-c445-4342-945f-1fc19ddc45fb"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Liu, Zhenan",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00001465"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-2896-1386"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1060053"
+            },
+            "signature_block": "Lz",
+            "uuid": "4631307d-2fc1-4ecd-b631-abcd5c198e77"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/911853"
+                    },
+                    "value": "Mainz U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Liu, Zhiqing",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00368710"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Johann-Joachim-Becher-Weg 45, D-55099 Mainz, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1060325"
+            },
+            "signature_block": "Lz",
+            "uuid": "242fe5da-7f50-4829-85cf-929c23195244"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1238006"
+                    },
+                    "value": "Peking U., Beijing"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Long, Yunfei",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00625897"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100871, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1471568"
+            },
+            "signature_block": "LANGy",
+            "uuid": "7343b925-839c-417c-952a-aeacd9addda6"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Lou, Xinchou",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00102733"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-0867-2189"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/999766"
+            },
+            "signature_block": "Lx",
+            "uuid": "5a10c746-2179-40c6-9c8f-2b71e0159dcd"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/912390"
+                    },
+                    "value": "Huangshan U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Lu, Hai-jiang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00449787"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Huangshan 245000, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1072413"
+            },
+            "signature_block": "Lh",
+            "uuid": "ad5849c1-6f1d-40fd-b85c-d6ab01b6e4ff"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Lu, Junguang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00387407"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-9566-5328"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029242"
+            },
+            "signature_block": "Lj",
+            "uuid": "f1838b29-dd4d-4bfc-8f47-31b49eff8014"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Lu, Yu",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446250"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-4416-6961"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/999677"
+            },
+            "signature_block": "Ly",
+            "uuid": "ef629443-2c85-4aab-bd6b-9c70b9042f23"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Lu, Yunpeng",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00409170"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-9070-5458"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1066780"
+            },
+            "signature_block": "Ly",
+            "uuid": "529b9ffc-3ab8-43c1-9880-ad00491d9117"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/905718"
+                    },
+                    "value": "Nanjing Normal U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Luo, Chenglin",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447140"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Nanjing 210023, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029243"
+            },
+            "signature_block": "Lc",
+            "uuid": "4880d3da-d611-4d45-9ce8-78a6b4088ba5"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904836"
+                    },
+                    "value": "Zhejiang U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Luo, Mingxing",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00228415"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hangzhou 310027, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/999547"
+            },
+            "signature_block": "Lm",
+            "uuid": "9d766e89-5ddf-4a2b-8bff-7738274459da"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Luo, Xiaolan",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00410023"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-2126-2862"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1042600"
+            },
+            "signature_block": "Lx",
+            "uuid": "5ae160f2-17f5-4e0a-b50a-975ab221fd35"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902889"
+                    },
+                    "value": "INFN, Turin"
+                }
+            ],
+            "full_name": "Lusso, Stefano",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "S.Lusso.2"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "INFN, I-10125, Turin, Italy"
+                }
+            ],
+            "signature_block": "LASs",
+            "uuid": "836757ed-8694-4e6d-8ccb-75c2208b3af8"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Lyu, Xiao-Rui",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00385243"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1066781"
+            },
+            "signature_block": "Lx",
+            "uuid": "988d5e59-8b6d-4061-836e-3ff02d7cbf44"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/907454"
+                    },
+                    "value": "Liaoning U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Ma, Fengcai",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447152"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Shenyang 110036, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029244"
+            },
+            "signature_block": "Mf",
+            "uuid": "c43ae12b-b4f8-49f2-bb0c-e69910c199cc"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Ma, Hailong",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00387242"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-9771-2802"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029245"
+            },
+            "signature_block": "Mh",
+            "uuid": "f3a181c7-df72-4760-bcd9-1279dc07f940"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904187"
+                    },
+                    "value": "Shandong U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Ma, Lianliang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00219535"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Jinan 250100, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1355155"
+            },
+            "signature_block": "Ml",
+            "uuid": "097f2804-2fd0-4186-9b52-925f123cd1c7"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Ma, Mingming",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00454830"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-0705-8745"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1355156"
+            },
+            "signature_block": "Mm",
+            "uuid": "e38ac727-8e45-43d8-a7e1-b34835d7ea84"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Ma, Qiumei",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00387084"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-3829-7044"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029247"
+            },
+            "signature_block": "Mq",
+            "uuid": "b5ee5b24-753a-4328-8b92-129a09476c80"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/906082"
+                    },
+                    "value": "Nankai U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Ma, Xuning",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00454840"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-2735-1244"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Tianjin 300071, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1355158"
+            },
+            "signature_block": "Mx",
+            "uuid": "dd16677a-9ada-415d-a4e0-fced19fd8880"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Ma, Xiaoyan",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00409988"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-9113-1476"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1042601"
+            },
+            "signature_block": "Mx",
+            "uuid": "e4be5fb3-fe35-49ec-b065-26b500efeed0"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904187"
+                    },
+                    "value": "Shandong U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Ma, YuMing",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00454857"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Jinan 250100, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1355159"
+            },
+            "signature_block": "My",
+            "uuid": "1948e4e0-9a64-4646-b24e-d0dd3f60c9d3"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/912519"
+                    },
+                    "value": "Helmholtz Inst., Mainz"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Maas, Frank",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00353660"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Johann-Joachim-Becher-Weg 45, D-55099 Mainz, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/999429"
+            },
+            "signature_block": "Mf",
+            "uuid": "4a47d68c-69b3-437b-a3d5-833b0efb4876"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903297"
+                    },
+                    "value": "Turin U."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902889"
+                    },
+                    "value": "INFN, Turin"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Maggiora, Marco",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00368057"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "University of Turin, I-10125, Turin, Italy"
+                },
+                {
+                    "value": "INFN, I-10125, Turin, Italy"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1043520"
+            },
+            "signature_block": "MAGARm",
+            "uuid": "b3ec029d-8499-4ea2-a2c9-2f46978950e0"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903141"
+                    },
+                    "value": "Punjab U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Malik, Qadeer Afzal",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446284"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Lahore-54590, Pakistan"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1057529"
+            },
+            "signature_block": "MALACq",
+            "uuid": "9ea36583-2c97-4372-81c8-001c1ca832a2"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904144"
+                    },
+                    "value": "Perugia U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Mangoni, Alessio",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "A.Mangoni.1"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "INFN and University of Perugia, I-06100, Perugia, Italy"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1498215"
+            },
+            "signature_block": "MANGANa",
+            "uuid": "d4a73876-4153-4ab2-aa20-402f93ecb227"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1238006"
+                    },
+                    "value": "Peking U., Beijing"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Mao, Yajun",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00170086"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100871, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1057627"
+            },
+            "signature_block": "My",
+            "uuid": "5f48a81b-572f-4f99-9c1d-cae54ddcf844"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Mao, Zepu",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00362616"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029249"
+            },
+            "signature_block": "Mz",
+            "uuid": "70738351-07f0-46d7-a8c6-66b2cced7323"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903297"
+                    },
+                    "value": "Turin U."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902889"
+                    },
+                    "value": "INFN, Turin"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Marcello, Simonetta",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446320"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "University of Turin, I-10125, Turin, Italy"
+                },
+                {
+                    "value": "INFN, I-10125, Turin, Italy"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/998866"
+            },
+            "signature_block": "MARCALs",
+            "uuid": "f87e4872-e00c-4c27-a90d-05fa5d324fdb"
+        },
+        {
+            "full_name": "Meng, Zhaoxiao",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "Zhao.Xiao.Meng.1"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Jinan 250022, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1426162"
+            },
+            "signature_block": "MANGz",
+            "uuid": "3afb6cad-6df8-4938-b6e9-ba8cf03256b1"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904316"
+                    },
+                    "value": "Groningen, KVI"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Messchendorp, Johan",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00396767"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "NL-9747 AA Groningen, The Netherlands"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1040858"
+            },
+            "signature_block": "MASANDARPj",
+            "uuid": "36e0959b-ad41-438a-a49c-323a451b6cad"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/905268"
+                    },
+                    "value": "INFN, Ferrara"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Mezzadri, Giulio",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00469751"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-0838-9631"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "INFN Sezione di Ferrara, I-44122, Ferrara, Italy"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1423323"
+            },
+            "signature_block": "MASADRg",
+            "uuid": "9722c099-d9ff-49ae-87b7-10fe4b4637ad"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Min, Jian",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447181"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-5700-5900"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1326095"
+            },
+            "signature_block": "MANj",
+            "uuid": "f2e5ad1f-b66a-4feb-a43f-ea7f4a89c174"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Min, Tianjue",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446270"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-2016-4849"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1256728"
+            },
+            "signature_block": "MANt",
+            "uuid": "9f48b013-e2cd-46a7-bf3e-995520f88cd1"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902874"
+                    },
+                    "value": "Indiana U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Mitchell, Ryan",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00271895"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Bloomington, Indiana 47405, USA"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1021321"
+            },
+            "signature_block": "MATCALr",
+            "uuid": "2f9324cf-48e6-4a2d-a143-620dc5e89724"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Mo, Xiaohu",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00386942"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-2543-7236"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029250"
+            },
+            "signature_block": "Mx",
+            "uuid": "e18025a8-0906-4bd2-8940-3149ebe30969"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1279835"
+                    },
+                    "value": "CCNU, Wuhan, Inst. Part. Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Mo, Yujin",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447197"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Wuhan 430079, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325252"
+            },
+            "signature_block": "My",
+            "uuid": "7373db7e-f9df-4dbd-9907-131446b5f4b9"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/912519"
+                    },
+                    "value": "Helmholtz Inst., Mainz"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Morales Morales, Cristina",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00387364"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Johann-Joachim-Becher-Weg 45, D-55099 Mainz, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1049338"
+            },
+            "signature_block": "MARALc",
+            "uuid": "709bb9f5-bb0f-4ab9-acbc-a4945f07fd92"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902807"
+                    },
+                    "value": "Frascati"
+                }
+            ],
+            "full_name": "Morello, Gianfranco",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "G.Morello.2"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "INFN Laboratori Nazionali di Frascati, I-00044, Frascati, Italy"
+                }
+            ],
+            "signature_block": "MARALg",
+            "uuid": "01b7d80a-9568-46a3-a76a-95ad2bf28944"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903088"
+                    },
+                    "value": "Novosibirsk, IYF"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Muchnoi, Nikolai Yu",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00374359"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Novosibirsk 630090, Russia"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1056645"
+            },
+            "signature_block": "MACHNn",
+            "uuid": "57527973-c626-4b19-b0aa-5ca5b2e19ca8"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903010"
+                    },
+                    "value": "Minnesota U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Muramatsu, Hajime",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00048850"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Minneapolis, Minnesota 55455, USA"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1023601"
+            },
+            "signature_block": "MARANATSh",
+            "uuid": "dcaaf981-2252-44c6-9ab3-3cca9dc3c16f"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903173"
+                    },
+                    "value": "Ruhr U., Bochum"
+                }
+            ],
+            "full_name": "Mustafa, Arber",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "A.Mustafa.2"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "D-44780 Bochum, Germany"
+                }
+            ],
+            "signature_block": "MASTAFa",
+            "uuid": "ad3e9517-d104-4bf3-8a2f-aa541e039dc5"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903807"
+                    },
+                    "value": "Darmstadt, GSI"
+                }
+            ],
+            "full_name": "Nakhoul, Simon",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "S.Nakhoul.2"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "D-64291 Darmstadt, Germany"
+                }
+            ],
+            "signature_block": "NACALs",
+            "uuid": "d331143a-b5b2-45b4-a7ed-975a2cc50443"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902780"
+                    },
+                    "value": "Dubna, JINR"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Nefedov, Yury",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00110745"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "141980 Dubna, Moscow region, Russia"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/995935"
+            },
+            "signature_block": "NAFADAVy",
+            "uuid": "4702de7a-c279-48d7-9049-953d776977d7"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903807"
+                    },
+                    "value": "Darmstadt, GSI"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Nerling, Frank",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00152473"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "D-64291 Darmstadt, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1044932"
+            },
+            "signature_block": "NARLANGf",
+            "uuid": "1a130655-e57f-4391-aa7e-3da14de6adc0"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903088"
+                    },
+                    "value": "Novosibirsk, IYF"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Nikolaev, Ivan",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00013481"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Novosibirsk 630090, Russia"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1054680"
+            },
+            "signature_block": "NACALAFi",
+            "uuid": "cc8d91d3-6654-4a93-8e17-78df38c8a8c3"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Ning, Zhe",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00409462"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-4884-5251"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1249426"
+            },
+            "signature_block": "NANGz",
+            "uuid": "016dfbea-c6c6-4253-9451-3f61eb4cbcb7"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1338296"
+                    },
+                    "value": "COMSATS, Lahore"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Nisar, Shabana",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00040279"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Defence Road, Off Raiwind Road, 54000 Lahore, Pakistan"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029075"
+            },
+            "signature_block": "NASARs",
+            "uuid": "51db6a09-cbaf-4e85-a6a8-d9cc2ae71fe0"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Niu, Shunli",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447209"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-2291-9053"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1327534"
+            },
+            "signature_block": "Ns",
+            "uuid": "5fb27f52-c254-461a-bf53-a5f21ac994af"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Niu, Xunyi",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447636"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-5078-6871"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1328119"
+            },
+            "signature_block": "Nx",
+            "uuid": "b0cc9e89-5dc0-46fd-9a5b-0db4aecf29c1"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903193"
+                    },
+                    "value": "Seoul Natl. U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Olsen, Stephen L",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00113094"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Seoul, 151-747 Korea"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/994903"
+            },
+            "signature_block": "OLSANs",
+            "uuid": "abddb9ec-08f0-440d-85f4-3042a85f277c"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Ouyang, Qun OuYang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00221456"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-8186-0082"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/994630"
+            },
+            "signature_block": "OYANGq",
+            "uuid": "13751c2d-8f3a-4624-8bf6-933a83687f25"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904144"
+                    },
+                    "value": "Perugia U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Pacetti, Simone",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00113782"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "INFN and University of Perugia, I-06100, Perugia, Italy"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/994549"
+            },
+            "signature_block": "PACATs",
+            "uuid": "1a456811-992c-47b5-bb7c-0a346d0f2a1d"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Pan, Yue",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00455520"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1355265"
+            },
+            "signature_block": "PANy",
+            "uuid": "ddadf142-02ca-4892-83f1-1eee6eb3516d"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903314"
+                    },
+                    "value": "Uppsala U."
+                }
+            ],
+            "full_name": "Papenbrock, Michael",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "M.Papenbrock.2"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Box 516, SE-75120 Uppsala, Sweden"
+                }
+            ],
+            "signature_block": "PAPANBRACm",
+            "uuid": "ecc990c5-9f1d-4894-8627-cbe605e3d11c"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902807"
+                    },
+                    "value": "Frascati"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Patteri, Piero",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00115106"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "INFN Laboratori Nazionali di Frascati, I-00044, Frascati, Italy"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/994055"
+            },
+            "signature_block": "PATARp",
+            "uuid": "3386bf23-20c0-4d0e-b2d0-cbab03069e02"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903173"
+                    },
+                    "value": "Ruhr U., Bochum"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Pelizaeus, Marc",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00043075"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "D-44780 Bochum, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1028279"
+            },
+            "signature_block": "PALASm",
+            "uuid": "c7650f27-a081-4fda-a478-61033c6bb549"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903297"
+                    },
+                    "value": "Turin U."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902889"
+                    },
+                    "value": "INFN, Turin"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Pellegrino, Jacopo",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00547535"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "University of Turin, I-10125, Turin, Italy"
+                },
+                {
+                    "value": "INFN, I-10125, Turin, Italy"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1417351"
+            },
+            "signature_block": "PALAGRANj",
+            "uuid": "e27366f1-aedb-4d1d-b524-2208688a1328"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Peng, Haiping",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00217635"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029252"
+            },
+            "signature_block": "PANGh",
+            "uuid": "8de11bf1-e5b6-46f9-b731-721ebdb5101e"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904005"
+                    },
+                    "value": "Guangxi U."
+                }
+            ],
+            "full_name": "Peng, Zhiyuan",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "Z.Peng.1"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Nanning 530004, People's Republic of China"
+                }
+            ],
+            "signature_block": "PANGz",
+            "uuid": "bbeb1463-cf7a-410c-aa05-143ad2ec863b"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903807"
+                    },
+                    "value": "Darmstadt, GSI"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Peters, Klaus",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00115920"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "D-64291 Darmstadt, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/993642"
+            },
+            "signature_block": "PATARk",
+            "uuid": "22c02b9c-e818-4780-bd0a-155993554246"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903314"
+                    },
+                    "value": "Uppsala U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Pettersson, Joachim",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00469773"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Box 516, SE-75120 Uppsala, Sweden"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1423328"
+            },
+            "signature_block": "PATARSANj",
+            "uuid": "10486018-c923-42a0-b496-c320e7da4fda"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/905718"
+                    },
+                    "value": "Nanjing Normal U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Ping, Jialun",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00342950"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Nanjing 210023, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/993319"
+            },
+            "signature_block": "PANGj",
+            "uuid": "91789343-cf60-4897-8da0-1f9cc9f43931"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Ping, Ronggang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00409726"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1247094"
+            },
+            "signature_block": "PANGr",
+            "uuid": "50e0faf2-ad7b-4acd-b76a-aa83457de0ed"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903173"
+                    },
+                    "value": "Ruhr U., Bochum"
+                }
+            ],
+            "full_name": "Pitka, Andreas",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "A.Pitka.2"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "D-44780 Bochum, Germany"
+                }
+            ],
+            "signature_block": "PATCa",
+            "uuid": "c15e2cfc-9313-4604-a3af-1f26b591071f"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903010"
+                    },
+                    "value": "Minnesota U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Poling, Ronald",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00117077"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Minneapolis, Minnesota 55455, USA"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/993066"
+            },
+            "signature_block": "PALANGr",
+            "uuid": "9c34d64d-5a34-4e5e-92b4-659817cc4ae8"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "full_name": "Prasad, Vindhyawasini",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "V.Prasad.1"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1068439"
+            },
+            "signature_block": "PRASADv",
+            "uuid": "b53f60a8-7116-4d10-9341-368dd49d301c"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/908524"
+                    },
+                    "value": "BeiHang U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Qi, Hongrong",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00454916"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100191, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1355268"
+            },
+            "signature_block": "Qh",
+            "uuid": "78091b60-6341-4ffc-9e6a-17a601893e8b"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904118"
+                    },
+                    "value": "Nanjing U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Qi, Ming",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00222211"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Nanjing 210093, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1066583"
+            },
+            "signature_block": "Qm",
+            "uuid": "01120d85-155a-4b5e-a298-a363ca7b150c"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/908524"
+                    },
+                    "value": "BeiHang U."
+                }
+            ],
+            "full_name": "Qi, Tianyu",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "T.Qi.2"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100191, People's Republic of China"
+                }
+            ],
+            "signature_block": "Qt",
+            "uuid": "4d92e3b9-4d00-4648-9a2b-21d94ec5b4bd"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Qian, Sen",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447226"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-2683-9117"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1327544"
+            },
+            "signature_block": "QANs",
+            "uuid": "ebd2c8e5-6191-4bd2-bcaa-f0b897da1ae5"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Qiao, Cong-Feng",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00415493"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/992567"
+            },
+            "signature_block": "Qc",
+            "uuid": "aa915357-9207-46be-ac30-33e1e7b32854"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904858"
+                    },
+                    "value": "Wuhan U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Qin, Nian",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447231"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-8027-1243"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Wuhan 430072, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325217"
+            },
+            "signature_block": "QANn",
+            "uuid": "46fdaa61-5986-4c87-bbd7-3c829ad94f51"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903173"
+                    },
+                    "value": "Ruhr U., Bochum"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Qin, Xiaoshuai",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00409333"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-5357-2294"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "D-44780 Bochum, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1060326"
+            },
+            "signature_block": "QANx",
+            "uuid": "1a29343d-08c2-45c7-889b-3438825c188a"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Qin, Zhonghua",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00408912"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-7946-5879"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1256731"
+            },
+            "signature_block": "QANz",
+            "uuid": "79b03e8e-b949-498b-a6ff-ae975eae60c5"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Qiu, Jinfa",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00386666"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-3395-9555"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029254"
+            },
+            "signature_block": "Qj",
+            "uuid": "8f8cef2a-b05f-475f-8bb7-f02e66706ac0"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903141"
+                    },
+                    "value": "Punjab U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Rashid, Khawaja Haris",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446352"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Lahore-54590, Pakistan"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1074555"
+            },
+            "signature_block": "RASADk",
+            "uuid": "2becb28a-567d-4327-83f8-de73a02a9457"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/911853"
+                    },
+                    "value": "Mainz U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Redmer, Christoph",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00403507"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Johann-Joachim-Becher-Weg 45, D-55099 Mainz, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1061566"
+            },
+            "signature_block": "RADNARc",
+            "uuid": "b5af1c8e-141f-4288-9a35-560cdb785c35"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903173"
+                    },
+                    "value": "Ruhr U., Bochum"
+                }
+            ],
+            "full_name": "Richter, Marvin",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "M.Richter.6"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "D-44780 Bochum, Germany"
+                }
+            ],
+            "signature_block": "RACHTARm",
+            "uuid": "cae6884b-e5e9-4b01-92ff-90f80ae52395"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/911853"
+                    },
+                    "value": "Mainz U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Ripka, Martin",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446369"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Johann-Joachim-Becher-Weg 45, D-55099 Mainz, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1274100"
+            },
+            "signature_block": "RAPCm",
+            "uuid": "02e7d1b4-26fa-4da1-89ff-e73aea1a0ec3"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902889"
+                    },
+                    "value": "INFN, Turin"
+                }
+            ],
+            "full_name": "Rolo, Manuel",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "M.Rolo.1"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "INFN, I-10125, Turin, Italy"
+                }
+            ],
+            "signature_block": "RALm",
+            "uuid": "9bd93613-3334-4078-a13a-51249f921e9d"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Rong, Gang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00043175"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-0363-0385"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1028268"
+            },
+            "signature_block": "RANGg",
+            "uuid": "92225c11-5d9d-44b1-9979-014e845053de"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/912519"
+                    },
+                    "value": "Helmholtz Inst., Mainz"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Rosner, Christoph",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00469711"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Johann-Joachim-Becher-Weg 45, D-55099 Mainz, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1423104"
+            },
+            "signature_block": "RASNARc",
+            "uuid": "dff65c39-d637-44e0-b5c1-3e649ba79edc"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904005"
+                    },
+                    "value": "Guangxi U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Ruan, Xiangdong",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446370"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Nanning 530004, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1049401"
+            },
+            "signature_block": "RANx",
+            "uuid": "33de139f-8abb-4ed8-b48d-da96c9b48598"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902780"
+                    },
+                    "value": "Dubna, JINR"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Sarantsev, Andrei",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446382"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "141980 Dubna, Moscow region, Russia"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1073168"
+            },
+            "signature_block": "SARANTSAFa",
+            "uuid": "fbb0c18d-d3ea-4569-add4-c83ebd6b5b2d"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902797"
+                    },
+                    "value": "Ferrara U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Savri\\'e, Mauro Savri\u00e9",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00258195"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "University of Ferrara, I-44122, Ferrara, Italy"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/990139"
+            },
+            "signature_block": "SAVRm",
+            "uuid": "dd9f6c1d-5b8d-450b-916c-ade9e566e4fe"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903173"
+                    },
+                    "value": "Ruhr U., Bochum"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Schnier, Claudius",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00469668"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "D-44780 Bochum, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1422237"
+            },
+            "signature_block": "SNARc",
+            "uuid": "46ff6675-e269-4247-8530-bb982a1b2bb6"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903314"
+                    },
+                    "value": "Uppsala U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Schoenning, Karin",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447747"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Box 516, SE-75120 Uppsala, Sweden"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1041221"
+            },
+            "signature_block": "SANANGk",
+            "uuid": "ca4d2252-509f-4f32-8160-711d580bef8e"
+        },
+        {
+            "curated_relation": true,
+            "full_name": "Shan, Wei",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447273"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-6355-1075"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Changsha 410081, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325234"
+            },
+            "signature_block": "SANw",
+            "uuid": "da05416e-6c0f-4c44-9a53-fc47624d501a"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "full_name": "Shan, Xinyu",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "X.Shan.2"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "signature_block": "SANx",
+            "uuid": "fbcab830-458c-4c07-a2af-63d29044fe0a"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Shao, Ming",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00183051"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1058739"
+            },
+            "signature_block": "Sm",
+            "uuid": "d66fd61d-6f08-4908-bf3c-2c25ec30e0f9"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/908524"
+                    },
+                    "value": "BeiHang U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Shen, Chengping",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00369785"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100191, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1246090"
+            },
+            "signature_block": "SANc",
+            "uuid": "f0a63f77-8eb2-426d-b5cc-b9b8acf467d5"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/906082"
+                    },
+                    "value": "Nankai U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Shen, Peixun",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00454937"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Tianjin 300071, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1355424"
+            },
+            "signature_block": "SANp",
+            "uuid": "d3b1538c-dd23-4201-b04b-c84800f91a21"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Shen, Xiaoyan",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00266820"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-6087-5517"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/989064"
+            },
+            "signature_block": "SANx",
+            "uuid": "350b1cfe-3369-439c-b032-82f8f97d5a9c"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Sheng, Huayi",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00409630"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029261"
+            },
+            "signature_block": "SANGh",
+            "uuid": "18a24bd0-4a56-4052-95a5-06c0fc892efe"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "full_name": "Shi, Xin",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "X.Shi.15"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "signature_block": "Sx",
+            "uuid": "d3e09468-229f-4058-bec1-52a265b1cbfc"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904187"
+                    },
+                    "value": "Shandong U."
+                }
+            ],
+            "full_name": "Song, Jiaojiao",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "J.Song.5"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Jinan 250100, People's Republic of China"
+                }
+            ],
+            "signature_block": "SANGj",
+            "uuid": "bb02c383-9d66-4e1c-8852-a912a72e2e0c"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904187"
+                    },
+                    "value": "Shandong U."
+                }
+            ],
+            "full_name": "Song, Weimin",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "Wei.Min.Song.1"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Jinan 250100, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1256733"
+            },
+            "signature_block": "SANGw",
+            "uuid": "bcd4598e-e99c-4d6a-9c28-9357dd36b261"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Song, Xinying",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00408496"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1074544"
+            },
+            "signature_block": "SANGx",
+            "uuid": "7c21cd74-e692-4f07-8aa0-cc2bd69213c6"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903297"
+                    },
+                    "value": "Turin U."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902889"
+                    },
+                    "value": "INFN, Turin"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Sosio, Stefano",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446396"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "University of Turin, I-10125, Turin, Italy"
+                },
+                {
+                    "value": "INFN, I-10125, Turin, Italy"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1057773"
+            },
+            "signature_block": "SASs",
+            "uuid": "c8d0afcd-7f7c-4a1d-8e51-f92bc418e0b5"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903173"
+                    },
+                    "value": "Ruhr U., Bochum"
+                }
+            ],
+            "full_name": "Sowa, Cathrina",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "C.Sowa.2"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "D-44780 Bochum, Germany"
+                }
+            ],
+            "signature_block": "Sc",
+            "uuid": "33a1c80f-da6b-44cb-bf6c-d2c12d7df266"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903297"
+                    },
+                    "value": "Turin U."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902889"
+                    },
+                    "value": "INFN, Turin"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Spataro, Stefano",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446403"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "University of Turin, I-10125, Turin, Italy"
+                },
+                {
+                    "value": "INFN, I-10125, Turin, Italy"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1045436"
+            },
+            "signature_block": "SPATARs",
+            "uuid": "24a52201-bdfb-4259-9f91-d1ead6b5adab"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Sun, Gongxing",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00351625"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-4771-3000"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1066453"
+            },
+            "signature_block": "SANg",
+            "uuid": "9d29f467-736d-4133-9744-f04f7afabd38"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904857"
+                    },
+                    "value": "Henan Normal U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Sun, Junfeng",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447280"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Xinxiang 453007, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029263"
+            },
+            "signature_block": "SANj",
+            "uuid": "6ac2dcd8-ccca-46de-b750-8ab49dd67d92"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904858"
+                    },
+                    "value": "Wuhan U."
+                }
+            ],
+            "full_name": "Sun, Liang",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "L.Sun.1"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Wuhan 430072, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1065440"
+            },
+            "signature_block": "SANl",
+            "uuid": "bb2f0ed1-e235-4bec-a9e9-788150ce3eb8"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Sun, Shengsen",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00410430"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-0453-7388"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029264"
+            },
+            "signature_block": "SANs",
+            "uuid": "e46133d7-9cad-4dc9-828f-406b0406e84d"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Sun, Xinhua",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00454964"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-1513-279X"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1355434"
+            },
+            "signature_block": "SANx",
+            "uuid": "e574f063-f513-4566-bab7-5df2db56136f"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Sun, Yongjie SUN",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00183228"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1065953"
+            },
+            "signature_block": "SANy",
+            "uuid": "a29df05a-1184-4fde-8710-0d78f5b04b10"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "full_name": "Sun, Yankun",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "Y.Sun.17"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "signature_block": "SANy",
+            "uuid": "3376186f-a5cc-4357-99e2-85b9d6adb450"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Sun, Yongzhao",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00409598"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-8505-1151"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029265"
+            },
+            "signature_block": "SANy",
+            "uuid": "7a316cac-ca46-479b-809e-77ef023afffb"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Sun, Zhijia",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00409587"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-7517-621X"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029266"
+            },
+            "signature_block": "SANz",
+            "uuid": "761e233a-80a0-464f-b419-383faf0b7f26"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902874"
+                    },
+                    "value": "Indiana U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Sun, Zhentian",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446427"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-8270-8146"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Bloomington, Indiana 47405, USA"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1066451"
+            },
+            "signature_block": "SANz",
+            "uuid": "92ec9bd8-1066-40a8-8912-a34bb8cefb37"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "full_name": "Tan, Yaxing",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "Y.Tan.4"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "signature_block": "TANy",
+            "uuid": "9ae8a130-2224-4d94-bcd4-b5161654bd3a"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904226"
+                    },
+                    "value": "Sichuan U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Tang, Changjian",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446437"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Chengdu 610064, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1066442"
+            },
+            "signature_block": "TANGc",
+            "uuid": "09a7fef2-13b1-4ad4-8b5d-975875477901"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Tang, Guangyi",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00469000"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1426078"
+            },
+            "signature_block": "TANGg",
+            "uuid": "b9117e54-c391-4803-bcc7-ffda0564d359"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Tang, Xiao",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447292"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-8292-5426"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1327562"
+            },
+            "signature_block": "TANGx",
+            "uuid": "6c005f62-2596-4881-8f3e-fedc1c92517e"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/908339"
+                    },
+                    "value": "Uludag U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Tapan, Ilhan",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446447"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Uludag University, 16059 Bursa, Turkey"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1256734"
+            },
+            "signature_block": "TAPANi",
+            "uuid": "56b9ae3a-a793-4bd3-8c66-b103057c4ce2"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904316"
+                    },
+                    "value": "Groningen, KVI"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Tiemens, Marcel",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447301"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "NL-9747 AA Groningen, The Netherlands"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325263"
+            },
+            "signature_block": "TANANm",
+            "uuid": "5360bfa8-a340-4f04-a0aa-fcf2e9a7e331"
+        },
+        {
+            "full_name": "Tsednee, Banzragch",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "B.Tsednee.1"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Peace Ave. 54B, Ulaanbaatar 13330, Mongolia"
+                }
+            ],
+            "signature_block": "TSADNYb",
+            "uuid": "91f77fae-fdd1-4abb-879b-47a1efd1af16"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/906860"
+                    },
+                    "value": "Near East U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Uman, Ismail",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00029513"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Near East University, Nicosia, North Cyprus, Mersin 10, Turkey"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1041604"
+            },
+            "signature_block": "UNANi",
+            "uuid": "0b99a956-51c6-49eb-9778-b1ca8bb685a5"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902838"
+                    },
+                    "value": "Hawaii U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Varner, Gary S",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00133527"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Honolulu, Hawaii 96822, USA"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/984944"
+            },
+            "signature_block": "VARNARg",
+            "uuid": "d7406c0e-106f-4979-a684-465d0225bf68"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Wang, Bin",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00426340"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-3581-1263"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1409978"
+            },
+            "signature_block": "WANGb",
+            "uuid": "3b973929-9d6e-4b96-abbe-ef7a2e2c5c36"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Wang, Binlong",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447317"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325270"
+            },
+            "signature_block": "WANGb",
+            "uuid": "11245b19-0f59-48d1-97f5-dd9c8f310a23"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904118"
+                    },
+                    "value": "Nanjing U."
+                }
+            ],
+            "full_name": "Wang, Chengwei",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "C.Wang.14"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Nanjing 210093, People's Republic of China"
+                }
+            ],
+            "signature_block": "WANGc",
+            "uuid": "f04e8cf3-23e5-44a5-b7e8-2e6c399dd0c9"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1238006"
+                    },
+                    "value": "Peking U., Beijing"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Wang, Dong",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447329"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100871, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325595"
+            },
+            "signature_block": "WANGd",
+            "uuid": "9a5a0068-9cd3-4b57-b92c-5122c15eca12"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1238006"
+                    },
+                    "value": "Peking U., Beijing"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Wang, Dayong",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00164378"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100871, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1233253"
+            },
+            "signature_block": "WANGd",
+            "uuid": "dba2e768-43db-40b7-9bc2-4472dca22df8"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Wang, Dan",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00637593"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1496421"
+            },
+            "signature_block": "WANGd",
+            "uuid": "b87c16f7-2436-4e5e-870c-2658dcb1bd10"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Wang, Ke",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447337"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-0548-6292"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1327564"
+            },
+            "signature_block": "WANGk",
+            "uuid": "c24178a2-4056-4fe3-a41b-4c4264445d0c"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Wang, Liangliang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00040089"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-1476-6942"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029270"
+            },
+            "signature_block": "WANGl",
+            "uuid": "0169e8b3-afa0-4ebd-8022-12983ca9c9a8"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Wang, Lingshu",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00410124"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-7070-8854"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1245518"
+            },
+            "signature_block": "WANGl",
+            "uuid": "924b9408-ff46-4238-a186-bf987fbd9f98"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904187"
+                    },
+                    "value": "Shandong U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Wang, Meng",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00338851"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Jinan 250100, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1020209"
+            },
+            "uuid": "986d27a9-5890-445a-bb35-00f56bea003e"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "full_name": "Wang, Meng",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "Meng.Wang.1"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1020209"
+            },
+            "signature_block": "WANGm",
+            "uuid": "9b645148-a13c-47e2-9e24-8e9b173e308b"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Wang, Ping",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00302129"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-8536-1846"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/984139"
+            },
+            "signature_block": "WANGp",
+            "uuid": "82a83198-44f2-4ffc-b4a9-77a6cd1e89a4"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Wang, Peiliang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447344"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1323582"
+            },
+            "signature_block": "WANGp",
+            "uuid": "0e1d3f3c-9053-4454-87c3-cf3ca3182a60"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Wang, Weiping",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00456005"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-8479-8563"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1357656"
+            },
+            "signature_block": "WANGw",
+            "uuid": "f27a62c6-7f78-4ecf-97e5-29c8ff0ec42d"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Wang, Xiongfei",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447733"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1328288"
+            },
+            "signature_block": "WANGx",
+            "uuid": "ca2a746b-c9c9-4ddd-8c05-cd48647994eb"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "full_name": "Wang, Yue",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "Yue.Wang.1"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1422849"
+            },
+            "signature_block": "WANGy",
+            "uuid": "e00cda41-0661-4310-821c-5f9ddf029b3d"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Wang, Yifang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00267690"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-8331-6980"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/984106"
+            },
+            "signature_block": "WANGy",
+            "uuid": "a6238d7b-4193-417f-a2ce-d12bfd379271"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/911853"
+                    },
+                    "value": "Mainz U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Wang, Yaqian",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447725"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Johann-Joachim-Becher-Weg 45, D-55099 Mainz, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325245"
+            },
+            "signature_block": "WANGy",
+            "uuid": "c5074a24-7ff2-4536-818c-513a20bac60f"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Wang, Zheng",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00408362"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-5802-6949"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1244939"
+            },
+            "signature_block": "WANGz",
+            "uuid": "05eb9c03-c605-4733-b075-1434e257fc14"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Wang, Zhigang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00368440"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-6714-3274"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1246840"
+            },
+            "signature_block": "WANGz",
+            "uuid": "3c89aede-1c7e-4535-af4e-27c8ec87b4c9"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Wang, Zhiyong",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00390217"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-0245-3260"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029271"
+            },
+            "signature_block": "WANGz",
+            "uuid": "5e773f9a-be28-4409-81d0-e7c438971a84"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Wang, Zongyuan",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00455414"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-3251-9136"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1358589"
+            },
+            "signature_block": "WANGz",
+            "uuid": "965f1892-b972-4ec7-9ab2-08647967260c"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903173"
+                    },
+                    "value": "Ruhr U., Bochum"
+                }
+            ],
+            "full_name": "Weber, Tobias",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "T.Weber.4"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "D-44780 Bochum, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1423106"
+            },
+            "signature_block": "WABARt",
+            "uuid": "077957a8-bac1-4c0b-80f3-76d8f0e5f950"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904983"
+                    },
+                    "value": "Guangxi Normal U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Wei, Daihui",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00410613"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Guilin 541004, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029273"
+            },
+            "signature_block": "Wd",
+            "uuid": "c295361b-499a-4ffd-8de6-cda6ffa0f874"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/911853"
+                    },
+                    "value": "Mainz U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Weidenkaff, Peter",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00393605"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Johann-Joachim-Becher-Weg 45, D-55099 Mainz, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1256737"
+            },
+            "signature_block": "WADANCAFp",
+            "uuid": "0ec76dd3-b8ea-4484-96b3-43c610c0bcf8"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Wen, Shuopin",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00409296"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-3521-5338"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1066351"
+            },
+            "signature_block": "WANs",
+            "uuid": "9a60f2ca-7eb8-4a78-b378-1b06a5910da4"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903173"
+                    },
+                    "value": "Ruhr U., Bochum"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Wiedner, Ulrich",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00297983"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "D-44780 Bochum, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/983604"
+            },
+            "signature_block": "WADNARu",
+            "uuid": "39bfb00d-fede-425d-a9e8-e0c430a9b875"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903314"
+                    },
+                    "value": "Uppsala U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Wolke, Magnus",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00291124"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Box 516, SE-75120 Uppsala, Sweden"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029442"
+            },
+            "signature_block": "WALCm",
+            "uuid": "45db5575-21e8-4fbc-aefe-5535bdb34571"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Wu, Linghui",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446490"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-8613-084X"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1066336"
+            },
+            "signature_block": "Wl",
+            "uuid": "bfe95f40-052e-4fb4-b016-fe168308a891"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Wu, Lianjin",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00456061"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-3171-2436"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1360240"
+            },
+            "signature_block": "Wl",
+            "uuid": "6be74d46-c8cc-415b-bb88-a5a492b9c308"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Wu, Zhi",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00409479"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-1796-8347"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1249423"
+            },
+            "signature_block": "Wz",
+            "uuid": "04d8bc66-4f06-4c82-99a8-087aca7368ea"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Xia, Lei",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00467662"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1415530"
+            },
+            "signature_block": "Xl",
+            "uuid": "6aff1a03-5d41-4122-8632-4215c72a6ebf"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904187"
+                    },
+                    "value": "Shandong U."
+                }
+            ],
+            "full_name": "Xia, Xin",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "Xin.Xia.1"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Jinan 250100, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1338302"
+            },
+            "signature_block": "Xx",
+            "uuid": "9543a02b-aed2-460e-81f6-bb5c44498f84"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/908732"
+                    },
+                    "value": "Hunan U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Xia, Yu",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447370"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Changsha 410082, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325250"
+            },
+            "signature_block": "Xy",
+            "uuid": "fcb27946-d0fa-4c73-98ff-7c50506c053c"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Xiao, Dong",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447380"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-4319-1305"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1323583"
+            },
+            "signature_block": "Xd",
+            "uuid": "7e2d0e77-046a-4b43-903c-b579e5b543fd"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "full_name": "Xiao, Yanjia",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "Y.Xiao.9"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "signature_block": "Xy",
+            "uuid": "a2e948ea-7454-41be-8950-e44b7932cef6"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/905718"
+                    },
+                    "value": "Nanjing Normal U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Xiao, Zhenjun",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00136945"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Nanjing 210023, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/983035"
+            },
+            "signature_block": "Xz",
+            "uuid": "70808aa0-4c09-464f-b585-8cba84d70411"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Xie, Yuguang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00408088"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-0365-4256"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1287389"
+            },
+            "signature_block": "XYy",
+            "uuid": "8a11d72f-01f1-4570-9186-117978acf335"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1279835"
+                    },
+                    "value": "CCNU, Wuhan, Inst. Part. Phys."
+                }
+            ],
+            "full_name": "Xie, Yuehong",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "Y.Xie.11"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Wuhan 430079, People's Republic of China"
+                }
+            ],
+            "signature_block": "XYy",
+            "uuid": "4d13039c-872e-4cb5-bdad-5a5e0e69da8b"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "full_name": "Xiong, XiAn",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "X.Xiong.3"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "signature_block": "XANGx",
+            "uuid": "c26fc3c5-5c71-4160-a712-6d213c851f5f"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Xiu, Qinlei",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00422115"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-2001-6398"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1256740"
+            },
+            "signature_block": "Xq",
+            "uuid": "70049ad5-72b0-4f33-925e-2fb629fc2a69"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Xu, Guofa",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00136950"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-8281-7828"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/983016"
+            },
+            "signature_block": "Xg",
+            "uuid": "3d7b1f11-0e18-4b08-98dd-5a1cac9e0ab0"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Xu, Jingjing",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00450390"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-2758-4969"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1346318"
+            },
+            "signature_block": "Xj",
+            "uuid": "1e7d7378-c78e-408b-9310-e26a1173326f"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Xu, Lei",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447392"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-0268-7972"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1323672"
+            },
+            "signature_block": "Xl",
+            "uuid": "4164e9e1-c78e-4d6f-8448-67196a86f87d"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904986"
+                    },
+                    "value": "Hangzhou Normal U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Xu, Qingjun",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446520"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hangzhou 310036, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1256741"
+            },
+            "signature_block": "Xq",
+            "uuid": "808d914e-8dd1-473d-b129-d688a626e586"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Xu, Qingnian",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446535"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1256742"
+            },
+            "signature_block": "Xq",
+            "uuid": "ff3f2936-07fd-4ad6-9353-f25c275ccad0"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904407"
+                    },
+                    "value": "Suzhou, Soochow U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Xu, Xinping",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446549"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Suzhou 215006, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029398"
+            },
+            "signature_block": "Xx",
+            "uuid": "817f15a1-41aa-49e3-8fcd-b95eb5cebe4f"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1121481"
+                    },
+                    "value": "U. South China, Hengyang"
+                }
+            ],
+            "full_name": "Yan, Fang",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "F.Yan.1"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hengyang 421001, People's Republic of China"
+                }
+            ],
+            "signature_block": "YANf",
+            "uuid": "93624562-0813-42f0-b104-2c089ab40795"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903297"
+                    },
+                    "value": "Turin U."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902889"
+                    },
+                    "value": "INFN, Turin"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Yan, Liang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00450488"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "University of Turin, I-10125, Turin, Italy"
+                },
+                {
+                    "value": "INFN, I-10125, Turin, Italy"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1346435"
+            },
+            "signature_block": "YANl",
+            "uuid": "7fa73c71-e38e-446e-842f-20147cb83e2f"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Yan, Wenbiao",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00218038"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1250053"
+            },
+            "signature_block": "YANw",
+            "uuid": "3d13bc68-2d9c-4e9a-a7e9-6d47f638e6df"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/908524"
+                    },
+                    "value": "BeiHang U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Yan, Wencheng",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447410"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100191, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325260"
+            },
+            "signature_block": "YANw",
+            "uuid": "0bbb94a6-3dab-429f-9ded-80bc72056130"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/908732"
+                    },
+                    "value": "Hunan U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Yan, Yonghong",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446555"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Changsha 410082, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1066326"
+            },
+            "signature_block": "YANy",
+            "uuid": "6378b003-c363-441c-8aff-ceefc5838b20"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904740"
+                    },
+                    "value": "Shanghai Jiaotong U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Yang, Haijun",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00059882"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Shanghai 200240, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1019294"
+            },
+            "signature_block": "YANGh",
+            "uuid": "bc6dda74-18ab-41f3-96ed-6412761cec34"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Yang, Hongxun",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00410588"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-7549-7531"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029276"
+            },
+            "signature_block": "YANGh",
+            "uuid": "33154aa2-c6ea-45c8-996a-0150f5fef015"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904858"
+                    },
+                    "value": "Wuhan U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Yang, Liu",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447710"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-3123-2675"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Wuhan 430072, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1328266"
+            },
+            "signature_block": "YANGl",
+            "uuid": "4c581ed0-8781-499f-b59f-117eeb4dbb6e"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "full_name": "Yang, Shuangli",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "S.Yang.28"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "signature_block": "YANGs",
+            "uuid": "ccab1b0d-9148-49ae-8283-b6296a230fd2"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904118"
+                    },
+                    "value": "Nanjing U."
+                }
+            ],
+            "full_name": "Yang, Youhua",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "Y.Yang.5"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Nanjing 210093, People's Republic of China"
+                }
+            ],
+            "signature_block": "YANGy",
+            "uuid": "7c47fb05-eaba-44db-ac50-001d59074a5c"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904983"
+                    },
+                    "value": "Guangxi Normal U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Yang, Yongxu",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446587"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Guilin 541004, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029277"
+            },
+            "signature_block": "YANGy",
+            "uuid": "451615f7-5c79-49dd-9e5d-bdf6a22369cf"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "full_name": "Yang, Yifan",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "Yifan.Yang.1"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1190390"
+            },
+            "signature_block": "YANGy",
+            "uuid": "946f6522-1afb-426b-8d9f-170c803c0bbf"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Ye, Mei",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447706"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-9437-1405"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1328264"
+            },
+            "signature_block": "Ym",
+            "uuid": "ded4042e-7ea5-403e-a213-c6d2b4b32bd8"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/905335"
+                    },
+                    "value": "CCAST World Lab, Beijing"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Ye, Minghan",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446598"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100190, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029278"
+            },
+            "signature_block": "Ym",
+            "uuid": "3d62fe2c-d730-4ab5-98ff-09daf1ca6b21"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Yin, Junhao",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00449070"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-1479-9349"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1340267"
+            },
+            "signature_block": "YANj",
+            "uuid": "f5d4e786-97aa-47c4-be20-6b768a10e560"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1283410"
+                    },
+                    "value": "SYSU, Guangzhou"
+                }
+            ],
+            "full_name": "You, Zhengyun",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "Zheng.Yun.You.1"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Guangzhou 510275, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1070098"
+            },
+            "signature_block": "Yz",
+            "uuid": "d94acd30-06bb-42a1-8e55-4d64f3042ea8"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Yu, Boxiang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447439"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-8331-0113"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1066323"
+            },
+            "signature_block": "Yb",
+            "uuid": "b71b85ae-b6c7-4d4e-8267-79ebd05ba4fd"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/906082"
+                    },
+                    "value": "Nankai U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Yu, Chun-Xu",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00409697"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Tianjin 300071, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/982535"
+            },
+            "signature_block": "Yc",
+            "uuid": "5ec92030-9969-4cb2-a04c-ab2ee4bc2e7b"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904070"
+                    },
+                    "value": "Lanzhou U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Yu, Jiesheng",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447456"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Lanzhou 730000, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1072081"
+            },
+            "signature_block": "Yj",
+            "uuid": "8c5f7985-c196-4f2a-a301-9b66685c70c9"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Yuan, Changzheng",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00137773"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/982514"
+            },
+            "signature_block": "YANc",
+            "uuid": "041558be-0c47-4e63-bb66-b8c8bca45fd3"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Yuan, Ye",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00362634"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-3414-9212"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1206698"
+            },
+            "signature_block": "YANy",
+            "uuid": "7e83b995-f602-4afa-9e89-5e88d7ac813f"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1392572"
+                    },
+                    "value": "Istanbul Bilgi U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Yuncu, Alperen",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447464"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Istanbul Bilgi University, 34060 Eyup, Istanbul, Turkey"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325265"
+            },
+            "signature_block": "YANCa",
+            "uuid": "24d106fc-d0ea-42fd-8b4c-fc47badbceae"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903141"
+                    },
+                    "value": "Punjab U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zafar, Abrar Ahmad",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446624"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Lahore-54590, Pakistan"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1074521"
+            },
+            "signature_block": "ZAFARa",
+            "uuid": "547b097f-8fac-465a-9751-31f4594fbb29"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902807"
+                    },
+                    "value": "Frascati"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zallo, Adriano",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00138035"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "INFN Laboratori Nazionali di Frascati, I-00044, Frascati, Italy"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/982390"
+            },
+            "signature_block": "ZALa",
+            "uuid": "8d5d48d9-39d8-4822-aea0-7e708a291840"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/908732"
+                    },
+                    "value": "Hunan U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zeng, Yun",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447479"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Changsha 410082, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325251"
+            },
+            "signature_block": "ZANGy",
+            "uuid": "b93b6f82-dac0-4b5f-96bc-f500e53ccea1"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zeng, Zhe",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00467653"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1258883"
+            },
+            "signature_block": "ZANGz",
+            "uuid": "9a9a499d-37df-4dbf-9925-784f69b855b3"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhang, Bingxin",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00410476"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-0331-1408"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029284"
+            },
+            "signature_block": "ZANGb",
+            "uuid": "b80a09be-8f9a-4ec4-97f7-36fdf0e6ba33"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhang, Bingyun",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00410444"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-4562-3653"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029285"
+            },
+            "signature_block": "ZANGb",
+            "uuid": "61825f09-760a-4b44-af46-561d9daf7881"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhang, Changchun",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00368744"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/982225"
+            },
+            "signature_block": "ZANGc",
+            "uuid": "488736cf-8de5-4944-97c2-1880ec00c15c"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhang, Dahua",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446613"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/982220"
+            },
+            "signature_block": "ZANGd",
+            "uuid": "d3f826dd-3379-4384-b51f-bd6eacca29ee"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1283410"
+                    },
+                    "value": "SYSU, Guangzhou"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhang, Hong-Hao",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00448897"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Guangzhou 510275, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1336666"
+            },
+            "signature_block": "ZANGh",
+            "uuid": "e78c0427-8eec-4d05-ae74-32a58f600c43"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhang, Hongyu",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447497"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-8333-9231"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1323677"
+            },
+            "signature_block": "ZANGh",
+            "uuid": "a1cc7e4a-1359-439f-bbc1-eaf6af1131eb"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhang, Jin",
+            "ids": [
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-7752-8538"
+                },
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "Jin.Zhang.1"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1340500"
+            },
+            "signature_block": "ZANGj",
+            "uuid": "f7830c7d-348c-4abd-82e7-f09e1bd69a44"
+        },
+        {
+            "curated_relation": true,
+            "full_name": "Zhang, Jielei",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00449179"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-8592-2335"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Xinyang 464000, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1340499"
+            },
+            "signature_block": "ZANGj",
+            "uuid": "cfbb733c-5892-49e9-8f12-0b7d21fc1972"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903173"
+                    },
+                    "value": "Ruhr U., Bochum"
+                }
+            ],
+            "full_name": "Zhang, Jingqing",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "Jia.Quan.Zhang.1"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "D-44780 Bochum, Germany"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1035209"
+            },
+            "signature_block": "ZANGj",
+            "uuid": "3caa49bc-02ad-40b7-87c8-8d1bb64fe4b3"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhang, Jiawen",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00410035"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-7794-7014"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1245940"
+            },
+            "signature_block": "ZANGj",
+            "uuid": "ef044b96-1f53-4263-b097-3117564d8c44"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhang, Jianyong",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00410418"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-0533-4371"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029287"
+            },
+            "signature_block": "ZANGj",
+            "uuid": "9bfec255-2633-4e6c-8a79-37c0577d20f6"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhang, Jingzhi",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00320723"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-6535-0659"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1064703"
+            },
+            "signature_block": "ZANGj",
+            "uuid": "cc321eed-5b15-4b55-8fb3-2b122da6e881"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhang, Kun",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00449199"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-9968-3811"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1340501"
+            },
+            "signature_block": "ZANGk",
+            "uuid": "e4c4c8e5-2e5d-4b89-90ec-893bdce5273a"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904826"
+                    },
+                    "value": "Tsinghua U., Beijing"
+                }
+            ],
+            "full_name": "Zhang, Lei",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "Lei.Zhang.3"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100084, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1340502"
+            },
+            "signature_block": "ZANGl",
+            "uuid": "608b5e31-7f36-4a90-9f04-0b1b98e6bfff"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904118"
+                    },
+                    "value": "Nanjing U."
+                }
+            ],
+            "full_name": "Zhang, Sifan",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "S.Zhang.42"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Nanjing 210093, People's Republic of China"
+                }
+            ],
+            "signature_block": "ZANGs",
+            "uuid": "b2bb50f1-c76c-4796-a997-0935e1aeb3b4"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904740"
+                    },
+                    "value": "Shanghai Jiaotong U."
+                }
+            ],
+            "full_name": "Zhang, Tianjiao",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "T.Zhang.17"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Shanghai 200240, People's Republic of China"
+                }
+            ],
+            "signature_block": "ZANGt",
+            "uuid": "1e27b7bd-347d-4a67-9100-db7e18499d79"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904187"
+                    },
+                    "value": "Shandong U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhang, Xueyao",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00226365"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Jinan 250100, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1019824"
+            },
+            "signature_block": "ZANGx",
+            "uuid": "a5e20599-ec0e-47ab-99e6-2f05e486eb2c"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "full_name": "Zhang, Yan",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "Yan.Zhang.4"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/982180"
+            },
+            "signature_block": "ZANGy",
+            "uuid": "106c1989-20ab-45f8-92d8-86b80e75f507"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhang, Yinhong",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447531"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-0893-2449"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1323676"
+            },
+            "signature_block": "ZANGy",
+            "uuid": "259e6f0a-b21f-487a-b82c-6c268535dd04"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhang, Yateng",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00449241"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1340977"
+            },
+            "signature_block": "ZANGy",
+            "uuid": "e7f52a15-1886-49f1-b9df-43ea1d510318"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "full_name": "Zhang, Yang",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "Y.Zhang.63"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "signature_block": "ZANGy",
+            "uuid": "cc9593e6-ebb0-4ec6-b2f8-0f520f9f187c"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhang, Yao",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00463167"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-3310-6728"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1395164"
+            },
+            "signature_block": "ZANGy",
+            "uuid": "ac9850a5-2ba8-45ce-9632-2ed167922967"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhang, Yu",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00469638"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1422017"
+            },
+            "signature_block": "ZANGy",
+            "uuid": "1e26207d-9f85-4ebf-9037-d2b349c3c594"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1279835"
+                    },
+                    "value": "CCNU, Wuhan, Inst. Part. Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhang, Zhenghao",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447540"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-0856-3177"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Wuhan 430079, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325253"
+            },
+            "signature_block": "ZANGz",
+            "uuid": "3e7a3275-be03-4e88-abbd-11bf2c10adf8"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhang, Ziping",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00149639"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/982164"
+            },
+            "signature_block": "ZANGz",
+            "uuid": "c4eac777-7d4d-43a1-9f11-4a7f7afe3e94"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904858"
+                    },
+                    "value": "Wuhan U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhang, Zhenyu",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447555"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Wuhan 430072, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325223"
+            },
+            "signature_block": "ZANGz",
+            "uuid": "49d88052-3e91-4720-b14f-c716d70305f5"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhao, Guang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447563"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1323679"
+            },
+            "signature_block": "Zg",
+            "uuid": "f6749a3a-eea0-4f02-918f-397d2e810061"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhao, Jingwei",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00180939"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-4474-9964"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029291"
+            },
+            "signature_block": "Zj",
+            "uuid": "81c6fbdb-7ff2-4b57-8b6a-c4a60c49566c"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhao, Jingyi",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00449298"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-2028-7286"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1342311"
+            },
+            "signature_block": "Zj",
+            "uuid": "c3da31a7-a2d2-4098-ac53-1d2a4715002a"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhao, Jingzhou",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00375220"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-8365-7726"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1231548"
+            },
+            "signature_block": "Zj",
+            "uuid": "cf7eec8c-64c3-437d-9531-194be94d056a"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhao, Lei",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446642"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1256747"
+            },
+            "signature_block": "Zl",
+            "uuid": "616550cf-c570-48b6-bc12-ed869791b127"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhao, Ling",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446654"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-7152-1466"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1256748"
+            },
+            "signature_block": "Zl",
+            "uuid": "9f48caf4-984e-49ee-881b-79c91f1de1a6"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/906082"
+                    },
+                    "value": "Nankai U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhao, Minggang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00410329"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Tianjin 300071, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029292"
+            },
+            "signature_block": "Zm",
+            "uuid": "4e6611ce-ae6b-4ccf-a71f-9d40869adb55"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhao, Qiang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00386246"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-8334-2580"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1246205"
+            },
+            "signature_block": "Zq",
+            "uuid": "33bee6f2-8441-4258-af6e-94b46a99463a"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904424"
+                    },
+                    "value": "Zhengzhou U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhao, Shujun",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446661"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Zhengzhou 450001, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1066310"
+            },
+            "signature_block": "Zs",
+            "uuid": "5cd1a616-5693-4650-94d5-5ee8ab7fd63c"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhao, Tianchi",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00138355"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/982150"
+            },
+            "signature_block": "Zt",
+            "uuid": "5d868a16-2ed1-4629-917f-2927c77de7e1"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhao, Yubin",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00409867"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-3954-3195"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1042610"
+            },
+            "signature_block": "Zy",
+            "uuid": "eb79c3a0-3efb-4db0-a517-e4210a46c753"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhao, Zhengguo",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00226382"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/982141"
+            },
+            "signature_block": "Zz",
+            "uuid": "93a4fc43-7582-41c4-bfb9-e953e065ccfd"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/902780"
+                    },
+                    "value": "Dubna, JINR"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhemchugov, Alexey",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00226395"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "141980 Dubna, Moscow region, Russia"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1065820"
+            },
+            "signature_block": "ZANCAGAVa",
+            "uuid": "68e4b387-f67a-486d-a357-beed878723d5"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1121481"
+                    },
+                    "value": "U. South China, Hengyang"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zheng, Bo",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447697"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hengyang 421001, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1328263"
+            },
+            "signature_block": "ZANGb",
+            "uuid": "0e588ce2-d878-4b45-b66b-818e8ec8b1ad"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zheng, Jianping",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00410262"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-4308-3742"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029294"
+            },
+            "signature_block": "ZANGj",
+            "uuid": "509abf6d-4db9-4b3d-872f-cf29aec80c1d"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904187"
+                    },
+                    "value": "Shandong U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zheng, Wenjing",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00449352"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Jinan 250100, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1342512"
+            },
+            "signature_block": "ZANGw",
+            "uuid": "2a617337-75d5-4396-91b1-f1ac28ab71da"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zheng, Yangheng",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00138380"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/982117"
+            },
+            "signature_block": "ZANGy",
+            "uuid": "d25d79ea-d928-4b76-b385-cea7d903547f"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/905718"
+                    },
+                    "value": "Nanjing Normal U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhong, Bin",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446672"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Nanjing 210023, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1057533"
+            },
+            "signature_block": "ZANGb",
+            "uuid": "c0b9582a-ee48-4d0c-94d3-da586063617f"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhou, Li",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447675"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-0799-1233"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1328261"
+            },
+            "signature_block": "Zl",
+            "uuid": "859dbd12-6ad6-4c45-97ad-6d2aa6b6340c"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "full_name": "Zhou, Qiao",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "Q.Zhou.3"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "signature_block": "Zq",
+            "uuid": "ca39b4dc-d71a-49fc-94cc-56ef70d43523"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904858"
+                    },
+                    "value": "Wuhan U."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhou, Xiang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447584"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Wuhan 430072, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325224"
+            },
+            "signature_block": "Zx",
+            "uuid": "2b9bf494-1a5d-412a-b2cc-857b566147b4"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhou, Xiaokang",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00449852"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1074517"
+            },
+            "signature_block": "Zx",
+            "uuid": "dcb6192d-6b0c-4998-bf90-1cf68f0a97aa"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhou, Xiaorong",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447596"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1325602"
+            },
+            "signature_block": "Zx",
+            "uuid": "3217696c-7964-4caf-9e13-730181688e02"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhou, Xingyu",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447608"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-0299-4657"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1324316"
+            },
+            "signature_block": "Zx",
+            "uuid": "eb918103-4208-43d1-87c4-834f73c6588d"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "full_name": "Zhu, Aonan",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "A.Zhu.2"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "signature_block": "Za",
+            "uuid": "e87f12d1-453a-42c6-9e8a-a1116a65f20e"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/906082"
+                    },
+                    "value": "Nankai U."
+                }
+            ],
+            "full_name": "Zhu, Jiang",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "J.Zhu.14"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Tianjin 300071, People's Republic of China"
+                }
+            ],
+            "uuid": "62c46936-2c8b-4b0b-8f40-aa50dc98517c"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1283410"
+                    },
+                    "value": "SYSU, Guangzhou"
+                }
+            ],
+            "full_name": "Zhu, Jiang",
+            "ids": [
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "J.Zhu.14"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Guangzhou 510275, People's Republic of China"
+                }
+            ],
+            "signature_block": "Zj",
+            "uuid": "a119e088-333b-4128-b6ac-0959b83261e3"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhu, Kai",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447610"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-4365-8043"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1324319"
+            },
+            "signature_block": "Zk",
+            "uuid": "42d9b48b-01a9-474e-8a67-fe394d53c446"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhu, Kejun",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00319070"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-5473-235X"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1064643"
+            },
+            "signature_block": "Zk",
+            "uuid": "c131f933-ea96-44e8-b88c-2465aa50fe99"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhu, Shuai",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00465830"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-8047-8797"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1338631"
+            },
+            "signature_block": "Zs",
+            "uuid": "54c6c487-192e-4fce-a88f-8dddd2d68201"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/1386600"
+                    },
+                    "value": "USTL, Anshan"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhu, Shihai",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00355131"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0001-9731-4708"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Anshan 114051, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1048324"
+            },
+            "signature_block": "Zs",
+            "uuid": "8a672f30-8509-4012-bf8a-ddb4df583ae3"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904826"
+                    },
+                    "value": "Tsinghua U., Beijing"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhu, Xianglei",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00183811"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100084, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1065972"
+            },
+            "signature_block": "Zx",
+            "uuid": "ac845f88-1802-4887-a153-ea401eda35a1"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903800"
+                    },
+                    "value": "Hefei, CUST"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhu, yingchun",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00218063"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Hefei 230026, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029298"
+            },
+            "signature_block": "Zy",
+            "uuid": "4eeaa117-b910-42ca-8dc0-32c313dee5df"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhu, Yongsheng",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00138492"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/982057"
+            },
+            "signature_block": "Zy",
+            "uuid": "1073ca8e-1af8-42ab-a263-fcb46650795a"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                },
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/904611"
+                    },
+                    "value": "Beijing, GUCAS"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhu, Zi-An",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00351443"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-6229-5567"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1029299"
+            },
+            "signature_block": "Zz",
+            "uuid": "b15e7eff-59c1-48a1-b629-ef6198e117c0"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zhuang, Jian",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00446688"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-2765-6339"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                },
+                {
+                    "value": "Beijing 100049, Hefei 230026, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1066306"
+            },
+            "signature_block": "ZANGj",
+            "uuid": "a5cacf18-89da-4ee4-95d0-d9aa0c8e9715"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zou, Bingsong",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00170933"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0002-3000-7540"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/981943"
+            },
+            "signature_block": "Zb",
+            "uuid": "c4c06bd8-2a03-497a-82dd-a53d6e4bdda7"
+        },
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://qa.inspirehep.net/api/institutions/903123"
+                    },
+                    "value": "Beijing, Inst. High Energy Phys."
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Zou, Jiaheng",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00447625"
+                },
+                {
+                    "schema": "ORCID",
+                    "value": "0000-0003-3581-2829"
+                }
+            ],
+            "raw_affiliations": [
+                {
+                    "value": "Beijing 100049, People's Republic of China"
+                }
+            ],
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/authors/1066304"
+            },
+            "signature_block": "Zj",
+            "uuid": "bafdd8fa-9b17-4a93-8ba7-132e1b5a3498"
+        }
+    ],
+    "citeable": true,
+    "collaborations": [
+        {
+            "value": "BESIII"
+        }
+    ],
+    "control_number": 1662077,
+    "core": true,
+    "curated": true,
+    "document_type": [
+        "article"
+    ],
+    "documents": [
+        {
+            "fulltext": true,
+            "key": "1803.03802.pdf",
+            "source": "arXiv",
+            "url": "file:///afs/cern.ch/project/inspire/PROD/var/data/files/g159/3187651/content.pdf%3B1"
+        }
+    ],
+    "inspire_categories": [
+        {
+            "source": "arxiv",
+            "term": "Experiment-HEP"
+        },
+        {
+            "term": "Experiment-HEP"
+        }
+    ],
+    "keywords": [
+        {
+            "schema": "INSPIRE",
+            "value": "experimental results"
+        },
+        {
+            "schema": "INSPIRE",
+            "value": "electron positron: elastic scattering"
+        },
+        {
+            "schema": "INSPIRE",
+            "value": "psi(3770)"
+        },
+        {
+            "schema": "INSPIRE",
+            "value": "statistical analysis"
+        },
+        {
+            "schema": "INSPIRE",
+            "value": "elastic scattering: wide-angle"
+        },
+        {
+            "schema": "INSPIRE",
+            "value": "BES"
+        },
+        {
+            "schema": "INSPIRE",
+            "value": "electron positron --> anti-D D"
+        },
+        {
+            "schema": "INSPIRE",
+            "value": "luminosity"
+        },
+        {
+            "schema": "INSPIRE",
+            "value": "energy dependence"
+        },
+        {
+            "schema": "INSPIRE",
+            "value": "charmonium"
+        }
+    ],
+    "legacy_creation_date": "2018-03-13",
+    "license": [
+        {
+            "license": "arXiv nonexclusive-distrib 1.0",
+            "url": "http://arxiv.org/licenses/nonexclusive-distrib/1.0/"
+        }
+    ],
+    "preprint_date": "2018-03-10",
+    "references": [
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/literature/393074"
+            },
+            "reference": {
+                "authors": [
+                    {
+                        "full_name": "Ding, Y.B."
+                    }
+                ],
+                "label": "1",
+                "publication_info": {
+                    "artid": "5064",
+                    "journal_title": "Phys.Rev.D",
+                    "journal_volume": "51",
+                    "page_start": "5064",
+                    "year": 1995
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/literature/800097"
+            },
+            "reference": {
+                "authors": [
+                    {
+                        "full_name": "Ablikim, M."
+                    }
+                ],
+                "label": "2",
+                "misc": [
+                    "(BES Collaboration)"
+                ],
+                "publication_info": {
+                    "artid": "102004",
+                    "journal_title": "Phys.Rev.Lett.",
+                    "journal_volume": "101",
+                    "year": 2008
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/literature/770715"
+            },
+            "reference": {
+                "authors": [
+                    {
+                        "full_name": "Ablikim, M."
+                    }
+                ],
+                "label": "3",
+                "misc": [
+                    "(BES Collaboration)"
+                ],
+                "publication_info": {
+                    "artid": "122002",
+                    "journal_title": "Phys.Rev.D",
+                    "journal_volume": "76",
+                    "year": 2007
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/literature/779017"
+            },
+            "reference": {
+                "authors": [
+                    {
+                        "full_name": "Ablikim, M."
+                    }
+                ],
+                "label": "4",
+                "misc": [
+                    "(BES Collaboration)"
+                ],
+                "publication_info": {
+                    "artid": "74",
+                    "journal_title": "Phys.Lett.B",
+                    "journal_volume": "659",
+                    "page_start": "74",
+                    "year": 2008
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/literature/717720"
+            },
+            "reference": {
+                "authors": [
+                    {
+                        "full_name": "Ablikim, M."
+                    }
+                ],
+                "label": "5",
+                "misc": [
+                    "(BES Collaboration)"
+                ],
+                "publication_info": {
+                    "artid": "121801",
+                    "journal_title": "Phys.Rev.Lett.",
+                    "journal_volume": "97",
+                    "year": 2006
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/literature/717665"
+            },
+            "reference": {
+                "authors": [
+                    {
+                        "full_name": "Ablikim, M."
+                    }
+                ],
+                "label": "6",
+                "misc": [
+                    "(BES Collaboration)"
+                ],
+                "publication_info": {
+                    "artid": "145",
+                    "journal_title": "Phys.Lett.B",
+                    "journal_volume": "641",
+                    "page_start": "145",
+                    "year": 2006
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/literature/1650066"
+            },
+            "reference": {
+                "authors": [
+                    {
+                        "full_name": "Besson, D."
+                    }
+                ],
+                "label": "7",
+                "misc": [
+                    "(CLEO Collaboration)"
+                ],
+                "publication_info": {
+                    "artid": "159901",
+                    "journal_title": "Phys.Rev.Lett.",
+                    "journal_volume": "104",
+                    "year": 2010
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/literature/1241820"
+            },
+            "reference": {
+                "authors": [
+                    {
+                        "full_name": "Ablikim, M."
+                    }
+                ],
+                "label": "8",
+                "misc": [
+                    "(BESIII Collaboration)"
+                ],
+                "publication_info": {
+                    "artid": "123001",
+                    "journal_title": "Chin.Phys.C",
+                    "journal_volume": "37",
+                    "year": 2013
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/literature/838149"
+            },
+            "reference": {
+                "authors": [
+                    {
+                        "full_name": "Ablikim, M."
+                    }
+                ],
+                "label": "9",
+                "misc": [
+                    "(BESIII Collaboration)"
+                ],
+                "publication_info": {
+                    "artid": "345",
+                    "journal_title": "Nucl.Instrum.Meth.A",
+                    "journal_volume": "614",
+                    "page_start": "345",
+                    "year": 2010
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/literature/721717"
+            },
+            "reference": {
+                "authors": [
+                    {
+                        "full_name": "Balossini, G."
+                    }
+                ],
+                "label": "10",
+                "publication_info": {
+                    "artid": "227",
+                    "journal_title": "Nucl.Phys.B",
+                    "journal_volume": "758",
+                    "page_start": "227",
+                    "year": 2006
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/literature/877399"
+            },
+            "reference": {
+                "authors": [
+                    {
+                        "full_name": "Berger, N."
+                    }
+                ],
+                "label": "11",
+                "publication_info": {
+                    "artid": "1779",
+                    "journal_title": "Chin.Phys.C",
+                    "journal_volume": "34",
+                    "page_start": "1779",
+                    "year": 2010
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/literature/634282"
+            },
+            "reference": {
+                "authors": [
+                    {
+                        "full_name": "Calame, C.M. Carloni"
+                    }
+                ],
+                "label": "12",
+                "publication_info": {
+                    "artid": "48",
+                    "journal_title": "Nucl.Phys.B Proc.Suppl.",
+                    "journal_volume": "131",
+                    "page_start": "48",
+                    "year": 2004
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://qa.inspirehep.net/api/literature/777900"
+            },
+            "reference": {
+                "authors": [
+                    {
+                        "full_name": "Balossini, G."
+                    }
+                ],
+                "label": "12",
+                "publication_info": {
+                    "artid": "209",
+                    "journal_title": "Phys.Lett.B",
+                    "journal_volume": "663",
+                    "page_start": "209",
+                    "year": 2008
+                }
+            }
+        }
+    ],
+    "self": {
+        "$ref": "http://qa.inspirehep.net/api/literature/1662077"
+    },
+    "texkeys": [
+        "Ablikim:2018tdq"
+    ],
+    "titles": [
+        {
+            "source": "arXiv",
+            "title": "Measurement of the Integrated Luminosities of Cross-section Scan Data Samples Around the $\\psi(3770)$ Mass Region"
+        }
+    ]
+}

--- a/tests/integration/disambiguation/test_disambiguation_core_db_readers.py
+++ b/tests/integration/disambiguation/test_disambiguation_core_db_readers.py
@@ -68,6 +68,12 @@ def test_get_all_curated_signatures(isolated_app):
     assert expected in result
 
 
+def test_get_all_curated_signatures_does_not_raise_on_authors_without_a_signature_block(isolated_app):
+    TestRecordMetadata.create_from_file(__name__, '1662077.json')
+
+    list(get_all_curated_signatures())  # Does not raise.
+
+
 def test_get_signatures_matching_a_phonetic_encoding(isolated_app):
     TestRecordMetadata.create_from_file(__name__, '8201.json', index_name='records-hep')
     TestRecordMetadata.create_from_file(__name__, '1518353.json', index_name='records-hep')
@@ -149,3 +155,9 @@ def test_get_signatures_matching_a_phonetic_encoding(isolated_app):
     result = list(get_signatures_matching_a_phonetic_encoding('Rm'))
 
     assert sorted(expected) == sorted(result)
+
+
+def test_get_signatures_matching_a_phonetic_encoding_does_not_raise_on_authors_without_a_signature_block(isolated_app):
+    TestRecordMetadata.create_from_file(__name__, '1662077.json', index_name='records-hep')
+
+    list(get_signatures_matching_a_phonetic_encoding('WANGm'))  # Does not raise.


### PR DESCRIPTION
## Description:
Given that, as documented by https://github.com/inspirehep/inspire-next/blob/c7e0862cd5d2052de767eed5c7a9943d9467cc81/tests/unit/records/test_records_receivers.py#L396-L416 not every author signature is required to have a `signature_block`, the `disambiguation` module shouldn't expect that to be true.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.