### PR TITLE
disambiguation: fix typo in configuration key

### DIFF
--- a/inspirehep/modules/disambiguation/ext.py
+++ b/inspirehep/modules/disambiguation/ext.py
@@ -50,7 +50,7 @@ class InspireDisambiguation(object):
             disambiguation_base_path, 'signatures.jl')
         app.config['DISAMBIGUATION_ETHNICITY_DATA_PATH'] = os.path.join(
             disambiguation_base_path, 'ethnicity.csv')
-        app.config['DISAMBIGUATION_ETHNICITY_MOEL_PATH'] = os.path.join(
+        app.config['DISAMBIGUATION_ETHNICITY_MODEL_PATH'] = os.path.join(
             disambiguation_base_path, 'ethnicity.pkl')
 
         for k in dir(config):


### PR DESCRIPTION
## Description:
Spotted this typo during QA.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.