### PR TITLE
setup: pin coverage.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -147,6 +147,7 @@ docs_require = [
 ]
 
 tests_require = [
+    'coverage~=4.0,>=4.5.4',
     'flake8-future-import~=0.0,>=0.4.3',
     'freezegun~=0.3,>=0.3.11',
     'mock~=2.0,>=2.0.0',


### PR DESCRIPTION
Collecting the coverage metrics on Coveralls has been broken since
September 2018 due to a change in the format of the .coverage file
that happened in coverage==5.0a2. So we can restore it by pinning
the previous and current stable version.

Last build that passed: https://coveralls.io/builds/18814566
Offending release of `coverage`: https://pypi.org/project/coverage/5.0a2/
This build passes: https://coveralls.io/builds/27541479