### PR TITLE
honcho: removal of elasticsearch

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -26,4 +26,4 @@ worker: celery worker -E -A inspirehep.celery --loglevel=INFO --workdir="${VIRTU
 workermon: celery flower -A inspirehep.celery
 # beat: celery beat -A inspirehep.celery --loglevel=INFO --workdir="${VIRTUAL_ENV}" --pidfile="${VIRTUAL_ENV}/worker_beat.pid"
 # mathoid: node_modules/mathoid/server.js -c mathoid.config.yaml
-indexer: elasticsearch -Dcluster.name="inspire" -Ddiscovery.zen.ping.multicast.enabled=false -Dpath.data="$VIRTUAL_ENV/var/data/elasticsearch"  -Dpath.logs="$VIRTUAL_ENV/var/log/elasticsearch"
+# indexer: elasticsearch -Dcluster.name="inspire" -Ddiscovery.zen.ping.multicast.enabled=false -Dpath.data="$VIRTUAL_ENV/var/data/elasticsearch"  -Dpath.logs="$VIRTUAL_ENV/var/log/elasticsearch"


### PR DESCRIPTION
* Removing honcho elasticsearch start up. Installing ES5 locally works
  out-of-the-box.

Signed-off-by: Harris Tzovanakis <me@drjova.com>