### PR TITLE
docker: add workaround for centos7 version

### DIFF
--- a/CentOS-Base.repo
+++ b/CentOS-Base.repo
@@ -1,0 +1,17 @@
+[base]
+name=CentOS-$releasever - Base
+baseurl=http://vault.centos.org/$contentdir/$releasever/os/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+[updates]
+name=CentOS-$releasever - Updates
+baseurl=http://vault.centos.org/$contentdir/$releasever/updates/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+[extras]
+name=CentOS-$releasever - Extras
+baseurl=http://vault.centos.org/$contentdir/$releasever/extras/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,14 @@
 # to build an imagine to run in https://github.com/inspirehep/inspirehep
 
 FROM centos:7
+# https://www.redhat.com/en/blog/centos-linux-has-reached-its-end-life-eol
+# https://serverfault.com/a/1161904
+COPY CentOS-Base.repo ./etc/yum.repos.d/CentOS-Base.repo
+RUN yum clean all && yum makecache
 
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
-    yum update -y && \
-    yum install -y \
+    yum update -y --nogpgcheck && \
+    yum install -y --nogpgcheck \
     ImageMagick \
     transfig \
     file \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -25,8 +25,14 @@
 # to build an imagine to run in https://github.com/inspirehep/inspirehep
 
 FROM centos:7
+# https://www.redhat.com/en/blog/centos-linux-has-reached-its-end-life-eol
+# https://serverfault.com/a/1161904
+COPY CentOS-Base.repo ./etc/yum.repos.d/CentOS-Base.repo
+RUN yum clean all && yum makecache
 
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+    yum update -y --nogpgcheck && \
+    yum install -y --nogpgcheck \
     yum update -y && \
     yum install -y \
     ImageMagick \


### PR DESCRIPTION
Centos 7 reached its end of life: https://www.redhat.com/en/blog/centos-linux-has-reached-its-end-life-eol
with that the repositories were moved to the archive at vault.centos.org.

This PR is a workaround, changing the default repository url.