### PR TITLE
setup: add babel dependency back

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ readme = open('README.rst').read()
 setup_requires = []
 
 install_requires = [
-    "kombu>4.5,!=4.6.5"
+    "kombu>4.5,!=4.6.5",
     'Babel~=2.0,>=2.5.1',
     'Flask-Breadcrumbs~=0.0,>=0.4.0',
     'Flask-CeleryExt~=0.0,>=0.3.1',


### PR DESCRIPTION
* This was skipped due to a missing comma in setup.py and didn't fail
  when installing deps due to lax parsing of versions in pip:
  https://travis-ci.org/inspirehep/inspire-next/jobs/593223691#L549

Signed-off-by: Micha Moskovic <michamos@gmail.com>