### PR TITLE
records: fix publication_info wrapping

### DIFF
--- a/inspirehep/modules/records/wrappers.py
+++ b/inspirehep/modules/records/wrappers.py
@@ -22,6 +22,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+from six import iteritems
+
 from flask_login import current_user
 
 from inspirehep.utils.record import get_title
@@ -123,17 +125,21 @@ class LiteratureRecord(ESRecord, AdminToolsMixin):
         """
         pub_info_list = []
         for pub_info in self['publication_info']:
-            if pub_info.get('journal_title', '') or pub_info.get('pubinfo_freetext', ''):
-                pub_info_list.append({
-                    'journal_title': pub_info.get('journal_title', ''),
-                    'journal_volume': pub_info.get('journal_volume', ''),
+            item = {}
+            if pub_info.get('journal_title') or pub_info.get('pubinfo_freetext'):
+                item.update({
+                    'journal_title': pub_info.get('journal_title'),
+                    'journal_volume': pub_info.get('journal_volume'),
                     'year': str(pub_info.get('year', '')),
-                    'journal_issue': pub_info.get('journal_issue', ''),
+                    'journal_issue': pub_info.get('journal_issue'),
                     'page_start': str(pub_info.get('page_start', '')),
                     'page_end': str(pub_info.get('page_end', '')),
-                    'artid': pub_info.get('artid', ''),
-                    'pubinfo_freetext': pub_info.get('pubinfo_freetext', '')
+                    'artid': pub_info.get('artid'),
+                    'pubinfo_freetext': pub_info.get('pubinfo_freetext'),
                 })
+
+            if item:
+                pub_info_list.append({key: value for (key, value) in iteritems(item) if value})
 
         return pub_info_list
 

--- a/tests/unit/records/test_records_wrappers.py
+++ b/tests/unit/records/test_records_wrappers.py
@@ -101,3 +101,94 @@ def test_literature_record_external_system_identifiers_handles_kekscan():
     result = record.external_system_identifiers
 
     assert expected == result
+
+
+def test_literature_record_publication_information_with_pubinfo_freetext():
+    record = LiteratureRecord({
+        'publication_info': [
+            {
+                'pubinfo_freetext': 'Symmetry 10, 287 (2018)',
+            },
+            {
+                'cnum': 'C93-07-01',
+                'conference_recid': 968950,
+                'conference_record': {
+                    '$ref': 'http://labs.inspirehep.net/api/conferences/968950'
+                },
+            },
+        ],
+    })
+
+    expected = [
+        {
+            'pubinfo_freetext': 'Symmetry 10, 287 (2018)',
+        },
+    ]
+
+    assert expected == record.publication_information
+
+
+def test_literature_record_publication_information_with_journal_title():
+    record = LiteratureRecord({
+        'publication_info': [
+            {
+                'artid': '128',
+                'journal_issue': '7',
+                'journal_title': 'Astropart.Phys.',
+                'journal_volume': '103',
+                'page_end': '48',
+                'page_start': '41',
+                'year': '2018',
+            },
+            {
+                'cnum': 'C93-07-01',
+                'conference_recid': 968950,
+                'conference_record': {
+                    '$ref': 'http://labs.inspirehep.net/api/conferences/968950'
+                },
+            },
+        ],
+    })
+
+    expected = [
+        {
+            'artid': '128',
+            'journal_issue': '7',
+            'journal_title': 'Astropart.Phys.',
+            'journal_volume': '103',
+            'page_end': '48',
+            'page_start': '41',
+            'year': '2018',
+        },
+    ]
+
+    assert expected == record.publication_information
+
+
+def test_literature_record_publication_information_handles_missing_fields():
+    record = LiteratureRecord({
+        'publication_info': [
+            {
+                'journal_title': 'Astropart.Phys.',
+                'year': 2018,
+                'pubinfo_freetext': 'Symmetry 10, 287 (2018)',
+            },
+            {
+                'cnum': 'C93-07-01',
+                'conference_recid': 968950,
+                'conference_record': {
+                    '$ref': 'http://labs.inspirehep.net/api/conferences/968950'
+                },
+            },
+        ],
+    })
+
+    expected = [
+        {
+            'journal_title': 'Astropart.Phys.',
+            'year': '2018',
+            'pubinfo_freetext': 'Symmetry 10, 287 (2018)',
+        },
+    ]
+
+    assert expected == record.publication_information


### PR DESCRIPTION
Change the LiteratureWrapper's `publication_information` property to no longer return objects containing empty string values.

Signed-off-by: Iuliana Voinea <iulianavoinea96@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
