### PR TITLE
tests: cleanup workflow_app in fixture

### DIFF
--- a/tests/integration/workflows/conftest.py
+++ b/tests/integration/workflows/conftest.py
@@ -105,6 +105,10 @@ def workflow_app(higgs_ontology):
         )
 
     with app.app_context():
+        db.session.close_all()
+        drop_all(app)
+        create_all(app)
+
         yield app
 
 
@@ -135,13 +139,6 @@ def create_all(app):
     init_all_storage_paths()
     init_users_and_permissions()
     init_collections()
-
-
-@pytest.fixture(autouse=True)
-def cleanup_workflows(workflow_app):
-    db.session.close_all()
-    drop_all(app=workflow_app)
-    create_all(app=workflow_app)
 
 
 @pytest.fixture


### PR DESCRIPTION
This fixes the flaky workflow tests because of a race condition between
the auto-use `workflow_app` cleanup (invoked for all tests) and the
`isolated_app` cleanup.

Signed-off-by: Micha Moskovic <michamos@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
