### PR TITLE
1638 orcid tests: redis==3.0.0.post1 only allows accept basic data types

### DIFF
--- a/tests/integration/orcid/test_orcid_domain_models.py
+++ b/tests/integration/orcid/test_orcid_domain_models.py
@@ -79,6 +79,7 @@ class TestOrcidPusherCache(object):
 
         pusher = domain_models.OrcidPusher(self.orcid, self.recid, self.oauth_token)
         with mock.patch.object(OrcidClient, 'put_updated_work') as mock_put_updated_work:
+            mock_put_updated_work.return_value.__getitem__.return_value = '0000'
             pusher.push()
         mock_put_updated_work.assert_called_once_with(mock.ANY, putcode)
 


### PR DESCRIPTION
The test fails because it tries to cache a Mock object, now replaced
with the real string.