### PR TITLE
1642 requirements: inspire-service-orcid 5.0.1 > 5.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ install_requires = [
     'inspire-matcher~=7.0,>=7.0.0',
     'inspire-query-parser~=4.0,>=4.0.0',
     'inspire-schemas~=58.0,>=58.0.0',
-    'inspire-service-orcid~=5.0,>=5.0.1',
+    'inspire-service-orcid~=5.1,>=5.1.0',
     'inspire-utils~=2.0,>=2.0.7',
     'invenio-access~=1.0,>=1.0.0',
     'invenio-accounts~=1.0,>=1.0.0',


### PR DESCRIPTION
Introduce the new orcid_service_exc hook.