### PR TITLE
workflows: make robotupload priority configurable INSPIR-1899

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -1208,6 +1208,9 @@ INSPIRELABS_FEEDBACK_EMAIL = "labsfeedback@inspirehep.net"
 # ==========
 LEGACY_ROBOTUPLOAD_URL = None  # Disabled by default
 LEGACY_MATCH_ENDPOINT = "http://inspirehep.net/search"
+LEGACY_ROBOTUPLOAD_PRIORITY_ARTICLE = 4
+LEGACY_ROBOTUPLOAD_PRIORITY_AUTHOR = 4
+LEGACY_ROBOTUPLOAD_PRIORITY_EDIT_ARTICLE = 5
 
 # Web services and APIs
 # =====================

--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -276,7 +276,7 @@ POSTENHANCE_RECORD = [
 
 
 SEND_TO_LEGACY = [
-    send_to_legacy,
+    send_to_legacy(priority_config_key='LEGACY_ROBOTUPLOAD_PRIORITY_ARTICLE'),
 ]
 
 

--- a/inspirehep/modules/workflows/workflows/author.py
+++ b/inspirehep/modules/workflows/workflows/author.py
@@ -54,9 +54,7 @@ from inspirehep.modules.workflows.utils import do_not_repeat
 
 
 SEND_TO_LEGACY = [
-    send_robotupload(
-        mode="insert"
-    ),
+    send_robotupload(mode="insert", priority_config_key='LEGACY_ROBOTUPLOAD_PRIORITY_AUTHOR'),
 ]
 
 

--- a/inspirehep/modules/workflows/workflows/edit_article.py
+++ b/inspirehep/modules/workflows/workflows/edit_article.py
@@ -77,7 +77,7 @@ class EditArticle(object):
             change_status_to_waiting,
             validate_record('hep'),
             update_record,
-            send_robotupload(mode='replace'),
+            send_robotupload(mode='replace', priority_config_key='LEGACY_ROBOTUPLOAD_PRIORITY_EDIT_ARTICLE'),
             cleanup_pending_workflow,
         ]
     )

--- a/tests/unit/workflows/test_workflows_tasks_submission.py
+++ b/tests/unit/workflows/test_workflows_tasks_submission.py
@@ -994,7 +994,7 @@ def test_send_robotupload_update_article_when_feature_flag_is_disabled():
 
         expected_log = 'skipping upload to legacy, feature flag ``FEATURE_FLAG_ENABLE_UPDATE_TO_LEGACY`` is disabled.'
 
-        assert send_to_legacy(obj, eng) is None
+        assert send_to_legacy()(obj, eng) is None
         assert expected_log in obj.log._info.getvalue()
 
 
@@ -1024,7 +1024,7 @@ def test_send_robotupload_update_article_when_feature_flag_is_enabled():
             obj = MockObj(data, extra_data)
             eng = MockEng()
 
-            assert send_to_legacy(obj, eng) is None
+            assert send_to_legacy()(obj, eng) is None
 
             expected = (
                 'Robotupload sent!'


### PR DESCRIPTION
No tests for this as it's hard to test: requests in the workflow unit tests are tested with `request-mock`, which doesn't provide a simple way to match on POST request arguments. So it would require either implementing custom matching logic or using vcr instead.