### PR TITLE
gh-actions: bump cache and checkout action

### DIFF
--- a/.github/workflows/backend-tests-on-docker.yml
+++ b/.github/workflows/backend-tests-on-docker.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.2
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
       - name: Cache docker image
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v4.2.0
         id: cache
         with:
           path: /tmp/docker-images
@@ -45,12 +45,12 @@ jobs:
     needs: Build
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.2.2
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
       - name: Cache docker image
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v4.2.0
         id: cache
         with:
           path: /tmp/docker-images
@@ -81,12 +81,12 @@ jobs:
     needs: Build
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.2.2
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
       - name: Cache docker image
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v4.2.0
         id: cache
         with:
           path: /tmp/docker-images
@@ -119,12 +119,12 @@ jobs:
     needs: Build
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.2.2
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
       - name: Cache docker image
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v4.2.0
         id: cache
         with:
           path: /tmp/docker-images
@@ -144,12 +144,12 @@ jobs:
     needs: Build
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.2.2
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
       - name: Cache docker image
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v4.2.0
         id: cache
         with:
           path: /tmp/docker-images
@@ -169,12 +169,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.2.2
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
       - name: Cache docker image
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v4.2.0
         id: cache
         with:
           path: /tmp/docker-images
@@ -193,7 +193,7 @@ jobs:
       tag: ${{ steps.set-env.outputs.tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.2.2
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0


### PR DESCRIPTION
We need to bump actions/cache as its getting deprecated: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down


Also bumped the checkout action, because why not.