### PR TITLE
migrator view: filter out 'DELETED' invalid records

### DIFF
--- a/inspirehep/alembic/2f5368ff6d20_update_indices_on_legacy_records_mirror_table.py
+++ b/inspirehep/alembic/2f5368ff6d20_update_indices_on_legacy_records_mirror_table.py
@@ -1,0 +1,58 @@
+#
+# This file is part of Invenio.
+# Copyright (C) 2016-2018 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Add index on legacy_records_mirror"""
+
+from __future__ import absolute_import, division, print_function
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '2f5368ff6d20'
+down_revision = 'eaab22c59b89'
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    """Upgrade database."""
+    op.create_index(
+        'ix_legacy_records_mirror_valid_collection',
+        'legacy_records_mirror',
+        ['valid', 'collection'],
+    )
+
+    op.drop_index(
+        'ix_legacy_records_mirror_valid',
+        'legacy_records_mirror',
+    )
+
+    op.drop_index(
+        'ix_legacy_records_mirror_recid',
+        'legacy_records_mirror',
+    )
+
+
+def downgrade():
+    """Downgrade database."""
+    op.drop_index(
+        'ix_legacy_records_mirror_valid_collection',
+        'legacy_records_mirror',
+    )
+
+    op.create_index(
+        'ix_legacy_records_mirror_valid',
+        'legacy_records_mirror',
+        ['valid'],
+    )
+
+    op.create_index(
+        'ix_legacy_records_mirror_recid',
+        'legacy_records_mirror',
+        ['recid'],
+    )

--- a/inspirehep/modules/migrator/models.py
+++ b/inspirehep/modules/migrator/models.py
@@ -38,10 +38,14 @@ from .utils import get_collection_from_marcxml
 class LegacyRecordsMirror(db.Model):
     __tablename__ = 'legacy_records_mirror'
 
-    recid = db.Column(db.Integer, primary_key=True, index=True)
+    __table_args__ = (
+        db.Index('ix_legacy_records_mirror_valid_collection', 'valid', 'collection'),
+    )
+
+    recid = db.Column(db.Integer, primary_key=True)
     last_updated = db.Column(db.DateTime, default=datetime.utcnow, nullable=False, index=True)
     _marcxml = db.Column('marcxml', db.LargeBinary, nullable=False)
-    valid = db.Column(db.Boolean, default=None, nullable=True, index=True)
+    valid = db.Column(db.Boolean, default=None, nullable=True)
     _errors = db.Column('errors', db.Text(), nullable=True)
     collection = db.Column(db.Text(), default='')
 

--- a/inspirehep/modules/migrator/views.py
+++ b/inspirehep/modules/migrator/views.py
@@ -29,6 +29,7 @@ from flask import (
 from flask.views import MethodView
 
 from sqlalchemy import desc
+from sqlalchemy.sql.expression import false
 
 from inspirehep.modules.migrator.permissions import migrator_use_api_permission
 
@@ -48,7 +49,11 @@ class MigratorErrorListResource(MethodView):
     decorators = [migrator_use_api_permission.require(http_exception=403)]
 
     def get(self):
-        errors = LegacyRecordsMirror.query.filter_by(valid=False).order_by(desc(LegacyRecordsMirror.last_updated)).all()
+        errors = LegacyRecordsMirror.query\
+            .filter(LegacyRecordsMirror.valid == false())\
+            .filter(LegacyRecordsMirror.collection != 'DELETED')\
+            .order_by(desc(LegacyRecordsMirror.last_updated)).all()
+
         data = {'data': errors}
         response = jsonify(migrator_error_list_dumper(data))
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Do not return invalid records with collection 'DELETED' to the view.
Also, add a composite index on `valid` and `collection` columns of the
LegacyRecordsMirror table model and create an alembic recipe for it.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://its.cern.ch/jira/browse/INSPIR-867
https://its.cern.ch/jira/browse/INSPIR-868

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- We are not interested in checking errors for records that have been deleted.
- Indexing on 'collection' and 'valid' will increase the performance of the query.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Signed-off-by: Iuliana Voinea <iuliana.voinea@student.manchester.ac.uk>
