### PR TITLE
serializers: handle missing conference_record

### DIFF
--- a/inspirehep/modules/records/serializers/schemas/json/literature/common/conference_info_item.py
+++ b/inspirehep/modules/records/serializers/schemas/json/literature/common/conference_info_item.py
@@ -25,7 +25,7 @@ from __future__ import absolute_import, division, print_function
 from marshmallow import Schema, pre_dump, fields
 
 from inspirehep.modules.records.utils import get_pid_from_record_uri
-from inspirehep.utils.record_getter import get_db_record
+from inspirehep.utils.record_getter import get_db_record, RecordGetterError
 
 
 class ConferenceInfoItemSchemaV1(Schema):
@@ -37,8 +37,13 @@ class ConferenceInfoItemSchemaV1(Schema):
         conference_record = pub_info_item.get('conference_record')
         if conference_record is None:
             return {}
+
         _, recid = get_pid_from_record_uri(conference_record.get('$ref'))
-        conference = get_db_record('con', recid)
+        try:
+            conference = get_db_record('con', recid)
+        except RecordGetterError:
+            return {}
+
         titles = conference.get('titles')
         if titles is None:
             return {}

--- a/tests/integration/records/serializers/literature/test_schemas_json.py
+++ b/tests/integration/records/serializers/literature/test_schemas_json.py
@@ -293,6 +293,55 @@ def test_conference_info_schema_with_record(isolated_app):
     assert expected == result
 
 
+def test_conference_info_schema_with_absent_record(isolated_app):
+    schema = LiteratureRecordSchemaJSONUIV1()
+    record = {
+        'metadata': {
+            'publication_info': [
+                {
+                    'artid': '02B006',
+                    'journal_title': 'PTEP',
+                    'journal_volume': '2012',
+                    'year': 2012,
+                    'conference_record': {
+                        '$ref': 'http://localhost:5000/api/journals/oops'
+                    }
+                },
+                {
+                    'artid': '02B006',
+                    'journal_title': 'PTEP',
+                    'journal_volume': '2012',
+                    'year': 2012
+                }
+            ]
+        }
+    }
+
+    expected = {
+        'metadata': {
+            'publication_info': [
+                {
+                    'artid': '02B006',
+                    'journal_title': 'PTEP',
+                    'journal_volume': '2012',
+                    'year': 2012,
+
+                },
+                {
+                    'artid': '02B006',
+                    'journal_title': 'PTEP',
+                    'journal_volume': '2012',
+                    'year': 2012
+
+                }
+            ],
+        }
+    }
+
+    result = json.loads(schema.dumps(record).data)
+    assert expected == result
+
+
 def test_accelerator_experiments_schema_with_record(isolated_app):
     schema = LiteratureRecordSchemaJSONUIV1()
     cms_record = {


### PR DESCRIPTION
* Returns empty if conference_record.$ref is present but refereced
record is not on the DB.