### PR TITLE
1029 Dedupe matched references on control number

### DIFF
--- a/inspirehep/modules/workflows/tasks/refextract.py
+++ b/inspirehep/modules/workflows/tasks/refextract.py
@@ -274,10 +274,12 @@ def match_reference_with_config(reference, config, previous_matched_recid=None):
     except KeyError:
         pass
 
-    matched_records = dedupe_list(list(match(reference, config)))
-    same_as_previous = any(matched_record['_source']['control_number'] == previous_matched_recid for matched_record in matched_records)
-    if len(matched_records) == 1:
-        _add_match_to_reference(reference, matched_records[0]['_source']['control_number'], config['index'])
+    matched_recids = [matched_record['_source']['control_number'] for matched_record in match(reference, config)]
+    matched_recids = dedupe_list(matched_recids)
+
+    same_as_previous = any(matched_recid == previous_matched_recid for matched_recid in matched_recids)
+    if len(matched_recids) == 1:
+        _add_match_to_reference(reference, matched_recids[0], config['index'])
     elif same_as_previous:
         _add_match_to_reference(reference, previous_matched_recid, config['index'])
 


### PR DESCRIPTION
## Description
This fix causes the list of matched references to be deduped on control numbers rather than on the
raw Inspire Matcher match results.

## Related Issue
Fixes: https://its.cern.ch/jira/browse/INSPIR-1029

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Signed-off-by: Salman Maqbool <salman.maqbool@cern.ch>