### PR TITLE
records: wrapper handles empty publication_info

### DIFF
--- a/inspirehep/modules/records/wrappers.py
+++ b/inspirehep/modules/records/wrappers.py
@@ -123,6 +123,10 @@ class LiteratureRecord(ESRecord, AdminToolsMixin):
         Returns a list with information about each publication note in
         the record.
         """
+
+        if 'publication_info' not in self:
+            return None
+
         pub_info_list = []
         for pub_info in self['publication_info']:
             item = {}
@@ -143,7 +147,7 @@ class LiteratureRecord(ESRecord, AdminToolsMixin):
             if item:
                 pub_info_list.append({key: value for (key, value) in iteritems(item) if value})
 
-        return pub_info_list
+        return pub_info_list or None
 
     @property
     def external_system_identifiers(self):

--- a/inspirehep/modules/theme/jinja2filters.py
+++ b/inspirehep/modules/theme/jinja2filters.py
@@ -484,17 +484,19 @@ def publication_info(record):
     result = {}
     pub_infos = []
     if 'publication_info' in record:
-        for pub_info in record.publication_information:
-            pub_info_html = render_macro_from_template(
-                name="pub_info",
-                template="inspirehep_theme/format/record/Publication_info.tpl",
-                ctx=pub_info
-            )
-            if pub_info_html:
-                pub_infos.append(pub_info_html)
+        publication_information = record.publication_information
+        if publication_information:
+            for pub_info in publication_information:
+                pub_info_html = render_macro_from_template(
+                    name="pub_info",
+                    template="inspirehep_theme/format/record/Publication_info.tpl",
+                    ctx=pub_info
+                )
+                if pub_info_html:
+                    pub_infos.append(pub_info_html)
 
-        if pub_infos:
-            result['pub_info'] = pub_infos
+            if pub_infos:
+                result['pub_info'] = pub_infos
 
         # Conference info line
         for conf_info in record.conference_information:

--- a/tests/unit/records/test_records_wrappers.py
+++ b/tests/unit/records/test_records_wrappers.py
@@ -194,3 +194,25 @@ def test_literature_record_publication_information_handles_missing_fields():
     ]
 
     assert expected == record.publication_information
+
+
+def test_literature_record_publication_information_no_journal_title_or_pubinfo_freetext():
+    record = LiteratureRecord({
+        'publication_info': [
+            {
+                'cnum': 'C93-07-01',
+                'conference_recid': 968950,
+                'conference_record': {
+                    '$ref': 'http://labs.inspirehep.net/api/conferences/968950'
+                },
+            },
+        ],
+    })
+
+    assert not record.publication_information
+
+
+def test_literature_record_publication_information_no_publication_info():
+    record = LiteratureRecord({})
+
+    assert not record.publication_information


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Make the LiteratureWrapper property `publication_information` return `None` in case the `publication_info` key does not exist in the record or it does not contain objects that are relevant for the UI. This is necessary because otherwise the UI will render the`Published in` label without any content.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://its.cern.ch/jira/browse/INSPIR-1092

Signed-off-by: Iuliana Voinea <iulianavoinea96@gmail.com>

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
