### PR TITLE
tests: addition of workflow etag tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ install_requires = [
     'invenio-search[elasticsearch5]~=1.0,>=1.0.0',
     'invenio-userprofiles~=1.0,>=1.0.0',
     'invenio-workflows-files~=1.0,>=1.0.0',
-    'invenio-workflows-ui~=2.0,>=2.0.3',
+    'invenio-workflows-ui~=2.0,>=2.0.11',
     'invenio-workflows~=7.0,>=7.0.1',
     # Pin the version of jsonschema, as not to catch alpha 3.0 release
     'jsonschema~=2.0,>=2.6.0',

--- a/tests/integration/workflows/test_views.py
+++ b/tests/integration/workflows/test_views.py
@@ -25,6 +25,7 @@ from __future__ import absolute_import, division, print_function
 from copy import deepcopy
 import json
 
+from invenio_accounts.testutils import login_user_via_session
 from invenio_workflows import workflow_object_class
 from invenio_db import db
 
@@ -90,3 +91,37 @@ def test_inspect_merge_view_returns_400(workflow_app):
     with workflow_app.test_client() as client:
         response = client.get('/workflows/inspect_merge/{}'.format(obj.id))
         assert response.status_code == 400
+
+
+def test_responses_with_etag(workflow_app):
+
+    factory = TestRecordMetadata.create_from_kwargs(
+        json={'titles': [{'title': 'Etag version'}]}
+    )
+
+    obj = workflow_object_class.create(
+        data=factory.record_metadata.json,
+        data_type='hep',
+    )
+    obj.save()
+    db.session.commit()
+
+    workflow_url = '/api/holdingpen/{}'.format(obj.id)
+
+    with workflow_app.test_client() as client:
+        login_user_via_session(client, email='cataloger@inspirehep.net')
+        response = client.get(workflow_url)
+        assert response.status_code == 200
+
+        etag = response.headers['ETag']
+        last_modified = response.headers['Last-Modified']
+
+        response = client.get(
+            workflow_url, headers={'If-Modified-Since': last_modified})
+        assert response.status_code == 304
+
+        response = client.get(workflow_url, headers={'If-None-Match': etag})
+        assert response.status_code == 304
+
+        response = client.get(workflow_url, headers={'If-None-Match': 'Jessica Jones'})
+        assert response.status_code == 200


### PR DESCRIPTION
* Due to the limitation of ``invenio-workflows-ui`` test suite, we're
  adding the tests here to make sure the ``ETag`` is properly set.

Signed-off-by: Harris Tzovanakis <me@drjova.com>
