### PR TITLE
Distributed continuous migration INSPIR-2081

### DIFF
--- a/inspirehep/modules/migrator/tasks.py
+++ b/inspirehep/modules/migrator/tasks.py
@@ -230,12 +230,9 @@ def continuous_migration(skip_files=None):
             while r.llen('legacy_records'):
                 raw_record = r.lrange('legacy_records', 0, 0)
                 if raw_record:
-                    migrate_and_insert_record(
-                        zlib.decompress(raw_record[0]),
-                        skip_files=skip_files,
-                    )
-                    db.session.commit()
+                    insert_into_mirror([zlib.decompress(raw_record[0])])
                 r.lpop('legacy_records')
+            migrate_from_mirror(wait_for_results=True, skip_files=skip_files)
         finally:
             lock.release()
     else:


### PR DESCRIPTION
This should allow the continuous migration to run much faster by using the same trick as the migration from files (insert copies of legacy records into the mirror synchronously, then spawn tasks to do the migration proper from the mirror in chunks).

It requires extensive testing on QA to make sure that all the Celery stuff is working correctly, as it's spawning tasks from a celery task that then waits for those tasks to finish. I didn't manage to make it work using `integration_async`.