### PR TITLE
edit_article: use always latest data from db as payload

### DIFF
--- a/tests/integration/workflows/test_edit_article.py
+++ b/tests/integration/workflows/test_edit_article.py
@@ -24,9 +24,11 @@
 
 from __future__ import absolute_import, division, print_function
 
-import json
 
+import json
 import pytest
+from copy import deepcopy
+
 from invenio_workflows import ObjectStatus, WorkflowEngine, start, workflow_object_class
 from invenio_accounts.testutils import login_user_via_session
 
@@ -160,6 +162,30 @@ def test_edit_article_workflow(workflow_app, mocked_external_services):
 
     record = get_db_record('lit', 123)
     assert record['titles'][0]['title'] == new_title
+
+
+def test_edit_article_workflow_loads_latest_data(workflow_app, mocked_external_services):
+    app_client = workflow_app.test_client()
+    login_user_via_session(app_client, email='admin@inspirehep.net')
+
+    old_content = {
+        '$schema': 'http://localhost:5000/schemas/records/hep.json',
+        'control_number': 123,
+        'document_type': ['article'],
+        'titles': [{'title': 'Resource Pooling in Large-Scale Content Delivery Systems'}],
+        'self': {'$ref': 'http://localhost:5000/schemas/records/hep.json'},
+        '_collections': ['Literature']
+    }
+
+    new_content = deepcopy(old_content)
+    new_title = 'This is the newest content in the DB'
+    new_content['titles'][0]['title'] = new_title
+    TestRecordMetadata.create_from_kwargs(json=new_content)
+
+    eng_uuid = start('edit_article', data=old_content)
+    obj = WorkflowEngine.from_uuid(eng_uuid).objects[0]
+
+    assert obj.data['titles'][0]['title'] == new_title
 
 
 @pytest.mark.parametrize('user_info, expected_status_code', [


### PR DESCRIPTION
Signed-off-by: Antonio Cesarano <cesarano2607@gmail.com>

## Motivation and Context
When clicking on an outdated RT JLab ticket, the workflow's payload was showing old data. Now It will always load the latest info from the DB.
 
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
