### PR TITLE
records: don't assign an empty signature_block

### DIFF
--- a/inspirehep/modules/records/receivers.py
+++ b/inspirehep/modules/records/receivers.py
@@ -86,7 +86,7 @@ def assign_phonetic_block(sender, record, *args, **kwargs):
         return
 
     for author in record.get('authors', []):
-        if author['full_name'] in signature_blocks:
+        if author['full_name'] in signature_blocks and signature_blocks[author['full_name']]:
             author['signature_block'] = signature_blocks[author['full_name']]
 
 

--- a/tests/unit/records/test_records_receivers.py
+++ b/tests/unit/records/test_records_receivers.py
@@ -416,6 +416,29 @@ def test_assign_phonetic_block_ignores_malformed_names():
     assert expected == result
 
 
+def test_assign_phonetic_block_discards_empty_signature_blocks():
+    schema = load_schema('hep')
+    subschema = schema['properties']['authors']
+
+    record = {
+        '$schema': 'http://localhost:5000/records/schemas/hep.json',
+        'authors': [
+            {'full_name': 'ae'},
+        ],
+    }  # record/1422285
+    assert validate(record['authors'], subschema) is None
+
+    assign_phonetic_block(None, record)
+
+    expected = [
+        {'full_name': 'ae'},
+    ]
+    result = record['authors']
+
+    assert validate(result, subschema) is None
+    assert expected == result
+
+
 @mock.patch('inspirehep.modules.records.receivers.uuid.uuid4')
 def test_assign_uuid(mock_uuid4):
     mock_uuid4.return_value = UUID('727238f3-8ed6-40b6-97d2-dc3cd1429131')


### PR DESCRIPTION
## Description:
Another fix for a small bug in the `assign_phonetic_block` receiver.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.