### PR TITLE
Move collaboration logic to serializer

### DIFF
--- a/inspirehep/modules/records/serializers/schemas/json/literature/__init__.py
+++ b/inspirehep/modules/records/serializers/schemas/json/literature/__init__.py
@@ -41,6 +41,8 @@ from .common import (  # noqa: F401
     SupervisorSchemaV1,
     ThesisInfoSchemaV1,
     CitationItemSchemaV1,
+    CollaborationWithSuffixSchemaV1,
+    CollaborationSchemaV1
 )
 
 
@@ -56,7 +58,8 @@ class RecordMetadataSchemaV1(Schema):
     book_series = fields.Raw()
     # citeable = fields.Raw()
     citation_count = fields.Raw()
-    collaborations = fields.Raw()
+    collaborations = fields.List(fields.Nested(CollaborationSchemaV1, dump_only=True), attribute="collaborations")
+    collaborations_with_suffix = fields.List(fields.Nested(CollaborationWithSuffixSchemaV1, dump_only=True), attribute="collaborations")
     conference_info = fields.Nested(
         ConferenceInfoItemSchemaV1,
         dump_only=True,

--- a/inspirehep/modules/records/serializers/schemas/json/literature/common/collaboration.py
+++ b/inspirehep/modules/records/serializers/schemas/json/literature/common/collaboration.py
@@ -22,15 +22,17 @@
 
 from __future__ import absolute_import, division, print_function
 
-from .author import AuthorSchemaV1  # noqa: F401
-from .conference_info_item import ConferenceInfoItemSchemaV1  # noqa: F401
-from .doi import DOISchemaV1  # noqa: F401
-from .isbn import IsbnSchemaV1  # noqa: F401
-from .supervisor import SupervisorSchemaV1  # noqa: F401
-from .thesis_info import ThesisInfoSchemaV1  # noqa: F401
-from .publication_info_item import PublicationInfoItemSchemaV1  # noqa: F401
-from .external_system_identifier import ExternalSystemIdentifierSchemaV1    # noqa: F401
-from .reference_item import ReferenceItemSchemaV1  # noqa: F401
-from .citation_item import CitationItemSchemaV1   # noqa: F401
-from .collaboration_with_suffix import CollaborationWithSuffixSchemaV1   # noqa: F401
-from .collaboration import CollaborationSchemaV1   # noqa: F401
+from marshmallow import Schema, fields, pre_dump
+
+import re
+
+
+class CollaborationSchemaV1(Schema):
+    value = fields.Raw()
+    REGEX_COLLABORATIONS_WITH_SUFFIX = re.compile(r".*(group|groups|force|consortium|team)$", re.IGNORECASE)
+
+    @pre_dump
+    def filter(self, data):
+        if re.match(self.REGEX_COLLABORATIONS_WITH_SUFFIX, data.get('value')):
+                return {}
+        return data

--- a/inspirehep/modules/records/serializers/schemas/json/literature/common/collaboration_with_suffix.py
+++ b/inspirehep/modules/records/serializers/schemas/json/literature/common/collaboration_with_suffix.py
@@ -22,15 +22,17 @@
 
 from __future__ import absolute_import, division, print_function
 
-from .author import AuthorSchemaV1  # noqa: F401
-from .conference_info_item import ConferenceInfoItemSchemaV1  # noqa: F401
-from .doi import DOISchemaV1  # noqa: F401
-from .isbn import IsbnSchemaV1  # noqa: F401
-from .supervisor import SupervisorSchemaV1  # noqa: F401
-from .thesis_info import ThesisInfoSchemaV1  # noqa: F401
-from .publication_info_item import PublicationInfoItemSchemaV1  # noqa: F401
-from .external_system_identifier import ExternalSystemIdentifierSchemaV1    # noqa: F401
-from .reference_item import ReferenceItemSchemaV1  # noqa: F401
-from .citation_item import CitationItemSchemaV1   # noqa: F401
-from .collaboration_with_suffix import CollaborationWithSuffixSchemaV1   # noqa: F401
-from .collaboration import CollaborationSchemaV1   # noqa: F401
+from marshmallow import pre_dump
+
+from .collaboration import CollaborationSchemaV1
+
+import re
+
+
+class CollaborationWithSuffixSchemaV1(CollaborationSchemaV1):
+
+    @pre_dump
+    def filter(self, data):
+        if not re.match(self.REGEX_COLLABORATIONS_WITH_SUFFIX, data.get('value')):
+                return {}
+        return data

--- a/tests/unit/records/serializers/literature/common/test_collaboration.py
+++ b/tests/unit/records/serializers/literature/common/test_collaboration.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2018 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import json
+
+from inspirehep.modules.records.serializers.schemas.json.literature.common import CollaborationWithSuffixSchemaV1, CollaborationSchemaV1
+
+
+def test_collaboration_with_suffix_returns_empty_if_value_has_no_suffix():
+    schema = CollaborationWithSuffixSchemaV1()
+    dump = {'value': 'CMS'}
+    expected = {}
+
+    result = schema.dumps(dump).data
+
+    assert expected == json.loads(result)
+
+
+def test_collaboration_with_suffix_returns_value_if_value_has_suffix():
+    schema = CollaborationWithSuffixSchemaV1()
+    dump = {'value': 'CMS Team'}
+    expected = {'value': 'CMS Team'}
+
+    result = schema.dumps(dump).data
+
+    assert expected == json.loads(result)
+
+
+def test_collaboration_returns_empty_if_value_has_suffix():
+    schema = CollaborationSchemaV1()
+    dump = {'value': 'CMS Team'}
+    expected = {}
+
+    result = schema.dumps(dump).data
+
+    assert expected == json.loads(result)
+
+
+def test_collaboration_returns_value_if_value_has_no_suffix():
+    schema = CollaborationSchemaV1()
+    dump = {'value': 'CMS'}
+    expected = {'value': 'CMS'}
+
+    result = schema.dumps(dump).data
+
+    assert expected == json.loads(result)


### PR DESCRIPTION
Moved the collaboration logic from frontend to the serializers. Split collaborations into 2 lists : collaborations and collaborations_with_suffix.
