### PR TITLE
holdingpen: link workflow ids - use html tags

### DIFF
--- a/inspirehep/modules/search/bundles.py
+++ b/inspirehep/modules/search/bundles.py
@@ -34,6 +34,6 @@ js = NpmBundle(
     npm={
         'invenio-search-js': '~1.4.0',
         'angular-loading-bar': '~0.9.0',
-        'inspirehep-search-js': '~2.0.72'
+        'inspirehep-search-js': '~2.0.74'
     },
 )

--- a/inspirehep/modules/workflows/tasks/matching.py
+++ b/inspirehep/modules/workflows/tasks/matching.py
@@ -311,11 +311,11 @@ def raise_if_match_workflow(obj, eng):
         skip_halted=True
     )
     if bool(matched_ids):
-        urls = [get_hep_url_for_recid(id, 'holdingpen') for id in matched_ids]
+        urls = ["<a href='{0}' target='_blank'>{1}</a>".format(get_hep_url_for_recid(id, 'holdingpen'), id) for id in matched_ids]
 
         raise WorkflowsError(
-            'Cannot continue processing workflow {wf_id}.'
-            'Found not-completed workflows in holdingpen '
+            'Cannot continue processing workflow {wf_id}. '
+            'Found not-completed workflows in holdingpen'
             ': {blocking_ids}'.format(
                 wf_id=obj.id,
                 blocking_ids=urls)


### PR DESCRIPTION
* use html tags inside string for proper render of links
* ref: cern-sis/issues-inspire#20