### PR TITLE
1850 metrics: use timeexecution fork

### DIFF
--- a/inspirehep/utils/ext.py
+++ b/inspirehep/utils/ext.py
@@ -83,7 +83,7 @@ class INSPIREUtils(object):
                 backend_kwargs=dict(
                     hosts=app.config['APPMETRICS_ELASTICSEARCH_HOSTS'],
                     index=app.config['APPMETRICS_ELASTICSEARCH_INDEX']),
-                queue_maxsize=5000,
+                lazy_init=True,
             )
         else:
             backend = ElasticsearchBackend(

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,6 @@
 
 #Flask_sqlalchemy fork
 -e git+https://github.com/inspirehep/flask-sqlalchemy.git#egg=flask_sqlalchemy
+
+# Timeexecution fork, until https://github.com/kpn-digital/py-timeexecution/pull/38 gets merged:
+-e git+https://github.com/puntonim/py-timeexecution.git@lazy-init-tmp-3.4.0#egg=timeexecution

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,9 @@ install_requires = [
     'scikit-learn~=0.0,>=0.19.1',
     'setproctitle~=1.0,>=1.1.10',
     'timeout-decorator~=0.0,>=0.4.0',
-    'timeexecution~=3.3.0,<4',
+    # Use a timeexecution fork, until https://github.com/kpn-digital/py-timeexecution/pull/38 gets merged.
+    # See ./requirements.txt
+    # 'timeexecution~=3.3.0,<4',
     # Pin urllib3 to version 1.23 as version 1.24 is incompatible with requirements
     # from python-requests (<1.24) (https://travis-ci.org/inspirehep/inspire-next/builds/388221674)
     'urllib3~=1.0,<1.24',


### PR DESCRIPTION
Temporarily until https://github.com/kpn-digital/py-timeexecution/pull/38 gets merged