### PR TITLE
workflows: Allow workflows to create records via HTTP with inspirehep

### DIFF
--- a/inspirehep/config.py
+++ b/inspirehep/config.py
@@ -1225,6 +1225,8 @@ MAGPIE_API_URL = None  # e.g. "http://magpie.inspirehep.net/api"
 LEGACY_BASE_URL = "http://inspirehep.net"
 LEGACY_RECORD_URL_PATTERN = 'http://inspirehep.net/record/{recid}'
 AUTHENTICATION_TOKEN = "CHANGE_ME"
+INSPIREHEP_URL = "http://web:8000"
+ENABLE_INSPIREHEP_REMOTE_RECORD_MANAGEMENT = False
 
 # Harvesting and Workflows
 # ========================

--- a/inspirehep/modules/workflows/tasks/upload.py
+++ b/inspirehep/modules/workflows/tasks/upload.py
@@ -24,7 +24,9 @@
 
 from __future__ import absolute_import, division, print_function
 
+import requests
 from flask import current_app
+from invenio_workflows.errors import WorkflowsError
 
 from inspire_schemas.readers import LiteratureReader
 from invenio_db import db
@@ -43,33 +45,105 @@ def store_record(obj, eng):
     """Insert or replace a record."""
     is_update = obj.extra_data.get('is-update')
     is_authors = eng.workflow_definition.data_type == 'authors'
+    if not current_app.config.get("ENABLE_INSPIREHEP_REMOTE_RECORD_MANAGEMENT"):
+        with db.session.begin_nested():
+            if is_update:
+                if not is_authors and not current_app.config.get('FEATURE_FLAG_ENABLE_MERGER', False):
+                    obj.log.info(
+                        'skipping update record, feature flag ``FEATURE_FLAG_ENABLE_MERGER`` is disabled.'
+                    )
+                    return
 
-    with db.session.begin_nested():
-        if is_update:
-            if not is_authors and not current_app.config.get('FEATURE_FLAG_ENABLE_MERGER', False):
-                obj.log.info(
-                    'skipping update record, feature flag ``FEATURE_FLAG_ENABLE_MERGER`` is disabled.'
+                record = InspireRecord.get_record(obj.extra_data['head_uuid'])
+                obj.data['control_number'] = record['control_number']
+                record.clear()
+                record.update(obj.data, files_src_records=[obj])
+
+            else:
+                # Skip the files to avoid issues in case the record has already pid
+                # TODO: remove the skip files once labs becomes master
+                record = InspireRecord.create(obj.data, id_=None, skip_files=True)
+                # Create persistent identifier.
+                # Now that we have a recid, we can properly download the documents
+                record.download_documents_and_figures(src_records=[obj])
+
+                obj.data['control_number'] = record['control_number']
+                # store head_uuid to store the root later
+                obj.extra_data['head_uuid'] = str(record.id)
+
+            record.commit()
+            obj.save()
+    else:
+        store_record_inspirehep_api(obj, eng, is_update, is_authors)
+
+
+@with_debug_logging
+def store_record_inspirehep_api(obj, eng, is_update, is_authors):
+    """Saves record through inspirehep api by posting/pushing record to proper endpoint
+     in inspirehep"""
+    headers = {
+        "content-type": "application/json",
+        "Authorization": "Bearer {token}".format(
+            token=current_app.config['AUTHENTICATION_TOKEN']
+        ),
+    }
+    if is_authors:
+        endpoint = '/authors'
+    else:
+        endpoint = '/literature'
+    inspirehep_url = current_app.config.get("INSPIREHEP_URL")
+    if is_update:
+        if not is_authors and not current_app.config.get(
+            'FEATURE_FLAG_ENABLE_MERGER', False
+        ):
+            obj.log.info(
+                'skipping update record, feature flag ``FEATURE_FLAG_ENABLE_MERGER`` is disabled.'
+            )
+            return
+        control_number = obj.extra_data['matches']['approved']
+        response = requests.put(
+            "{inspirehep_url}{endpoint}/{control_number}".format(
+                inspirehep_url=inspirehep_url,
+                endpoint=endpoint,
+                control_number=control_number
+            ),
+            headers=headers,
+            json=obj.data
+        )
+        if response.status_code == 200:
+            obj.data['control_number'] = response.json()['control_number']
+            if response.json()['id_'] != obj.extra_data['head_uuid']:
+                obj.log.warning(
+                    "Record matched in workflow has different uuid than record updated in Inspirehep!"
                 )
-                return
-
-            record = InspireRecord.get_record(obj.extra_data['head_uuid'])
-            obj.data['control_number'] = record['control_number']
-            record.clear()
-            record.update(obj.data, files_src_records=[obj])
-
         else:
-            # Skip the files to avoid issues in case the record has already pid
-            # TODO: remove the skip files once labs becomes master
-            record = InspireRecord.create(obj.data, id_=None, skip_files=True)
-            # Create persistent identifier.
-            # Now that we have a recid, we can properly download the documents
-            record.download_documents_and_figures(src_records=[obj])
+            raise WorkflowsError(
+                "Response code from Inspirehep is {code}. This is wrong!"
+                " Message from the server: {message}".format(
+                    code=response.status_code, message=response.json()
+                )
+            )
+    else:
+        response = requests.post(
+            "{inspirehep_url}{endpoint}".format(
+                inspirehep_url=inspirehep_url,
+                endpoint=endpoint,
+            ),
+            headers=headers,
+            json=obj.data
+        )
 
-            obj.data['control_number'] = record['control_number']
-            # store head_uuid to store the root later
-            obj.extra_data['head_uuid'] = str(record.id)
-
-        record.commit()
+        if response.status_code == 201:
+            obj.data['control_number'] = response.json()['control_number']
+            obj.extra_data['head_uuid'] = response.json()['id_']
+        else:
+            raise WorkflowsError(
+                "Response code from Inspirehep is {code}."
+                " This is wrong! Message from the server: {message}".format(
+                    code=response.status_code, message=response.json()
+                )
+            )
+    with db.session.begin_nested():
         obj.save()
 
 


### PR DESCRIPTION
* add: Feature flag: ENABLE_INSPIREHEP_REMOTE_RECORD_MANAGEMENT - when set to true will save records through inspirehep records API

* INSPIR-2311