### PR TITLE
migrator: make exceptions dashboard fast

### DIFF
--- a/inspirehep/modules/migrator/utils.py
+++ b/inspirehep/modules/migrator/utils.py
@@ -35,6 +35,7 @@ REAL_COLLECTIONS = (
     'JOURNALS',
     'JOURNALSNEW',
     'HEPNAMES',
+    'HEP',
     'JOB',
     'JOBHIDDEN',
     'CONFERENCES',


### PR DESCRIPTION
The previous query was filtering out `DELETED` records in a naive way
that doesn't benefit from the DB index. This is fixed by providing the
explicit list of collections that we do want to return.