### PR TITLE
remove references from hep search results

### DIFF
--- a/inspirehep/modules/records/mappings/v5/records/hep.json
+++ b/inspirehep/modules/records/mappings/v5/records/hep.json
@@ -592,6 +592,9 @@
                 "number_of_pages": {
                     "type": "integer"
                 },
+                "number_of_references": {
+                    "type": "integer"
+                },
                 "persistent_identifiers": {
                     "properties": {
                         "material": {

--- a/inspirehep/modules/records/receivers.py
+++ b/inspirehep/modules/records/receivers.py
@@ -68,6 +68,7 @@ from inspirehep.modules.records.utils import (
     populate_experiment_suggest,
     populate_inspire_document_type,
     populate_name_variations,
+    populate_number_of_references,
     populate_recid_from_ref,
     populate_title_suggest,
 )
@@ -156,13 +157,16 @@ def index_after_commit(sender, changes):
     for model_instance, change in changes:
         if isinstance(model_instance, RecordMetadata):
             if change in ('insert', 'update') and not model_instance.json.get("deleted"):
-                indexer.index(InspireRecord(model_instance.json, model_instance))
+                indexer.index(InspireRecord(
+                    model_instance.json, model_instance))
             else:
                 try:
-                    indexer.delete(InspireRecord(model_instance.json, model_instance))
+                    indexer.delete(InspireRecord(
+                        model_instance.json, model_instance))
                 except NotFoundError:
                     # Record not found in ES
-                    LOGGER.debug('Record %s not found in ES', model_instance.json.get("id"))
+                    LOGGER.debug('Record %s not found in ES',
+                                 model_instance.json.get("id"))
                     pass
 
 
@@ -186,6 +190,7 @@ def enhance_after_index(sender, json, record, *args, **kwargs):
         populate_authors_full_name_unicode_normalized(json)
         populate_inspire_document_type(json)
         populate_name_variations(json)
+        populate_number_of_references(json)
         populate_citations_count(record=record, json=json)
 
     elif is_author(json):

--- a/inspirehep/modules/records/serializers/schemas/json/literature/__init__.py
+++ b/inspirehep/modules/records/serializers/schemas/json/literature/__init__.py
@@ -124,6 +124,10 @@ class RecordMetadataSchemaV1(Schema):
         return self.get_len_or_missing(authors)
 
     def get_number_of_references(self, data):
+        number_of_references = data.get('number_of_references')
+        if number_of_references is not None:
+            return number_of_references
+
         references = data.get('references')
         return self.get_len_or_missing(references)
 

--- a/inspirehep/modules/records/utils.py
+++ b/inspirehep/modules/records/utils.py
@@ -363,6 +363,14 @@ def populate_name_variations(json):
             }})
 
 
+def populate_number_of_references(json):
+    """Generate name variations for each signature of a Literature record."""
+    references = json.get('references')
+
+    if references is not None:
+        json['number_of_references'] = len(references)
+
+
 def populate_authors_name_variations(json):
     """Generate name variations for an Author record."""
     author_name = get_value(json, 'name.value')

--- a/inspirehep/modules/search/search_factory.py
+++ b/inspirehep/modules/search/search_factory.py
@@ -62,8 +62,8 @@ def select_source(search, search_index):
                                          "dois.value",
                                          "earliest_date",
                                          "inspire_categories",
+                                         "number_of_references",
                                          "publication_info",
-                                         "references",
                                          "report_numbers",
                                          "titles.title"])
     return search

--- a/tests/integration/test_search_views.py
+++ b/tests/integration/test_search_views.py
@@ -104,8 +104,8 @@ def test_search_logs(current_app_mock, api_client):
                     "dois.value",
                     "earliest_date",
                     "inspire_categories",
+                    "number_of_references",
                     "publication_info",
-                    "references",
                     "report_numbers",
                     "titles.title"
                 ]
@@ -136,8 +136,8 @@ def test_search_facets_logs(current_app_mock, api_client):
                     "dois.value",
                     "earliest_date",
                     "inspire_categories",
+                    "number_of_references",
                     "publication_info",
-                    "references",
                     "report_numbers",
                     "titles.title"
                 ]
@@ -266,8 +266,8 @@ def test_search_facets_logs_with_query(current_app_mock, api_client):
                     "dois.value",
                     "earliest_date",
                     "inspire_categories",
+                    "number_of_references",
                     "publication_info",
-                    "references",
                     "report_numbers",
                     "titles.title"
                 ]

--- a/tests/unit/records/serializers/literature/test_schemas_json.py
+++ b/tests/unit/records/serializers/literature/test_schemas_json.py
@@ -55,6 +55,18 @@ def test_record_metadata_schema_returns_number_of_references():
     assert expected == number_of_references
 
 
+def test_record_metadata_schema_uses_existing_number_of_references():
+    schema = RecordMetadataSchemaV1()
+    dump = {
+        'number_of_references': 2
+    }
+    expected = 2
+
+    result = schema.dumps(dump).data
+    number_of_references = json.loads(result)['number_of_references']
+    assert expected == number_of_references
+
+
 @mock.patch('inspirehep.modules.records.serializers.schemas.json.literature.format_date')
 def test_record_metadata_schema_returns_formatted_date(format_date):
     schema = RecordMetadataSchemaV1()

--- a/tests/unit/records/test_records_utils.py
+++ b/tests/unit/records/test_records_utils.py
@@ -38,7 +38,38 @@ from inspirehep.modules.records.utils import (
     populate_inspire_document_type,
     populate_recid_from_ref,
     populate_title_suggest,
+    populate_number_of_references,
 )
+
+
+def test_populate_number_references():
+    record = {
+        '$schema': 'http://localhost:5000/records/schemas/hep.json',
+        'references': [
+            {
+                'reference': {
+                    'label': '1'
+                }
+            }
+        ]
+    }
+
+    populate_number_of_references(record)
+
+    expected = 1
+    result = record['number_of_references']
+
+    assert expected == result
+
+
+def test_populate_number_references_does_nothing_if_references_is_none():
+    record = {
+        '$schema': 'http://localhost:5000/records/schemas/hep.json',
+    }
+
+    populate_number_of_references(record)
+
+    assert 'number_of_references' not in record
 
 
 def test_get_endpoint_from_record():


### PR DESCRIPTION
* Puts number of references into another field in order to avoid
returning all references just for counting later.