### PR TITLE
isolated_app: avoid control_number collisions

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -48,6 +48,11 @@ from inspirehep.modules.fixtures.users import init_users_and_permissions
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'helpers'))
 
 
+from factories.db.invenio_records import (
+    cleanup as invenio_records_factory_cleanup,
+)  # noqa
+
+
 @pytest.fixture(scope='session')
 def app():
     """
@@ -141,6 +146,7 @@ def isolated_app(app):
     transaction.rollback()
     connection.close()
     db.session = original_session
+    invenio_records_factory_cleanup()
 
 
 # TODO: all fixtures using ``app`` must be replaced by ones that use ``isolated_app``.

--- a/tests/integration/helpers/factories/db/invenio_records.py
+++ b/tests/integration/helpers/factories/db/invenio_records.py
@@ -37,6 +37,28 @@ from .base import TestBaseModel, generate_random_string
 from .invenio_pidstore import TestPersistentIdentifier
 
 
+USED_RECIDS = {}
+MAX_ES_INT = 2147483647
+
+
+def get_next_free_recid():
+    next_recid_candidate = random.randint(1, MAX_ES_INT)
+    while next_recid_candidate in USED_RECIDS:
+        next_recid_candidate = random.randint(1, MAX_ES_INT)
+
+    reserve_recid(next_recid_candidate)
+    return next_recid_candidate
+
+
+def reserve_recid(recid):
+    USED_RECIDS[recid] = True
+
+
+def cleanup():
+    global USED_RECIDS
+    USED_RECIDS = {}
+
+
 class TestRecordMetadata(TestBaseModel):
     """Create Record instance.
 
@@ -78,7 +100,9 @@ class TestRecordMetadata(TestBaseModel):
                 ]
             })
         if 'control_number' not in json_:
-            json_['control_number'] = random.randint(1, 9) * 5
+            json_['control_number'] = get_next_free_recid()
+        else:
+            reserve_recid(json_['control_number'])
 
         updated_kwargs['json'] = json_
 

--- a/tests/integration/helpers/factories/db/invenio_records.py
+++ b/tests/integration/helpers/factories/db/invenio_records.py
@@ -39,12 +39,20 @@ from .invenio_pidstore import TestPersistentIdentifier
 
 USED_RECIDS = {}
 MAX_ES_INT = 2147483647
+MAX_RANDOMIZE_TRIES = 100
 
 
 def get_next_free_recid():
     next_recid_candidate = random.randint(1, MAX_ES_INT)
-    while next_recid_candidate in USED_RECIDS:
+    cur_try = 0
+    while next_recid_candidate in USED_RECIDS and cur_try < MAX_RANDOMIZE_TRIES:
         next_recid_candidate = random.randint(1, MAX_ES_INT)
+        cur_try += 1
+
+    if cur_try >= MAX_RANDOMIZE_TRIES:
+        raise Exception(
+            'Unable to find a non-used record id, tried %d times.' % cur_try
+        )
 
     reserve_recid(next_recid_candidate)
     return next_recid_candidate

--- a/tests/integration/workflows/conftest.py
+++ b/tests/integration/workflows/conftest.py
@@ -43,6 +43,12 @@ from inspirehep.modules.records.api import InspireRecord
 # See: http://stackoverflow.com/a/33515264/374865
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'helpers'))
 
+
+from factories.db.invenio_records import (
+    cleanup as invenio_records_factory_cleanup,
+)  # noqa
+
+
 HIGGS_ONTOLOGY = '''<?xml version="1.0" encoding="UTF-8" ?>
 
 <rdf:RDF xmlns="http://www.w3.org/2004/02/skos/core#"
@@ -145,6 +151,7 @@ def cleanup_workflows(workflow_app):
     db.session.close_all()
     drop_all(app=workflow_app)
     create_all(app=workflow_app)
+    invenio_records_factory_cleanup()
 
 
 @pytest.fixture


### PR DESCRIPTION
This gets rid of the instability we were seeing in the workflow tests
when creating multiple fake inspire records.

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Signed-off-by: David Caro <david@dcaro.es>