### PR TITLE
serializers: fix "missing" not serializable bug

### DIFF
--- a/inspirehep/modules/records/serializers/fields/nested_without_empty_objects.py
+++ b/inspirehep/modules/records/serializers/fields/nested_without_empty_objects.py
@@ -23,14 +23,15 @@
 from __future__ import absolute_import, division, print_function
 
 from inspire_dojson.utils import strip_empty_values
-from marshmallow import fields
+from marshmallow import fields, missing
 
 
 class NestedWithoutEmptyObjects(fields.Nested):
 
     def _serialize(self, nested_obj, attr, obj):
-        result = super(NestedWithoutEmptyObjects, self)._serialize(nested_obj, attr, obj)
+        result = super(NestedWithoutEmptyObjects,
+                       self)._serialize(nested_obj, attr, obj)
         clean = strip_empty_values(result)
         if clean is None:
-            return self.default
+            return self.default if self.default is not missing else None
         return clean

--- a/inspirehep/modules/records/serializers/schemas/json/literature/common/citation_item.py
+++ b/inspirehep/modules/records/serializers/schemas/json/literature/common/citation_item.py
@@ -22,7 +22,9 @@
 
 from __future__ import absolute_import, division, print_function
 
-from marshmallow import Schema, fields
+from marshmallow import Schema, fields, post_dump
+
+from inspire_dojson.utils import strip_empty_values
 
 from inspirehep.modules.records.serializers.fields import ListWithLimit, NestedWithoutEmptyObjects
 
@@ -37,3 +39,7 @@ class CitationItemSchemaV1(Schema):
     publication_info = fields.List(
         NestedWithoutEmptyObjects(PublicationInfoItemSchemaV1, dump_only=True))
     titles = fields.Raw()
+
+    @post_dump
+    def strip_empty(self, data):
+        return strip_empty_values(data)


### PR DESCRIPTION
* Never returns "missing" from NestedWithoutEmptyObject.

* Adds cleanup @post_dump to CitationItemSchema in order to clean all
empty stuff, since now list with single None item can occur after the
change in NestedWithoutEmptyObject

Sentry:

https://sentry.inspirehep.net/inspire-sentry/inspire-qa/issues/229577