### PR TITLE
workflows: fix for ``author_list``

### DIFF
--- a/inspirehep/modules/workflows/tasks/arxiv.py
+++ b/inspirehep/modules/workflows/tasks/arxiv.py
@@ -233,9 +233,9 @@ def arxiv_author_list(stylesheet="authorlist2marcxml.xsl"):
     def _author_list(obj, eng):
         arxiv_id = get_arxiv_id(obj.data)
         filename = secure_filename('{0}.tar.gz'.format(arxiv_id))
-        tarball = obj.files[filename]
-
-        if not tarball:
+        try:
+            tarball = obj.files[filename]
+        except KeyError:
             obj.log.info(
                 'Skipping author list extraction, no tarball with name "%s" found' % filename
             )

--- a/tests/unit/workflows/test_workflows_tasks_arxiv.py
+++ b/tests/unit/workflows/test_workflows_tasks_arxiv.py
@@ -728,6 +728,43 @@ def test_arxiv_derive_inspire_categories_does_nothing_with_existing_categories()
     assert expected == result
 
 
+def test_arxiv_author_list_with_missing_tarball():
+    schema = load_schema('hep')
+
+    eprints_subschema = schema['properties']['arxiv_eprints']
+    data = {
+        'arxiv_eprints': [
+            {
+                'categories': [
+                    'hep-ex',
+                ],
+                'value': '1703.09986',
+            },
+        ],
+    }  # record/1519995
+    validate(data['arxiv_eprints'], eprints_subschema)
+
+    extra_data = {}
+    files = MockFiles({
+        'jessica.jones.tar.gz': AttrDict({
+            'file': AttrDict({
+                'uri': 'alias.investigations',
+            })
+        })
+    })
+
+    obj = MockObj(data, extra_data, files=files)
+    eng = MockEng()
+
+    default_arxiv_author_list = arxiv_author_list()
+    expected_message = \
+        'Skipping author list extraction, no tarball with name "1703.09986.tar.gz" found'
+
+    assert default_arxiv_author_list(obj, eng) is None
+
+    assert expected_message in obj.log._info.getvalue()
+
+
 def test_arxiv_author_list_handles_auto_ignore_comment():
     schema = load_schema('hep')
 


### PR DESCRIPTION
* Fixes a bug with ``author_list`` when the tarball is not part of the
  ``files``.

Signed-off-by: Harris Tzovanakis <me@drjova.com>