### PR TITLE
cli: decrease query time for simpleindex command

### DIFF
--- a/inspirehep/modules/records/cli.py
+++ b/inspirehep/modules/records/cli.py
@@ -58,11 +58,7 @@ from inspirehep.modules.search.api import LiteratureSearch
 
 
 from sqlalchemy import (
-    String,
     cast,
-    type_coerce,
-    or_,
-    not_
 )
 
 from sqlalchemy.dialects.postgresql import JSONB
@@ -118,8 +114,7 @@ def next_batch(iterator, batch_size):
 
 
 def get_query_records_to_index(pid_types):
-    """
-    Return a query for retrieving all non deleted records by pid_type
+    """Return a query for retrieving all records by pid_type.
 
     Args:
         pid_types(List[str]): a list of pid types
@@ -128,17 +123,10 @@ def get_query_records_to_index(pid_types):
         SQLAlchemy query for non deleted record with pid type in `pid_types`
     """
     query = (
-        db.session.query(PersistentIdentifier.object_uuid).join(RecordMetadata, type_coerce(PersistentIdentifier.object_uuid, String) == type_coerce(RecordMetadata.id, String))
-        .filter(
+        db.session.query(PersistentIdentifier.object_uuid).filter(
             PersistentIdentifier.pid_type.in_(pid_types),
             PersistentIdentifier.object_type == 'rec',
             PersistentIdentifier.status == PIDStatus.REGISTERED,
-            or_(
-                not_(
-                    type_coerce(RecordMetadata.json, JSONB).has_key('deleted')
-                ),
-                RecordMetadata.json["deleted"] == cast(False, JSONB)
-            )
             # noqa: F401
         )
     )

--- a/tests/integration_async/test_records_cli.py
+++ b/tests/integration_async/test_records_cli.py
@@ -197,13 +197,15 @@ def test_simpleindex_indexes_correct_pidtype(
     assert '0 failed' in result.output_bytes
 
 
-def test_simpleindex_using_multiple_batches(
+def test_simpleindex_using_multiple_batches_and_no_deleted(
     app_cli,
     celery_app_with_context,
     celery_session_worker,
     create_records,
 ):
     create_records(n=5)
+    create_records(n=2, additional_props={'deleted': True})
+
     result = app_cli.invoke(
         simpleindex,
         ['--yes-i-know', '-t', 'lit', '-s', '1', '--queue-name', ''],
@@ -281,21 +283,6 @@ def test_get_query_records_to_index_only_lit_adding_record(
     pids = ['lit']
     query = get_query_records_to_index(pids)
 
-    expected_count = 0  # does not take deleted record
-    result_count = query.count()
-    assert result_count == expected_count
-
-
-def test_get_query_records_to_index_only_lit_adding_record_deleted(
-    app,
-    create_records,
-):
-    create_records()
-    create_records(additional_props={'deleted': True})
-
-    pids = ['lit']
-    query = get_query_records_to_index(pids)
-
-    expected_count = 1
+    expected_count = 1  # takes also deleted record
     result_count = query.count()
     assert result_count == expected_count


### PR DESCRIPTION
This commit removes from the query for reindexing the check for deleted record. This is possible because the `batch_reindex` task already filters out deleted record when the metadata is loaded to be enhanced before reindexing.

* INSPIR-2353

Signed-off-by: Antonio Cesarano <cesarano2607@gmail.com>