### PR TITLE
utils: make is_pdf_link accept long lines

### DIFF
--- a/inspirehep/utils/url.py
+++ b/inspirehep/utils/url.py
@@ -50,7 +50,7 @@ def make_user_agent_string(component=""):
 def is_pdf_link(url):
     """Return ``True`` if ``url`` points to a PDF.
 
-    Returns ``True`` if the first significant line of the response starts with
+    Returns ``True`` if the first non-whitespace characters of the response are
     ``%PDF``.
 
     Args:
@@ -65,11 +65,9 @@ def is_pdf_link(url):
     except requests.exceptions.RequestException:
         return False
 
-    significant_lines = [line for line in response.iter_lines(10) if line.strip()]
-    if not significant_lines:
-        return False
+    significant_bytes = next(response.iter_content(10000), '').strip()
 
-    return significant_lines[0].startswith('%PDF')
+    return significant_bytes.startswith('%PDF')
 
 
 def copy_file(src_file, dst_file, buffer_size=io.DEFAULT_BUFFER_SIZE):


### PR DESCRIPTION
## Description

The previous (i.e. third) iteration of `is_pdf_link` didn't work when
all the content was on a single line, as it was then reading too much
resulting in the connection being killed.
This is avoided by reading a fixed number of bytes, instead of a fixed
number of lines.

<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://sentry.inspirehep.net/inspire-sentry/prod/issues/115184/

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
