### PR TITLE
search: fix inconsistent number of references

### DIFF
--- a/inspirehep/modules/search/search_factory.py
+++ b/inspirehep/modules/search/search_factory.py
@@ -61,7 +61,7 @@ def select_source(search, search_index):
                                          "earliest_date",
                                          "inspire_categories",
                                          "publication_info",
-                                         "references.reference.title",
+                                         "references",
                                          "report_numbers",
                                          "titles.title"])
     return search

--- a/tests/integration/test_search_views.py
+++ b/tests/integration/test_search_views.py
@@ -115,7 +115,7 @@ def test_search_logs(current_app_mock, api_client):
                     "earliest_date",
                     "inspire_categories",
                     "publication_info",
-                    "references.reference.title",
+                    "references",
                     "report_numbers",
                     "titles.title"
                 ]
@@ -242,7 +242,7 @@ def test_search_facets_logs(current_app_mock, api_client):
                     "earliest_date",
                     "inspire_categories",
                     "publication_info",
-                    "references.reference.title",
+                    "references",
                     "report_numbers",
                     "titles.title"
                 ]
@@ -372,7 +372,7 @@ def test_search_facets_logs_with_query(current_app_mock, api_client):
                     "earliest_date",
                     "inspire_categories",
                     "publication_info",
-                    "references.reference.title",
+                    "references",
                     "report_numbers",
                     "titles.title"
                 ]


### PR DESCRIPTION
number_of_references were inconsistent in search and detail page,
because search_factory was only getting reference that have reference.title.

