### PR TITLE
workflows: halt on multiple exact matches

### DIFF
--- a/inspirehep/modules/workflows/tasks/actions.py
+++ b/inspirehep/modules/workflows/tasks/actions.py
@@ -618,7 +618,7 @@ def jlab_ticket_needed(obj, eng):
 
 
 @with_debug_logging
-def load_from_source_data(obj, enj):
+def load_from_source_data(obj, eng):
     """Restore the workflow data and extra_data from source_data."""
     try:
         source_data = obj.extra_data['source_data']

--- a/inspirehep/modules/workflows/tasks/matching.py
+++ b/inspirehep/modules/workflows/tasks/matching.py
@@ -428,3 +428,10 @@ def stop_matched_holdingpen_wfs(obj, eng):
         # stop this holdingpen workflow by replacing its steps with a stop step
         holdingpen_wf_eng.callbacks.replace(stopping_steps)
         holdingpen_wf_eng.process([holdingpen_wf])
+
+
+@with_debug_logging
+def has_more_than_one_exact_match(obj, eng):
+    """Does the record have more than one exact match."""
+    exact_matches = obj.extra_data['matches']['exact']
+    return len(set(exact_matches)) > 1

--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -89,6 +89,7 @@ from inspirehep.modules.workflows.tasks.matching import (
     stop_matched_holdingpen_wfs,
     auto_approve,
     set_core_in_extra_data,
+    has_more_than_one_exact_match,
 )
 from inspirehep.modules.workflows.tasks.merging import (
     has_conflicts,
@@ -447,6 +448,13 @@ CHECK_IS_UPDATE = [
             set_exact_match_as_approved_in_extradata,
             mark('is-update', True),
             mark('exact-matched', True),
+            IF(
+                has_more_than_one_exact_match,
+                halt_record(
+                    action="resolve_multiple_exact_matches",
+                    message="Workflow halted for resolving multiple exact matches.",
+                )
+            ),
         ],
         IF_ELSE(
             fuzzy_match,

--- a/tests/integration/workflows/fixtures/multiple_matches_arxiv.json
+++ b/tests/integration/workflows/fixtures/multiple_matches_arxiv.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://localhost:5000/schemas/records/hep.json",
+  "_collections": [
+    "Literature"
+  ],
+  "acquisition_source": {
+    "datetime": "2018-08-21T08:55:02.670285",
+    "method": "hepcrawl",
+    "source": "arXiv",
+    "submission_number": "42"
+  },
+  "core": true,
+  "curated": false,
+  "document_type": [
+    "article"
+  ],
+  "arxiv_eprints": [
+    {
+      "categories": [
+        "cs.CE"
+      ],
+      "value": "1808.12345"
+    }
+  ],
+  "titles": [
+    {
+      "source": "submitter",
+      "title": "Test Record For Multiple Exact Matches"
+    }
+  ]
+}

--- a/tests/integration/workflows/fixtures/multiple_matches_arxiv_update.json
+++ b/tests/integration/workflows/fixtures/multiple_matches_arxiv_update.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://localhost:5000/schemas/records/hep.json",
+  "_collections": [
+    "Literature"
+  ],
+  "acquisition_source": {
+    "datetime": "2018-08-21T08:55:02.670285",
+    "method": "hepcrawl",
+    "source": "arXiv",
+    "submission_number": "42"
+  },
+  "core": true,
+  "curated": false,
+  "document_type": [
+    "article"
+  ],
+  "arxiv_eprints": [
+    {
+      "categories": [
+        "cs.CE"
+      ],
+      "value": "1808.12345"
+    }
+  ],
+  "dois": [
+    {
+      "source": "submitter",
+      "value": "10.1010/some-doi"
+    }
+  ],
+  "titles": [
+    {
+      "source": "submitter",
+      "title": "Test Record For Multiple Exact Matches"
+    }
+  ]
+}

--- a/tests/integration/workflows/fixtures/multiple_matches_publisher.json
+++ b/tests/integration/workflows/fixtures/multiple_matches_publisher.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://localhost:5000/schemas/records/hep.json",
+  "_collections": [
+    "Literature"
+  ],
+  "acquisition_source": {
+    "datetime": "2018-08-21T08:55:02.670285",
+    "method": "hepcrawl",
+    "source": "desy",
+    "submission_number": "43"
+  },
+  "core": true,
+  "curated": false,
+  "document_type": [
+    "article"
+  ],
+  "dois": [
+    {
+      "source": "submitter",
+      "value": "10.1010/some-doi"
+    }
+  ],
+  "titles": [
+    {
+      "source": "arXiv",
+      "title": "Test Record For Multiple Exact Matches"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

When a workflow matches exactly more than one record in inspire, halt it with an appropriate message, to review by a curator.

Supersedes #3587 and supersedes #3592 

## Related Issue

#3586 and [INSPIR-1223](https://its.cern.ch/jira/browse/INSPIR-1223)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
