### PR TITLE
Replace InvenioRecordIndexer with InspireRecordIndexer

### DIFF
--- a/inspirehep/alembic/53e8594bc789_fix_the_production_db.py
+++ b/inspirehep/alembic/53e8594bc789_fix_the_production_db.py
@@ -48,7 +48,6 @@ PRIMARY_KEYS_MAP = {
     'files_multipartobject_part': dict(old='files_multipartobject_part_pkey', new='pk_files_multipartobject_part'),
     'files_object': dict(old='files_object_pkey', new='pk_files_object'),
     'inspire_prod_records': dict(old='inspire_prod_records_pkey', new='pk_inspire_prod_records'),
-    'oaiharvester_configs': dict(old='oaiharvester_configs_pkey', new='pk_oaiharvester_configs'),
     'oauthclient_remoteaccount': dict(old='oauthclient_remoteaccount_pkey', new='pk_oauthclient_remoteaccount'),
     'oauthclient_remotetoken': dict(old='oauthclient_remotetoken_pkey', new='pk_oauthclient_remotetoken'),
     'oauthclient_useridentity': dict(old='oauthclient_useridentity_pkey', new='pk_oauthclient_useridentity'),
@@ -92,10 +91,6 @@ def upgrade():
     # - PostgreSQL 9.6.2 running in QA on 2018.04.25 does support the "IF NOT EXISTS" in "CREATE INDEX IF NOT EXISTS".
     # The simplest way to implement a "CREATE INDEX IF NOT EXISTS" compatible with old and new versions of PostgreSQL
     # is to first delete the index is exists.
-    op.execute("DROP INDEX IF EXISTS json_ids_index")
-    op.execute("DROP INDEX IF EXISTS json_export_to_index")
-    op.execute("DROP INDEX IF EXISTS _collections")
-    op.execute("DROP INDEX IF EXISTS journal_title")
 
     op.execute("CREATE INDEX json_ids_index ON records_metadata USING gin ((json -> 'ids'))")
     op.execute("CREATE INDEX json_export_to_index ON records_metadata USING gin ((json -> '_export_to'))")
@@ -117,3 +112,9 @@ def downgrade():
     for _, names_list in INDEXES_MAP.items():
         for names in names_list:
             op.execute('ALTER INDEX IF EXISTS {} RENAME TO {}'.format(names['new'], names['old']))
+
+    # Remove indexes
+    op.execute("DROP INDEX json_ids_index")
+    op.execute("DROP INDEX json_export_to_index")
+    op.execute("DROP INDEX _collections")
+    op.execute("DROP INDEX journal_title")

--- a/inspirehep/alembic/cb9f81e8251c_add_record_metadata_indices.py
+++ b/inspirehep/alembic/cb9f81e8251c_add_record_metadata_indices.py
@@ -36,6 +36,9 @@ depends_on = None
 def upgrade():
     """Upgrade database."""
     op.execute(
+        "ALTER TABLE records_metadata ALTER COLUMN json SET DATA TYPE jsonb USING json::jsonb"
+    )
+    op.execute(
         "CREATE INDEX idxgindoctype ON records_metadata USING gin ((json -> 'document_type'))"
     )
     op.execute(
@@ -55,3 +58,6 @@ def downgrade():
     op.execute("DROP INDEX IF EXISTS idxgintitles")
     op.execute("DROP INDEX IF EXISTS idxginjournaltitle")
     op.execute("DROP INDEX IF EXISTS idxgincollections")
+    op.execute(
+        "ALTER TABLE records_metadata ALTER COLUMN json SET DATA TYPE json USING json::json"
+    )

--- a/inspirehep/alembic/eaab22c59b89_insert_migrator_use_api_action_role.py
+++ b/inspirehep/alembic/eaab22c59b89_insert_migrator_use_api_action_role.py
@@ -15,6 +15,8 @@ from invenio_access.models import ActionRoles
 from invenio_accounts.models import Role
 
 # revision identifiers, used by Alembic.
+from sqlalchemy.orm.exc import NoResultFound
+
 revision = 'eaab22c59b89'
 down_revision = 'f9ea5752e7a5'
 branch_labels = ()
@@ -26,12 +28,15 @@ def upgrade():
     """Upgrade database."""
     bind = op.get_bind()
     session = Session(bind=bind)
-
-    cataloger = session.query(Role).filter(Role.name == 'cataloger').one()
-    session.add(ActionRoles(
-        action='migrator-use-api',
-        role=cataloger)
-    )
+    try:
+        cataloger = session.query(Role).filter(Role.name == 'cataloger').one()
+        session.add(ActionRoles(
+            action='migrator-use-api',
+            role=cataloger)
+        )
+    except NoResultFound:
+        # There can be no data in DB when migration runs, so Ignore if it is empty
+        return
 
     session.commit()
 

--- a/inspirehep/alembic/fddb3cfe7a9c_create_inspirehep_tables.py
+++ b/inspirehep/alembic/fddb3cfe7a9c_create_inspirehep_tables.py
@@ -62,7 +62,7 @@ def upgrade():
     op.create_table(
         'workflows_audit_logging',
         sa.Column('id', sa.Integer, primary_key=True, autoincrement=True),
-        sa.Column('last_updated', sa.DateTime, default=datetime.utcnow, nullable=False, index=True),
+        # sa.Column('last_updated', sa.DateTime, default=datetime.utcnow, nullable=False, index=True),  # Removed in one of the commits but not added to the migrations. Not creating new migration to not break production.
         sa.Column(
             'user_id',
             sa.Integer,
@@ -74,7 +74,10 @@ def upgrade():
         sa.Column('user_action', sa.Text, default='', nullable=False),
         sa.Column('decision', sa.Text, default='', nullable=False),
         sa.Column('source', sa.Text, default='', nullable=False),
-        sa.Column('action', sa.Text, default='', nullable=False)
+        sa.Column('action', sa.Text, default='', nullable=False),
+        sa.Column('created', sa.DateTime, default=datetime.utcnow, nullable=False),
+        sa.Column('object_id', sa.Integer, sa.ForeignKey("workflows_object.id", ondelete="CASCADE"), nullable=False,
+                  index=True)
     )
 
     op.create_table(

--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -249,6 +249,7 @@ LITERATURE_REST_ENDPOINT = {
     'pid_minter': 'inspire_recid_minter',
     'pid_fetcher': 'inspire_recid_fetcher',
     'search_class': 'inspirehep.modules.search:LiteratureSearch',
+    'indexer_class': 'inspirehep.modules.records:indexer:InspireRecordIndexer',
     'record_serializers': {
         'application/json': 'invenio_records_rest.serializers:json_v1_response',
         'application/vnd+inspire.record.ui+json': INSPIRE_SERIALIZERS + ':json_literature_ui_v1_response',

--- a/inspirehep/modules/records/indexer.py
+++ b/inspirehep/modules/records/indexer.py
@@ -1,0 +1,52 @@
+from __future__ import absolute_import, division, print_function
+
+from invenio_indexer.api import RecordIndexer
+
+from inspirehep.modules.records.api import InspireRecord
+
+
+class InspireRecordIndexer(RecordIndexer):
+    def index_by_id(self, record_uuid):
+        """Index a record by record identifier.
+        :param record_uuid: Record identifier.
+        """
+        return self.index(InspireRecord.get_record(record_uuid))
+
+    def delete_by_id(self, record_uuid):
+        """Delete record from index by record identifier."""
+        self.delete(InspireRecord.get_record(record_uuid))
+
+    def _delete_action(self, payload):
+        """Bulk delete action.
+        :param payload: Decoded message body.
+        :returns: Dictionary defining an Elasticsearch bulk 'delete' action.
+        """
+        index, doc_type = payload.get('index'), payload.get('doc_type')
+        if not (index and doc_type):
+            record = InspireRecord.get_record(payload['id'])
+            index, doc_type = self.record_to_index(record)
+
+        return {
+            '_op_type': 'delete',
+            '_index': index,
+            '_type': doc_type,
+            '_id': payload['id'],
+        }
+
+    def _index_action(self, payload):
+        """Bulk index action.
+        :param payload: Decoded message body.
+        :returns: Dictionary defining an Elasticsearch bulk 'index' action.
+        """
+        record = InspireRecord.get_record(payload['id'])
+        index, doc_type = self.record_to_index(record)
+
+        return {
+            '_op_type': 'index',
+            '_index': index,
+            '_type': doc_type,
+            '_id': str(record.id),
+            '_version': record.revision_id,
+            '_version_type': self._version_type,
+            '_source': self._prepare_record(record, index, doc_type),
+        }

--- a/inspirehep/modules/records/indexer.py
+++ b/inspirehep/modules/records/indexer.py
@@ -7,8 +7,10 @@ from inspirehep.modules.records.api import InspireRecord
 
 class InspireRecordIndexer(RecordIndexer):
     def index_by_id(self, record_uuid):
-        """Index a record by record identifier.
-        :param record_uuid: Record identifier.
+        """
+        Index a record by record identifier
+        Args:
+            record_uuid: Record uuid
         """
         return self.index(InspireRecord.get_record(record_uuid))
 
@@ -17,9 +19,14 @@ class InspireRecordIndexer(RecordIndexer):
         self.delete(InspireRecord.get_record(record_uuid))
 
     def _delete_action(self, payload):
-        """Bulk delete action.
-        :param payload: Decoded message body.
-        :returns: Dictionary defining an Elasticsearch bulk 'delete' action.
+        """
+        Bulk delete action.
+        Args:
+            payload: Decoded message body.
+
+        Returns:
+            Dictionary defining an Elasticsearch bulk 'delete' action.
+
         """
         index, doc_type = payload.get('index'), payload.get('doc_type')
         if not (index and doc_type):
@@ -34,9 +41,14 @@ class InspireRecordIndexer(RecordIndexer):
         }
 
     def _index_action(self, payload):
-        """Bulk index action.
-        :param payload: Decoded message body.
-        :returns: Dictionary defining an Elasticsearch bulk 'index' action.
+        """
+        Bulk index action.
+        Args:
+            payload: Decoded message body.
+
+        Returns:
+            Dictionary defining an Elasticsearch bulk 'index' action.
+
         """
         record = InspireRecord.get_record(payload['id'])
         index, doc_type = self.record_to_index(record)

--- a/inspirehep/modules/records/indexer.py
+++ b/inspirehep/modules/records/indexer.py
@@ -1,3 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
 from __future__ import absolute_import, division, print_function
 
 from invenio_indexer.api import RecordIndexer

--- a/inspirehep/modules/records/receivers.py
+++ b/inspirehep/modules/records/receivers.py
@@ -29,6 +29,7 @@ from itertools import chain
 from unicodedata import normalize
 
 import six
+
 from celery import Task
 from flask import current_app
 from flask_sqlalchemy import models_committed
@@ -195,11 +196,12 @@ def enhance_after_index(sender, json, *args, **kwargs):
     populate_citations_count(sender, json, *args, **kwargs)
 
 
-def populate_citations_count(sender, json, *args, **kwargs):
+def populate_citations_count(sender, json, record, *args, **kwargs):
     """Populate citations_count in ES from"""
-    if (is_hep(json) or is_data(json)) and hasattr(sender, 'get_citations_count'):
-        # Make sure that sender has method get_citations_count
-        citation_count = sender.get_citations_count()
+
+    if (is_hep(json) or is_data(json)) and hasattr(record, 'get_citations_count'):
+        # Make sure that record has method get_citations_count
+        citation_count = record.get_citations_count()
         json.update({'citation_count': citation_count})
 
 

--- a/inspirehep/modules/records/serializers/json_literature.py
+++ b/inspirehep/modules/records/serializers/json_literature.py
@@ -74,7 +74,7 @@ def _preprocess_result(result, original_record=None):
     if original_record is not None:
         # If it is an db object then get citations from db
         # Otherwise if it is from ES it has citations already in json
-        result['metadata']['citations_count'] = get_citations_count(original_record)
+        result['metadata']['citation_count'] = get_citations_count(original_record)
     record = result['metadata']
     ui_metadata = _get_ui_metadata(record)
     # FIXME: Deprecated, must be removed once the new UI is released

--- a/inspirehep/modules/records/serializers/schemas/json/literature/__init__.py
+++ b/inspirehep/modules/records/serializers/schemas/json/literature/__init__.py
@@ -54,7 +54,7 @@ class RecordMetadataSchemaV1(Schema):
         AuthorSchemaV1, dump_only=True), limit=10)
     book_series = fields.Raw()
     # citeable = fields.Raw()
-    citations_count = fields.Raw()
+    citation_count = fields.Raw()
     collaborations = fields.Raw()
     conference_info = fields.Nested(
         ConferenceInfoItemSchemaV1,

--- a/inspirehep/wsgi_with_coverage.py
+++ b/inspirehep/wsgi_with_coverage.py
@@ -39,6 +39,7 @@ from flask_alembic import Alembic
 from inspire_crawler.tasks import schedule_crawl
 from inspire_utils.logging import getStackTraceLogger
 from invenio_db import db
+from invenio_db.utils import drop_alembic_version_table
 
 from inspirehep.modules.authors.views import validate as author_validate
 from inspirehep.modules.fixtures.files import init_all_storage_paths
@@ -86,11 +87,9 @@ def init_db():
     LOGGER.info('Recreating the DB')
     db.session.close()
     db.drop_all()
+    drop_alembic_version_table()
 
     alembic = Alembic(app=current_app)
-    db.create_all()
-    alembic.stamp()
-    alembic.downgrade()
     alembic.upgrade()
 
     db.session.commit()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -36,6 +36,7 @@ from flask import current_app
 from flask.cli import ScriptInfo
 
 from invenio_db import db
+from invenio_db.utils import drop_alembic_version_table
 from invenio_search import current_search_client as es
 
 from inspirehep.factory import create_app
@@ -85,11 +86,9 @@ def app():
 
         db.session.close()
         db.drop_all()
+        drop_alembic_version_table()
 
         alembic = Alembic(app=current_app)
-        db.create_all()
-        alembic.stamp()
-        alembic.downgrade()
         alembic.upgrade()
 
         _es = app.extensions['invenio-search']

--- a/tests/integration/migrator/test_migrator_cli.py
+++ b/tests/integration/migrator/test_migrator_cli.py
@@ -27,7 +27,9 @@ import os
 
 import pkg_resources
 import pytest
+from flask import current_app
 
+from mock import patch
 from invenio_db import db
 from inspirehep.modules.migrator.cli import migrate
 from inspirehep.modules.migrator.models import LegacyRecordsMirror
@@ -35,21 +37,29 @@ from inspirehep.modules.migrator.tasks import populate_mirror_from_file
 
 
 def test_migrate_file_halts_in_debug_mode(app_cli_runner):
-    file_name = pkg_resources.resource_filename(__name__, os.path.join('fixtures', '1663923.xml'))
+    config = {
+        'DEBUG': True
+    }
+    with patch.dict(current_app.config, config):
+        file_name = pkg_resources.resource_filename(__name__, os.path.join('fixtures', '1663923.xml'))
 
-    result = app_cli_runner.invoke(migrate, ['file', file_name])
+        result = app_cli_runner.invoke(migrate, ['file', file_name])
 
-    assert result.exit_code == 1
-    assert 'DEBUG' in result.output
+        assert result.exit_code == 1
+        assert 'DEBUG' in result.output
 
 
 def test_migrate_file_doesnt_halt_in_debug_mode_when_forced(app_cli_runner):
-    file_name = pkg_resources.resource_filename(__name__, os.path.join('fixtures', '1663923.xml'))
+    config = {
+        'DEBUG': True
+    }
+    with patch.dict(current_app.config, config):
+        file_name = pkg_resources.resource_filename(__name__, os.path.join('fixtures', '1663923.xml'))
 
-    result = app_cli_runner.invoke(migrate, ['file', '-f', file_name])
+        result = app_cli_runner.invoke(migrate, ['file', '-f', file_name])
 
-    assert result.exit_code == 0
-    assert 'DEBUG' not in result.output
+        assert result.exit_code == 0
+        assert 'DEBUG' not in result.output
 
 
 def test_migrate_file(app_cli_runner, api_client):
@@ -76,17 +86,25 @@ def test_migrate_file_mirror_only(app_cli_runner, api_client):
 
 
 def test_migrate_mirror_halts_in_debug_mode(app_cli_runner):
-    result = app_cli_runner.invoke(migrate, ['mirror', '-a'])
+    config = {
+        'DEBUG': True
+    }
+    with patch.dict(current_app.config, config):
+        result = app_cli_runner.invoke(migrate, ['mirror', '-a'])
 
-    assert result.exit_code == 1
-    assert 'DEBUG' in result.output
+        assert result.exit_code == 1
+        assert 'DEBUG' in result.output
 
 
 def test_migrate_mirror_doesnt_halt_in_debug_mode_when_forced(app_cli_runner):
-    result = app_cli_runner.invoke(migrate, ['mirror', '-f'])
+    config = {
+        'DEBUG': True
+    }
+    with patch.dict(current_app.config, config):
+        result = app_cli_runner.invoke(migrate, ['mirror', '-f'])
 
-    assert result.exit_code == 0
-    assert 'DEBUG' not in result.output
+        assert result.exit_code == 0
+        assert 'DEBUG' not in result.output
 
 
 def test_migrate_mirror_migrates_pending(app_cli_runner, api_client):

--- a/tests/integration/records/test_records_api.py
+++ b/tests/integration/records/test_records_api.py
@@ -106,7 +106,8 @@ def test_citations_count_non_zero(isolated_app):
         'control_number': 321,
     }
     record_1 = TestRecordMetadata.create_from_kwargs(json=record_json).inspire_record
-    ref = {'control_number': 4321, 'references': [{'record': {'$ref': record_1._get_ref()}}]}
 
+    ref = {'control_number': 4321, 'references': [{'record': {'$ref': record_1._get_ref()}}]}
     TestRecordMetadata.create_from_kwargs(json=ref)
+
     assert record_1.get_citations_count() == 1L

--- a/tests/integration/records/test_records_serializers_json.py
+++ b/tests/integration/records/test_records_serializers_json.py
@@ -152,22 +152,20 @@ def test_zero_citations_in_vnd_plus_inspire_record_ui_json(isolated_api_client):
 
 
 def test_non_zero_citation_count_in_vnd_plus_inspire_record_ui_json(isolated_api_client):
-    from invenio_db import db
-    with db.session.begin_nested():
-        record_json = {
-            'control_number': 123,
-        }
-        record = TestRecordMetadata.create_from_kwargs(json=record_json).inspire_record
-        url = '/literature/123'
-        # Add citation
-        ref = {'control_number': 1234, 'references': [{'record': {'$ref': record._get_ref()}}]}
-        TestRecordMetadata.create_from_kwargs(json=ref)
+    record_json = {
+        'control_number': 123,
+    }
+    record = TestRecordMetadata.create_from_kwargs(json=record_json).inspire_record
+    url = '/literature/123'
+    # Add citation
+    ref = {'control_number': 1234, 'references': [{'record': {'$ref': record._get_ref()}}]}
+    TestRecordMetadata.create_from_kwargs(json=ref)
 
-        response = isolated_api_client.get(url,
-                                           headers={'Accept': 'application/vnd+inspire.record.ui+json'})
-        assert response.status_code == 200
-        result = json.loads(response.get_data(as_text=True))
-        assert result['metadata']['citation_count'] == 1
+    response = isolated_api_client.get(url,
+                                       headers={'Accept': 'application/vnd+inspire.record.ui+json'})
+    assert response.status_code == 200
+    result = json.loads(response.get_data(as_text=True))
+    assert result['metadata']['citation_count'] == 1
 
 
 def test_zero_citation_count_in_es(isolated_api_client):

--- a/tests/integration/records/test_records_serializers_json.py
+++ b/tests/integration/records/test_records_serializers_json.py
@@ -169,16 +169,6 @@ def test_non_zero_citation_count_in_vnd_plus_inspire_record_ui_json(isolated_api
         result = json.loads(response.get_data(as_text=True))
         assert result['metadata']['citation_count'] == 1
 
-        # # Add second citation
-        # ref = {'control_number': 12341, 'references': [{'record': {'$ref': record._get_ref()}}]}
-        # TestRecordMetadata.create_from_kwargs(json=ref)
-        #
-        # response = isolated_api_client.get(url,
-        #                                    headers={'Accept': 'application/vnd+inspire.record.ui+json'})
-        # assert response.status_code == 200
-        # result = json.loads(response.get_data(as_text=True))
-        # assert result['metadata']['citation_count'] == 2
-
 
 def test_zero_citation_count_in_es(isolated_api_client):
     cn_map = {

--- a/tests/integration/test_alembic.py
+++ b/tests/integration/test_alembic.py
@@ -22,79 +22,60 @@
 
 from __future__ import absolute_import, division, print_function
 
-import pytest
+from flask_alembic import Alembic
 from sqlalchemy import inspect, text
 
 from invenio_db import db
-from invenio_db.utils import drop_alembic_version_table
-
-from inspirehep.factory import create_app
-from inspirehep.modules.fixtures.users import init_users_and_permissions
 
 
-@pytest.fixture()
-def alembic_app():
-    """Flask application for Alembic tests."""
-    app = create_app(
-        DEBUG=False,
-        # Tests may fail when turned on because of Flask bug (A setup function was called after the first request was handled. when initializing - when Alembic initialization)
-        SQLALCHEMY_DATABASE_URI='postgresql+psycopg2://inspirehep:dbpass123@localhost:5432/inspirehep_alembic',
-    )
+def test_downgrade(isolated_app):
+    alembic = Alembic(isolated_app)
+    alembic.upgrade()
 
-    with app.app_context():
-        db.drop_all()
-        db.create_all()
-        init_users_and_permissions()
-        yield app
-        db.drop_all()
-        drop_alembic_version_table()
+    # downgrade 0bc0a6ee1bc0 == downgrade to 2f5368ff6d20
 
-
-def test_downgrade(alembic_app):
-    ext = alembic_app.extensions['invenio-db']
-    ext.alembic.stamp()
-
-    # 0bc0a6ee1bc0
-
-    ext.alembic.downgrade(target='0bc0a6ee1bc0')
-    assert 'ix_records_metadata_json_referenced_records' not in _get_indexes('records_metadata')
+    alembic.downgrade(target='2f5368ff6d20')
+    assert 'ix_records_metadata_json_referenced_records' not in _get_indexes(
+        'records_metadata')
 
     # 2f5368ff6d20
-    # TODO Create proper tests for 2f5368ff6d20, eaab22c59b89, f9ea5752e7a5, 17ff155db70d
+    # TODO |Create proper tests for 2f5368ff6d20, eaab22c59b89, f9ea5752e7a5
+    # TODO | and 17ff155db70d
 
-    ext.alembic.downgrade(target="2f5368ff6d20")
+    alembic.downgrade(target="eaab22c59b89")
 
     # eaab22c59b89
-    ext.alembic.downgrade(target="eaab22c59b89")
+    alembic.downgrade(target="f9ea5752e7a5")
 
     # f9ea5752e7a5
 
-    ext.alembic.downgrade(target="f9ea5752e7a5")
+    alembic.downgrade(target="17ff155db70d")
 
     # 17ff155db70d
 
-    ext.alembic.downgrade(target="17ff155db70d")
+    alembic.downgrade(target="402af3fbf68b")
 
     # 402af3fbf68b
 
-    ext.alembic.downgrade(target='d99c70308006')
+    alembic.downgrade(target='53e8594bc789')
+
+    # 53e8594bc789
+
+    alembic.downgrade(target='d99c70308006')
 
     assert 'inspire_prod_records' in _get_table_names()
     assert 'inspire_prod_records_recid_seq' in _get_sequences()
     assert 'legacy_records_mirror' not in _get_table_names()
     assert 'legacy_records_mirror_recid_seq' not in _get_sequences()
 
-    # 53e8594bc789
-
-    ext.alembic.downgrade(target='53e8594bc789')
-
     # d99c70308006
 
-    ext.alembic.downgrade(target='d99c70308006')
+    alembic.downgrade(target='cb9f81e8251c')
+    alembic.downgrade(target='cb5153afd839')
 
     # cb9f81e8251c & cb5153afd839
 
-    ext.alembic.downgrade(target='fddb3cfe7a9c')
+    alembic.downgrade(target='fddb3cfe7a9c')
 
     assert 'idxgindoctype' not in _get_indexes('records_metadata')
     assert 'idxgintitles' not in _get_indexes('records_metadata')
@@ -105,7 +86,7 @@ def test_downgrade(alembic_app):
 
     # fddb3cfe7a9c
 
-    ext.alembic.downgrade(target='a82a46d12408')
+    alembic.downgrade(target='a82a46d12408')
 
     assert 'inspire_prod_records' not in _get_table_names()
     assert 'inspire_prod_records_recid_seq' not in _get_sequences()
@@ -114,14 +95,14 @@ def test_downgrade(alembic_app):
     assert 'workflows_pending_record' not in _get_table_names()
 
 
-def test_upgrade(alembic_app):
-    ext = alembic_app.extensions['invenio-db']
-    ext.alembic.stamp()
-    ext.alembic.downgrade(target='a82a46d12408')
+def test_upgrade(app):
+    alembic = Alembic(app)
+    alembic.upgrade()
+    alembic.downgrade(target='a82a46d12408')
 
     # fddb3cfe7a9c
 
-    ext.alembic.upgrade(target='fddb3cfe7a9c')
+    alembic.upgrade(target='fddb3cfe7a9c')
 
     assert 'inspire_prod_records' in _get_table_names()
     assert 'inspire_prod_records_recid_seq' in _get_sequences()
@@ -131,7 +112,7 @@ def test_upgrade(alembic_app):
 
     # cb9f81e8251c
 
-    ext.alembic.upgrade(target='cb9f81e8251c')
+    alembic.upgrade(target='cb9f81e8251c')
 
     assert 'idxgindoctype' in _get_indexes('records_metadata')
     assert 'idxgintitles' in _get_indexes('records_metadata')
@@ -140,22 +121,22 @@ def test_upgrade(alembic_app):
 
     # cb5153afd839
 
-    ext.alembic.downgrade(target='fddb3cfe7a9c')
-    ext.alembic.upgrade(target='cb5153afd839')
+    alembic.downgrade(target='fddb3cfe7a9c')
+    alembic.upgrade(target='cb5153afd839')
 
     assert 'workflows_record_sources' in _get_table_names()
 
     # d99c70308006
 
-    ext.alembic.upgrade(target='d99c70308006')
+    alembic.upgrade(target='d99c70308006')
 
     # 53e8594bc789
 
-    ext.alembic.upgrade(target='53e8594bc789')
+    alembic.upgrade(target='53e8594bc789')
 
     # 402af3fbf68b
 
-    ext.alembic.upgrade(target='402af3fbf68b')
+    alembic.upgrade(target='402af3fbf68b')
 
     assert 'inspire_prod_records' not in _get_table_names()
     assert 'inspire_prod_records_recid_seq' not in _get_sequences()
@@ -164,26 +145,28 @@ def test_upgrade(alembic_app):
 
     # 17ff155db70d
 
-    ext.alembic.upgrade(target="17ff155db70d")
+    alembic.upgrade(target="17ff155db70d")
     # Not checking as it only adds or modifies columns
 
     # f9ea5752e7a5
 
-    ext.alembic.upgrade(target="f9ea5752e7a5")
+    alembic.upgrade(target="f9ea5752e7a5")
     # Not checking as it only adds or modifies columns
 
     # eaab22c59b89
-    ext.alembic.upgrade(target="eaab22c59b89")
+    alembic.upgrade(target="eaab22c59b89")
 
     # 2f5368ff6d20
-    ext.alembic.upgrade(target="2f5368ff6d20")
-    # TODO Create proper tests for 2f5368ff6d20, eaab22c59b89, f9ea5752e7a5, 17ff155db70d
+    alembic.upgrade(target="2f5368ff6d20")
+    # TODO Create proper tests for 2f5368ff6d20, eaab22c59b89, f9ea5752e7a5,
+    # 17ff155db70d
 
     # 0bc0a6ee1bc0
 
-    ext.alembic.upgrade(target='0bc0a6ee1bc0')
+    alembic.upgrade(target='0bc0a6ee1bc0')
 
-    assert 'ix_records_metadata_json_referenced_records' in _get_indexes('records_metadata')
+    assert 'ix_records_metadata_json_referenced_records' in _get_indexes(
+        'records_metadata')
 
 
 def _get_indexes(tablename):

--- a/tests/integration/test_alembic.py
+++ b/tests/integration/test_alembic.py
@@ -36,7 +36,8 @@ from inspirehep.modules.fixtures.users import init_users_and_permissions
 def alembic_app():
     """Flask application for Alembic tests."""
     app = create_app(
-        DEBUG=True,
+        DEBUG=False,
+        # Tests may fail when turned on because of Flask bug (A setup function was called after the first request was handled. when initializing - when Alembic initialization)
         SQLALCHEMY_DATABASE_URI='postgresql+psycopg2://inspirehep:dbpass123@localhost:5432/inspirehep_alembic',
     )
 

--- a/tests/integration/workflows/conftest.py
+++ b/tests/integration/workflows/conftest.py
@@ -28,6 +28,7 @@ import pytest
 import requests_mock
 import sys
 
+from flask_alembic import Alembic
 from invenio_db import db
 from invenio_pidstore.models import PersistentIdentifier
 from invenio_search.cli import current_search_client as es
@@ -40,7 +41,6 @@ from inspirehep.modules.records.api import InspireRecord
 # Use the helpers folder to store test helpers.
 # See: http://stackoverflow.com/a/33515264/374865
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'helpers'))
-
 
 HIGGS_ONTOLOGY = '''<?xml version="1.0" encoding="UTF-8" ?>
 
@@ -91,7 +91,8 @@ def workflow_app(higgs_ontology):
             CELERY_TASK_EAGER_PROPAGATES=True,
             CELERY_RESULT_BACKEND='cache',
             CFG_BIBCATALOG_SYSTEM_RT_URL=RT_URL,
-            DEBUG=True,
+            DEBUG=False,
+            # Tests may fail when turned on because of Flask bug (A setup function was called after the first request was handled. when initializing - when Alembic initialization)
             HEP_ONTOLOGY_FILE=higgs_ontology,
             PRODUCTION_MODE=True,
             LEGACY_ROBOTUPLOAD_URL=(
@@ -128,6 +129,11 @@ def drop_all(app):
 
 def create_all(app):
     db.create_all()
+    alembic = Alembic(app=app)
+    alembic.stamp()
+    alembic.downgrade()
+    alembic.upgrade()
+
     _es = app.extensions['invenio-search']
     list(_es.create(ignore=[400]))
 

--- a/tests/integration/workflows/conftest.py
+++ b/tests/integration/workflows/conftest.py
@@ -30,6 +30,7 @@ import sys
 
 from flask_alembic import Alembic
 from invenio_db import db
+from invenio_db.utils import drop_alembic_version_table
 from invenio_pidstore.models import PersistentIdentifier
 from invenio_search.cli import current_search_client as es
 
@@ -123,15 +124,13 @@ def workflow_api_client(workflow_api):
 
 def drop_all(app):
     db.drop_all()
+    drop_alembic_version_table()
     _es = app.extensions['invenio-search']
     list(_es.delete(ignore=[404]))
 
 
 def create_all(app):
-    db.create_all()
     alembic = Alembic(app=app)
-    alembic.stamp()
-    alembic.downgrade()
     alembic.upgrade()
 
     _es = app.extensions['invenio-search']

--- a/tests/integration/workflows/test_arxiv_merge.py
+++ b/tests/integration/workflows/test_arxiv_merge.py
@@ -420,6 +420,7 @@ def test_merge_with_conflicts_callback_url(
         mocked_external_services,
         disable_file_upload,
         enable_merge_on_update,
+
 ):
     with patch('inspire_json_merger.config.ArxivOnArxivOperations.conflict_filters', ['acquisition_source.source']):
         factory = TestRecordMetadata.create_from_file(

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -23,6 +23,7 @@
 from __future__ import absolute_import, division, print_function
 
 import pytest
+from flask_alembic import Alembic
 
 from invenio_db import db
 from invenio_records.models import RecordMetadata
@@ -53,7 +54,7 @@ def app(request):
     See: http://flask.pocoo.org/docs/0.12/appcontext/.
     """
     app = create_app()
-    app.config.update({'DEBUG': True})
+    # app.config.update({'DEBUG': True})
 
     with app.app_context():
         # Celery task imports must be local, otherwise their
@@ -61,7 +62,12 @@ def app(request):
         from inspirehep.modules.migrator.tasks import migrate_from_file
 
         db.drop_all()
+
+        alembic = Alembic(app=app)
         db.create_all()
+        alembic.stamp()
+        alembic.downgrade()
+        alembic.upgrade()
 
         _es = app.extensions['invenio-search']
         list(_es.delete(ignore=[404]))

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -26,6 +26,7 @@ import pytest
 from flask_alembic import Alembic
 
 from invenio_db import db
+from invenio_db.utils import drop_alembic_version_table
 from invenio_records.models import RecordMetadata
 from invenio_search import current_search_client as es
 from invenio_workflows import workflow_object_class
@@ -60,13 +61,10 @@ def app(request):
         # Celery task imports must be local, otherwise their
         # configuration would use the default pickle serializer.
         from inspirehep.modules.migrator.tasks import migrate_from_file
-
         db.drop_all()
+        drop_alembic_version_table()
 
         alembic = Alembic(app=app)
-        db.create_all()
-        alembic.stamp()
-        alembic.downgrade()
         alembic.upgrade()
 
         _es = app.extensions['invenio-search']

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -29,7 +29,6 @@ import pytest
 
 from inspirehep.factory import create_app
 
-
 # Use the helpers folder to store test helpers.
 # See: http://stackoverflow.com/a/33515264/374865
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'helpers'))
@@ -46,7 +45,8 @@ def app():
     See: http://flask.pocoo.org/docs/0.12/appcontext/.
     """
     app = create_app(
-        DEBUG=True,
+        DEBUG=False,
+        # Tests may fail when turned on because of Flask bug (A setup function was called after the first request was handled. when initializing - when Alembic initialization)
         WTF_CSRF_ENABLED=False,
         CELERY_TASK_ALWAYS_EAGER=True,
         CELERY_RESULT_BACKEND='cache',


### PR DESCRIPTION
updated tests. Fixing issue with missing citation_count on ES

InvenioRecordIndexer assumes that all records are (Invenio) Records, so when record is passed to ES it cannot check its own citations count as the method for it is a part of InspireRecord
Thanks to this change ES will be now populated with proper data about citations
INSPIR-1126

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
