### PR TITLE
workflows: make reference information available to the templates

### DIFF
--- a/inspirehep/modules/workflows/search.py
+++ b/inspirehep/modules/workflows/search.py
@@ -43,13 +43,13 @@ def holdingpen_search_factory(self, search, **kwargs):
         'metadata.number_of_pages', 'metadata.arxiv_eprints',
         'metadata.public_notes', 'metadata.inspire_categories',
         'metadata.name', 'metadata.positions', 'metadata.acquisition_source',
-        'metadata.arxiv_categories', '_workflow',
+        'metadata.arxiv_categories', 'metadata.references', '_workflow',
         '_extra_data.relevance_prediction', '_extra_data.user_action',
         '_extra_data.classifier_results.complete_output',
         '_extra_data.classifier_results.fulltext_used',
         '_extra_data.journal_coverage', '_extra_data._action',
         '_extra_data.matches', '_extra_data.crawl_errors',
-        '_extra_data.conflicts',
+        '_extra_data.conflicts', '_extra_data.reference_count',
         '_extra_data.validation_errors', '_extra_data.callback_url',
     ]
     search = search.extra(_source={"include": includes})


### PR DESCRIPTION
Signed-off-by: Dinika Saxena <dinika.saxena@cern.ch>

User-story: [INSPIR-192](https://its.cern.ch/jira/browse/INSPIR-192)

## Description
Required for [PR 85](https://github.com/inspirehep/inspirehep-search-js/pull/85) in inspirehep-search-js to display the number of core and matched references for a given record.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
