### PR TITLE
INSPIR-1087: do relevance check only for new articles

### DIFF
--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -278,15 +278,6 @@ STOP_IF_EXISTING_SUBMISSION = [
 
 
 HALT_FOR_APPROVAL_IF_NEW_OR_STOP_IF_NOT_RELEVANT = [
-    IF_NOT(
-        is_record_relevant,
-        [
-            reject_record('Article automatically rejected'),
-            mark('approved', False),
-            save_workflow,
-            stop_processing,
-        ],
-    ),
     preserve_root,
     IF_ELSE(
         is_marked('is-update'),
@@ -305,10 +296,21 @@ HALT_FOR_APPROVAL_IF_NEW_OR_STOP_IF_NOT_RELEVANT = [
         IF_ELSE(
             is_marked('auto-approved'),
             mark('approved', True),
-            halt_record(
-                action="hep_approval",
-                message="Submission halted for curator approval.",
-            )
+            [
+                IF_NOT(
+                    is_record_relevant,
+                    [
+                        reject_record('Article automatically rejected'),
+                        mark('approved', False),
+                        save_workflow,
+                        stop_processing,
+                    ],
+                ),
+                halt_record(
+                    action="hep_approval",
+                    message="Submission halted for curator approval.",
+                )
+            ]
         ),
     ),
 ]


### PR DESCRIPTION
Signed-off-by: Antonio Cesarano <cesarano2607@gmail.com>

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
