### PR TITLE
workflows: no error when refextract times out

### DIFF
--- a/inspirehep/modules/workflows/tasks/arxiv.py
+++ b/inspirehep/modules/workflows/tasks/arxiv.py
@@ -120,7 +120,7 @@ def arxiv_package_download(obj, eng):
         obj.log.error('Cannot retrieve tarball from arXiv for %s', arxiv_id)
 
 
-@ignore_timeout_error
+@ignore_timeout_error()
 @timeout(5 * 60)
 @with_debug_logging
 def arxiv_plot_extract(obj, eng):

--- a/inspirehep/modules/workflows/tasks/refextract.py
+++ b/inspirehep/modules/workflows/tasks/refextract.py
@@ -114,7 +114,7 @@ def extract_journal_info(obj, eng):
     obj.data['publication_info'] = convert_old_publication_info_to_new(obj.data['publication_info'])
 
 
-@ignore_timeout_error
+@ignore_timeout_error(return_value=[])
 @timeout(5 * 60)
 def extract_references_from_pdf(filepath, source=None, custom_kbs_file=None):
     """Extract references from PDF and return in INSPIRE format."""
@@ -128,7 +128,7 @@ def extract_references_from_pdf(filepath, source=None, custom_kbs_file=None):
     return map_refextract_to_schema(extracted_references, source=source)
 
 
-@ignore_timeout_error
+@ignore_timeout_error(return_value=[])
 @timeout(5 * 60)
 def extract_references_from_text(text, source=None, custom_kbs_file=None):
     """Extract references from text and return in INSPIRE format."""
@@ -142,7 +142,7 @@ def extract_references_from_text(text, source=None, custom_kbs_file=None):
     return map_refextract_to_schema(extracted_references, source=source)
 
 
-@ignore_timeout_error
+@ignore_timeout_error(return_value=[])
 @timeout(5 * 60)
 def extract_references_from_raw_refs(references, custom_kbs_file=None):
     """Extract references from raw references in reference list.

--- a/inspirehep/modules/workflows/utils/__init__.py
+++ b/inspirehep/modules/workflows/utils/__init__.py
@@ -158,23 +158,25 @@ def with_debug_logging(func):
     return _decorator
 
 
-def ignore_timeout_error(func):
-    """Ignore the TimeoutError.
+def ignore_timeout_error(return_value=None):
+    """Ignore the TimeoutError, returning return_value when it happens.
 
     Quick fix for ``refextract`` and ``plotextract`` tasks only. It
     shouldn't be used for others!
     """
-
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-        except TimeoutError:
-            LOGGER.error(
-                'Timeout error while extracting raised from: %s.',
-                func.__name__
-            )
-    return wrapper
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except TimeoutError:
+                LOGGER.error(
+                    'Timeout error while extracting raised from: %s.',
+                    func.__name__
+                )
+                return return_value
+        return wrapper
+    return decorator
 
 
 @contextmanager

--- a/tests/unit/workflows/test_workflows_utils.py
+++ b/tests/unit/workflows/test_workflows_utils.py
@@ -215,7 +215,7 @@ def test_xslt(oai_xml, oai_xml_result):
 @patch('inspirehep.modules.workflows.utils.LOGGER')
 def test_ignore_timeout_decorator(mock_logger):
 
-    @ignore_timeout_error
+    @ignore_timeout_error()
     @timeout(1)
     def f():
         time.sleep(2)
@@ -223,6 +223,20 @@ def test_ignore_timeout_decorator(mock_logger):
     f()
 
     assert mock_logger.error.called
+
+
+@patch('inspirehep.modules.workflows.utils.LOGGER')
+def test_ignore_timeout_decorator_returns_the_argument_on_error(mock_logger):
+
+    @ignore_timeout_error('foo')
+    @timeout(1)
+    def f():
+        time.sleep(2)
+
+    result = f()
+
+    assert mock_logger.error.called
+    assert result == 'foo'
 
 
 @pytest.mark.parametrize('source,expected_source', [


### PR DESCRIPTION
Signed-off-by: Micha Moskovic <michamos@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
