### PR TITLE
holdingpen: fix holdingpen-hep mapping for facets

### DIFF
--- a/inspirehep/modules/workflows/mappings/holdingpen/hep.json
+++ b/inspirehep/modules/workflows/mappings/holdingpen/hep.json
@@ -10,6 +10,10 @@
             "properties": {
                 "_extra_data": {
                     "properties": {
+                        "_action": {
+                            "index": "not_analyzed",
+                            "type": "string"
+                        },
                         "is-update": {
                             "type": "boolean"
                         },


### PR DESCRIPTION
## Description
**See: https://its.cern.ch/jira/browse/INSPIR-907**

This fixes:
- 'Filter by action' facet

## Related Issue
Some facets in holdingpen don't have explicit mapping.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
