### PR TITLE
Dockerfile: disable pip cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,6 @@ RUN npm install -g \
 
 COPY . .
 
-RUN pip install --upgrade pip && \
- pip install --upgrade setuptools && \
- pip install -e .[all] && \ 
- pip install -r requirements.txt
+RUN pip install --no-cache-dir --upgrade pip && \
+ pip install --no-cache-dir --upgrade setuptools && \
+ pip install --no-cache-dir -e .[all] -r requirements.txt


### PR DESCRIPTION
This also installs the `requirements.txt` in the same step as all other requirements.
As a result, the docker image is now 200 MB smaller (1.51 GB instead of 1.71 GB).