### PR TITLE
global: remove the version check

### DIFF
--- a/inspirehep/__init__.py
+++ b/inspirehep/__init__.py
@@ -24,12 +24,4 @@
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-
-from .version import __version__, get_git_tag_version  # noqa: F401
-
-
-logger = logging.getLogger(__name__)
-
-latest_commit = get_git_tag_version()
-logger.info('HEAD SHA: {}'.format(latest_commit))
+from .version import __version__  # noqa: F401

--- a/inspirehep/version.py
+++ b/inspirehep/version.py
@@ -22,23 +22,4 @@
 
 from __future__ import absolute_import, division, print_function
 
-import logging
-import pkg_resources
-from subprocess import check_output
-
-
-logger = logging.getLogger(__name__)
-
-
-def get_git_tag_version():
-    try:
-        return check_output('git log -1 --pretty=format:%H'.split())
-    except Exception:
-        git_repo_path = pkg_resources.get_distribution('inspirehep').location
-        logger.error(
-            'Error reading ``SHA`` from path "{}".'.format(git_repo_path)
-        )
-        return -1
-
-
 __version__ = '0.1.0'

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,8 @@ install_requires = [
     'invenio-records-files>=1.0.0a10',
     'invenio-records-rest~=1.0,>=1.0.1',
     'invenio-records-ui~=1.0,>=1.0.0',
-    'invenio-records~=1.0,>=1.0.0',
+    # invenio-records@1.2.0 requires Flask>=1.0
+    'invenio-records~=1.0,<1.2.0',
     'invenio-rest~=1.0,>=1.0.0',
     'invenio-search[elasticsearch5]~=1.0,>=1.0.0',
     'invenio-userprofiles~=1.0,>=1.0.0',


### PR DESCRIPTION
* We don't need the version check anymore, we'll
  use inspire-next on kb8s.

Signed-off-by: Harris Tzovanakis <me@drjova.com>