### PR TITLE
1313 orcid: generate random email when email is blank in import_legacy_orcid_tokens

### DIFF
--- a/inspirehep/modules/orcid/tasks.py
+++ b/inspirehep/modules/orcid/tasks.py
@@ -45,6 +45,7 @@ from inspirehep.modules.orcid.utils import get_literature_recids_for_orcid
 
 
 LOGGER = getStackTraceLogger(__name__)
+USER_EMAIL_EMPTY_PATTERN = '{}@FAKEEMAILINSPIRE.FAKE'
 
 
 def legacy_orcid_arrays():
@@ -151,6 +152,12 @@ def _register_user(name, email, orcid, token):
 
     # Make the user if didn't find existing one
     if not user:
+
+        if not email:
+            # Generate a (fake) unique email address as User.email is a unique
+            # field.
+            email = USER_EMAIL_EMPTY_PATTERN.format(orcid)
+
         with db.session.begin_nested():
             user = User()
             user.email = email

--- a/tests/integration/orcid/fixtures/test_orcid_tasks_import_legacy_tokens_TestImportLegacyOrcidTokens_author.json
+++ b/tests/integration/orcid/fixtures/test_orcid_tasks_import_legacy_tokens_TestImportLegacyOrcidTokens_author.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://labs.inspirehep.net/schemas/records/authors.json",
+    "_collections": [
+      "Authors"
+    ],
+    "ids": [
+        {
+            "schema":"ORCID",
+            "value":"0000-0002-0942-3697"
+        }
+    ],
+    "name": {
+        "value":"Rossoni, A."
+    },
+    "control_number": 1259096
+}

--- a/tests/integration/orcid/fixtures/test_orcid_tasks_import_legacy_tokens_TestImportLegacyOrcidTokens_literature.json
+++ b/tests/integration/orcid/fixtures/test_orcid_tasks_import_legacy_tokens_TestImportLegacyOrcidTokens_literature.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://labs.inspirehep.net/schemas/records/hep.json",
+    "_collections": [
+      "Literature"
+    ],
+    "titles": [
+        {
+            "source":"submitter",
+            "title":"Some Results Arising from the Study of ORCID push"
+        }
+    ],
+    "abstracts": [
+        {
+            "source": "submitter",
+            "value": "This is a record used for testing the ORCID feature."
+        }
+    ],
+    "authors":[
+        {
+            "full_name":"Rossoni, A.",
+            "inspire_roles":[
+                "author"
+            ],
+            "curated_relation": true,
+            "record": {
+                "$ref": "http://labs.inspirehep.net/api/authors/1259096"
+            },
+            "recid":1259096
+        }
+    ],
+    "dois": [
+        {
+            "value": "10.1000/test.orcid.push"
+        }
+    ],
+    "collaborations": [
+    ],
+    "document_type": [
+      "article"
+    ],
+    "preprint_date": "2017-05"
+}


### PR DESCRIPTION
Legacy might send (orcid, token, email, name) with an empty string as email or name (because this info was not found in the PERSON table nor in HepNames, yet there is a valid orcid token).

Labs creates a User and email is a mandatory and unique field.
To solve this issue, we generate a random string as email (in case the email is empty) according to a pattern.