### PR TITLE
records: add authors prop to literature wrapper

### DIFF
--- a/inspirehep/modules/records/serializers/fields/__init__.py
+++ b/inspirehep/modules/records/serializers/fields/__init__.py
@@ -22,8 +22,4 @@
 
 from __future__ import absolute_import, division, print_function
 
-from .author import AuthorSchemaV1  # noqa: F401
-from .conference_info_item import ConferenceInfoItemSchemaV1  # noqa: F401
-from .isbn import IsbnSchemaV1  # noqa: F401
-from .supervisor import SupervisorSchemaV1  # noqa: F401
-from .thesis_info import ThesisInfoSchemaV1  # noqa: F401
+from .list_with_limit import ListWithLimit  # noqa: F401

--- a/inspirehep/modules/records/serializers/fields/list_with_limit.py
+++ b/inspirehep/modules/records/serializers/fields/list_with_limit.py
@@ -22,8 +22,13 @@
 
 from __future__ import absolute_import, division, print_function
 
-from .author import AuthorSchemaV1  # noqa: F401
-from .conference_info_item import ConferenceInfoItemSchemaV1  # noqa: F401
-from .isbn import IsbnSchemaV1  # noqa: F401
-from .supervisor import SupervisorSchemaV1  # noqa: F401
-from .thesis_info import ThesisInfoSchemaV1  # noqa: F401
+from marshmallow import fields, utils
+
+
+class ListWithLimit(fields.List):
+    def _serialize(self, value, attr, obj):
+        if utils.is_collection(value):
+            limit = self.metadata.get('limit')
+            if limit:
+                return super(ListWithLimit, self)._serialize(value[:limit], attr, obj)
+        return super(ListWithLimit, self)._serialize(value, attr, obj)

--- a/inspirehep/modules/records/serializers/schemas/common/author.py
+++ b/inspirehep/modules/records/serializers/schemas/common/author.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2018 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+from marshmallow import Schema, fields, missing, pre_dump
+
+
+class AuthorSchemaV1(Schema):
+    affiliations = fields.Raw()
+    alternative_names = fields.Raw()
+    credit_roles = fields.Raw()
+    curated_relation = fields.Raw()
+    emails = fields.Raw()
+    full_name = fields.Raw()
+    ids = fields.Raw()
+    inspire_roles = fields.Raw()
+    raw_affilitaions = fields.Raw()
+    record = fields.Raw()
+    signature_block = fields.Raw()
+    uuid = fields.Raw()
+    first_name = fields.Method('get_first_name')
+    last_name = fields.Method('get_last_name')
+
+    def get_first_name(self, data):
+        names = data.get('full_name', '').split(',', 1)
+
+        if len(names) > 1:
+            return names[1].replace(',', '').strip()
+
+        return names[0]
+
+    def get_last_name(self, data):
+        names = data.get('full_name', '').split(',', 1)
+
+        if len(names) > 1:
+            return names[0]
+
+        return missing
+
+    @pre_dump
+    def filter(self, data):
+        if 'inspire_roles' in data:
+            if 'supervisor' in data.get('inspire_roles', ['author']):
+                return {}
+        return data

--- a/inspirehep/modules/records/serializers/schemas/common/conference_info_item.py
+++ b/inspirehep/modules/records/serializers/schemas/common/conference_info_item.py
@@ -36,10 +36,10 @@ class ConferenceInfoItemSchemaV1(Schema):
     def resolve_conference_record_as_root(self, pub_info_item):
         conference_record = pub_info_item.get('conference_record')
         if conference_record is None:
-            return None
+            return {}
         _, recid = get_pid_from_record_uri(conference_record.get('$ref'))
         conference = get_db_record('con', recid).dumps()
         titles = conference.get('titles')
         if titles is None:
-            return None
+            return {}
         return conference

--- a/inspirehep/modules/records/serializers/schemas/common/supervisor.py
+++ b/inspirehep/modules/records/serializers/schemas/common/supervisor.py
@@ -22,8 +22,16 @@
 
 from __future__ import absolute_import, division, print_function
 
-from .author import AuthorSchemaV1  # noqa: F401
-from .conference_info_item import ConferenceInfoItemSchemaV1  # noqa: F401
-from .isbn import IsbnSchemaV1  # noqa: F401
-from .supervisor import SupervisorSchemaV1  # noqa: F401
-from .thesis_info import ThesisInfoSchemaV1  # noqa: F401
+from marshmallow import pre_dump
+
+from .author import AuthorSchemaV1
+
+
+class SupervisorSchemaV1(AuthorSchemaV1):
+    @pre_dump
+    def filter(self, data):
+        if 'inspire_roles' not in data:
+            return {}
+        elif 'supervisor' not in data.get('inspire_roles', ['author']):
+            return {}
+        return data

--- a/tests/integration/records/serializers/test_schemas_json.py
+++ b/tests/integration/records/serializers/test_schemas_json.py
@@ -42,6 +42,14 @@ def test_references_schema_with_record(isolated_app):
             {
                 'full_name': 'Frank Castle',
             },
+            {
+                'full_name': 'Smith, Jim',
+                'inspire_roles': ['editor'],
+            },
+            {
+                'full_name': 'Jimmy',
+                'inspire_roles': ['supervisor'],
+            },
         ],
         'dois': [
             {
@@ -125,10 +133,24 @@ def test_references_schema_with_record(isolated_app):
                             'title': 'Jessica Jones'
                         }
                     ],
-                    'authors': [
+                    'authors': [  # only first 10 authors and supervisors are returned
                         {
-                            'full_name': 'Frank Castle'
-                        }
+                            'full_name': 'Frank Castle',
+                            'first_name': 'Frank Castle',
+                        },
+                        {
+                            'full_name': 'Smith, Jim',
+                            'first_name': 'Jim',
+                            'last_name': 'Smith',
+                            'inspire_roles': ['editor'],
+                        },
+                    ],
+                    'supervisors': [
+                        {
+                            'full_name': 'Jimmy',
+                            'first_name': 'Jimmy',
+                            'inspire_roles': ['supervisor'],
+                        },
                     ],
                     'publication_info': [
                         {

--- a/tests/integration/records/test_records_serializers_json.py
+++ b/tests/integration/records/test_records_serializers_json.py
@@ -39,6 +39,10 @@ def test_literature_authors_serializer_record(isolated_api_client):
             {
                 'full_name': 'Frank Castle',
             },
+            {
+                'full_name': 'Smith, John',
+                'inspire_roles': ['supervisor'],
+            },
         ],
         'collaborations': [{
             'value': 'LHCb',
@@ -68,14 +72,23 @@ def test_literature_authors_serializer_record(isolated_api_client):
     expected_metadata = {
         'authors': [
             {
-                'full_name': 'Frank Castle'
+                'full_name': 'Frank Castle',
+                'first_name': 'Frank Castle',
             }
         ],
         'collaborations': [
             {
                 'value': 'LHCb'
             }
-        ]
+        ],
+        'supervisors': [
+            {
+                'full_name': 'Smith, John',
+                'first_name': 'John',
+                'last_name': 'Smith',
+                'inspire_roles': ['supervisor'],
+            }
+        ],
     }
 
     result = json.loads(response.get_data(as_text=True))

--- a/tests/unit/records/serializers/test_schemas_json.py
+++ b/tests/unit/records/serializers/test_schemas_json.py
@@ -52,6 +52,10 @@ def test_references_schema_without_record():
                             {
                                 'full_name': 'Hahn, F.'
                             },
+                            {
+                                'full_name': 'Smith, J.',
+                                'inspire_roles': ['supervisor'],
+                            },
                         ],
                         'label': '388',
                         'misc': [
@@ -90,8 +94,18 @@ def test_references_schema_without_record():
                     ],
                     'authors': [
                         {
-                            'full_name': 'Hahn, F.'
-                        }
+                            'full_name': 'Hahn, F.',
+                            'first_name': 'F.',
+                            'last_name': 'Hahn',
+                        },
+                    ],
+                    'supervisors': [
+                        {
+                            'full_name': 'Smith, J.',
+                            'first_name': 'J.',
+                            'last_name': 'Smith',
+                            'inspire_roles': ['supervisor'],
+                        },
                     ],
                     'dois': [
                         {
@@ -160,6 +174,18 @@ def test_authors_schema():
                 {
                     'full_name': 'Frank Castle',
                 },
+                {
+                    'full_name': 'Smith, John',
+                    'inspire_roles': ['author'],
+                },
+                {
+                    'full_name': 'Black, Joe Jr.',
+                    'inspire_roles': ['editor'],
+                },
+                {
+                    'full_name': 'Jimmy',
+                    'inspire_roles': ['supervisor'],
+                },
             ],
             'collaborations': [{
                 'value': 'LHCb',
@@ -185,14 +211,34 @@ def test_authors_schema():
         'metadata': {
             'authors': [
                 {
-                    'full_name': 'Frank Castle'
-                }
+                    'full_name': 'Frank Castle',
+                    'first_name': 'Frank Castle',
+                },
+                {
+                    'full_name': 'Smith, John',
+                    'first_name': 'John',
+                    'last_name': 'Smith',
+                    'inspire_roles': ['author'],
+                },
+                {
+                    'full_name': 'Black, Joe Jr.',
+                    'first_name': 'Joe Jr.',
+                    'last_name': 'Black',
+                    'inspire_roles': ['editor'],
+                },
             ],
             'collaborations': [
                 {
                     'value': 'LHCb'
                 }
-            ]
+            ],
+            'supervisors': [
+                {
+                    'full_name': 'Jimmy',
+                    'first_name': 'Jimmy',
+                    'inspire_roles': ['supervisor'],
+                },
+            ],
         }
     }
     result = json.loads(schema.dumps(record).data)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Add `authors` and `supervisors` properties to LiteratureRecord wrapper. Two new fields are added in order to be used by the UI: first_name, last_name.

Signed-off-by: Iuliana Voinea <iulianavoinea96@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://its.cern.ch/jira/browse/INSPIR-1044

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
