### PR TITLE
workflows: remove prepare_keywords step

### DIFF
--- a/inspirehep/modules/workflows/workflows/article.py
+++ b/inspirehep/modules/workflows/workflows/article.py
@@ -121,7 +121,6 @@ from inspirehep.modules.workflows.tasks.submission import (
     close_ticket,
     create_ticket,
     filter_keywords,
-    prepare_keywords,
     reply_ticket,
     send_to_legacy
 )
@@ -341,7 +340,6 @@ POSTENHANCE_RECORD = [
         add_core,
     ),
     filter_keywords,
-    prepare_keywords,
     set_refereed_and_fix_document_type,
     fix_submission_number,
     IF(is_core, normalize_author_affiliations),

--- a/inspirehep/modules/workflows/workflows/core_selection.py
+++ b/inspirehep/modules/workflows/workflows/core_selection.py
@@ -13,8 +13,7 @@ from inspirehep.modules.workflows.tasks.actions import (
     add_core, halt_record, is_core, link_institutions_with_affiliations,
     load_record_from_hep, normalize_author_affiliations,
     remove_inspire_categories_derived_from_core_arxiv_categories)
-from inspirehep.modules.workflows.tasks.submission import (create_ticket,
-                                                           prepare_keywords)
+from inspirehep.modules.workflows.tasks.submission import create_ticket
 from inspirehep.modules.workflows.tasks.upload import store_record
 from inspirehep.modules.workflows.utils import do_not_repeat
 
@@ -35,7 +34,6 @@ class CoreSelection(object):
         IF_ELSE(
             is_core,
             [
-                prepare_keywords,
                 normalize_author_affiliations,
                 link_institutions_with_affiliations,
                 do_not_repeat("create_ticket_curator_core_publisher")(

--- a/tests/integration/workflows/test_article_workflow.py
+++ b/tests/integration/workflows/test_article_workflow.py
@@ -348,69 +348,6 @@ def test_set_fermilab_collection_even_when_record_is_hidden_and_affiliations_are
     return_value="1234",
 )
 @mock.patch("inspirehep.modules.workflows.tasks.submission.send_robotupload")
-def test_keywords_are_stored_in_record_when_record_is_core(
-    mocked_api_request_magpie,
-    mocked_api_request_classifier,
-    mocked_robotupload,
-    mocked_create_ticket,
-    mocked_store_record,
-    mocked_external_services,
-    workflow_app,
-):
-    record = {
-        "$schema": "https://labs.inspirehep.net/schemas/records/hep.json",
-        "titles": [
-            {"title": "Update without conflicts title."},
-        ],
-        "authors": [
-            {
-                "full_name": "Some author",
-                "raw_affiliations": [
-                    {
-                        "value": "Some longer description CErN? with proper keyword included"
-                    }
-                ],
-            }
-        ],
-        "document_type": ["article"],
-        "_collections": ["Literature"],
-        "abstracts": [
-            {"value": "Very interesting paper about the Higgs boson."},
-        ],
-        "acquisition_source": {
-            "datetime": "2020-11-12T04:49:13.369515",
-            "method": "hepcrawl",
-            "submission_number": "978",
-            "source": "Elsevier",
-        },
-    }
-
-    expected_keywords = [
-        {"value": "Higgs particle", "schema": "INSPIRE", "source": "classifier"}
-    ]
-    workflow = build_workflow(record)
-    start("article", object_id=workflow.id)
-    wf = workflow_object_class.get(workflow.id)
-    mark("approved", True)(workflow, None)
-    mark("core", True)(workflow, None)
-    wf.continue_workflow()
-    assert wf.data["keywords"] == expected_keywords
-
-
-@mock.patch(
-    "inspirehep.modules.workflows.tasks.classifier.json_api_request",
-    side_effect=fake_classifier_api_request,
-)
-@mock.patch(
-    "inspirehep.modules.workflows.tasks.magpie.json_api_request",
-    side_effect=fake_magpie_api_request,
-)
-@mock.patch("inspirehep.modules.workflows.tasks.upload.store_record")
-@mock.patch(
-    "inspirehep.modules.workflows.tasks.submission.submit_rt_ticket",
-    return_value="1234",
-)
-@mock.patch("inspirehep.modules.workflows.tasks.submission.send_robotupload")
 def test_run_next_wf_is_not_starting_core_selection_wfs(
     mocked_api_request_magpie,
     mocked_api_request_classifier,


### PR DESCRIPTION
kept the actual function in case we need it again at some later stage

ref: https://github.com/cern-sis/issues-inspire/issues/554