### PR TITLE
editor: bump editor patch version

### DIFF
--- a/inspirehep/modules/editor/bundles.py
+++ b/inspirehep/modules/editor/bundles.py
@@ -28,6 +28,6 @@ from invenio_assets import NpmBundle
 
 js = NpmBundle(
     npm={
-        "record-editor": "^0.13.0"
+        "record-editor": "^0.13.23"
     }
 )


### PR DESCRIPTION
* This shouldn't be needed but there is no way to force deployment of
new inspire-next image with new record-editor without pushing to this
repo.