### PR TITLE
841 requirements: pin urllib3==1.22

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,9 @@ install_requires = [
     'scikit-learn~=0.0,>=0.19.1',
     'setproctitle~=1.0,>=1.1.10',
     'timeout-decorator~=0.0,>=0.4.0',
+    # Pin urllib3 to version 1.22 as version 1.23 is incompatible with requirements
+    # from python-requests (<1.23) (https://travis-ci.org/inspirehep/inspire-next/builds/388221674)
+    'urllib3~=1.0,<1.23',
     'workflow~=2.0,>=2.1.3',
 ]
 


### PR DESCRIPTION
## Description
Build fails as installed version of urllib3 (1.23) fails the requirements of python-requests.
See: https://travis-ci.org/inspirehep/inspire-next/jobs/388221675

## Related Issue
https://its.cern.ch/jira/browse/INSPIR-841

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
