### PR TITLE
citation count: index new citation's records - INSPIR-1127

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -22,7 +22,7 @@
 
 web: gunicorn inspirehep.wsgi -c gunicorn.cfg
 cache: redis-server
-worker: celery worker -E -A inspirehep.celery --loglevel=INFO --workdir="${VIRTUAL_ENV}" --pidfile="${VIRTUAL_ENV}/worker.pid" --purge -Q celery,migrator,harvests,orcid_push
+worker: celery worker -E -A inspirehep.celery --loglevel=INFO --workdir="${VIRTUAL_ENV}" --pidfile="${VIRTUAL_ENV}/worker.pid" --purge -Q celery,migrator,harvests,orcid_push,bulk_index
 workermon: celery flower -A inspirehep.celery
 # beat: celery beat -A inspirehep.celery --loglevel=INFO --workdir="${VIRTUAL_ENV}" --pidfile="${VIRTUAL_ENV}/worker_beat.pid"
 # mathoid: node_modules/mathoid/server.js -c mathoid.config.yaml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
   worker:
     extends:
       service: service_base
-    command: celery worker -E -A inspirehep.celery --loglevel=INFO --purge --queues celery,migrator,harvests,orcid_push,indexer_task
+    command: celery worker -E -A inspirehep.celery --loglevel=INFO --purge --queues celery,migrator,harvests,orcid_push,indexer_task,bulk_index
     volumes_from:
       - static
     healthcheck:

--- a/inspirehep/modules/records/receivers.py
+++ b/inspirehep/modules/records/receivers.py
@@ -47,7 +47,9 @@ from inspirehep.modules.orcid.utils import (
     get_push_access_tokens,
     get_orcids_for_push,
 )
+from inspirehep.modules.pidstore.utils import get_pid_type_from_schema
 from inspirehep.modules.records.api import InspireRecord
+from inspirehep.modules.records.tasks import index_modified_citations_from_record
 from inspirehep.modules.records.utils import (
     is_author,
     is_book,
@@ -169,9 +171,15 @@ def index_after_commit(sender, changes):
                                  model_instance.json.get("id"))
                     pass
 
+            pid_type = get_pid_type_from_schema(model_instance.json['$schema'])
+            pid_value = model_instance.json['control_number']
+            db_version = model_instance.version_id
+
+            index_modified_citations_from_record.delay(pid_type, pid_value, db_version)
+
 
 @before_record_index.connect
-def enhance_after_index(sender, json, record, *args, **kwargs):
+def enhance_before_index(sender, json, record, *args, **kwargs):
     """Run all the receivers that enhance the record for ES in the right order.
 
     .. note::

--- a/tests/integration/workflows/conftest.py
+++ b/tests/integration/workflows/conftest.py
@@ -22,9 +22,10 @@
 
 from __future__ import absolute_import, division, print_function
 
+import mock
 import os
-import re
 import pytest
+import re
 import requests_mock
 import sys
 
@@ -112,7 +113,9 @@ def workflow_app(higgs_ontology):
         )
 
     with app.app_context():
-        yield app
+        with mock.patch('inspirehep.modules.records.receivers.index_modified_citations_from_record.apply_async'):
+
+            yield app
 
 
 @pytest.fixture

--- a/tests/integration/workflows/test_workflows_tasks_actions.py
+++ b/tests/integration/workflows/test_workflows_tasks_actions.py
@@ -347,7 +347,9 @@ def test_normalize_journal_titles_unknown_journals_no_ref(workflow_app, insert_j
     'inspirehep.modules.workflows.tasks.magpie.json_api_request',
     side_effect=fake_magpie_api_request,
 )
+@mock.patch('inspirehep.modules.records.receivers.index_modified_citations_from_record.apply_async')
 def test_refextract_from_pdf(
+    mocked_indexing_task,
     mocked_api_request_magpie,
     mocked_api_request_beard,
     mocked_is_pdf_link,
@@ -424,7 +426,9 @@ def test_refextract_from_pdf(
     'inspirehep.modules.workflows.tasks.magpie.json_api_request',
     side_effect=fake_magpie_api_request,
 )
+@mock.patch('inspirehep.modules.records.receivers.index_modified_citations_from_record.apply_async')
 def test_count_reference_coreness(
+    mocked_indexing_task,
     mocked_api_request_magpie,
     mocked_api_request_beard,
     mocked_is_pdf_link,


### PR DESCRIPTION
Changes in the current receiver `models_committed` to trigger a celery task, which computes the references diff between the current and previous version of the record and indexes the cited records.
However, before computing the references diff, the task checks that the current version of the record in the DB is the one it expects to find (passed before by the receiver). If it is not, it retries itself with exponential time.
A new celery queue called `bulk_index` is used for reindexing the cited records.

Signed-off-by: Antonio Cesarano <cesarano2607@gmail.com>