### PR TITLE
Sort citations by earliest_date

### DIFF
--- a/inspirehep/modules/records/serializers/json_literature.py
+++ b/inspirehep/modules/records/serializers/json_literature.py
@@ -71,11 +71,6 @@ def get_citations_count(original_record):
 
 def _preprocess_result(result, original_record=None):
     """Add additional fields to output json"""
-    if original_record is not None:
-        # If it is an db object then get citations from db
-        # Otherwise if it is from ES it has citations already in json
-        result['metadata']['citation_count'] = get_citations_count(
-            original_record)
     record = result['metadata']
     ui_metadata = _get_ui_metadata(record)
     # FIXME: Deprecated, must be removed once the new UI is released
@@ -106,7 +101,7 @@ class LiteratureCitationsJSONSerializer(JSONSerializer):
 
     def preprocess_record(self, pid, record, links_factory=None, **kwargs):
         """Prepare a record and persistent identifier for serialization."""
-        return record.dumps()
+        return record
 
     def serialize(self, pid, data, links_factory=None, **kwargs):
         return json.dumps(

--- a/inspirehep/modules/records/serializers/schemas/json/literature/common/citation_item.py
+++ b/inspirehep/modules/records/serializers/schemas/json/literature/common/citation_item.py
@@ -39,6 +39,7 @@ class CitationItemSchemaV1(Schema):
     publication_info = fields.List(
         NestedWithoutEmptyObjects(PublicationInfoItemSchemaV1, dump_only=True))
     titles = fields.Raw()
+    earliest_date = fields.Raw()
 
     @post_dump
     def strip_empty(self, data):

--- a/tests/integration/records/test_records_serializers_json.py
+++ b/tests/integration/records/test_records_serializers_json.py
@@ -138,36 +138,6 @@ def test_literature_authors_serializer_search(isolated_api_client):
     assert response.status_code == 200
 
 
-def test_zero_citations_in_vnd_plus_inspire_record_ui_json(isolated_api_client):
-    record_json = {
-        'control_number': 123,
-    }
-    TestRecordMetadata.create_from_kwargs(json=record_json)
-    url = '/literature/123'
-    response = isolated_api_client.get(url,
-                                       headers={'Accept': 'application/vnd+inspire.record.ui+json'})
-    assert response.status_code == 200
-    result = json.loads(response.get_data(as_text=True))
-    assert result['metadata']['citation_count'] == 0
-
-
-def test_non_zero_citation_count_in_vnd_plus_inspire_record_ui_json(isolated_api_client):
-    record_json = {
-        'control_number': 123,
-    }
-    record = TestRecordMetadata.create_from_kwargs(json=record_json).inspire_record
-    url = '/literature/123'
-    # Add citation
-    ref = {'control_number': 1234, 'references': [{'record': {'$ref': record._get_ref()}}]}
-    TestRecordMetadata.create_from_kwargs(json=ref)
-
-    response = isolated_api_client.get(url,
-                                       headers={'Accept': 'application/vnd+inspire.record.ui+json'})
-    assert response.status_code == 200
-    result = json.loads(response.get_data(as_text=True))
-    assert result['metadata']['citation_count'] == 1
-
-
 def test_zero_citation_count_in_es(isolated_api_client):
     cn_map = {
         1234: 1,


### PR DESCRIPTION
Replaced the db query with an elastic search query which contains pagination and sorting. Added earliest_date to the serializer.
Removed citations_count from the literature endpoint as it was not used.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have all the information that I need (if not, move to `RFC` and look for it).
- [x] I linked the related issue(s) in the corresponding commit logs.
- [x] I wrote [good commit log messages](https://github.com/torvalds/subsurface-for-dirk/blob/5f15ad5a86ada3c5e574041a5f9d85235322dabb/README#L92-L119).
- [x] My code follows the code style of this project.
- [ ] I've added any new docs if API/utils methods were added.
- [ ] I have updated the existing documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- After this you can move the PR to `Needs Review` -->
