### PR TITLE
records: add a cli for parallel bulk reindex

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -1185,7 +1185,7 @@ JSONSCHEMAS_LOADER_CLS = 'inspirehep.modules.records.json_ref_loader.SCHEMA_LOAD
 INDEXER_DEFAULT_INDEX = "records-hep"
 INDEXER_DEFAULT_DOC_TYPE = "hep"
 INDEXER_REPLACE_REFS = False
-INDEXER_BULK_REQUEST_TIMEOUT = float(120)
+INDEXER_BULK_REQUEST_TIMEOUT = float(900)
 
 # OAuthclient
 # ===========

--- a/inspirehep/modules/migrator/tasks.py
+++ b/inspirehep/modules/migrator/tasks.py
@@ -46,7 +46,6 @@ from redis import StrictRedis
 from redis_lock import Lock
 
 from invenio_db import db
-from invenio_indexer.api import RecordIndexer, current_record_to_index
 from invenio_pidstore.models import PersistentIdentifier
 from invenio_search import current_search_client as es
 from invenio_search.utils import schema_to_index
@@ -62,6 +61,7 @@ from inspirehep.modules.pidstore.utils import (
 )
 from inspirehep.modules.records.receivers import index_after_commit
 from inspirehep.utils.schema import ensure_valid_schema
+from inspirehep.utils.record import create_index_op
 
 from .models import LegacyRecordsMirror
 
@@ -247,20 +247,6 @@ def continuous_migration(skip_files=None):
             lock.release()
     else:
         LOGGER.info("Continuous_migration already executed. Skipping.")
-
-
-def create_index_op(record):
-    index, doc_type = current_record_to_index(record)
-
-    return {
-        '_op_type': 'index',
-        '_index': index,
-        '_type': doc_type,
-        '_id': str(record.id),
-        '_version': record.revision_id,
-        '_version_type': 'external_gte',
-        '_source': RecordIndexer._prepare_record(record, index, doc_type),
-    }
 
 
 @shared_task(ignore_result=False, queue='migrator')

--- a/inspirehep/modules/records/cli.py
+++ b/inspirehep/modules/records/cli.py
@@ -22,12 +22,19 @@
 
 from __future__ import absolute_import, division, print_function
 
+from time import sleep
+
 import click
 import click_spinner
+import json
 
+from invenio_db import db
+from invenio_pidstore.models import PersistentIdentifier, PIDStatus
+from flask import current_app
 from flask.cli import with_appcontext
 
 from .checkers import check_unlinked_references
+from .tasks import batch_reindex
 
 
 @click.group()
@@ -59,3 +66,151 @@ def unlinked_references(doi_file_name, arxiv_file_name):
 
     for item in result_arxiv:
         arxiv_file_name.write(u'{i[0]}: {i[1]}\n'.format(i=item))
+
+
+def next_batch(iterator, batch_size):
+    """Get first batch_size elements from the iterable, or remaining if less.
+
+    :param iterator: the iterator for the iterable
+    :param batch_size: size of the requested batch
+    :return: batch (list)
+    """
+    batch = []
+
+    try:
+        for idx in range(batch_size):
+            batch.append(next(iterator))
+    except StopIteration:
+        pass
+
+    return batch
+
+
+@click.command()
+@click.option('--yes-i-know', is_flag=True)
+@click.option('-t', '--pid-type', multiple=True, required=True)
+@click.option('-s', '--batch-size', default=200)
+@click.option('-q', '--queue-name', default='indexer_task')
+@with_appcontext
+def simpleindex(yes_i_know, pid_type, batch_size, queue_name):
+    """Bulk reindex all records in a parallel manner.
+
+    :param yes_i_know: if True, skip confirmation screen
+    :param pid_type: array of PID types, allowed: lit, con, exp, jou, aut, job, ins
+    :param batch_size: number of documents per batch sent to workers.
+    :param queue_name: name of the celery queue
+    """
+    if not yes_i_know:
+        click.confirm(
+            'Do you really want to reindex the record?',
+            abort=True,
+        )
+
+    click.secho('Sending record UUIDs to the indexing queue...', fg='green')
+
+    query = (
+        db.session.query(PersistentIdentifier.object_uuid)
+        .filter(
+            PersistentIdentifier.pid_type.in_(pid_type),
+            PersistentIdentifier.object_type == 'rec',
+            PersistentIdentifier.status == PIDStatus.REGISTERED,
+        )
+    )
+    request_timeout = current_app.config.get('INDEXER_BULK_REQUEST_TIMEOUT')
+    all_tasks = []
+    records_per_tasks = {}
+
+    with click.progressbar(
+        query.yield_per(2000),
+        length=query.count(),
+        label='Scheduling indexing tasks'
+    ) as items:
+        batch = next_batch(items, batch_size)
+
+        while batch:
+            uuids = [str(item[0]) for item in batch]
+            indexer_task = batch_reindex.apply_async(
+                kwargs={
+                    'uuids': uuids,
+                    'request_timeout': request_timeout,
+                },
+                queue=queue_name,
+            )
+
+            records_per_tasks[indexer_task.id] = uuids
+            all_tasks.append(indexer_task)
+            batch = next_batch(items, batch_size)
+
+    click.secho('Created {} tasks.'.format(len(all_tasks)), fg='green')
+
+    with click.progressbar(
+        length=len(all_tasks),
+        label='Indexing records'
+    ) as progressbar:
+        def _finished_tasks_count():
+            return len(filter(lambda task: task.ready(), all_tasks))
+
+        while len(all_tasks) != _finished_tasks_count():
+            sleep(0.5)
+            # this is so click doesn't divide by 0:
+            progressbar.pos = _finished_tasks_count() or 1
+            progressbar.update(0)
+
+    failures = []
+    successes = 0
+    batch_errors = []
+
+    for task in all_tasks:
+        result = task.result
+        if task.failed():
+            batch_errors.append({
+                'task_id': task.id,
+                'error': result,
+            })
+        else:
+            successes += result['success']
+            failures += result['failures']
+
+    color = 'red' if failures or batch_errors else 'green'
+    click.secho(
+        'Reindexing finished: {} failed, {} succeeded, additionally {} batches errored.'.format(
+            len(failures),
+            successes,
+            len(batch_errors),
+        ),
+        fg=color,
+    )
+
+    failures_log_path = '/tmp/records_index_failures.log'
+    errors_log_path = '/tmp/records_index_errors.log'
+
+    if failures:
+        failures_json = []
+        for failure in failures:
+            try:
+                failures_json.append({
+                    'id': failure['index']['_id'],
+                    'error': failure['index']['error'],
+                })
+            except Exception:
+                failures_json.append({
+                    'error': repr(failure),
+                })
+        with open(failures_log_path, 'w') as log:
+            json.dump(failures_json, log)
+
+        click.secho('You can see the index failures in %s' % failures_log_path)
+
+    if batch_errors:
+        errors_json = []
+        for error in batch_errors:
+            task_id = error['task_id']
+            failed_uuids = records_per_tasks[task_id]
+            errors_json.append({
+                'ids': failed_uuids,
+                'error': repr(error['error']),
+            })
+        with open(errors_log_path, 'w') as log:
+            json.dump(errors_json, log)
+
+        click.secho('You can see the errors in %s' % errors_log_path)

--- a/inspirehep/modules/records/ext.py
+++ b/inspirehep/modules/records/ext.py
@@ -24,7 +24,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-from .cli import check
+from .cli import check, simpleindex
 
 
 class InspireRecords(object):
@@ -34,6 +34,7 @@ class InspireRecords(object):
 
     def init_app(self, app):
         app.cli.add_command(check)
+        app.cli.add_command(simpleindex)
         app.extensions['inspire-records'] = self
 
         # Register the receivers:

--- a/inspirehep/utils/record.py
+++ b/inspirehep/utils/record.py
@@ -24,6 +24,8 @@ from __future__ import absolute_import, division, print_function
 
 from itertools import chain
 
+from invenio_indexer.api import RecordIndexer, current_record_to_index
+
 from inspire_utils.record import get_value
 
 
@@ -268,3 +270,17 @@ def get_title(record):
 
     """
     return get_value(record, 'titles.title[0]', default='')
+
+
+def create_index_op(record, version_type='external_gte'):
+    index, doc_type = current_record_to_index(record)
+
+    return {
+        '_op_type': 'index',
+        '_index': index,
+        '_type': doc_type,
+        '_id': str(record.id),
+        '_version': record.revision_id,
+        '_version_type': version_type,
+        '_source': RecordIndexer._prepare_record(record, index, doc_type),
+    }


### PR DESCRIPTION
## Description

Introduce a `simpleindex` cli to replace `invenio_indexer` for re-indexing record. This has an advantage of:
- actual parametrised bulk indexing (`invenio_indexer` bulk size is constant, and equal to one)
- better error reporting
- use one celery queue for indexing, without the intermediate RabbitMQ step

## Motivation and Context
- easier to tell what breaks, if it does
- better
- faster
- stronger

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
