### PR TITLE
global: don't redirect with trailing slashes

### DIFF
--- a/inspirehep/factory.py
+++ b/inspirehep/factory.py
@@ -36,7 +36,12 @@ from . import config
 
 env_prefix = 'APP'
 
-config_loader = create_config_loader(config=config, env_prefix=env_prefix)
+
+def config_loader(app, **kwargs_config):
+    invenio_config_loader = create_config_loader(config=config, env_prefix=env_prefix)
+    result = invenio_config_loader(app, **kwargs_config)
+    app.url_map.strict_slashes = False
+    return result
 
 
 def api_config_loader(app, **kwargs_config):


### PR DESCRIPTION
This saves an extra request as the UI always uses the url without
the trailing slash, and gets a 301

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [x] I've added any new docs if API/utils methods were added.
- [x] I have updated the existing documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->

Signed-off-by: David Caro <david@dcaro.es>