### PR TITLE
1026 literaturesuggest, authors: add source_data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,5 @@ inspirehep/modules/editor/temp/
 
 # scrapy generated files
 .scrapy/
+.lastruns/
+scrapy/

--- a/inspirehep/modules/authors/views.py
+++ b/inspirehep/modules/authors/views.py
@@ -301,6 +301,10 @@ def submitnew():
     workflow_object.extra_data['formdata'] = copy.deepcopy(visitor.data)
     workflow_object.extra_data['is-update'] = False
     workflow_object.data = formdata_to_model(workflow_object, visitor.data)
+    workflow_object.extra_data['source_data'] = {
+        'extra_data': copy.deepcopy(workflow_object.extra_data),
+        'data': copy.deepcopy(workflow_object.data),
+    }
     workflow_object.save()
     db.session.commit()
 

--- a/inspirehep/modules/literaturesuggest/views.py
+++ b/inspirehep/modules/literaturesuggest/views.py
@@ -89,6 +89,10 @@ def submit():
     workflow_object.extra_data['formdata'] = copy.deepcopy(visitor.data)
     visitor.data = normalize_formdata(workflow_object, visitor.data)
     workflow_object.data = formdata_to_model(workflow_object, visitor.data)
+    workflow_object.extra_data['source_data'] = {
+        'extra_data': copy.deepcopy(workflow_object.extra_data),
+        'data': copy.deepcopy(workflow_object.data),
+    }
     workflow_object.save()
     db.session.commit()
 

--- a/inspirehep/testlib/api/__init__.py
+++ b/inspirehep/testlib/api/__init__.py
@@ -28,7 +28,9 @@ import requests
 import re
 
 from posixpath import join as urljoin
+from inspirehep.testlib.api.author_form import AuthorFormApiClient
 from inspirehep.testlib.api.literature import LiteratureApiClient
+from inspirehep.testlib.api.literature_form import LiteratureFormApiClient
 from inspirehep.testlib.api.callback import CallbackClient
 from inspirehep.testlib.api.holdingpen import HoldingpenApiClient
 from inspirehep.testlib.api.e2e import E2EClient
@@ -105,6 +107,8 @@ class InspireApiClient(object):
         self.literature = LiteratureApiClient(self._client)
         self.callback = CallbackClient(self._client)
         self.e2e = E2EClient(self._client)
+        self.literature_form = LiteratureFormApiClient(self._client)
+        self.author_form = AuthorFormApiClient(self._client)
 
     def login_local(self, user='admin@inspirehep.net', password='123456'):
         """Perform a local log-in in Inspire storing the session"""

--- a/inspirehep/testlib/api/author_form.py
+++ b/inspirehep/testlib/api/author_form.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2018 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Literature suggestion form testlib."""
+
+from __future__ import absolute_import, division, print_function
+
+
+class AuthorFormInputData(object):
+    def __init__(
+        self,
+        given_names,
+        research_field,
+        status='active',
+        family_name=None,
+        display_name=None
+    ):
+        self.given_names = given_names
+        self.family_name = family_name
+        self.display_name = display_name
+        self.status = status
+        self.research_field = research_field
+
+    def request_data(self):
+        formdata = {
+            'given_names': self.given_names,
+            'family_name': self.family_name,
+            'display_name': self.display_name,
+            'status': self.status,
+            'research_field': self.research_field,
+        }
+
+        return formdata
+
+
+class AuthorFormApiClient(object):
+    SUBMIT_AUTHOR_FORM_URL = '/authors/new/submit'
+
+    def __init__(self, client):
+        self._client = client
+
+    def submit(self, form_input_data):
+        response = self._client.post(
+            self.SUBMIT_AUTHOR_FORM_URL,
+            data=form_input_data.request_data()
+        )
+        response.raise_for_status()
+        return response

--- a/inspirehep/testlib/api/holdingpen.py
+++ b/inspirehep/testlib/api/holdingpen.py
@@ -35,35 +35,27 @@ from inspirehep.testlib.api.literature import LiteratureResourceTitle
 class HoldingpenResource(BaseResource):
     """Inspire holdingpen entry to represent a workflow"""
 
-    def __init__(self, workflow_id, approved, is_update, core, status, titles, auto_approved=None, doi=None, arxiv_eprint=None, control_number=None, approved_match=None):
+    def __init__(self, workflow_id, approved, is_update, core, status, control_number):
         """
         Don't use this constructor yet unless you know what you are doing, use
         `from_json` instead as this one does not create a full holdingpen entry.
 
         """
+        self.control_number = control_number
         self.approved = approved
-        self.auto_approved = auto_approved
         self.is_update = is_update
         self.core = core
         self.status = status
         self.workflow_id = workflow_id
-        self.control_number = control_number
-        self.titles = titles
-        self.arxiv_eprint = arxiv_eprint
-        self.doi = doi
-        self.approved_match = approved_match
         self._raw_json = None
 
     def set_action(self, action):
         self._raw_json['_extra_data']['_action'] = action
 
-    def set_conflicts(self, conflicts):
-        self._raw_json['_extra_data']['conflicts'] = conflicts
-
     @classmethod
     def from_json(cls, json, workflow_id=None):
         """
-        Construcor for a holdingpen entry, it will be able to be mapped to and
+        Constructor for a holdingpen entry, it will be able to be mapped to and
         from json, and used to fully edit entries. Usually you pass to it the
         full raw json from the details of a holdingpen entry.
 
@@ -74,20 +66,35 @@ class HoldingpenResource(BaseResource):
             workflow_id = json['id']
 
         extra_data = json.get('_extra_data', {})
+        data_type = json['_workflow']['data_type']
 
-        hp_entry = cls(
-            workflow_id=workflow_id,
-            approved=extra_data.get('approved'),
-            auto_approved=extra_data.get('auto-approved'),
-            is_update=extra_data.get('is-update'),
-            core=extra_data.get('core'),
-            status=json['_workflow']['status'],
-            titles=[LiteratureResourceTitle.from_json(title) for title in json['metadata']['titles']],
-            control_number=json['metadata'].get('control_number'),
-            arxiv_eprint=json['metadata'].get('arxiv_eprints', [{}])[0].get('value'),
-            doi=json['metadata'].get('dois', [{}])[0].get('value'),
-            approved_match=extra_data.get('matches', {}).get('approved'),
-        )
+        if data_type == 'hep':
+            hp_entry = HoldingpenLiteratureResource(
+                workflow_id=workflow_id,
+                approved=extra_data.get('approved'),
+                auto_approved=extra_data.get('auto-approved'),
+                is_update=extra_data.get('is-update'),
+                core=extra_data.get('core'),
+                status=json['_workflow']['status'],
+                titles=[LiteratureResourceTitle.from_json(title) for title in json['metadata']['titles']],
+                control_number=json['metadata'].get('control_number'),
+                arxiv_eprint=json['metadata'].get('arxiv_eprints', [{}])[0].get('value'),
+                doi=json['metadata'].get('dois', [{}])[0].get('value'),
+                approved_match=extra_data.get('matches', {}).get('approved'),
+            )
+        elif data_type == 'authors':
+            hp_entry = HoldingpenAuthorResource(
+                workflow_id=workflow_id,
+                approved=extra_data.get('approved'),
+                is_update=extra_data.get('is-update'),
+                core=extra_data.get('core'),
+                status=json['_workflow']['status'],
+                control_number=json['metadata'].get('control_number'),
+                display_name=json['metadata']['name']['preferred_name'],
+            )
+        else:
+            raise ValueError('Unsupported holdingpen resource type "{}"'.format(data_type))
+
         hp_entry._raw_json = json
         return hp_entry
 
@@ -98,7 +105,7 @@ class HoldingpenResource(BaseResource):
         it's instantiation.
 
         Returns:
-            json: Json view of the current status of the entry.
+            dict: Json view of the current status of the entry.
         """
         new_json = copy.deepcopy(self._raw_json or {})
 
@@ -109,11 +116,35 @@ class HoldingpenResource(BaseResource):
         }
         new_json['_extra_data'].update(new_extra_data)
         new_json['workflow_id'] = self.workflow_id,
-        new_json['metadata']['titles'] = [title.to_json() for title in self.titles]
         new_json['_workflow']['status'] = self.status
 
         if self.control_number is not None:
             new_json['metadata']['control_number'] = self.control_number
+
+        return new_json
+
+    @property
+    def extra_data(self):
+        return self._raw_json['_extra_data']
+
+
+class HoldingpenLiteratureResource(HoldingpenResource):
+    """Holdingpen entry for a literature workflow."""
+    def __init__(self, titles, auto_approved=None, doi=None, arxiv_eprint=None, approved_match=None, **kwargs):
+        self.auto_approved = auto_approved
+        self.titles = titles
+        self.arxiv_eprint = arxiv_eprint
+        self.doi = doi
+        self.approved_match = approved_match
+        super(HoldingpenLiteratureResource, self).__init__(**kwargs)
+
+    def set_conflicts(self, conflicts):
+        self._raw_json['_extra_data']['conflicts'] = conflicts
+
+    def to_json(self):
+        new_json = super(HoldingpenLiteratureResource, self).to_json()
+
+        new_json['metadata']['titles'] = [title.to_json() for title in self.titles]
 
         if self.arxiv_eprint is not None:
             new_json['metadata']['arxiv_eprints'][0]['value'] = self.arxiv_eprint
@@ -122,6 +153,13 @@ class HoldingpenResource(BaseResource):
             new_json['metadata']['dois'][0]['value'] = self.doi
 
         return new_json
+
+
+class HoldingpenAuthorResource(HoldingpenResource):
+    """Holdingpen for an author workflow."""
+    def __init__(self, display_name, **kwargs):
+        self.display_name = display_name
+        super(HoldingpenAuthorResource, self).__init__(**kwargs)
 
 
 class HoldingpenApiClient(object):

--- a/inspirehep/testlib/api/literature_form.py
+++ b/inspirehep/testlib/api/literature_form.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2018 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Literature suggestion form testlib."""
+
+from __future__ import absolute_import, division, print_function
+
+
+class LiteratureFormInputData(object):
+    def __init__(self, title, language='en', type_of_doc='article'):
+        self.type_of_doc = type_of_doc
+        self.title = title
+        self.language = language
+        self.authors = []
+
+    def add_author(self, name, affiliation=None):
+        self.authors.append({
+            'name': name,
+            'affiliation': affiliation,
+        })
+
+    def _authors_request_data(self):
+        formdata = {
+            'authors-__last_index__': len(self.authors) - 1,
+        }
+
+        for idx, author in enumerate(self.authors):
+            formdata['authors-{}-name'.format(idx)] = author['name']
+            formdata['authors-{}-affiliation'.format(idx)] = author['affiliation']
+
+        return formdata
+
+    def request_data(self):
+        formdata = {
+            'type_of_doc': self.type_of_doc,
+            'language': self.language,
+            'title': self.title,
+        }
+
+        formdata.update(self._authors_request_data())
+
+        return formdata
+
+
+class LiteratureFormApiClient(object):
+    SUBMIT_LITERATURE_FORM_URL = '/literature/new/submit'
+
+    def __init__(self, client):
+        self._client = client
+
+    def submit(self, form_input_data):
+        response = self._client.post(
+            self.SUBMIT_LITERATURE_FORM_URL,
+            data=form_input_data.request_data()
+        )
+        response.raise_for_status()
+        return response

--- a/tests/e2e/scenarios/author_submission_has_source_data/RTService/authenticate.yaml
+++ b/tests/e2e/scenarios/author_submission_has_source_data/RTService/authenticate.yaml
@@ -1,0 +1,26 @@
+request:
+  headers:
+    Host: [rt.inspirehep.net]
+    Connection: [keep-alive]
+    Accept-Encoding: ['gzip, deflate']
+    Accept: ['*/*']
+    User-Agent: ['python-requests/2.18.4']
+    Content-Length: ['27']
+    Content-Type: [application/x-www-form-urlencoded]
+  method: POST
+  url: https://rt.inspirehep.net/REST/1.0/
+  body: user=rtuser&pass=rtpass
+response:
+  headers:
+    Date: ['Wed, 23 May 2018 14:18:12 GMT']
+    Server: [Apache]
+    Set-Cookie: ['RT_SID_INSPIRE-HEP.443=b16459f905f0f82a5b38704f7e321473; path=/; secure; HttpOnly']
+    X-Frame-Options: [DENY]
+    Connection: [close]
+    Transfer-Encoding: [chunked]
+    Content-Type: ['text/plain; charset=utf-8']
+  status: {code: 200, message: OK}
+  body: |
+    RT/4.2.14 200 Ok
+    # Invalid object specification: ''
+    id:

--- a/tests/e2e/scenarios/author_submission_has_source_data/RTService/ticket_comment.yaml
+++ b/tests/e2e/scenarios/author_submission_has_source_data/RTService/ticket_comment.yaml
@@ -1,0 +1,29 @@
+callbacks: []
+match: {}
+request:
+  body: content=id%3A+723851%0AAction%3A+correspond%0AText%3A+Dear+admin%40inspirehep.net%2C%0A+++++++%0A+++++++Thank+you+very+much+for+suggesting+information+about+%22Homer+Simpson%22+to+INSPIRE.+It+has+been+received+and+will+be+reviewed+by+our+staff+as+soon+as+possible.+You+will+hear+back+from+us+shortly.%0A+++++++%0A+++++++Thank+you+for+sharing+with+INSPIRE%21%0ACc%3A+%0ABcc%3A+
+  headers:
+    Accept: ['*/*']
+    Accept-Encoding: ['gzip, deflate']
+    Connection: [keep-alive]
+    Content-Length: ['376']
+    Content-Type: [application/x-www-form-urlencoded]
+    Cookie: [RT_SID_INSPIRE-HEP.443=2356e17e7fb25cb47ee568459fd6e0b7]
+    Host: [rt.inspirehep.net]
+    User-Agent: [python-requests/2.19.1]
+  method: POST
+  url: https://rt.inspirehep.net/REST/1.0/ticket/723851/comment
+response:
+  headers:
+    Date: ['Wed, 23 May 2018 14:20:15 GMT']
+    Server: [Apache]
+    Set-Cookie: ['RT_SID_INSPIRE-HEP.443=2356e17e7fb25cb47ee568459fd6e0b7; path=/; secure; HttpOnly']
+    X-Frame-Options: [DENY]
+    Connection: [close]
+    Transfer-Encoding: [chunked]
+    Content-Type: ['text/plain; charset=utf-8']
+  status: {code: 200, message: OK}
+  body: |
+    RT/4.2.14 200 Ok
+
+    # Correspondence added

--- a/tests/e2e/scenarios/author_submission_has_source_data/RTService/ticket_edit.yaml
+++ b/tests/e2e/scenarios/author_submission_has_source_data/RTService/ticket_edit.yaml
@@ -1,0 +1,29 @@
+callbacks: []
+match: {}
+request:
+  body: content=Status%3A+new%0A
+  headers:
+    Accept: ['*/*']
+    Accept-Encoding: ['gzip, deflate']
+    Connection: [keep-alive]
+    Content-Length: ['24']
+    Content-Type: [application/x-www-form-urlencoded]
+    Cookie: [RT_SID_INSPIRE-HEP.443=2356e17e7fb25cb47ee568459fd6e0b7]
+    Host: [rt.inspirehep.net]
+    User-Agent: [python-requests/2.19.1]
+  method: POST
+  url: https://rt.inspirehep.net/REST/1.0/ticket/723851/edit
+response:
+  headers:
+    Date: ['Wed, 23 May 2018 14:20:15 GMT']
+    Server: [Apache]
+    Set-Cookie: ['RT_SID_INSPIRE-HEP.443=2356e17e7fb25cb47ee568459fd6e0b7; path=/; secure; HttpOnly']
+    X-Frame-Options: [DENY]
+    Connection: [close]
+    Transfer-Encoding: [chunked]
+    Content-Type: ['text/plain; charset=utf-8']
+  status: {code: 200, message: OK}
+  body: |
+    RT/4.2.14 200 Ok
+
+    # Ticket 723875 updated.

--- a/tests/e2e/scenarios/author_submission_has_source_data/RTService/ticket_new.yaml
+++ b/tests/e2e/scenarios/author_submission_has_source_data/RTService/ticket_new.yaml
@@ -1,0 +1,34 @@
+callbacks: []
+match:
+  exact:
+    - url
+    - method
+  regex:
+    body: .*Authors_add_user.*holdingpen%2Fdetails%2F1.*
+request:
+  body: content=id%3A+ticket%2Fnew%0AQueue%3A+Authors_add_user%0AText%3A+New+author+from+admin%40inspirehep.net%0A+++++++%0A+++++++Approve%2Freject+it+here%3A+http%3A%2F%2Ftest-web-e2e.local%3A5000%2Fholdingpen%2Fdetails%2F1%0ASubject%3A+Your+suggestion+to+INSPIRE%3A+author+Homer+Simpson%0A
+  headers:
+    Accept: ['*/*']
+    Accept-Encoding: ['gzip, deflate']
+    Connection: [keep-alive]
+    Content-Length: ['283']
+    Content-Type: [application/x-www-form-urlencoded]
+    Cookie: [RT_SID_INSPIRE-HEP.443=2356e17e7fb25cb47ee568459fd6e0b7]
+    Host: [rt.inspirehep.net]
+    User-Agent: [python-requests/2.19.1]
+  method: POST
+  url: https://rt.inspirehep.net/REST/1.0/ticket/new
+response:
+  headers:
+    Date: ['Wed, 23 May 2018 14:20:15 GMT']
+    Server: [Apache]
+    Set-Cookie: ['RT_SID_INSPIRE-HEP.443=2356e17e7fb25cb47ee568459fd6e0b7; path=/; secure; HttpOnly']
+    X-Frame-Options: [DENY]
+    Connection: [close]
+    Transfer-Encoding: [chunked]
+    Content-Type: ['text/plain; charset=utf-8']
+  status: {code: 200, message: OK}
+  body: |
+    RT/4.2.14 200 Ok
+
+    # Ticket 723851 created.

--- a/tests/e2e/scenarios/literature_submission_has_source_data/RTService/authenticate.yaml
+++ b/tests/e2e/scenarios/literature_submission_has_source_data/RTService/authenticate.yaml
@@ -1,0 +1,26 @@
+request:
+  headers:
+    Host: [rt.inspirehep.net]
+    Connection: [keep-alive]
+    Accept-Encoding: ['gzip, deflate']
+    Accept: ['*/*']
+    User-Agent: ['python-requests/2.18.4']
+    Content-Length: ['27']
+    Content-Type: [application/x-www-form-urlencoded]
+  method: POST
+  url: https://rt.inspirehep.net/REST/1.0/
+  body: user=rtuser&pass=rtpass
+response:
+  headers:
+    Date: ['Wed, 23 May 2018 14:18:12 GMT']
+    Server: [Apache]
+    Set-Cookie: ['RT_SID_INSPIRE-HEP.443=b16459f905f0f82a5b38704f7e321473; path=/; secure; HttpOnly']
+    X-Frame-Options: [DENY]
+    Connection: [close]
+    Transfer-Encoding: [chunked]
+    Content-Type: ['text/plain; charset=utf-8']
+  status: {code: 200, message: OK}
+  body: |
+    RT/4.2.14 200 Ok
+    # Invalid object specification: ''
+    id:

--- a/tests/e2e/scenarios/literature_submission_has_source_data/RTService/ticket_comment.yaml
+++ b/tests/e2e/scenarios/literature_submission_has_source_data/RTService/ticket_comment.yaml
@@ -1,0 +1,29 @@
+callbacks: []
+match: {}
+request:
+  body: content=id%3A+723851%0AAction%3A+correspond%0AText%3A+Dear+admin%40inspirehep.net%2C%0A+++++++%0A+++++++Thank+you+very+much+for+suggesting+%22Physics+of+Donut%22+to+INSPIRE.+It+has+been+received+and+will+be+reviewed+by+our+staff+as+soon+as+possible.+You+will+hear+back+from+us+shortly.%0A+++++++%0A+++++++Thank+you+for+sharing+with+INSPIRE%21%0ACc%3A+%0ABcc%3A+
+  headers:
+    Accept: ['*/*']
+    Accept-Encoding: ['gzip, deflate']
+    Connection: [keep-alive]
+    Content-Length: ['361']
+    Content-Type: [application/x-www-form-urlencoded]
+    Cookie: [RT_SID_INSPIRE-HEP.443=2356e17e7fb25cb47ee568459fd6e0b7]
+    Host: [rt.inspirehep.net]
+    User-Agent: [python-requests/2.19.1]
+  method: POST
+  url: https://rt.inspirehep.net/REST/1.0/ticket/723851/comment
+response:
+  headers:
+    Date: ['Wed, 23 May 2018 14:20:15 GMT']
+    Server: [Apache]
+    Set-Cookie: ['RT_SID_INSPIRE-HEP.443=2356e17e7fb25cb47ee568459fd6e0b7; path=/; secure; HttpOnly']
+    X-Frame-Options: [DENY]
+    Connection: [close]
+    Transfer-Encoding: [chunked]
+    Content-Type: ['text/plain; charset=utf-8']
+  status: {code: 200, message: OK}
+  body: |
+    RT/4.2.14 200 Ok
+
+    # Correspondence added

--- a/tests/e2e/scenarios/literature_submission_has_source_data/RTService/ticket_edit.yaml
+++ b/tests/e2e/scenarios/literature_submission_has_source_data/RTService/ticket_edit.yaml
@@ -1,0 +1,29 @@
+callbacks: []
+match: {}
+request:
+  body: content=Status%3A+new%0A
+  headers:
+    Accept: ['*/*']
+    Accept-Encoding: ['gzip, deflate']
+    Connection: [keep-alive]
+    Content-Length: ['24']
+    Content-Type: [application/x-www-form-urlencoded]
+    Cookie: [RT_SID_INSPIRE-HEP.443=2356e17e7fb25cb47ee568459fd6e0b7]
+    Host: [rt.inspirehep.net]
+    User-Agent: [python-requests/2.19.1]
+  method: POST
+  url: https://rt.inspirehep.net/REST/1.0/ticket/723851/edit
+response:
+  headers:
+    Date: ['Wed, 23 May 2018 14:20:15 GMT']
+    Server: [Apache]
+    Set-Cookie: ['RT_SID_INSPIRE-HEP.443=2356e17e7fb25cb47ee568459fd6e0b7; path=/; secure; HttpOnly']
+    X-Frame-Options: [DENY]
+    Connection: [close]
+    Transfer-Encoding: [chunked]
+    Content-Type: ['text/plain; charset=utf-8']
+  status: {code: 200, message: OK}
+  body: |
+    RT/4.2.14 200 Ok
+
+    # Ticket 723875 updated.

--- a/tests/e2e/scenarios/literature_submission_has_source_data/RTService/ticket_new.yaml
+++ b/tests/e2e/scenarios/literature_submission_has_source_data/RTService/ticket_new.yaml
@@ -1,0 +1,34 @@
+callbacks: []
+match:
+  exact:
+    - url
+    - method
+  regex:
+    body: .*HEP_add_user.*holdingpen%2Fdetails%2F1.*
+request:
+  body: content=id%3A+ticket%2Fnew%0AQueue%3A+HEP_add_user%0AText%3A+New+submission+from+admin%40inspirehep.net%0A+++++++Approve%2Freject+it+here%3A+http%3A%2F%2Ftest-web-e2e.local%3A5000%2Fholdingpen%2Fdetails%2F1%0ASubject%3A+Your+suggestion+to+INSPIRE%3A+Physics+of+Donut%0A
+  headers:
+    Accept: ['*/*']
+    Accept-Encoding: ['gzip, deflate']
+    Connection: [keep-alive]
+    Content-Length: ['269']
+    Content-Type: [application/x-www-form-urlencoded]
+    Cookie: [RT_SID_INSPIRE-HEP.443=2356e17e7fb25cb47ee568459fd6e0b7]
+    Host: [rt.inspirehep.net]
+    User-Agent: [python-requests/2.19.1]
+  method: POST
+  url: https://rt.inspirehep.net/REST/1.0/ticket/new
+response:
+  headers:
+    Date: ['Wed, 23 May 2018 14:20:15 GMT']
+    Server: [Apache]
+    Set-Cookie: ['RT_SID_INSPIRE-HEP.443=2356e17e7fb25cb47ee568459fd6e0b7; path=/; secure; HttpOnly']
+    X-Frame-Options: [DENY]
+    Connection: [close]
+    Transfer-Encoding: [chunked]
+    Content-Type: ['text/plain; charset=utf-8']
+  status: {code: 200, message: OK}
+  body: |
+    RT/4.2.14 200 Ok
+
+    # Ticket 723851 created.

--- a/tests/e2e/test_submissions.py
+++ b/tests/e2e/test_submissions.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2018 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import backoff
+
+from inspirehep.testlib.api.author_form import AuthorFormInputData
+from inspirehep.testlib.api.literature_form import LiteratureFormInputData
+from inspirehep.testlib.api.mitm_client import with_mitmproxy
+
+
+def wait_for(func, *args, **kwargs):
+    max_time = kwargs.pop('max_time', 200)
+    interval = kwargs.pop('interval', 2)
+
+    decorator = backoff.on_exception(
+        backoff.constant,
+        AssertionError,
+        interval=interval,
+        max_time=max_time,
+    )
+    decorated = decorator(func)
+    return decorated(*args, **kwargs)
+
+
+def _workflows_in_status(holdingpen_client, num_entries, status):
+    hp_entries = holdingpen_client.get_list_entries()
+    entries_in_status = [entry for entry in hp_entries if entry.status == status]
+    try:
+        assert len(entries_in_status) == num_entries
+    except AssertionError:
+        print(
+            'Current holdingpen entries (waiting for %s of them to be in %s status): %s'
+            % (num_entries, status, hp_entries)
+        )
+        raise
+    return entries_in_status
+
+
+@with_mitmproxy
+def test_literature_submission_has_source_data(inspire_client, mitm_client):
+    literature_form = LiteratureFormInputData(
+        title='Physics of Donut',
+        type_of_doc='article',
+        language='en',
+    )
+    literature_form.add_author('Simpson, Homer J.')
+    inspire_client.literature_form.submit(literature_form)
+
+    completed_entry = wait_for(
+        lambda: _workflows_in_status(
+            holdingpen_client=inspire_client.holdingpen,
+            status='HALTED',
+            num_entries=1,
+        )
+    )[0]
+    entry = inspire_client.holdingpen.get_detail_entry(
+        completed_entry.workflow_id
+    )
+
+    result_source_data = entry.extra_data['source_data']
+
+    assert result_source_data['data']
+    assert result_source_data['extra_data']
+
+
+@with_mitmproxy
+def test_author_submission_has_source_data(inspire_client, mitm_client):
+    author_form = AuthorFormInputData(
+        given_names='Homer Jay',
+        family_name='Simpson',
+        display_name='Homer Simpson',
+        status='retired',
+        research_field='econ',
+    )
+
+    inspire_client.author_form.submit(author_form)
+
+    completed_entry = wait_for(
+        lambda: _workflows_in_status(
+            holdingpen_client=inspire_client.holdingpen,
+            status='HALTED',
+            num_entries=1,
+        )
+    )[0]
+    entry = inspire_client.holdingpen.get_detail_entry(
+        completed_entry.workflow_id
+    )
+
+    assert entry.display_name == 'Homer Simpson'
+
+    result_source_data = entry.extra_data['source_data']
+
+    assert result_source_data['data']
+    assert result_source_data['extra_data']


### PR DESCRIPTION
## Description

Initialise `source_data` (with `formdata`) for workflows created with submission forms for literature and authors.

## Related Issue
Restartable Workflows: https://its.cern.ch/jira/browse/INSPIR-1026

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
