### PR TITLE
DEMO: Halt gently to resolve DOI conflicts

### DIFF
--- a/inspirehep/modules/workflows/tasks/matching.py
+++ b/inspirehep/modules/workflows/tasks/matching.py
@@ -91,7 +91,6 @@ def fuzzy_match(obj, eng):
     matches = dedupe_list(match(obj.data, fuzzy_match_config))
     record_ids = [_get_hep_record_brief(el['_source']) for el in matches]
     obj.extra_data.setdefault('matches', {})['fuzzy'] = record_ids[0:5]
-#    obj.extra_data['test'] = obj.extra_data['matches']['exact']
     return bool(record_ids)
 
 

--- a/inspirehep/modules/workflows/tasks/matching.py
+++ b/inspirehep/modules/workflows/tasks/matching.py
@@ -41,7 +41,7 @@ from ..utils import with_debug_logging
 
 @with_debug_logging
 def exact_match(obj, eng):
-    """Return ``True`` if the record is already present in the system.
+    """Return ``True`` if the record is already present in the system once.
 
     Uses the default configuration of the ``inspire-matcher`` to find
     duplicates of the current workflow object in the system.
@@ -54,7 +54,7 @@ def exact_match(obj, eng):
         eng: a workflow engine.
 
     Returns:
-        bool: ``True`` if the workflow object has a duplicate in the system
+        bool: ``True`` if the workflow object has exactly one duplicate in the system
         ``False`` otherwise.
 
     """
@@ -62,7 +62,7 @@ def exact_match(obj, eng):
     matches = dedupe_list(match(obj.data, exact_match_config))
     record_ids = [el['_source']['control_number'] for el in matches]
     obj.extra_data.setdefault('matches', {})['exact'] = record_ids
-    return bool(record_ids)
+    return len(record_ids) == 1
 
 
 @with_debug_logging
@@ -91,6 +91,7 @@ def fuzzy_match(obj, eng):
     matches = dedupe_list(match(obj.data, fuzzy_match_config))
     record_ids = [_get_hep_record_brief(el['_source']) for el in matches]
     obj.extra_data.setdefault('matches', {})['fuzzy'] = record_ids[0:5]
+#    obj.extra_data['test'] = obj.extra_data['matches']['exact']
     return bool(record_ids)
 
 


### PR DESCRIPTION
**untested!**

* exact match requires exactly one exact match
* otherwise it proceeds to search for fuzzy matches

This is a minimal solution!
It assumes that at least one exact match is also found as fuzzy match.
If would be better if the workflow would halt in case of more than one exact matches,
present the result to a cataloger to resolve.

Signed-off-by: Kirsten Sachs <kirsten.sachs@desy.de>

<!--- Provide a general summary of your changes in the Title above -->


## Related Issue
https://github.com/inspirehep/inspire-next/issues/3586

## Motivation and Context
unresolved multiple exact matches lead to upload failures and workflows in error state that have to be resolved manually.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
