### PR TITLE
Revert "Automatic merge pull request #3515 from ammirate/edit_article…

### DIFF
--- a/inspirehep/modules/workflows/workflows/edit_article.py
+++ b/inspirehep/modules/workflows/workflows/edit_article.py
@@ -22,8 +22,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-from invenio_db import db
-
 from inspirehep.modules.workflows.tasks.actions import validate_record
 from inspirehep.modules.workflows.tasks.submission import send_robotupload
 from inspirehep.modules.workflows.utils import get_resolve_edit_article_callback_url
@@ -37,21 +35,11 @@ def change_status_to_waiting(obj, eng):
     eng.wait(msg='Waiting for curation.')
 
 
-@with_debug_logging
 def update_record(obj, eng):
     control_number = obj.data['control_number']
     record = get_db_record('lit', control_number)
     record.update(obj.data)
     record.commit()
-
-
-@with_debug_logging
-def update_wf_payload_from_db(obj, eng):
-    control_number = obj.data['control_number']
-    record = get_db_record('lit', control_number)
-    obj.data = record
-    obj.save()
-    db.session.commit()
 
 
 class EditArticle(object):
@@ -62,7 +50,6 @@ class EditArticle(object):
 
     workflow = (
         [
-            update_wf_payload_from_db,
             change_status_to_waiting,
             validate_record('hep'),
             send_robotupload(mode='replace'),

--- a/tests/integration/workflows/test_edit_article.py
+++ b/tests/integration/workflows/test_edit_article.py
@@ -24,11 +24,9 @@
 
 from __future__ import absolute_import, division, print_function
 
-
 import json
-import pytest
-from copy import deepcopy
 
+import pytest
 from invenio_workflows import ObjectStatus, WorkflowEngine, start, workflow_object_class
 from invenio_accounts.testutils import login_user_via_session
 
@@ -162,30 +160,6 @@ def test_edit_article_workflow(workflow_app, mocked_external_services):
 
     record = get_db_record('lit', 123)
     assert record['titles'][0]['title'] == new_title
-
-
-def test_edit_article_workflow_loads_latest_data(workflow_app, mocked_external_services):
-    app_client = workflow_app.test_client()
-    login_user_via_session(app_client, email='admin@inspirehep.net')
-
-    old_content = {
-        '$schema': 'http://localhost:5000/schemas/records/hep.json',
-        'control_number': 123,
-        'document_type': ['article'],
-        'titles': [{'title': 'Resource Pooling in Large-Scale Content Delivery Systems'}],
-        'self': {'$ref': 'http://localhost:5000/schemas/records/hep.json'},
-        '_collections': ['Literature']
-    }
-
-    new_content = deepcopy(old_content)
-    new_title = 'This is the newest content in the DB'
-    new_content['titles'][0]['title'] = new_title
-    TestRecordMetadata.create_from_kwargs(json=new_content)
-
-    eng_uuid = start('edit_article', data=old_content)
-    obj = WorkflowEngine.from_uuid(eng_uuid).objects[0]
-
-    assert obj.data['titles'][0]['title'] == new_title
 
 
 @pytest.mark.parametrize('user_info, expected_status_code', [


### PR DESCRIPTION
## Motivation and Context
Record is already loaded in the view that triggers the `edit_article` workflow.
The issue here is that browser cache prevents curators to see new contents.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
