### PR TITLE
disambiguation: add signature pairs sampling

### DIFF
--- a/inspirehep/modules/disambiguation/api.py
+++ b/inspirehep/modules/disambiguation/api.py
@@ -35,6 +35,7 @@ from inspirehep.modules.disambiguation.core.db.readers import (
     get_all_publications,
 )
 from inspirehep.modules.disambiguation.core.ml.models import EthnicityEstimator
+from inspirehep.modules.disambiguation.core.ml.sampling import sample_signature_pairs
 from inspirehep.modules.disambiguation.utils import open_file_in_folder
 
 
@@ -70,6 +71,21 @@ def save_curated_signatures_and_input_clusters():
                 'cluster_id': cluster_id,
                 'signature_uuids': [signature_uuid],
             }) + '\n')
+
+
+def save_sampled_pairs():
+    """Save sampled signature pairs to disk.
+
+    Save a file to disk called (by default) ``sampled_pairs.jsonl``, which
+    contains one line per each pair of signatures sampled from INSPIRE that
+    will be used by ``BEARD`` during training.
+    """
+    with open_file_in_folder(current_app.config['DISAMBIGUATION_SAMPLED_PAIRS_PATH'], 'w') as fd:
+        signatures_path = current_app.config['DISAMBIGUATION_CURATED_SIGNATURES_PATH']
+        clusters_path = current_app.config['DISAMBIGUATION_INPUT_CLUSTERS_PATH']
+        pairs_size = current_app.config['DISAMBIGUATION_SAMPLED_PAIRS_SIZE']
+        for pair in sample_signature_pairs(signatures_path, clusters_path, pairs_size):
+            fd.write(json.dumps(pair) + '\n')
 
 
 def save_publications():

--- a/inspirehep/modules/disambiguation/config.py
+++ b/inspirehep/modules/disambiguation/config.py
@@ -23,3 +23,6 @@
 """Disambiguation configuration."""
 
 from __future__ import absolute_import, division, print_function
+
+
+DISAMBIGUATION_SAMPLED_PAIRS_SIZE = 1000000

--- a/inspirehep/modules/disambiguation/core/ml/sampling.py
+++ b/inspirehep/modules/disambiguation/core/ml/sampling.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Disambiguation core ML sampling."""
+
+from __future__ import absolute_import, division, print_function
+
+import itertools
+import json
+from collections import defaultdict
+
+import numpy as np
+import six
+
+
+def sample_signature_pairs(signatures_path, clusters_path, pairs_size):
+    """Sample signature pairs to generate less training data.
+
+    Since INSPIRE contains ~3M curated signatures it would take too much time
+    to train on all possible pairs, so we sample a subset in such a way that
+    they are representative of the known cluster structure.
+
+    This is accomplished in three steps:
+
+        1. First we read all the clusters and signatures and build in-memory
+           data structures to perform fast lookups of the id of the cluster
+           to which a signature belongs as well as lookups of the name of the
+           author associated with the signature.
+
+           At the same time we partition the signatures in blocks according
+           to the phonetic encoding of the name. Note that two signatures
+           pointing to two distinct authors might end up in the same block.
+
+        2. Then we classify signature pairs that belong to the same block
+           according to whether they belong to same cluster and whether they
+           share the same author name.
+
+           The former is because we want to have both examples of pairs of
+           signatures in the same block pointing to the same author and
+           different authors, while the latter is to avoid oversampling the
+           typical case of signatures with exactly the same author name.
+
+        3. Finally we sample from each of the four categories uniformly with
+           replacement a quarter of the samples.
+
+    Yields:
+        dict: a signature pair.
+
+    """
+
+    #
+    # 1. Read & Build
+    #
+
+    blocks = defaultdict(list)
+    signatures_reversed = {}
+    with open(signatures_path, 'r') as fd:
+        for line in fd:
+            signature = json.loads(line)
+            blocks[signature['signature_block']].append(signature['signature_uuid'])
+            signatures_reversed[signature['signature_uuid']] = signature['author_name']
+
+    clusters_reversed = {}
+    with open(clusters_path, 'r') as fd:
+        for line in fd:
+            cluster = json.loads(line)
+            for signature_uuid in cluster['signature_uuids']:
+                clusters_reversed[signature_uuid] = cluster['cluster_id']
+
+    #
+    # 2. Classify
+    #
+
+    same_cluster_same_name = []
+    same_cluster_different_name = []
+    different_cluster_same_name = []
+    different_cluster_different_name = []
+    for _, block in six.iteritems(blocks):
+        for s1, s2 in itertools.combinations(block, 2):
+            s1_cluster_id = clusters_reversed[s1]
+            s2_cluster_id = clusters_reversed[s2]
+            s1_author_name = signatures_reversed[s1]
+            s2_author_name = signatures_reversed[s2]
+            if s1_cluster_id == s2_cluster_id and s1_author_name == s2_author_name:
+                same_cluster_same_name.append({'same_cluster': True, 'signature_uuids': [s1, s2]})
+            elif s1_cluster_id == s2_cluster_id and s1_author_name != s2_author_name:
+                same_cluster_different_name.append({'same_cluster': True, 'signature_uuids': [s1, s2]})
+            elif s1_cluster_id != s2_cluster_id and s1_author_name == s2_author_name:
+                different_cluster_same_name.append({'same_cluster': False, 'signature_uuids': [s1, s2]})
+            elif s1_cluster_id != s2_cluster_id and s1_author_name != s2_author_name:
+                different_cluster_different_name.append({'same_cluster': False, 'signature_uuids': [s1, s2]})
+
+    #
+    # 3. Sample
+    #
+
+    for category in [
+        same_cluster_same_name,
+        same_cluster_different_name,
+        different_cluster_same_name,
+        different_cluster_different_name,
+    ]:
+        if category:
+            for pair in np.random.choice(category, replace=True, size=(pairs_size // 4)):
+                yield pair

--- a/inspirehep/modules/disambiguation/ext.py
+++ b/inspirehep/modules/disambiguation/ext.py
@@ -46,6 +46,8 @@ class InspireDisambiguation(object):
             disambiguation_base_path, 'curated_signatures.jsonl')
         app.config['DISAMBIGUATION_INPUT_CLUSTERS_PATH'] = os.path.join(
             disambiguation_base_path, 'input_clusters.jsonl')
+        app.config['DISAMBIGUATION_SAMPLED_PAIRS_PATH'] = os.path.join(
+            disambiguation_base_path, 'sampled_pairs.jsonl')
         app.config['DISAMBIGUATION_PUBLICATIONS_PATH'] = os.path.join(
             disambiguation_base_path, 'publications.jsonl')
         app.config['DISAMBIGUATION_ETHNICITY_DATA_PATH'] = os.path.join(

--- a/tests/integration/disambiguation/fixtures/765515.json
+++ b/tests/integration/disambiguation/fixtures/765515.json
@@ -1,0 +1,782 @@
+{
+    "$schema": "https://labs.inspirehep.net/schemas/records/hep.json",
+    "_collections": [
+        "Literature"
+    ],
+    "_private_notes": [
+        {
+            "source": "SPIRES-HIDDEN",
+            "value": "49 References from LaTeX"
+        },
+        {
+            "source": "SPIRES-HIDDEN",
+            "value": "5 PACS from LaTeX"
+        },
+        {
+            "source": "SPIRES-HIDDEN",
+            "value": "PPF.CHECKS done 14:30:46 11/26/07 by LI.ARW"
+        }
+    ],
+    "abstracts": [
+        {
+            "source": "arXiv",
+            "value": "Make-or-break time is near for the Higgs boson and supersymmetry. The LHC will soon put to the sword many theoretical ideas, and define the future for collider physics."
+        }
+    ],
+    "arxiv_eprints": [
+        {
+            "categories": [
+                "hep-ph"
+            ],
+            "value": "0710.4959"
+        }
+    ],
+    "authors": [
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://labs.inspirehep.net/api/institutions/902725"
+                    },
+                    "value": "CERN"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Ellis, John R.",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00146525"
+                },
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "J.R.Ellis.1"
+                }
+            ],
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/authors/1010819"
+            },
+            "signature_block": "ELj",
+            "uuid": "d08e1eb7-fa1b-4ea0-8917-5b3de969c582"
+        }
+    ],
+    "citeable": true,
+    "control_number": 765515,
+    "core": true,
+    "curated": true,
+    "document_type": [
+        "conference paper"
+    ],
+    "documents": [
+        {
+            "key": "arXiv:0710.4959.pdf",
+            "source": "arXiv",
+            "url": "file:///afs/cern.ch/project/inspire/PROD/var/data/files/g4/83270/arXiv%3A0710.4959.pdf%3B2"
+        }
+    ],
+    "external_system_identifiers": [
+        {
+            "schema": "CDS",
+            "value": "1065202"
+        },
+        {
+            "schema": "SPIRES",
+            "value": "SPIRES-7461879"
+        }
+    ],
+    "inspire_categories": [
+        {
+            "term": "Phenomenology-HEP"
+        }
+    ],
+    "keywords": [
+        {
+            "schema": "PACS",
+            "value": "12.10.-g"
+        },
+        {
+            "schema": "PACS",
+            "value": "11.15.Ex"
+        },
+        {
+            "schema": "PACS",
+            "value": "14.80.Bn"
+        },
+        {
+            "schema": "PACS",
+            "value": "11.30.Pb"
+        },
+        {
+            "schema": "PACS",
+            "value": "12.60.Jv"
+        }
+    ],
+    "legacy_creation_date": "2007-10-28",
+    "number_of_pages": 9,
+    "preprint_date": "2007-10",
+    "publication_info": [
+        {
+            "cnum": "C07-07-26",
+            "conference_record": {
+                "$ref": "http://labs.inspirehep.net/api/conferences/978144"
+            },
+            "page_end": "225",
+            "page_start": "216",
+            "parent_record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/792568"
+            }
+        },
+        {
+            "pubinfo_freetext": "In *Karlsruhe 2007, SUSY 2007* 216-225"
+        }
+    ],
+    "references": [
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/759496"
+            },
+            "reference": {
+                "arxiv_eprint": "0708.4236",
+                "publication_info": {
+                    "artid": "1791",
+                    "journal_title": "Int.J.Mod.Phys.A",
+                    "journal_volume": "23",
+                    "page_start": "1791"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/765178"
+            },
+            "reference": {
+                "arxiv_eprint": "0710.4265"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/725768"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ph/0609102"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/763777"
+            },
+            "reference": {
+                "arxiv_eprint": "0710.1954"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/191839"
+            },
+            "reference": {
+                "publication_info": {
+                    "artid": "453",
+                    "journal_title": "Nucl.Phys.B",
+                    "journal_volume": "238",
+                    "page_start": "453"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/724190"
+            },
+            "reference": {
+                "arxiv_eprint": "astro-ph/0608408",
+                "publication_info": {
+                    "artid": "937",
+                    "journal_title": "Astrophys.J.",
+                    "journal_volume": "652",
+                    "page_start": "937"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/746342"
+            },
+            "reference": {
+                "arxiv_eprint": "astro-ph/0703308",
+                "publication_info": {
+                    "artid": "948",
+                    "journal_title": "Astrophys.J.",
+                    "journal_volume": "663",
+                    "page_start": "948"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/614533"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ph/0303043",
+                "publication_info": {
+                    "artid": "176",
+                    "journal_title": "Phys.Lett.B",
+                    "journal_volume": "565",
+                    "page_start": "176"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/656202"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ph/0408118",
+                "publication_info": {
+                    "artid": "51",
+                    "journal_title": "Phys.Lett.B",
+                    "journal_volume": "603",
+                    "page_start": "51"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/763827"
+            },
+            "reference": {
+                "arxiv_eprint": "0710.2062"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/752325"
+            },
+            "reference": {
+                "arxiv_eprint": "0706.0652",
+                "publication_info": {
+                    "artid": "083",
+                    "journal_title": "JHEP",
+                    "journal_volume": "08",
+                    "page_start": "083",
+                    "year": 2007
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/756540"
+            },
+            "reference": {
+                "arxiv_eprint": "0707.3447",
+                "publication_info": {
+                    "artid": "87",
+                    "journal_title": "Phys.Lett.B",
+                    "journal_volume": "657",
+                    "page_start": "87"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/764231"
+            },
+            "reference": {
+                "arxiv_eprint": "0710.2897"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/764137"
+            },
+            "reference": {
+                "arxiv_eprint": "0710.2670"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/765006"
+            },
+            "reference": {
+                "arxiv_eprint": "0710.4098"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/753397"
+            },
+            "reference": {
+                "arxiv_eprint": "0706.2569",
+                "publication_info": {
+                    "artid": "473",
+                    "journal_title": "Eur.Phys.J.C",
+                    "journal_volume": "53",
+                    "page_start": "473"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/763081"
+            },
+            "reference": {
+                "arxiv_eprint": "0710.1013"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/662983"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ph/0410364",
+                "publication_info": {
+                    "artid": "47",
+                    "journal_title": "Phys.Rept.",
+                    "journal_volume": "426",
+                    "page_start": "47"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/761479"
+            },
+            "reference": {
+                "arxiv_eprint": "0709.3303"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/759576"
+            },
+            "reference": {
+                "arxiv_eprint": "0709.0098",
+                "publication_info": {
+                    "artid": "092",
+                    "journal_title": "JHEP",
+                    "journal_volume": "10",
+                    "page_start": "092",
+                    "year": 2007
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/760146"
+            },
+            "reference": {
+                "arxiv_eprint": "0709.1030",
+                "publication_info": {
+                    "artid": "SUS03",
+                    "journal_title": "eConf C",
+                    "journal_volume": "0705302"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/763850"
+            },
+            "reference": {
+                "arxiv_eprint": "0710.2111"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/763950"
+            },
+            "reference": {
+                "arxiv_eprint": "0710.2322"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/717382"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ph/0605215",
+                "publication_info": {
+                    "artid": "231301",
+                    "journal_title": "Phys.Rev.Lett.",
+                    "journal_volume": "98"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/765310"
+            },
+            "reference": {
+                "arxiv_eprint": "0710.4548",
+                "publication_info": {
+                    "artid": "287",
+                    "journal_title": "Eur.Phys.J.C",
+                    "journal_volume": "56",
+                    "page_start": "287"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/763903"
+            },
+            "reference": {
+                "arxiv_eprint": "0710.2213",
+                "publication_info": {
+                    "artid": "181",
+                    "journal_title": "Phys.Lett.B",
+                    "journal_volume": "666",
+                    "page_start": "181"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/722234"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ph/0607261",
+                "publication_info": {
+                    "artid": "061",
+                    "journal_title": "JHEP",
+                    "journal_volume": "10",
+                    "page_start": "061",
+                    "year": 2006
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/746272"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ph/0703130",
+                "publication_info": {
+                    "artid": "015",
+                    "journal_title": "JHEP",
+                    "journal_volume": "08",
+                    "page_start": "015",
+                    "year": 2007
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/743345"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ph/0701229",
+                "publication_info": {
+                    "artid": "003",
+                    "journal_title": "JHEP",
+                    "journal_volume": "05",
+                    "page_start": "003",
+                    "year": 2007
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/761845"
+            },
+            "reference": {
+                "arxiv_eprint": "0709.3952"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/690222"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ph/0508198",
+                "publication_info": {
+                    "artid": "1041",
+                    "journal_title": "Eur.Phys.J.C",
+                    "journal_volume": "49",
+                    "page_start": "1041"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/724700"
+            },
+            "reference": {
+                "arxiv_eprint": "astro-ph/0608562",
+                "publication_info": {
+                    "artid": "014",
+                    "journal_title": "JCAP",
+                    "journal_volume": "11",
+                    "page_start": "014",
+                    "year": 2006
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/723348"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ph/0608079"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/764100"
+            },
+            "reference": {
+                "arxiv_eprint": "0710.2578"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/566907"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ph/0111245",
+                "publication_info": {
+                    "artid": "345",
+                    "journal_title": "Nucl.Phys.B",
+                    "journal_volume": "625",
+                    "page_start": "345"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/764226"
+            },
+            "reference": {
+                "arxiv_eprint": "0710.2883"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/698797"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ph/0511289",
+                "publication_info": {
+                    "artid": "011701",
+                    "journal_title": "Phys.Rev.D",
+                    "journal_volume": "74"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/765004"
+            },
+            "reference": {
+                "arxiv_eprint": "0710.4091"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/764065"
+            },
+            "reference": {
+                "arxiv_eprint": "0710.2525"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/764033"
+            },
+            "reference": {
+                "arxiv_eprint": "0710.2468",
+                "publication_info": {
+                    "artid": "461",
+                    "journal_title": "Eur.Phys.J.C",
+                    "journal_volume": "56",
+                    "page_start": "461"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/764647"
+            },
+            "reference": {
+                "arxiv_eprint": "0710.3407"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/761710"
+            },
+            "reference": {
+                "arxiv_eprint": "0709.3816"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/711142"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-th/0602239",
+                "publication_info": {
+                    "artid": "021",
+                    "journal_title": "JHEP",
+                    "journal_volume": "04",
+                    "page_start": "021",
+                    "year": 2006
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/178505"
+            },
+            "reference": {
+                "publication_info": {
+                    "artid": "227",
+                    "journal_title": "Phys.Lett.B",
+                    "journal_volume": "114",
+                    "page_start": "227"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/679795"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ph/0504036",
+                "publication_info": {
+                    "artid": "015004",
+                    "journal_title": "Phys.Rev.D",
+                    "journal_volume": "72"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/679796"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ph/0504037",
+                "publication_info": {
+                    "artid": "039",
+                    "journal_title": "JHEP",
+                    "journal_volume": "09",
+                    "page_start": "039",
+                    "year": 2005
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/763699"
+            },
+            "reference": {
+                "arxiv_eprint": "0710.1843"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/720689"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ph/0607002",
+                "publication_info": {
+                    "artid": "389",
+                    "journal_title": "Phys.Lett.B",
+                    "journal_volume": "642",
+                    "page_start": "389"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/749318"
+            },
+            "reference": {
+                "arxiv_eprint": "0704.3446",
+                "publication_info": {
+                    "artid": "079",
+                    "journal_title": "JHEP",
+                    "journal_volume": "06",
+                    "page_start": "079",
+                    "year": 2007
+                }
+            }
+        }
+    ],
+    "report_numbers": [
+        {
+            "value": "CERN-PH-TH-2007-204"
+        }
+    ],
+    "self": {
+        "$ref": "http://labs.inspirehep.net/api/literature/765515"
+    },
+    "texkeys": [
+        "Ellis:2007mc"
+    ],
+    "titles": [
+        {
+            "title": "Outlook from SUSY07"
+        },
+        {
+            "source": "arXiv",
+            "title": "Outlook from SUSY07"
+        }
+    ],
+    "urls": [
+        {
+            "value": "http://weblib.cern.ch/abstract?CERN-PH-TH-2007-204"
+        },
+        {
+            "description": "Electronic Version from a server",
+            "value": "http://www.susy07.uni-karlsruhe.de/Proceedings/proceedings/susy07.pdf"
+        }
+    ]
+}

--- a/tests/integration/disambiguation/fixtures/765975.json
+++ b/tests/integration/disambiguation/fixtures/765975.json
@@ -1,0 +1,1140 @@
+{
+    "$schema": "https://labs.inspirehep.net/schemas/records/hep.json",
+    "_collections": [
+        "Literature"
+    ],
+    "_private_notes": [
+        {
+            "source": "SPIRES-HIDDEN",
+            "value": "65 References from LaTeX"
+        },
+        {
+            "source": "SPIRES-HIDDEN",
+            "value": "PPF.CHECKS done 13:26:02 11/14/07 by LI.ARW"
+        },
+        {
+            "source": "SPIRES-HIDDEN",
+            "value": "80 cites (new:5) from citesj on 07/06/2008"
+        },
+        {
+            "source": "SPIRES-HIDDEN",
+            "value": "JHEP cites changed 1-28-10 via DOI lookup, sul"
+        }
+    ],
+    "abstracts": [
+        {
+            "source": "arXiv",
+            "value": "Within particle physics itself, Gauguin's questions may be interpreted as: P1 - What is the status of the Standard Model? P2 - What physics may lie beyond the Standard Model? P3 - What is the `Theory of Everything'? Gauguin's questions may also asked within a cosmological context: C1 - What were the early stages of the Big Bang? C2 - What is the material content of the Universe today? C3 - What is the future of the Universe? In this talk I preview many of the topics to be discussed in the plenary sessions of this conference, highlighting how they bear on these fundamental questions."
+        }
+    ],
+    "arxiv_eprints": [
+        {
+            "categories": [
+                "hep-ph"
+            ],
+            "value": "0710.5590"
+        }
+    ],
+    "authors": [
+        {
+            "affiliations": [
+                {
+                    "record": {
+                        "$ref": "http://labs.inspirehep.net/api/institutions/902725"
+                    },
+                    "value": "CERN"
+                }
+            ],
+            "curated_relation": true,
+            "full_name": "Ellis, John R.",
+            "ids": [
+                {
+                    "schema": "INSPIRE ID",
+                    "value": "INSPIRE-00146525"
+                },
+                {
+                    "schema": "INSPIRE BAI",
+                    "value": "J.R.Ellis.1"
+                }
+            ],
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/authors/1010819"
+            },
+            "signature_block": "ELj",
+            "uuid": "cbf081db-fcb7-4386-baaf-f30636debfa7"
+        }
+    ],
+    "citeable": true,
+    "control_number": 765975,
+    "core": true,
+    "curated": true,
+    "document_type": [
+        "conference paper"
+    ],
+    "documents": [
+        {
+            "key": "arXiv:0710.5590.pdf",
+            "source": "arXiv",
+            "url": "file:///afs/cern.ch/project/inspire/PROD/var/data/files/g4/83533/arXiv%3A0710.5590.pdf%3B2"
+        }
+    ],
+    "dois": [
+        {
+            "value": "10.1088/1742-6596/110/1/012001"
+        }
+    ],
+    "external_system_identifiers": [
+        {
+            "schema": "ADS",
+            "value": "2008JPhCS.110a2001E"
+        },
+        {
+            "schema": "CDS",
+            "value": "1065838"
+        },
+        {
+            "schema": "SPIRES",
+            "value": "SPIRES-7467400"
+        }
+    ],
+    "inspire_categories": [
+        {
+            "term": "Phenomenology-HEP"
+        }
+    ],
+    "legacy_creation_date": "2007-10-30",
+    "number_of_pages": 16,
+    "preprint_date": "2007-10",
+    "publication_info": [
+        {
+            "artid": "012001",
+            "journal_record": {
+                "$ref": "http://labs.inspirehep.net/api/journals/1212279"
+            },
+            "journal_title": "J.Phys.Conf.Ser.",
+            "journal_volume": "110",
+            "year": 2008
+        },
+        {
+            "cnum": "C07-07-19",
+            "conference_record": {
+                "$ref": "http://labs.inspirehep.net/api/conferences/978092"
+            },
+            "parent_record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/874905"
+            }
+        }
+    ],
+    "references": [
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/81350"
+            },
+            "reference": {
+                "publication_info": {
+                    "artid": "652",
+                    "journal_title": "Prog.Theor.Phys.",
+                    "journal_volume": "49",
+                    "page_start": "652"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/749379"
+            },
+            "reference": {
+                "arxiv_eprint": "0704.3575"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/755026"
+            },
+            "reference": {
+                "arxiv_eprint": "0707.0636",
+                "publication_info": {
+                    "artid": "049",
+                    "journal_title": "JHEP",
+                    "journal_volume": "03",
+                    "page_start": "049",
+                    "year": 2008
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/808681"
+            },
+            "reference": {
+                "arxiv_eprint": "0710.2838"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/746749"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ex/0703034"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/359646"
+            },
+            "reference": {
+                "publication_info": {
+                    "artid": "148",
+                    "journal_title": "Phys.Lett.B",
+                    "journal_volume": "318",
+                    "page_start": "148"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/764539"
+            },
+            "reference": {
+                "arxiv_eprint": "0710.3294",
+                "publication_info": {
+                    "artid": "012014",
+                    "journal_title": "J.Phys.Conf.Ser.",
+                    "journal_volume": "110"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/763777"
+            },
+            "reference": {
+                "arxiv_eprint": "0710.1954"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/763081"
+            },
+            "reference": {
+                "arxiv_eprint": "0710.1013"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/624071"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ph/0307305",
+                "publication_info": {
+                    "artid": "033",
+                    "journal_title": "JHEP",
+                    "journal_volume": "08",
+                    "page_start": "033",
+                    "year": 2003
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/470671"
+            },
+            "reference": {
+                "arxiv_eprint": "astro-ph/9805201",
+                "publication_info": {
+                    "artid": "1009",
+                    "journal_title": "Astron.J.",
+                    "journal_volume": "116",
+                    "page_start": "1009"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/484837"
+            },
+            "reference": {
+                "arxiv_eprint": "astro-ph/9812133",
+                "publication_info": {
+                    "artid": "565",
+                    "journal_title": "Astrophys.J.",
+                    "journal_volume": "517",
+                    "page_start": "565"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/154280"
+            },
+            "reference": {
+                "publication_info": {
+                    "artid": "347",
+                    "journal_title": "Phys.Rev.D",
+                    "journal_volume": "23",
+                    "page_start": "347"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/168781"
+            },
+            "reference": {
+                "publication_info": {
+                    "artid": "389",
+                    "journal_title": "Phys.Lett.B",
+                    "journal_volume": "108",
+                    "page_start": "389"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/176612"
+            },
+            "reference": {
+                "publication_info": {
+                    "artid": "1220",
+                    "journal_title": "Phys.Rev.Lett.",
+                    "journal_volume": "48",
+                    "page_start": "1220"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/182708"
+            },
+            "reference": {
+                "publication_info": {
+                    "artid": "1110",
+                    "journal_title": "Phys.Rev.Lett.",
+                    "journal_volume": "49",
+                    "page_start": "1110"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/13328"
+            },
+            "reference": {
+                "publication_info": {
+                    "artid": "679",
+                    "journal_title": "Phys.Rev.D",
+                    "journal_volume": "28",
+                    "page_start": "679"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/183488"
+            },
+            "reference": {
+                "publication_info": {
+                    "artid": "180",
+                    "journal_title": "Nucl.Phys.B",
+                    "journal_volume": "224",
+                    "page_start": "180"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/761334"
+            },
+            "reference": {
+                "arxiv_eprint": "0709.3102"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/502651"
+            },
+            "reference": {
+                "arxiv_eprint": "astro-ph/9906463",
+                "publication_info": {
+                    "artid": "1481",
+                    "journal_title": "Science",
+                    "journal_volume": "284",
+                    "page_start": "1481"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/51345"
+            },
+            "reference": {
+                "publication_info": {
+                    "artid": "32",
+                    "journal_title": "Pisma Zh.Eksp.Teor.Fiz.",
+                    "journal_volume": "5",
+                    "page_start": "32"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/191839"
+            },
+            "reference": {
+                "publication_info": {
+                    "artid": "453",
+                    "journal_title": "Nucl.Phys.B",
+                    "journal_volume": "238",
+                    "page_start": "453"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/119084"
+            },
+            "reference": {
+                "publication_info": {
+                    "artid": "1440",
+                    "journal_title": "Phys.Rev.Lett.",
+                    "journal_volume": "38",
+                    "page_start": "1440"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/122138"
+            },
+            "reference": {
+                "publication_info": {
+                    "artid": "223",
+                    "journal_title": "Phys.Rev.Lett.",
+                    "journal_volume": "40",
+                    "page_start": "223"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/5997"
+            },
+            "reference": {
+                "publication_info": {
+                    "artid": "279",
+                    "journal_title": "Phys.Rev.Lett.",
+                    "journal_volume": "40",
+                    "page_start": "279"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/40440"
+            },
+            "reference": {
+                "publication_info": {
+                    "artid": "132",
+                    "journal_title": "Phys.Lett.",
+                    "journal_volume": "12",
+                    "page_start": "132"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/12291"
+            },
+            "reference": {
+                "publication_info": {
+                    "artid": "321",
+                    "journal_title": "Phys.Rev.Lett.",
+                    "journal_volume": "13",
+                    "page_start": "321"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/764180"
+            },
+            "reference": {
+                "arxiv_eprint": "0710.2786",
+                "publication_info": {
+                    "artid": "072030",
+                    "journal_title": "J.Phys.Conf.Ser.",
+                    "journal_volume": "110"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/765178"
+            },
+            "reference": {
+                "arxiv_eprint": "0710.4265"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/725768"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ph/0609102"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/764647"
+            },
+            "reference": {
+                "arxiv_eprint": "0710.3407"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/590188"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ph/0207123",
+                "publication_info": {
+                    "artid": "073002",
+                    "journal_title": "Phys.Rev.D",
+                    "journal_volume": "66"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/530815"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ph/0007265"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/557090"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ph/0105239",
+                "publication_info": {
+                    "artid": "232",
+                    "journal_title": "Phys.Lett.B",
+                    "journal_volume": "513",
+                    "page_start": "232"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/764043"
+            },
+            "reference": {
+                "arxiv_eprint": "0710.2484",
+                "publication_info": {
+                    "artid": "002",
+                    "journal_title": "JCAP",
+                    "journal_volume": "05",
+                    "page_start": "002",
+                    "year": 2008
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/713764"
+            },
+            "reference": {
+                "arxiv_eprint": "astro-ph/0604069"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/716859"
+            },
+            "reference": {
+                "arxiv_eprint": "astro-ph/0605338",
+                "publication_info": {
+                    "artid": "023502",
+                    "journal_title": "Phys.Rev.D",
+                    "journal_volume": "74"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/340964"
+            },
+            "reference": {
+                "publication_info": {
+                    "artid": "1912",
+                    "journal_title": "Phys.Rev.Lett.",
+                    "journal_volume": "70",
+                    "page_start": "1912"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/616054"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ph/0303242",
+                "publication_info": {
+                    "artid": "9",
+                    "journal_title": "Phys.Lett.B",
+                    "journal_volume": "581",
+                    "page_start": "9"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/167850"
+            },
+            "reference": {
+                "publication_info": {
+                    "artid": "267",
+                    "journal_title": "Phys.Lett.B",
+                    "journal_volume": "105",
+                    "page_start": "267"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/298254"
+            },
+            "reference": {
+                "publication_info": {
+                    "artid": "441",
+                    "journal_title": "Phys.Lett.B",
+                    "journal_volume": "249",
+                    "page_start": "441"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/304282"
+            },
+            "reference": {
+                "publication_info": {
+                    "artid": "131",
+                    "journal_title": "Phys.Lett.B",
+                    "journal_volume": "260",
+                    "page_start": "131"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/314885"
+            },
+            "reference": {
+                "publication_info": {
+                    "artid": "447",
+                    "journal_title": "Phys.Lett.B",
+                    "journal_volume": "260",
+                    "page_start": "447"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/321063"
+            },
+            "reference": {
+                "publication_info": {
+                    "artid": "1745",
+                    "journal_title": "Mod.Phys.Lett.A",
+                    "journal_volume": "6",
+                    "page_start": "1745"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/693494"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ph/0509331",
+                "publication_info": {
+                    "artid": "583",
+                    "journal_title": "Phys.Lett.B",
+                    "journal_volume": "633",
+                    "page_start": "583"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/756540"
+            },
+            "reference": {
+                "arxiv_eprint": "0707.3447",
+                "publication_info": {
+                    "artid": "87",
+                    "journal_title": "Phys.Lett.B",
+                    "journal_volume": "657",
+                    "page_start": "87"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/724190"
+            },
+            "reference": {
+                "arxiv_eprint": "astro-ph/0608408",
+                "publication_info": {
+                    "artid": "937",
+                    "journal_title": "Astrophys.J.",
+                    "journal_volume": "652",
+                    "page_start": "937"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/750638"
+            },
+            "reference": {
+                "arxiv_eprint": "0705.2171",
+                "publication_info": {
+                    "artid": "728",
+                    "journal_title": "Astrophys.J.",
+                    "journal_volume": "661",
+                    "page_start": "728"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/742799"
+            },
+            "reference": {
+                "arxiv_eprint": "astro-ph/0701594",
+                "publication_info": {
+                    "artid": "286",
+                    "journal_title": "Nature",
+                    "journal_volume": "445",
+                    "page_start": "286"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/552899"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ex/0102017",
+                "publication_info": {
+                    "artid": "2227",
+                    "journal_title": "Phys.Rev.Lett.",
+                    "journal_volume": "86",
+                    "page_start": "2227"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/614533"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ph/0303043",
+                "publication_info": {
+                    "artid": "176",
+                    "journal_title": "Phys.Lett.B",
+                    "journal_volume": "565",
+                    "page_start": "176"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/761479"
+            },
+            "reference": {
+                "arxiv_eprint": "0709.3303"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/656202"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ph/0408118",
+                "publication_info": {
+                    "artid": "51",
+                    "journal_title": "Phys.Lett.B",
+                    "journal_volume": "603",
+                    "page_start": "51"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/752325"
+            },
+            "reference": {
+                "arxiv_eprint": "0706.0652",
+                "publication_info": {
+                    "artid": "083",
+                    "journal_title": "JHEP",
+                    "journal_volume": "08",
+                    "page_start": "083",
+                    "year": 2007
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/645602"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-th/0403047",
+                "publication_info": {
+                    "artid": "006",
+                    "journal_title": "JHEP",
+                    "journal_volume": "09",
+                    "page_start": "006",
+                    "year": 2004
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/651094"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-th/0405231",
+                "publication_info": {
+                    "artid": "111601",
+                    "journal_title": "Phys.Rev.Lett.",
+                    "journal_volume": "94"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/614185"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-th/0302219"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/650609"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-th/0405159",
+                "publication_info": {
+                    "artid": "073",
+                    "journal_title": "JHEP",
+                    "journal_volume": "06",
+                    "page_start": "073",
+                    "year": 2005
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/651938"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ph/0406088",
+                "publication_info": {
+                    "artid": "65",
+                    "journal_title": "Nucl.Phys.B",
+                    "journal_volume": "699",
+                    "page_start": "65"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/558356"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-th/0106109"
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/336563"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-th/9207103",
+                "publication_info": {
+                    "artid": "37",
+                    "journal_title": "Phys.Lett.B",
+                    "journal_volume": "293",
+                    "page_start": "37"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/415952"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-th/9602070",
+                "publication_info": {
+                    "artid": "135",
+                    "journal_title": "Nucl.Phys.B",
+                    "journal_volume": "471",
+                    "page_start": "135"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/297524"
+            },
+            "reference": {
+                "publication_info": {
+                    "artid": "377",
+                    "journal_title": "Phys.Lett.B",
+                    "journal_volume": "246",
+                    "page_start": "377"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/469596"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ph/9804398",
+                "publication_info": {
+                    "artid": "257",
+                    "journal_title": "Phys.Lett.B",
+                    "journal_volume": "436",
+                    "page_start": "257"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/499284"
+            },
+            "reference": {
+                "arxiv_eprint": "hep-ph/9905221",
+                "publication_info": {
+                    "artid": "3370",
+                    "journal_title": "Phys.Rev.Lett.",
+                    "journal_volume": "83",
+                    "page_start": "3370"
+                }
+            }
+        },
+        {
+            "reference": {
+                "publication_info": {
+                    "artid": "1237",
+                    "journal_title": "J.Vac.Sci.Tech.B",
+                    "journal_volume": "10",
+                    "page_start": "1237"
+                }
+            }
+        },
+        {
+            "reference": {
+                "publication_info": {
+                    "artid": "965",
+                    "journal_title": "J.Appl.Phys.",
+                    "journal_volume": "87",
+                    "page_start": "965"
+                }
+            }
+        },
+        {
+            "reference": {
+                "publication_info": {
+                    "artid": "L74",
+                    "journal_title": "Jap.J.Appl.Phys.",
+                    "journal_volume": "35",
+                    "page_start": "L74"
+                }
+            }
+        },
+        {
+            "reference": {
+                "publication_info": {
+                    "artid": "1105",
+                    "journal_title": "Electron.Lett.",
+                    "journal_volume": "32",
+                    "page_start": "1105"
+                }
+            }
+        },
+        {
+            "reference": {
+                "publication_info": {
+                    "artid": "826",
+                    "journal_title": "J.Appl.Phys.",
+                    "journal_volume": "83",
+                    "page_start": "826"
+                }
+            }
+        },
+        {
+            "reference": {
+                "publication_info": {
+                    "artid": "3317",
+                    "journal_title": "Phys.Rev.B",
+                    "journal_volume": "39",
+                    "page_start": "3317"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/614778"
+            },
+            "reference": {
+                "arxiv_eprint": "gr-qc/0303038",
+                "publication_info": {
+                    "artid": "063517",
+                    "journal_title": "Phys.Rev.D",
+                    "journal_volume": "68"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/642112"
+            },
+            "reference": {
+                "arxiv_eprint": "gr-qc/0401010",
+                "publication_info": {
+                    "artid": "41",
+                    "journal_title": "Int.J.Geom.Meth.Mod.Phys.",
+                    "journal_volume": "2",
+                    "page_start": "41"
+                }
+            }
+        },
+        {
+            "reference": {
+                "publication_info": {
+                    "artid": "25",
+                    "journal_title": "New J.Phys.",
+                    "journal_volume": "6",
+                    "page_start": "25"
+                }
+            }
+        },
+        {
+            "curated_relation": false,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/literature/614635"
+            },
+            "reference": {
+                "arxiv_eprint": "astro-ph/0303150",
+                "publication_info": {
+                    "artid": "001",
+                    "journal_title": "JCAP",
+                    "journal_volume": "01",
+                    "page_start": "001",
+                    "year": 2004
+                }
+            }
+        }
+    ],
+    "report_numbers": [
+        {
+            "value": "CERN-PH-TH-2007-210"
+        }
+    ],
+    "self": {
+        "$ref": "http://labs.inspirehep.net/api/literature/765975"
+    },
+    "texkeys": [
+        "Ellis:2007kd"
+    ],
+    "titles": [
+        {
+            "title": "Gauguin's questions in particle physics: Where are we coming from? What are we? Where are we going?"
+        },
+        {
+            "source": "arXiv",
+            "title": "Gauguin's questions in particle physics: Where are we coming from? What are we? Where are we going?"
+        }
+    ],
+    "urls": [
+        {
+            "value": "http://weblib.cern.ch/abstract?CERN-PH-TH-2007-210"
+        }
+    ]
+}

--- a/tests/integration/disambiguation/test_disambiguation_api.py
+++ b/tests/integration/disambiguation/test_disambiguation_api.py
@@ -32,6 +32,7 @@ from factories.db.invenio_records import TestRecordMetadata
 from inspirehep.modules.disambiguation.api import (
     save_curated_signatures_and_input_clusters,
     save_publications,
+    save_sampled_pairs,
     train_and_save_ethnicity_model,
 )
 from inspirehep.modules.disambiguation.core.ml.models import EthnicityEstimator
@@ -80,6 +81,42 @@ def test_save_curated_signatures_and_input_clusters(isolated_app, tmpdir):
         'signature_block': 'ELj',
         'signature_uuid': '94f560d2-6791-43ec-a379-d3dc4ad0ceb7',
     } in curated_signatures
+
+
+def test_save_sampled_signature_pairs(isolated_app, tmpdir):
+    TestRecordMetadata.create_from_file(__name__, '765515.json')
+    TestRecordMetadata.create_from_file(__name__, '765975.json')
+
+    curated_signatures_fd = tmpdir.join('curated_signatures.jsonl')
+    input_clusters_fd = tmpdir.join('input_clusters.jsonl')
+    sampled_pairs_fd = tmpdir.join('sampled_pairs.jsonl')
+
+    config = {
+        'DISAMBIGUATION_CURATED_SIGNATURES_PATH': str(curated_signatures_fd),
+        'DISAMBIGUATION_INPUT_CLUSTERS_PATH': str(input_clusters_fd),
+        'DISAMBIGUATION_SAMPLED_PAIRS_PATH': str(sampled_pairs_fd),
+        'DISAMBIGUATION_SAMPLED_PAIRS_SIZE': 1000,
+    }
+
+    with patch.dict(current_app.config, config):
+        save_curated_signatures_and_input_clusters()
+        save_sampled_pairs()
+
+    sampled_pairs = [json.loads(line) for line in sampled_pairs_fd.readlines()]
+    normalized_sampled_pairs = [
+        {
+            'same_cluster': sampled_pair['same_cluster'],
+            'signature_uuids': sorted(sampled_pair['signature_uuids']),
+        } for sampled_pair in sampled_pairs
+    ]  # XXX: so that the assertion doesn't depend on signature order.
+
+    assert {
+        'same_cluster': True,
+        'signature_uuids': [
+            'cbf081db-fcb7-4386-baaf-f30636debfa7',
+            'd08e1eb7-fa1b-4ea0-8917-5b3de969c582',
+        ],
+    } in normalized_sampled_pairs
 
 
 def test_save_publications(isolated_app, tmpdir):

--- a/tests/integration/disambiguation/test_disambiguation_api.py
+++ b/tests/integration/disambiguation/test_disambiguation_api.py
@@ -118,7 +118,7 @@ def test_save_publications(isolated_app, tmpdir):
     } in publications
 
 
-def test_train_and_save_ethnicity_model(tmpdir):
+def test_train_and_save_ethnicity_model(isolated_app, tmpdir):
     ethnicity_data_fd = tmpdir.join('ethnicity.csv')
     ethnicity_data_fd.write(TRAINING_DATA)
     ethnicity_model_fd = tmpdir.join('ethnicity.pkl')


### PR DESCRIPTION
## Description:
One test depended implicitly on the presence of an application
context, but didn't explicitly require an application fixture.
This meant that the test was failing when run in isolation.

Since INSPIRE has ~3M curated signatures it would take too much time
to train on all possible pairs, so we sample 1M pairs in such a way
that they are representative of the known clusters structure.

## Checklist:
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.