### PR TITLE
pin flask-shell-ipython version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,9 @@ install_requires = [
     'elasticsearch-dsl>=5.0.0,<6.0.0',
     'elasticsearch>=5.1.0,<6.0.0',
     'enum34~=1.0,>=1.1.6',
-    'flask-shell-ipython~=0.0,>=0.3.0',
+    # flask-shell-ipython==0.4.0 breaks our code
+    # as it requires flask>=1.0
+    'flask-shell-ipython==0.3.1',
     'fs~=0.0,>=0.5.4',
     'inspire-crawler~=3.0,>=3.0.0',
     'inspire-dojson~=60.0,>=60.0.3',


### PR DESCRIPTION
As mentioned in the comment on the code, ``flask-shell-ipython`` requires a ``flask>=1.0`` which is incompatible with our code, as we use ``flask>=0.12.4`` . Pinning the version of ``flask-shell-ipython`` to the last one that works with the same ``flask`` version as ours.

Signed-off-by: Victor Balbuena <vbalbp@gmail.com>