### PR TITLE
792 testlib: add mitmproxy scenario recording client

### DIFF
--- a/tests/e2e/test_arxiv_harvest.py
+++ b/tests/e2e/test_arxiv_harvest.py
@@ -29,7 +29,7 @@ import backoff
 import pytest
 
 from inspirehep.testlib.api import InspireApiClient
-from inspirehep.testlib.api.mitm_client import MITMClient
+from inspirehep.testlib.api.mitm_client import MITMClient, with_mitmproxy
 
 
 @pytest.fixture
@@ -70,9 +70,8 @@ def wait_for(func, *args, **kwargs):
     return decorated(*args, **kwargs)
 
 
+@with_mitmproxy
 def test_harvest_non_core_article_goes_in(inspire_client, mitm_client):
-    mitm_client.set_scenario('harvest_non_core_article_goes_in')
-
     inspire_client.e2e.schedule_crawl(
         spider='arXiv',
         workflow='article',
@@ -117,9 +116,8 @@ def test_harvest_non_core_article_goes_in(inspire_client, mitm_client):
     )
 
 
+@with_mitmproxy
 def test_harvest_core_article_goes_in(inspire_client, mitm_client):
-    mitm_client.set_scenario('harvest_core_article_goes_in')
-
     inspire_client.e2e.schedule_crawl(
         spider='arXiv',
         workflow='article',
@@ -169,9 +167,8 @@ def test_harvest_core_article_goes_in(inspire_client, mitm_client):
     )
 
 
+@with_mitmproxy
 def test_harvest_core_article_manual_accept_goes_in(inspire_client, mitm_client):
-    mitm_client.set_scenario('harvest_core_article_manual_accept_goes_in')
-
     inspire_client.e2e.schedule_crawl(
         spider='arXiv',
         workflow='article',


### PR DESCRIPTION
## Description
Adds a client function for recording new interactions and a helper in the form of a decorator to abstract E2E test scenario management.

## Motivation and Context
Makes it easier to use the mitmproxy for E2E tests in inspire-next. To record interactions during a test:

```python
from inspirehep.testlib.api.mitm_client import with_mitmproxy

@with_mitmproxy(should_record=True)
def test_get_record_from_legacy():
    response = requests.get('http://inspirehep.net/record/123456')
    response.raise_for_status()
```

Bear in mind that the service has to still be registered in the mitmproxy to allow for recording (functionality to do it dynamically is coming soon, for now we have Arxiv, Legacy and RT). After the interactions are recorded you can run your test like so, to avoid recording (`should_record` is `False` by default).

```python
from inspirehep.testlib.api.mitm_client import with_mitmproxy

@with_mitmproxy
def test_get_record_from_legacy():
    response = requests.get('http://inspirehep.net/record/123456')
    response.raise_for_status()
```

Default name for a scenario is the test name without leading `test_`, so in the above case the recording will be saved in `$SCENARIOS_PATH/get_record_from_legacy/LegacyService/interaction_0.yaml`. When using default setting in `docker-compose.yaml`, `"$SCENARIOS_PATH" == "/inspire-next/tests/e2e/scenarios/"`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
