### PR TITLE
workflows: put the refextract timeout on subtasks

### DIFF
--- a/inspirehep/modules/workflows/tasks/actions.py
+++ b/inspirehep/modules/workflows/tasks/actions.py
@@ -38,7 +38,6 @@ from sqlalchemy import (
     cast,
     type_coerce,
 )
-from timeout_decorator import timeout
 from werkzeug import secure_filename
 
 from invenio_db import db
@@ -62,7 +61,6 @@ from inspirehep.modules.workflows.utils import (
     get_document_in_workflow,
     get_resolve_validation_callback_url,
     get_validation_errors,
-    ignore_timeout_error,
     log_workflows_action,
     with_debug_logging,
 )
@@ -401,8 +399,6 @@ def download_documents(obj, eng):
                 'Cannot download document from %s', url)
 
 
-@ignore_timeout_error
-@timeout(10 * 60)
 @with_debug_logging
 def refextract(obj, eng):
     """Extract references from various sources and add them to the workflow.

--- a/inspirehep/modules/workflows/tasks/refextract.py
+++ b/inspirehep/modules/workflows/tasks/refextract.py
@@ -28,6 +28,8 @@ from flask import current_app
 
 from itertools import chain
 
+from timeout_decorator import timeout
+
 from inspire_dojson.utils import (
     get_record_ref,
     get_recid_from_ref
@@ -37,6 +39,7 @@ from inspire_schemas.utils import (
     convert_old_publication_info_to_new,
     split_page_artid,
 )
+from inspirehep.modules.workflows.utils import ignore_timeout_error
 from inspire_utils.dedupers import dedupe_list
 from inspire_utils.helpers import maybe_int
 from inspire_utils.logging import getStackTraceLogger
@@ -111,6 +114,8 @@ def extract_journal_info(obj, eng):
     obj.data['publication_info'] = convert_old_publication_info_to_new(obj.data['publication_info'])
 
 
+@ignore_timeout_error
+@timeout(5 * 60)
 def extract_references_from_pdf(filepath, source=None, custom_kbs_file=None):
     """Extract references from PDF and return in INSPIRE format."""
     with local_refextract_kbs_path() as kbs_path:
@@ -123,6 +128,8 @@ def extract_references_from_pdf(filepath, source=None, custom_kbs_file=None):
     return map_refextract_to_schema(extracted_references, source=source)
 
 
+@ignore_timeout_error
+@timeout(5 * 60)
 def extract_references_from_text(text, source=None, custom_kbs_file=None):
     """Extract references from text and return in INSPIRE format."""
     with local_refextract_kbs_path() as kbs_path:
@@ -135,6 +142,8 @@ def extract_references_from_text(text, source=None, custom_kbs_file=None):
     return map_refextract_to_schema(extracted_references, source=source)
 
 
+@ignore_timeout_error
+@timeout(5 * 60)
 def extract_references_from_raw_refs(references, custom_kbs_file=None):
     """Extract references from raw references in reference list.
 


### PR DESCRIPTION
Increasing the timeout to 10 min in
92d3166d84652520cf294aef430ae9c8296ea9de didn't solve the problem. This
might be because when there are lots of references, also reference
matching takes a long time, exceeding the allowed time. As we really
want to protect from refextract going wild and never finishing, rather
than ensuring the task runs in a fixed amount of time, it makes sense
not to include reference matching in the timeout.

Signed-off-by: Micha Moskovic <michamos@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
