### PR TITLE
workflows: add endpoint to inspect merge operations

### DIFF
--- a/tests/integration/workflows/test_views.py
+++ b/tests/integration/workflows/test_views.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2018 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+from copy import deepcopy
+import json
+
+from invenio_workflows import workflow_object_class
+from invenio_db import db
+
+from factories.db.invenio_records import TestRecordMetadata
+
+
+def test_inspect_merge_view(isolated_app):
+
+    factory = TestRecordMetadata.create_from_kwargs(
+        json={'titles': [{'title': 'Curated version'}]}
+    )
+
+    obj = workflow_object_class.create(
+        data=factory.record_metadata.json,
+        data_type='hep',
+    )
+    obj.save()
+    db.session.commit()
+
+    head = deepcopy(factory.record_metadata.json)
+    factory.record_metadata.json['titles'][0]['title'] = 'second curated version'
+    db.session.add(factory.record_metadata)
+    db.session.commit()
+
+    obj.extra_data['merger_root'] = {
+        'titles': [{'title': 'Second version'}],
+        'document_type': ['article'],
+        '_collections': ['Literature'],
+    }
+    obj.extra_data['merger_original_root'] = {
+        'titles': [{'title': 'First version'}],
+        'document_type': ['article'],
+        '_collections': ['Literature'],
+    }
+    obj.extra_data['merger_head_revision'] = factory.inspire_record.revision_id
+
+    expected = {
+        'root': obj.extra_data['merger_original_root'],
+        'head': head,
+        'update': obj.extra_data['merger_root'],
+        'merged': factory.record_metadata.json
+    }
+
+    with isolated_app.test_client() as client:
+        response = client.get('/workflows/inspect_merge/{}'.format(obj.id))
+        assert response.status_code == 200
+        assert json.loads(response.data) == expected
+
+
+def test_inspect_merge_view_returns_400(isolated_app):
+
+    factory = TestRecordMetadata.create_from_kwargs(
+        json={'titles': [{'title': 'Curated version'}]}
+    )
+
+    obj = workflow_object_class.create(
+        data=factory.record_metadata.json,
+        data_type='hep',
+    )
+    obj.save()
+    db.session.commit()
+
+    with isolated_app.test_client() as client:
+        response = client.get('/workflows/inspect_merge/{}'.format(obj.id))
+        assert response.status_code == 400

--- a/tests/integration/workflows/test_views.py
+++ b/tests/integration/workflows/test_views.py
@@ -31,7 +31,7 @@ from invenio_db import db
 from factories.db.invenio_records import TestRecordMetadata
 
 
-def test_inspect_merge_view(isolated_app):
+def test_inspect_merge_view(workflow_app):
 
     factory = TestRecordMetadata.create_from_kwargs(
         json={'titles': [{'title': 'Curated version'}]}
@@ -68,13 +68,13 @@ def test_inspect_merge_view(isolated_app):
         'merged': factory.record_metadata.json
     }
 
-    with isolated_app.test_client() as client:
+    with workflow_app.test_client() as client:
         response = client.get('/workflows/inspect_merge/{}'.format(obj.id))
         assert response.status_code == 200
         assert json.loads(response.data) == expected
 
 
-def test_inspect_merge_view_returns_400(isolated_app):
+def test_inspect_merge_view_returns_400(workflow_app):
 
     factory = TestRecordMetadata.create_from_kwargs(
         json={'titles': [{'title': 'Curated version'}]}
@@ -87,6 +87,6 @@ def test_inspect_merge_view_returns_400(isolated_app):
     obj.save()
     db.session.commit()
 
-    with isolated_app.test_client() as client:
+    with workflow_app.test_client() as client:
         response = client.get('/workflows/inspect_merge/{}'.format(obj.id))
         assert response.status_code == 400

--- a/tests/integration/workflows/test_workflows_tasks_actions.py
+++ b/tests/integration/workflows/test_workflows_tasks_actions.py
@@ -49,7 +49,7 @@ from mocks import (
 
 
 @pytest.fixture(scope='function')
-def insert_journals_in_db(isolated_app):
+def insert_journals_in_db(workflow_app):
     """Temporarily add few journals in the DB"""
     TestRecordMetadata.create_from_file(
         __name__, 'jou_record_refereed.json', pid_type='jou', index_name='records-journals'
@@ -59,7 +59,7 @@ def insert_journals_in_db(isolated_app):
     )
 
 
-def test_normalize_journal_titles_known_journals_with_ref(isolated_app, insert_journals_in_db):
+def test_normalize_journal_titles_known_journals_with_ref(workflow_app, insert_journals_in_db):
     record = {
         "_collections": [
             "Literature"
@@ -105,7 +105,7 @@ def test_normalize_journal_titles_known_journals_with_ref(isolated_app, insert_j
     assert obj.data['publication_info'][2]['journal_record'] == {'$ref': 'http://localhost:5000/api/journals/1936476'}
 
 
-def test_normalize_journal_titles_known_journals_with_ref_from_variants(isolated_app, insert_journals_in_db):
+def test_normalize_journal_titles_known_journals_with_ref_from_variants(workflow_app, insert_journals_in_db):
     record = {
         "_collections": [
             "Literature"
@@ -151,7 +151,7 @@ def test_normalize_journal_titles_known_journals_with_ref_from_variants(isolated
     assert obj.data['publication_info'][2]['journal_record'] == {'$ref': 'http://localhost:5000/api/journals/1936476'}
 
 
-def test_normalize_journal_titles_known_journals_no_ref(isolated_app, insert_journals_in_db):
+def test_normalize_journal_titles_known_journals_no_ref(workflow_app, insert_journals_in_db):
     record = {
         "_collections": [
             "Literature"
@@ -191,7 +191,7 @@ def test_normalize_journal_titles_known_journals_no_ref(isolated_app, insert_jou
     assert obj.data['publication_info'][2]['journal_record'] == {'$ref': 'http://localhost:5000/api/journals/1936476'}
 
 
-def test_normalize_journal_titles_known_journals_wrong_ref(isolated_app, insert_journals_in_db):
+def test_normalize_journal_titles_known_journals_wrong_ref(workflow_app, insert_journals_in_db):
     record = {
         "_collections": [
             "Literature"
@@ -237,7 +237,7 @@ def test_normalize_journal_titles_known_journals_wrong_ref(isolated_app, insert_
     assert obj.data['publication_info'][2]['journal_record'] == {'$ref': 'http://localhost:5000/api/journals/1936476'}
 
 
-def test_normalize_journal_titles_unknown_journals_with_ref(isolated_app, insert_journals_in_db):
+def test_normalize_journal_titles_unknown_journals_with_ref(workflow_app, insert_journals_in_db):
     record = {
         "_collections": [
             "Literature"
@@ -283,7 +283,7 @@ def test_normalize_journal_titles_unknown_journals_with_ref(isolated_app, insert
     assert obj.data['publication_info'][2]['journal_record'] == {'$ref': 'http://localhost:5000/api/journals/1111111'}
 
 
-def test_normalize_journal_titles_unknown_journals_no_ref(isolated_app, insert_journals_in_db):
+def test_normalize_journal_titles_unknown_journals_no_ref(workflow_app, insert_journals_in_db):
     record = {
         "_collections": [
             "Literature"
@@ -349,7 +349,7 @@ def test_refextract_from_pdf(
     mocked_is_pdf_link,
     mocked_package_download,
     mocked_arxiv_download,
-    isolated_app,
+    workflow_app,
     mocked_external_services
 ):
     """Test refextract from PDF and reference matching for default Configuration
@@ -389,7 +389,7 @@ def test_refextract_from_pdf(
 
     assert validate(citing_record['acquisition_source'], subschema) is None
 
-    with mock.patch.dict(isolated_app.config, extra_config):
+    with mock.patch.dict(workflow_app.config, extra_config):
         citing_doc_workflow_uuid = start('article', [citing_record])
 
     citing_doc_eng = WorkflowEngine.from_uuid(citing_doc_workflow_uuid)
@@ -425,7 +425,7 @@ def test_count_reference_coreness(
     mocked_is_pdf_link,
     mocked_package_download,
     mocked_arxiv_download,
-    isolated_app,
+    workflow_app,
     mocked_external_services
 ):
     cited_record_json = {
@@ -462,7 +462,7 @@ def test_count_reference_coreness(
 
     assert validate(citing_record['acquisition_source'], subschema) is None
 
-    with mock.patch.dict(isolated_app.config, extra_config):
+    with mock.patch.dict(workflow_app.config, extra_config):
         citing_doc_workflow_uuid = start('article', [citing_record])
 
     citing_doc_eng = WorkflowEngine.from_uuid(citing_doc_workflow_uuid)


### PR DESCRIPTION
Add the endpoint `/workflows/inspect_merge/<holdingpen_id>` to get the `root`, `head`, `update`, and `merged` records in a given workflow - if it's an update.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
