### PR TITLE
Improve wf test speed

### DIFF
--- a/tests/integration/workflows/conftest.py
+++ b/tests/integration/workflows/conftest.py
@@ -61,14 +61,14 @@ HIGGS_ONTOLOGY = '''<?xml version="1.0" encoding="UTF-8" ?>
 '''
 
 
-@pytest.fixture()
-def higgs_ontology(tmpdir):
-    ontology = tmpdir.join('HEPont.rdf')
+@pytest.fixture(scope='module')
+def higgs_ontology(tmpdir_factory):
+    ontology = tmpdir_factory.mktemp('data').join('HEPont.rdf')
     ontology.write(HIGGS_ONTOLOGY)
     yield str(ontology)
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def workflow_app(higgs_ontology):
     """Flask application with no records and function scope.
 

--- a/tests/integration/workflows/test_arxiv_workflow.py
+++ b/tests/integration/workflows/test_arxiv_workflow.py
@@ -946,7 +946,7 @@ def test_match_wf_in_error_goes_in_error_state(workflow_app):
     es.indices.refresh('holdingpen-hep')
 
     with pytest.raises(WorkflowsError):
-        start('article', record)
+        start('article', [record])
 
 
 def test_match_wf_in_error_goes_in_initial_state(workflow_app):
@@ -958,4 +958,4 @@ def test_match_wf_in_error_goes_in_initial_state(workflow_app):
     es.indices.refresh('holdingpen-hep')
 
     with pytest.raises(WorkflowsError):
-        start('article', record)
+        start('article', [record])

--- a/tests/integration/workflows/test_edit_article.py
+++ b/tests/integration/workflows/test_edit_article.py
@@ -176,20 +176,20 @@ def test_edit_article_workflow(workflow_app, mocked_external_services):
     ({'email': 'admin@inspirehep.net'}, 302),
 ])
 def test_edit_article_start_permission(
-    app,
-    app_client,
+    workflow_app,
+    workflow_api_client,
     user_info,
     expected_status_code,
     mocked_external_services,
 ):
     if user_info:
-        login_user_via_session(app_client, email=user_info['email'])
+        login_user_via_session(workflow_api_client, email=user_info['email'])
 
     factory = TestRecordMetadata.create_from_kwargs(json={})
     control_number = factory.record_metadata.json['control_number']
     endpoint_url = "/workflows/edit_article/{}".format(control_number)
 
-    response = app_client.get(endpoint_url)
+    response = workflow_api_client.get(endpoint_url)
     assert response.status_code == expected_status_code
 
 


### PR DESCRIPTION
Workflow tests go down from ~23 min to ~13 min on Travis with this little improvement.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
