### PR TITLE
disambiguation: refactor to use JSON Lines

### DIFF
--- a/inspirehep/modules/disambiguation/api.py
+++ b/inspirehep/modules/disambiguation/api.py
@@ -27,6 +27,7 @@ from __future__ import absolute_import, division, print_function
 import json
 from collections import defaultdict
 
+import six
 from flask import current_app
 
 from inspirehep.modules.disambiguation.core.db.readers import (
@@ -37,38 +38,50 @@ from inspirehep.modules.disambiguation.core.ml.models import EthnicityEstimator
 from inspirehep.modules.disambiguation.utils import open_file_in_folder
 
 
-def save_signatures_and_clusters():
-    """Save signatures and starting clusters to disk.
+def save_curated_signatures_and_input_clusters():
+    """Save curated signatures and input clusters to disk.
 
-    Saves two files to disk called (by default) ``clusters.json`` and ``signatures.jl``.
-    The former contains a dictionary that represents the starting clusters that are used
-    by ``BEARD`` as ground truth, while the latter contains one line per curated signature
-    present in INSPIRE.
+    Saves two files to disk called (by default) ``input_clusters.jsonl`` and
+    ``curated_signatures.jsonl``. The former contains one line per each cluster
+    initially present in INSPIRE, while the latter contains one line per each
+    curated signature that will be used as ground truth by ``BEARD``.
     """
-    clusters = defaultdict(list)
+    signatures_with_author = defaultdict(list)
+    signatures_without_author = []
 
-    with open_file_in_folder(current_app.config['DISAMBIGUATION_SIGNATURES_PATH'], 'w') as fd:
+    with open_file_in_folder(current_app.config['DISAMBIGUATION_CURATED_SIGNATURES_PATH'], 'w') as fd:
         for signature in get_all_curated_signatures():
             if signature.get('author_id'):
-                clusters[signature['author_id']].append(signature['signature_uuid'])
+                signatures_with_author[signature['author_id']].append(signature['signature_uuid'])
                 fd.write(json.dumps(signature) + '\n')
+            else:
+                signatures_without_author.append(signature['signature_uuid'])
 
-    with open_file_in_folder(current_app.config['DISAMBIGUATION_CLUSTERS_PATH'], 'w') as fd:
-        json.dump(clusters, fd)
+    with open_file_in_folder(current_app.config['DISAMBIGUATION_INPUT_CLUSTERS_PATH'], 'w') as fd:
+        for cluster_id, (author_id, signature_uuids) in enumerate(six.iteritems(signatures_with_author)):
+            fd.write(json.dumps({
+                'author_id': author_id,
+                'cluster_id': cluster_id,
+                'signature_uuids': signature_uuids,
+            }) + '\n')
+        for cluster_id, signature_uuid in enumerate(signatures_without_author, cluster_id + 1):
+            fd.write(json.dumps({
+                'author_id': None,
+                'cluster_id': cluster_id,
+                'signature_uuids': [signature_uuid],
+            }) + '\n')
 
 
 def save_publications():
     """Save publications to disk.
 
-    Saves a file to disk called (by default) ``publications.json`` which contains all
-    information that will be useful for ``BEARD`` during training and prediction.
+    Saves a file to disk called (by default) ``publications.jsonl``, which
+    contains one line per record in INSPIRE with information that will be
+    useful for ``BEARD`` during training and prediction.
     """
-    publications = {}
-    for publication in get_all_publications():
-        publications[publication['publication_id']] = publication
-
     with open_file_in_folder(current_app.config['DISAMBIGUATION_PUBLICATIONS_PATH'], 'w') as fd:
-        json.dump(publications, fd)
+        for publication in get_all_publications():
+            fd.write(json.dumps(publication) + '\n')
 
 
 def train_and_save_ethnicity_model():

--- a/inspirehep/modules/disambiguation/ext.py
+++ b/inspirehep/modules/disambiguation/ext.py
@@ -42,12 +42,12 @@ class InspireDisambiguation(object):
         disambiguation_base_path = os.path.join(app.instance_path, 'disambiguation')
 
         app.config['DISAMBIGUATION_BASE_PATH'] = disambiguation_base_path
-        app.config['DISAMBIGUATION_CLUSTERS_PATH'] = os.path.join(
-            disambiguation_base_path, 'clusters.json')
+        app.config['DISAMBIGUATION_CURATED_SIGNATURES_PATH'] = os.path.join(
+            disambiguation_base_path, 'curated_signatures.jsonl')
+        app.config['DISAMBIGUATION_INPUT_CLUSTERS_PATH'] = os.path.join(
+            disambiguation_base_path, 'input_clusters.jsonl')
         app.config['DISAMBIGUATION_PUBLICATIONS_PATH'] = os.path.join(
-            disambiguation_base_path, 'publications.json')
-        app.config['DISAMBIGUATION_SIGNATURES_PATH'] = os.path.join(
-            disambiguation_base_path, 'signatures.jl')
+            disambiguation_base_path, 'publications.jsonl')
         app.config['DISAMBIGUATION_ETHNICITY_DATA_PATH'] = os.path.join(
             disambiguation_base_path, 'ethnicity.csv')
         app.config['DISAMBIGUATION_ETHNICITY_MODEL_PATH'] = os.path.join(

--- a/tests/integration/disambiguation/test_disambiguation_api.py
+++ b/tests/integration/disambiguation/test_disambiguation_api.py
@@ -30,8 +30,8 @@ from flask import current_app
 from factories.db.invenio_records import TestRecordMetadata
 
 from inspirehep.modules.disambiguation.api import (
+    save_curated_signatures_and_input_clusters,
     save_publications,
-    save_signatures_and_clusters,
     train_and_save_ethnicity_model,
 )
 from inspirehep.modules.disambiguation.core.ml.models import EthnicityEstimator
@@ -43,26 +43,34 @@ RACE,NAMELAST,NAMEFRST
 '''
 
 
-def test_save_signatures_and_clusters(isolated_app, tmpdir):
+def test_save_curated_signatures_and_input_clusters(isolated_app, tmpdir):
     TestRecordMetadata.create_from_file(__name__, '792017.json')
 
-    clusters_fd = tmpdir.join('clusters.json')
-    signatures_fd = tmpdir.join('signatures.jl')
+    curated_signatures_fd = tmpdir.join('curated_signatures.jsonl')
+    input_clusters_fd = tmpdir.join('input_clusters.jsonl')
 
     config = {
-        'DISAMBIGUATION_CLUSTERS_PATH': str(clusters_fd),
-        'DISAMBIGUATION_SIGNATURES_PATH': str(signatures_fd),
+        'DISAMBIGUATION_CURATED_SIGNATURES_PATH': str(curated_signatures_fd),
+        'DISAMBIGUATION_INPUT_CLUSTERS_PATH': str(input_clusters_fd),
     }
 
     with patch.dict(current_app.config, config):
-        save_signatures_and_clusters()
+        save_curated_signatures_and_input_clusters()
 
-    clusters = json.load(clusters_fd)
+    input_clusters = [json.loads(line) for line in input_clusters_fd.readlines()]
+    reversed_input_clusters = {
+        input_cluster['cluster_id']: {
+            'author_id': input_cluster['author_id'],
+            'signature_uuids': input_cluster['signature_uuids'],
+        } for input_cluster in input_clusters
+    }  # XXX: so that the assertion doesn't depend on cluster_id.
 
-    assert '1010819' in clusters
-    assert ['94f560d2-6791-43ec-a379-d3dc4ad0ceb7'] == clusters['1010819']
+    assert {
+        'author_id': 1010819,
+        'signature_uuids': ['94f560d2-6791-43ec-a379-d3dc4ad0ceb7'],
+    } in reversed_input_clusters.values()
 
-    signatures = [json.loads(line) for line in signatures_fd.readlines()]
+    curated_signatures = [json.loads(line) for line in curated_signatures_fd.readlines()]
 
     assert {
         'author_affiliation': 'CERN',
@@ -71,22 +79,21 @@ def test_save_signatures_and_clusters(isolated_app, tmpdir):
         'publication_id': 792017,
         'signature_block': 'ELj',
         'signature_uuid': '94f560d2-6791-43ec-a379-d3dc4ad0ceb7',
-    } in signatures
+    } in curated_signatures
 
 
 def test_save_publications(isolated_app, tmpdir):
     TestRecordMetadata.create_from_file(__name__, '792017.json')
 
-    publications_fd = tmpdir.join('publications.json')
+    publications_fd = tmpdir.join('publications.jsonl')
 
     config = {'DISAMBIGUATION_PUBLICATIONS_PATH': str(publications_fd)}
 
     with patch.dict(current_app.config, config):
         save_publications()
 
-    publications = json.load(publications_fd)
+    publications = [json.loads(line) for line in publications_fd.readlines()]
 
-    assert '792017' in publications
     assert {
         'abstract': 'This talk describes past progress in probing the structure of matter and the content of the Universe, which has led to the Standard Model of elementary particles, and the prospects for establishing new physics beyond the Standard Model using the LHC particle collider at CERN.',
         'authors': ['Ellis, John R.'],
@@ -108,7 +115,7 @@ def test_save_publications(isolated_app, tmpdir):
         'publication_id': 792017,
         'title': 'The quest for elementary particles',
         'topics': ['Phenomenology-HEP'],
-    } == publications['792017']
+    } in publications
 
 
 def test_train_and_save_ethnicity_model(tmpdir):


### PR DESCRIPTION
## Description:
The main benefit of this refactor is that now `author_id` and `cluster_id` are independent, which means that we can represent in a uniform way
1. An input cluster that refers to an author.
2. An input cluster that does not refer to an author.
3. An output cluster.

This also prevents some needless copies that happen in the various disambiguation steps (for example: https://github.com/inspirehep/beard/blob/87b37a3028825b5199616b195663fee526c26be3/examples/applications/author-disambiguation/sampling.py#L177-L179).

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.