### PR TITLE
workflow: preserve original merging root

### DIFF
--- a/inspirehep/modules/workflows/tasks/merging.py
+++ b/inspirehep/modules/workflows/tasks/merging.py
@@ -24,6 +24,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+from copy import deepcopy
 from flask import current_app
 
 from inspire_json_merger.api import merge
@@ -73,6 +74,9 @@ def merge_articles(obj, eng):
     update_source = get_source(update).lower()
     head_root = read_wf_record_source(record_uuid=head.id, source=update_source)
     head_root = head_root.json if head_root else {}
+
+    obj.extra_data['merger_head_revision'] = head.revision_id
+    obj.extra_data['merger_original_root'] = deepcopy(head_root)
 
     merged, conflicts = merge(
         head=head.dumps(),

--- a/tests/integration/workflows/test_arxiv_merge.py
+++ b/tests/integration/workflows/test_arxiv_merge.py
@@ -219,6 +219,8 @@ def test_merge_without_conflicts_handles_update_without_acquisition_source_and_a
 
         assert obj.extra_data.get('callback_url') is None
         assert obj.extra_data.get('is-update') is True
+        assert obj.extra_data['merger_head_revision'] == 0
+        assert obj.extra_data['merger_original_root'] == {}
 
         # source us unknown, so no new root is saved.
         roots = read_all_wf_record_sources(factory.record_metadata.id)
@@ -261,6 +263,8 @@ def test_merge_with_conflicts_handles_update_without_acquisition_source_and_acts
         assert obj.extra_data.get('callback_url') is not None
         assert obj.extra_data.get('is-update') is True
         assert obj.extra_data['merger_root'] == record_update
+        assert obj.extra_data['merger_head_revision'] == 0
+        assert obj.extra_data['merger_original_root'] == {}
 
 
 @patch(
@@ -299,6 +303,8 @@ def test_merge_with_conflicts_rootful(
         assert obj.extra_data.get('callback_url') is not None
         assert obj.extra_data.get('is-update') is True
         assert obj.extra_data['merger_root'] == record_update
+        assert obj.extra_data['merger_head_revision'] == 0
+        assert obj.extra_data['merger_original_root'] == {}
 
 
 @patch(
@@ -337,6 +343,8 @@ def test_merge_without_conflicts_rootful(
 
         assert obj.extra_data.get('callback_url') is None
         assert obj.extra_data.get('is-update') is True
+        assert obj.extra_data['merger_head_revision'] == 0
+        assert obj.extra_data['merger_original_root'] == ARXIV_ROOT
 
         updated_root = read_wf_record_source(factory.record_metadata.id, 'arxiv')
         assert updated_root.json == record_update


### PR DESCRIPTION
Save the root used in the three-way-merge in order to facilitate debug/content checking afterwards

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
