### PR TITLE
INSPIR-1126 and INSPIR-1149

### DIFF
--- a/inspirehep/alembic/0bc0a6ee1bc0_create_index_on_referenced_records.py
+++ b/inspirehep/alembic/0bc0a6ee1bc0_create_index_on_referenced_records.py
@@ -1,0 +1,42 @@
+#
+# This file is part of Invenio.
+# Copyright (C) 2016-2018 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""create index on referenced_records"""
+from __future__ import absolute_import, division, print_function
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '0bc0a6ee1bc0'
+down_revision = '2f5368ff6d20'
+branch_labels = ()
+depends_on = '07fb52561c5c'
+
+
+def upgrade():
+    """Upgrade database."""
+    op.execute('''
+        create or replace function referenced_records(json jsonb) returns text[] as  $$
+        select
+            array_agg(
+                references_arr->'record'->>'$ref'
+            )  as result
+         from
+            jsonb_array_elements(json->'references') as references_arr; $$
+        language sql immutable
+    ''')
+    op.execute('''
+        create index ix_records_metadata_json_referenced_records
+            on records_metadata
+            using gin(referenced_records(json))
+    ''')
+
+
+def downgrade():
+    """Downgrade database."""
+    op.execute('drop index if exists ix_records_metadata_json_referenced_records')
+    op.execute('drop function if exists referenced_records(json jsonb)')

--- a/inspirehep/modules/records/mappings/v5/records/data.json
+++ b/inspirehep/modules/records/mappings/v5/records/data.json
@@ -13,6 +13,9 @@
                 "_collections": {
                     "type": "string"
                 },
+                "citation_count": {
+                    "type": "integer"
+                },
                 "control_number": {
                     "type": "integer"
                 },

--- a/inspirehep/modules/records/receivers.py
+++ b/inspirehep/modules/records/receivers.py
@@ -59,6 +59,10 @@ def is_hep(record):
     return 'hep.json' in record.get('$schema')
 
 
+def is_data(record):
+    return 'data.json' in record.get('$schema')
+
+
 #
 # before_record_insert & before_record_update
 #
@@ -183,6 +187,15 @@ def enhance_after_index(sender, json, *args, **kwargs):
     populate_inspire_document_type(sender, json, *args, **kwargs)
     populate_name_variations(sender, json, *args, **kwargs)
     populate_title_suggest(sender, json, *args, **kwargs)
+    populate_citations_count(sender, json, *args, **kwargs)
+
+
+def populate_citations_count(sender, json, *args, **kwargs):
+    """Populate citations_count in ES from"""
+    if is_hep(json) and is_data(json) and hasattr(sender, 'get_citations_count'):
+        # Make sure that sender has method get_citations_count
+        citation_count = sender.get_citations_count()
+        json.update({'citation_count': citation_count})
 
 
 def populate_bookautocomplete(sender, json, *args, **kwargs):
@@ -287,14 +300,13 @@ def populate_recid_from_ref(sender, json, *args, **kwargs):
             items = []
 
         for key, value in items:
-            if (isinstance(json_root, dict) and isinstance(value, dict) and
-                    '$ref' in value):
+            if (isinstance(json_root, dict) and isinstance(value, dict) and '$ref' in value):
                 # Append '_recid' and remove 'record' from the key name.
                 key_basename = key.replace('record', '').rstrip('_')
                 new_key = '{}_recid'.format(key_basename).lstrip('_')
                 json_root[new_key] = get_recid_from_ref(value)
             elif (isinstance(json_root, dict) and isinstance(value, list) and
-                    key in list_ref_fields_translations):
+                  key in list_ref_fields_translations):
                 new_list = [get_recid_from_ref(v) for v in value]
                 new_key = list_ref_fields_translations[key]
                 json_root[new_key] = new_list

--- a/inspirehep/modules/records/serializers/json_literature.py
+++ b/inspirehep/modules/records/serializers/json_literature.py
@@ -59,9 +59,21 @@ def _get_ui_metadata(record):
     return display
 
 
-def _preprocess_result(result):
-    record = result['metadata']
+def get_citations_count(original_record):
+    """ Try to get citations"""
+    if hasattr(original_record, 'get_citations_count'):
+        """Call it only when it has this method"""
+        return original_record.get_citations_count()
+    return None
 
+
+def _preprocess_result(result, original_record=None):
+    """Add additional fields to output json"""
+    if original_record is not None:
+        # If it is an db object then get citations from db
+        # Otherwise if it is from ES it has citations already in json
+        result['metadata']['citations_count'] = get_citations_count(original_record)
+    record = result['metadata']
     ui_metadata = _get_ui_metadata(record)
     # FIXME: Deprecated, must be removed once the new UI is released
     result['display'] = ui_metadata
@@ -77,11 +89,11 @@ class LiteratureJSONUISerializer(JSONSerializer):
         result = super(LiteratureJSONUISerializer, self).preprocess_record(
             pid, record, links_factory=links_factory, **kwargs
         )
-        return _preprocess_result(result)
+        return _preprocess_result(result, record)
 
     def preprocess_search_hit(self, pid, record_hit, links_factory=None,
                               **kwargs):
-        result = super(LiteratureJSONUISerializer, self).\
+        result = super(LiteratureJSONUISerializer, self). \
             preprocess_search_hit(pid, record_hit,
                                   links_factory=links_factory, **kwargs)
         return _preprocess_result(result)

--- a/inspirehep/modules/records/serializers/schemas/json.py
+++ b/inspirehep/modules/records/serializers/schemas/json.py
@@ -53,6 +53,7 @@ class RecordMetadataSchemaV1(Schema):
         AuthorSchemaV1, dump_only=True), limit=10)
     book_series = fields.Raw()
     # citeable = fields.Raw()
+    citations_count = fields.Raw()
     collaborations = fields.Raw()
     conference_info = fields.Nested(
         ConferenceInfoItemSchemaV1,


### PR DESCRIPTION
INSPIR-1126 alembic: Allow querying for citing records
INSPIR-1149 serializers: Extend the json sent to elasticsearch to include the citation count
Also fixes problem with testing alembic migrations added after "eaab22c59b89".

Elastic search now will receive citation counts
Also Serializer for search page will receive citation count
Also Serializer for single Literature entry will now receive citation count

Also fixed few Indentation to be consistent with PEP8


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
