### PR TITLE
DEMO: Halt gently to resolve DOI conflicts - V2

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -1547,8 +1547,11 @@ INSPIRE_REF_UPDATER_WHITELISTS = {
 
 # Configuration for the matcher
 # =============================
+MATCH_DISPLAY_FIELDS = ['control_number', 'titles', 'abstracts', 'authors',
+               'arxiv_eprints', 'public_notes', 'number_of_pages',
+               'publication_info', 'earliest_date']
 EXACT_MATCH = exact_match
-EXACT_MATCH['source'] = ['control_number']
+EXACT_MATCH['source'] = MATCH_DISPLAY_FIELDS
 
 FUZZY_MATCH = {
     'algorithm': [
@@ -1581,7 +1584,6 @@ FUZZY_MATCH = {
     ],
     'doc_type': 'hep',
     'index': 'records-hep',
-    'source': ['control_number', 'titles', 'abstracts', 'authors',
-               'arxiv_eprints', 'public_notes', 'number_of_pages',
-               'publication_info', 'earliest_date']
+    'source': MATCH_DISPLAY_FIELDS
 }
+MAX_FUZZY_MATCH_DISPLAY = 5


### PR DESCRIPTION
**untested!**

* exact match requires exactly one exact match
* in case of more than one exact matches:
  store the brief, halt the workflow
* fuzzy matches don't include conflicting exact matches

A more advanced solution than #3587 .

Signed-off-by: Kirsten Sachs <kirsten.sachs@desy.de>

<!--- Provide a general summary of your changes in the Title above -->

## Related Issue
#3586 

## Motivation and Context

unresolved multiple exact matches lead to upload failures and workflows in error state that have to be resolved manually. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
