### PR TITLE
disambiguation: add get_all_signatures

### DIFF
--- a/inspirehep/modules/disambiguation/core/db/readers.py
+++ b/inspirehep/modules/disambiguation/core/db/readers.py
@@ -52,6 +52,25 @@ SIGNATURE_FIELDS = [
 ]
 
 
+def get_all_signatures():
+    """Get all signatures from the DB.
+
+    Walks through all Literature records and collects all signatures
+    in order to build the running set for ``BEARD``.
+
+    Yields:
+        dict: a signature.
+
+    """
+    query = RecordMetadata.query.with_entities(RecordMetadata.json).filter(
+        type_coerce(RecordMetadata.json, JSONB)['_collections'].contains(['Literature']))
+
+    for record in query.yield_per(1000):
+        publication_id = record.json['control_number']
+        for author in record.json.get('authors', []):
+            yield _build_signature(author, publication_id)
+
+
 def get_all_curated_signatures():
     """Get all curated signatures from the DB.
 

--- a/tests/integration/disambiguation/test_disambiguation_core_db_readers.py
+++ b/tests/integration/disambiguation/test_disambiguation_core_db_readers.py
@@ -27,8 +27,25 @@ from factories.db.invenio_records import TestRecordMetadata
 from inspirehep.modules.disambiguation.core.db.readers import (
     get_all_curated_signatures,
     get_all_publications,
+    get_all_signatures,
     get_signatures_matching_a_phonetic_encoding,
 )
+
+
+def test_get_all_signatures(isolated_app):
+    TestRecordMetadata.create_from_file(__name__, '8201.json')
+
+    expected = {
+        'author_affiliation': 'SUNY, Stony Brook',
+        'author_id': None,
+        'author_name': 'Rho, Mannque',
+        'publication_id': 8201,
+        'signature_block': 'Rm',
+        'signature_uuid': 'fe4220bf-7c57-4191-8d0c-6e791e84c505',
+    }
+    result = list(get_all_signatures())
+
+    assert expected in result
 
 
 def test_get_all_curated_signatures(isolated_app):


### PR DESCRIPTION
## Description:
We use `get_all_curated_signatures` to build the training set, while we use `get_all_signatures` to build the running set.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.