### PR TITLE
receivers: populate name_variations for author records

### DIFF
--- a/inspirehep/modules/records/mappings/v5/records/authors.json
+++ b/inspirehep/modules/records/mappings/v5/records/authors.json
@@ -230,6 +230,9 @@
                 "other_names": {
                     "type": "string"
                 },
+                "name_variations": {
+                    "type": "keyword"
+                },
                 "past_emails_addresses": {
                     "type": "string"
                 },

--- a/inspirehep/modules/records/receivers.py
+++ b/inspirehep/modules/records/receivers.py
@@ -55,6 +55,10 @@ from inspirehep.modules.orcid.utils import (
 )
 
 
+def is_author(record):
+    return 'authors.json' in record.get('$schema')
+
+
 def is_hep(record):
     return 'hep.json' in record.get('$schema')
 
@@ -185,6 +189,7 @@ def enhance_after_index(sender, json, *args, **kwargs):
     populate_earliest_date(sender, json, *args, **kwargs)
     populate_experiment_suggest(sender, json, *args, **kwargs)
     populate_inspire_document_type(sender, json, *args, **kwargs)
+    populate_authors_name_variations(sender, json, *args, **kwargs)
     populate_name_variations(sender, json, *args, **kwargs)
     populate_title_suggest(sender, json, *args, **kwargs)
     populate_citations_count(sender, json, *args, **kwargs)
@@ -449,6 +454,18 @@ def populate_name_variations(sender, json, *args, **kwargs):
             author.update({'name_suggest': {
                 'input': [variation for variation in name_variations if variation],
             }})
+
+
+def populate_authors_name_variations(sender, json, *args, **kwargs):
+    """Generate name variations for an Author record."""
+    if not is_author(json):
+        return
+
+    author_name = get_value(json, 'name.value')
+
+    if author_name:
+        name_variations = generate_name_variations(author_name)
+        json.update({'name_variations': name_variations})
 
 
 def populate_author_count(sender, json, *args, **kwargs):


### PR DESCRIPTION
Added name_variation field to author records mappings as they are needed in in order to support the current minimal author search.

Signed-off-by: Iuliana Voinea <iulianavoinea96@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have all the information that I need (if not, move to `RFC` and look for it).
- [ ] I linked the related issue(s) in the corresponding commit logs.
- [ ] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [ ] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
