### PR TITLE
workflows: rename id_ to uuid

### DIFF
--- a/inspirehep/modules/workflows/tasks/upload.py
+++ b/inspirehep/modules/workflows/tasks/upload.py
@@ -134,7 +134,7 @@ def send_record_to_hep(obj, endpoint, control_number=None):
 
         if response.status_code == 201:
             obj.data['control_number'] = response.json()['metadata']['control_number']
-            obj.extra_data['head_uuid'] = response.json()['id_']
+            obj.extra_data['head_uuid'] = response.json()['uuid']
         else:
             create_error(response)
     with db.session.begin_nested():

--- a/tests/integration/workflows/test_edit_article.py
+++ b/tests/integration/workflows/test_edit_article.py
@@ -425,7 +425,7 @@ def test_edit_article_workflow_sending_to_hep(workflow_app, mocked_external_serv
                     "metadata": {
                         'control_number': record['control_number'],
                     },
-                    'id_': 1
+                    'uuid': 1
                 }
             )
 

--- a/tests/integration/workflows/test_workflows_tasks_upload.py
+++ b/tests/integration/workflows/test_workflows_tasks_upload.py
@@ -235,7 +235,7 @@ def test_store_record_inspirehep_api_literature_new(workflow_app):
                     "metadata": {
                         "control_number": expected_control_number
                     },
-                    'id_': expected_head_uuid
+                    'uuid': expected_head_uuid
                 }
             )
             store_record(workflow, eng)  # not throwing exception
@@ -276,7 +276,7 @@ def test_store_record_inspirehep_api_literature_update(workflow_app):
                     "metadata": {
                         "control_number": expected_control_number
                     },
-                    'id_': expected_head_uuid
+                    'uuid': expected_head_uuid
                 }
             )
             store_record(workflow, eng)  # not throwing exception
@@ -311,7 +311,7 @@ def test_store_record_inspirehep_api_author_new(workflow_app):
                     "metadata": {
                         "control_number": expected_control_number
                     },
-                    'id_': expected_head_uuid
+                    'uuid': expected_head_uuid
                 }
             )
             store_record(workflow, eng)  # not throwing exception
@@ -351,7 +351,7 @@ def test_store_record_inspirehep_api_author_update(workflow_app):
                     "metadata": {
                         "control_number": expected_control_number
                     },
-                    'id_': expected_head_uuid
+                    'uuid': expected_head_uuid
                 }
             )
             store_record(workflow, eng)  # not throwing exception


### PR DESCRIPTION
* Receive uuid instead of _id in store record because Inspirehep no longer send id_, it now sends uuid 
* INSPIR-2572