### PR TITLE
Split aggregation and query in two queries

### DIFF
--- a/inspirehep/modules/records/serializers/__init__.py
+++ b/inspirehep/modules/records/serializers/__init__.py
@@ -30,6 +30,7 @@ from invenio_records_rest.serializers.json import JSONSerializer
 from .json_literature import (
     LiteratureCitationsJSONSerializer,
     LiteratureJSONUISerializer,
+    FacetsJSONUISerializer
 )
 from .pybtex_serializer_base import PybtexSerializerBase
 from .writers import BibtexWriter
@@ -41,7 +42,7 @@ from .schemas.json import (
     CitationItemSchemaV1,
 )
 from .marcxml import MARCXMLSerializer
-from .response import record_responsify_nocache
+from .response import record_responsify_nocache, facets_responsify
 
 json_literature_ui_v1 = LiteratureJSONUISerializer(
     LiteratureRecordSchemaJSONUIV1
@@ -50,6 +51,7 @@ json_literature_ui_v1_search = search_responsify(
     json_literature_ui_v1,
     'application/vnd+inspire.literature.ui+json'
 )
+
 json_literature_ui_v1_response = record_responsify_nocache(
     json_literature_ui_v1,
     'application/vnd+inspire.literature.ui+json'
@@ -87,11 +89,22 @@ json_literature_authors_v1_response = record_responsify_nocache(
     'application/json',
 )
 
+json_aggregations_ui_v1 = FacetsJSONUISerializer(
+    json_literature_ui_v1
+)
+
+json_literature_search_aggregations_ui_v1 = facets_responsify(
+    json_aggregations_ui_v1,
+    'application/json',
+)
+
 bibtex_v1 = PybtexSerializerBase(PybtexSchema(), BibtexWriter())
 marcxml_v1 = MARCXMLSerializer()
 
-bibtex_v1_response = record_responsify_nocache(bibtex_v1, 'application/x-bibtex')
-marcxml_v1_response = record_responsify_nocache(marcxml_v1, 'application/marcxml+xml')
+bibtex_v1_response = record_responsify_nocache(bibtex_v1,
+                                               'application/x-bibtex')
+marcxml_v1_response = record_responsify_nocache(marcxml_v1,
+                                                'application/marcxml+xml')
 
 bibtex_v1_search = search_responsify(bibtex_v1, 'application/x-bibtex')
 marcxml_v1_search = search_responsify(marcxml_v1, 'application/marcxml+xml')

--- a/inspirehep/modules/records/serializers/__init__.py
+++ b/inspirehep/modules/records/serializers/__init__.py
@@ -89,12 +89,12 @@ json_literature_authors_v1_response = record_responsify_nocache(
     'application/json',
 )
 
-json_aggregations_ui_v1 = FacetsJSONUISerializer(
+json_literature_aggregations_ui_v1 = FacetsJSONUISerializer(
     json_literature_ui_v1
 )
 
 json_literature_search_aggregations_ui_v1 = facets_responsify(
-    json_aggregations_ui_v1,
+    json_literature_aggregations_ui_v1,
     'application/json',
 )
 

--- a/inspirehep/modules/records/serializers/json_literature.py
+++ b/inspirehep/modules/records/serializers/json_literature.py
@@ -74,7 +74,8 @@ def _preprocess_result(result, original_record=None):
     if original_record is not None:
         # If it is an db object then get citations from db
         # Otherwise if it is from ES it has citations already in json
-        result['metadata']['citation_count'] = get_citations_count(original_record)
+        result['metadata']['citation_count'] = get_citations_count(
+            original_record)
     record = result['metadata']
     ui_metadata = _get_ui_metadata(record)
     # FIXME: Deprecated, must be removed once the new UI is released
@@ -118,4 +119,15 @@ class LiteratureCitationsJSONSerializer(JSONSerializer):
                     'citation_count': data['citation_count']
                 },
             }, **self._format_args()
+        )
+
+
+class FacetsJSONUISerializer(JSONSerializer):
+    """JSON brief format serializer."""
+
+    def serialize_facets(self, query_results, **kwargs):
+        return json.dumps(
+            {
+                'aggregations': query_results.aggregations.to_dict()
+            }
         )

--- a/inspirehep/modules/records/serializers/response.py
+++ b/inspirehep/modules/records/serializers/response.py
@@ -48,3 +48,26 @@ def record_responsify_nocache(serializer, mimetype):
             response.headers.extend(headers)
         return response
     return view
+
+
+def facets_responsify(serializer, mimetype):
+    """Create a Facets serializer
+
+    As aggregations were removed from search query,
+    now second call to the server is required to acquire data for Facets
+
+    Args:
+        serializer: Serializer instance.
+        mimetype: MIME type of response.
+
+    """
+
+    def view(pid, query_results, code=200, headers=None, links_factory=None):
+        response = current_app.response_class(
+            serializer.serialize_facets(query_results),
+            mimetype=mimetype)
+        response.status_code = code
+        if headers is not None:
+            response.headers.extend(headers)
+        return response
+    return view

--- a/tests/integration/test_search_views.py
+++ b/tests/integration/test_search_views.py
@@ -63,61 +63,322 @@ def test_search_falls_back_to_hep(app_client):
 def test_search_logs(current_app_mock, api_client):
     def _debug(log_output):
         query = {
-            u'sort': [{u'earliest_date': {u'order': u'desc'}}],
-            u'from': 0,
-            u'_source': {u'includes': [u'$schema', u'abstracts.value',
-                                       u'arxiv_eprints.value',
-                                       u'authors.affiliation',
-                                       u'authors.full_name',
-                                       u'authors.control_number',
-                                       u'collaborations',
-                                       u'control_number',
-                                       u'citation_count', u'dois.value',
-                                       u'earliest_date',
-                                       u'inspire_categories',
-                                       u'publication_info',
-                                       u'references.reference.title',
-                                       u'report_numbers',
-                                       u'titles.title']},
-            u'aggs': {
-                u'doc_type': {
-                    u'meta': {u'order': 6, u'title': u'Document Type'},
-                    u'terms': {
-                        u'field': u'facet_inspire_doc_type',
-                        u'size': 20}},
-                u'author': {
-                    u'meta': {u'order': 2, u'title': u'Author'},
-                    u'terms': {u'field': u'facet_author_name',
-                               u'size': 20}},
-                u'arxiv_categories': {
-                    u'meta': {u'order': 4, u'title': u'arXiv Category'},
-                    u'terms': {u'field': u'facet_arxiv_categories',
-                               u'size': 20}},
-                u'experiment': {
-                    u'meta': {u'order': 5, u'title': u'Experiment'},
-                    u'terms': {u'field': u'facet_experiment',
-                               u'size': 20}},
-                u'subject': {
-                    u'meta': {u'order': 3, u'title': u'Subject'},
-                    u'terms': {
-                        u'field': u'facet_inspire_categories',
-                        u'size': 20}}, u'earliest_date': {
-                    u'date_histogram': {
-                        u'field': u'earliest_date',
-                        u'interval': u'year',
-                        u'min_doc_count': 1,
-                        u'format': u'yyyy'},
-                    u'meta': {u'order': 1, u'title': u'Date'}}},
-            u'query': {
-                u'bool': {
-                    u'filter': [{u'bool': {u'must_not': [
-                        {u'match': {
-                            u'_collections': u'HERMES Internal Notes'}}],
-                        u'must': [{u'match': {
-                            u'_collections': u'Literature'}}]}}],
-                    u'minimum_should_match': u'0<1',
-                    u'must': [{u'match_all': {}}]}}, u'size': 10}
+            "sort": [
+                {
+                    "earliest_date": {
+                        "order": "desc"
+                    }
+                }
+            ],
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "bool": {
+                                "must_not": [
+                                    {
+                                        "match": {
+                                            "_collections": "HERMES Internal Notes"
+                                        }
+                                    }
+                                ],
+                                "must": [
+                                    {
+                                        "match": {
+                                            "_collections": "Literature"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "minimum_should_match": "0<1",
+                    "must": [
+                        {
+                            "match_all": {}
+                        }
+                    ]
+                }
+            },
+            "_source": {
+                "includes": [
+                    "$schema",
+                    "abstracts.value",
+                    "arxiv_eprints.value",
+                    "authors.affiliation",
+                    "authors.full_name",
+                    "authors.control_number",
+                    "collaborations",
+                    "control_number",
+                    "citation_count",
+                    "dois.value",
+                    "earliest_date",
+                    "inspire_categories",
+                    "publication_info",
+                    "references.reference.title",
+                    "report_numbers",
+                    "titles.title"
+                ]
+            },
+            "from": 0,
+            "size": 10
+        }
         assert query == json.loads(log_output)
 
     current_app_mock.logger.debug.side_effect = _debug
     api_client.get('/literature/')
+
+
+@patch('inspirehep.modules.search.search_factory.current_app')
+def test_search_facets_logs(current_app_mock, api_client):
+    def _debug(log_output):
+        query = {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "bool": {
+                                "must_not": [
+                                    {
+                                        "match": {
+                                            "_collections": "HERMES Internal Notes"
+                                        }
+                                    }
+                                ],
+                                "must": [
+                                    {
+                                        "match": {
+                                            "_collections": "Literature"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "minimum_should_match": "0<1",
+                    "must": [
+                        {
+                            "match_all": {}
+                        }
+                    ]
+                }
+            },
+            "aggs": {
+                "doc_type": {
+                    "meta": {
+                        "order": 6,
+                        "title": "Document Type"
+                    },
+                    "terms": {
+                        "field": "facet_inspire_doc_type",
+                        "size": 20
+                    }
+                },
+                "author": {
+                    "meta": {
+                        "order": 2,
+                        "title": "Author"
+                    },
+                    "terms": {
+                        "field": "facet_author_name",
+                        "size": 20
+                    }
+                },
+                "arxiv_categories": {
+                    "meta": {
+                        "order": 4,
+                        "title": "arXiv Category"
+                    },
+                    "terms": {
+                        "field": "facet_arxiv_categories",
+                        "size": 20
+                    }
+                },
+                "experiment": {
+                    "meta": {
+                        "order": 5,
+                        "title": "Experiment"
+                    },
+                    "terms": {
+                        "field": "facet_experiment",
+                        "size": 20
+                    }
+                },
+                "subject": {
+                    "meta": {
+                        "order": 3,
+                        "title": "Subject"
+                    },
+                    "terms": {
+                        "field": "facet_inspire_categories",
+                        "size": 20
+                    }
+                },
+                "earliest_date": {
+                    "date_histogram": {
+                        "field": "earliest_date",
+                        "interval": "year",
+                        "min_doc_count": 1,
+                        "format": "yyyy"
+                    },
+                    "meta": {
+                        "order": 1,
+                        "title": "Date"
+                    }
+                }
+            },
+            "_source": {
+                "includes": [
+                    "$schema",
+                    "abstracts.value",
+                    "arxiv_eprints.value",
+                    "authors.affiliation",
+                    "authors.full_name",
+                    "authors.control_number",
+                    "collaborations",
+                    "control_number",
+                    "citation_count",
+                    "dois.value",
+                    "earliest_date",
+                    "inspire_categories",
+                    "publication_info",
+                    "references.reference.title",
+                    "report_numbers",
+                    "titles.title"
+                ]
+            }
+        }
+        assert query == json.loads(log_output)
+
+    current_app_mock.logger.debug.side_effect = _debug
+    api_client.get('/literature/facets')
+
+
+@patch('inspirehep.modules.search.search_factory.current_app')
+def test_search_facets_logs_with_query(current_app_mock, api_client):
+    def _debug(log_output):
+        query = {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "bool": {
+                                "must_not": [
+                                    {
+                                        "match": {
+                                            "_collections": "HERMES Internal Notes"
+                                        }
+                                    }
+                                ],
+                                "must": [
+                                    {
+                                        "match": {
+                                            "_collections": "Literature"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "minimum_should_match": "0<1",
+                    "must": [
+                        {
+                            "match": {
+                                "_all": {
+                                    "operator": "and",
+                                    "query": "test query"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "aggs": {
+                "doc_type": {
+                    "meta": {
+                        "order": 6,
+                        "title": "Document Type"
+                    },
+                    "terms": {
+                        "field": "facet_inspire_doc_type",
+                        "size": 20
+                    }
+                },
+                "author": {
+                    "meta": {
+                        "order": 2,
+                        "title": "Author"
+                    },
+                    "terms": {
+                        "field": "facet_author_name",
+                        "size": 20
+                    }
+                },
+                "arxiv_categories": {
+                    "meta": {
+                        "order": 4,
+                        "title": "arXiv Category"
+                    },
+                    "terms": {
+                        "field": "facet_arxiv_categories",
+                        "size": 20
+                    }
+                },
+                "experiment": {
+                    "meta": {
+                        "order": 5,
+                        "title": "Experiment"
+                    },
+                    "terms": {
+                        "field": "facet_experiment",
+                        "size": 20
+                    }
+                },
+                "subject": {
+                    "meta": {
+                        "order": 3,
+                        "title": "Subject"
+                    },
+                    "terms": {
+                        "field": "facet_inspire_categories",
+                        "size": 20
+                    }
+                },
+                "earliest_date": {
+                    "date_histogram": {
+                        "field": "earliest_date",
+                        "interval": "year",
+                        "min_doc_count": 1,
+                        "format": "yyyy"
+                    },
+                    "meta": {
+                        "order": 1,
+                        "title": "Date"
+                    }
+                }
+            },
+            "_source": {
+                "includes": [
+                    "$schema",
+                    "abstracts.value",
+                    "arxiv_eprints.value",
+                    "authors.affiliation",
+                    "authors.full_name",
+                    "authors.control_number",
+                    "collaborations",
+                    "control_number",
+                    "citation_count",
+                    "dois.value",
+                    "earliest_date",
+                    "inspire_categories",
+                    "publication_info",
+                    "references.reference.title",
+                    "report_numbers",
+                    "titles.title"
+                ]
+            }
+        }
+        assert query == json.loads(log_output)
+
+    current_app_mock.logger.debug.side_effect = _debug
+    api_client.get('/literature/facets?q=test query')


### PR DESCRIPTION
Aggregations for facets are now splitted from main query
url for aggregations: api/literature/facets



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
