### PR TITLE
refextract: correct punctuation in journal kb

### DIFF
--- a/inspirehep/modules/refextract/utils.py
+++ b/inspirehep/modules/refextract/utils.py
@@ -30,7 +30,7 @@ from fs.opener import fsopen
 from inspirehep.utils.url import copy_file
 
 
-RE_ALPHANUMERIC = re.compile('\W+', re.UNICODE)
+RE_PUNCTUATION = re.compile(r"[\.,;'\(\)-]", re.UNICODE)
 
 
 class KbWriter(object):
@@ -81,7 +81,7 @@ class KbWriter(object):
         if not s:
             return
 
-        result = RE_ALPHANUMERIC.sub(' ', s)
+        result = RE_PUNCTUATION.sub(' ', s)
         result = ' '.join(result.split())
         result = result.upper()
 

--- a/tests/unit/refextract/test_refextract_utils.py
+++ b/tests/unit/refextract/test_refextract_utils.py
@@ -53,6 +53,19 @@ def test_kb_writer_unicode(tmpdir):
     assert expected == kb_file.readlines()
 
 
+def test_kb_writer_keeps_colons(tmpdir):
+    kb_file = tmpdir.join('keeps_colons.kb')
+
+    with KbWriter(str(kb_file)) as writer:
+        writer.add_entry('J PHYS G: NUCL PART PHYS', 'J.Phys.')
+
+    expected = [
+        'J PHYS G: NUCL PART PHYS---J.Phys.\n',
+    ]
+
+    assert expected == kb_file.readlines()
+
+
 def test_kb_writer_many_lines(tmpdir):
     kb_file = tmpdir.join('many_lines.kb')
 


### PR DESCRIPTION
Punctuation handling was incorrect, resulting in wrong journal normalizations. See https://inspirehep.zulipchat.com/#narrow/stream/122202-devel/topic/wrong.20refextract.20normalization/near/166211712 for details.