### PR TITLE
records: fix transaction issue causing zomie pids

### DIFF
--- a/inspirehep/modules/records/api.py
+++ b/inspirehep/modules/records/api.py
@@ -96,8 +96,9 @@ class InspireRecord(Record):
         id_ = id_ or uuid.uuid4()
         data = strip_empty_values(data)
 
-        cls.mint(id_, data)
-        record = super(InspireRecord, cls).create(data, id_=id_, **kwargs)
+        with db.session.begin_nested():
+            cls.mint(id_, data)
+            record = super(InspireRecord, cls).create(data, id_=id_, **kwargs)
 
         if not skip_files:
             record.download_documents_and_figures(


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Encapsulate the record creation and minting statements found in `InspireRecord.create()` in a `with db.session.negin_nested():` SAVEPOINT. In case of an exception, the state of the DB will be rolled back to the savepoint, regardless of whether a PID or a record has already been created. Thus, now a PID cannot be created without an associated record. The opposite is also true.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://its.cern.ch/jira/browse/INSPIR-732

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
At the moment, if the record creation fails because of errors like `ValidationError` , a PID is still created and stored for that record. Similarly, we had the opposite problem in the past: inspire records were saved with no associated PIDs when the minting process would fail because of errors like `PIDAlreadyExists`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Signed-off-by: Iuliana Voinea <iuliana.voinea@student.manchester.ac.uk>